### PR TITLE
chore: rename reearth/reearth repo name to reearth/reearth-visualizer

### DIFF
--- a/.github/workflows/deploy_server_nightly.yml
+++ b/.github/workflows/deploy_server_nightly.yml
@@ -12,7 +12,7 @@ jobs:
   deploy_test:
     name: Deploy app to test env
     runs-on: ubuntu-latest
-    if: github.event.repository.full_name == 'reearth/reearth'
+    if: github.event.repository.full_name == 'reearth/reearth-visualizer'
     steps:
       - uses: google-github-actions/auth@v0
         with:

--- a/.github/workflows/deploy_web_nightly.yml
+++ b/.github/workflows/deploy_web_nightly.yml
@@ -11,7 +11,7 @@ jobs:
   deploy_test:
     name: Deploy test env
     runs-on: ubuntu-latest
-    if: github.event.repository.full_name == 'reearth/reearth'
+    if: github.event.repository.full_name == 'reearth/reearth-visualizer'
     steps:
       - uses: google-github-actions/auth@v0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,154 +8,154 @@ All notable changes to this project will be documented in this file.
 
 #### 🔧 Bug Fixes
 
-- GlobalModal not showing when it should ([#857](https://github.com/reearth/reearth/pull/857)) [`8df7d0`](https://github.com/reearth/reearth/commit/8df7d0)
-- Support built-in widget visible on WAS ([#839](https://github.com/reearth/reearth/pull/839)) [`227ae7`](https://github.com/reearth/reearth/commit/227ae7)
-- Core marker extrude check for coordinates height ([#834](https://github.com/reearth/reearth/pull/834)) [`7fcaa2`](https://github.com/reearth/reearth/commit/7fcaa2)
+- GlobalModal not showing when it should ([#857](https://github.com/reearth/reearth-visualizer/pull/857)) [`8df7d0`](https://github.com/reearth/reearth-visualizer/commit/8df7d0)
+- Support built-in widget visible on WAS ([#839](https://github.com/reearth/reearth-visualizer/pull/839)) [`227ae7`](https://github.com/reearth/reearth-visualizer/commit/227ae7)
+- Core marker extrude check for coordinates height ([#834](https://github.com/reearth/reearth-visualizer/pull/834)) [`7fcaa2`](https://github.com/reearth/reearth-visualizer/commit/7fcaa2)
 
 #### 🧪 Testing
 
-- Fix useEngineRef [`854de7`](https://github.com/reearth/reearth/commit/854de7)
+- Fix useEngineRef [`854de7`](https://github.com/reearth/reearth-visualizer/commit/854de7)
 
 #### Miscellaneous Tasks
 
-- Handle invalid date in time convert ([#878](https://github.com/reearth/reearth/pull/878)) [`c8e825`](https://github.com/reearth/reearth/commit/c8e825)
-- Timeline bug fixing ([#876](https://github.com/reearth/reearth/pull/876)) [`46593d`](https://github.com/reearth/reearth/commit/46593d)
-- Disable PBR when material has texture ([#875](https://github.com/reearth/reearth/pull/875)) [`969a63`](https://github.com/reearth/reearth/commit/969a63)
-- Add hideIndicator On Selecting ([#866](https://github.com/reearth/reearth/pull/866)) [`9a1e32`](https://github.com/reearth/reearth/commit/9a1e32)
-- Fix scene undefined bug in heatmap ([#873](https://github.com/reearth/reearth/pull/873)) [`ace172`](https://github.com/reearth/reearth/commit/ace172)
-- Invoke requestRender before capture screen [`86f666`](https://github.com/reearth/reearth/commit/86f666)
-- Sketch layer UI implementation ([#855](https://github.com/reearth/reearth/pull/855)) [`9b9d4b`](https://github.com/reearth/reearth/commit/9b9d4b)
-- Add flyToBBox ([#865](https://github.com/reearth/reearth/pull/865)) [`76ada0`](https://github.com/reearth/reearth/commit/76ada0)
-- Timeline with padding ([#853](https://github.com/reearth/reearth/pull/853)) [`a16870`](https://github.com/reearth/reearth/commit/a16870)
-- Fix frustum instance [`146872`](https://github.com/reearth/reearth/commit/146872)
-- Add support for heatMap in beta ([#835](https://github.com/reearth/reearth/pull/835)) [`0c4c02`](https://github.com/reearth/reearth/commit/0c4c02)
-- Add some functionalities for pedestrian ([#862](https://github.com/reearth/reearth/pull/862)) [`293335`](https://github.com/reearth/reearth/commit/293335)
-- Remember the editor settings ([#825](https://github.com/reearth/reearth/pull/825)) [`02aac2`](https://github.com/reearth/reearth/commit/02aac2)
-- Add frustum model ([#861](https://github.com/reearth/reearth/pull/861)) [`2b6895`](https://github.com/reearth/reearth/commit/2b6895)
-- Add transition appearance ([#860](https://github.com/reearth/reearth/pull/860)) [`fb496e`](https://github.com/reearth/reearth/commit/fb496e)
-- Refactoring web code ([#858](https://github.com/reearth/reearth/pull/858)) [`7f0e76`](https://github.com/reearth/reearth/commit/7f0e76)
-- Extend camera and marker APIs for pedestrian ([#859](https://github.com/reearth/reearth/pull/859)) [`1d35d9`](https://github.com/reearth/reearth/commit/1d35d9)
-- Improve Story Panel UX ([#856](https://github.com/reearth/reearth/pull/856)) [`d8d9f3`](https://github.com/reearth/reearth/commit/d8d9f3)
-- Multiple bug fixes ([#854](https://github.com/reearth/reearth/pull/854)) [`574037`](https://github.com/reearth/reearth/commit/574037)
-- Fix assets not refetching ([#852](https://github.com/reearth/reearth/pull/852)) [`0b60ec`](https://github.com/reearth/reearth/commit/0b60ec)
-- Fix published WAS area padding ([#850](https://github.com/reearth/reearth/pull/850)) [`569681`](https://github.com/reearth/reearth/commit/569681)
-- Fixing a few bugs ([#849](https://github.com/reearth/reearth/pull/849)) [`c8ad89`](https://github.com/reearth/reearth/commit/c8ad89)
-- Color bug fix ([#843](https://github.com/reearth/reearth/pull/843)) [`76f514`](https://github.com/reearth/reearth/commit/76f514)
-- Stringify label text ([#848](https://github.com/reearth/reearth/pull/848)) [`17bcc6`](https://github.com/reearth/reearth/commit/17bcc6)
-- Next page button story block ([#846](https://github.com/reearth/reearth/pull/846)) [`7aa346`](https://github.com/reearth/reearth/commit/7aa346)
-- Fix timeline block breaking when time set to current day ([#847](https://github.com/reearth/reearth/pull/847)) [`a69d81`](https://github.com/reearth/reearth/commit/a69d81)
-- Fix unsafe builtin widget logic to work well on published page ([#845](https://github.com/reearth/reearth/pull/845)) [`1b1e83`](https://github.com/reearth/reearth/commit/1b1e83)
-- Fix title padding changes updating page padding ([#840](https://github.com/reearth/reearth/pull/840)) [`42d9ed`](https://github.com/reearth/reearth/commit/42d9ed)
-- Finalize Japanese translations ([#842](https://github.com/reearth/reearth/pull/842)) [`1ff1f7`](https://github.com/reearth/reearth/commit/1ff1f7)
-- Add page name tag to indicator and fix some small bugs ([#841](https://github.com/reearth/reearth/pull/841)) [`968b6b`](https://github.com/reearth/reearth/commit/968b6b)
-- Improve asset modal ([#838](https://github.com/reearth/reearth/pull/838)) [`68c18d`](https://github.com/reearth/reearth/commit/68c18d)
-- Modify zoom level field ([#808](https://github.com/reearth/reearth/pull/808)) [`1b79cf`](https://github.com/reearth/reearth/commit/1b79cf)
-- Fix story block creation and preview ([#837](https://github.com/reearth/reearth/pull/837)) [`ebf99c`](https://github.com/reearth/reearth/commit/ebf99c)
-- Update switch layer block functionality  ([#833](https://github.com/reearth/reearth/pull/833)) [`ed2931`](https://github.com/reearth/reearth/commit/ed2931)
-- Fix story block bugs ([#829](https://github.com/reearth/reearth/pull/829)) [`d6bf3e`](https://github.com/reearth/reearth/commit/d6bf3e)
-- Timefield bug fix ([#828](https://github.com/reearth/reearth/pull/828)) [`df99b1`](https://github.com/reearth/reearth/commit/df99b1)
-- Fix story page bugs ([#826](https://github.com/reearth/reearth/pull/826)) [`09338f`](https://github.com/reearth/reearth/commit/09338f)
-- Fix type errors in align system [`91a821`](https://github.com/reearth/reearth/commit/91a821)
-- Fix camera behavior in interaction mode ([#824](https://github.com/reearth/reearth/pull/824)) [`912d68`](https://github.com/reearth/reearth/commit/912d68)
-- Fix WAS gap [`b80a31`](https://github.com/reearth/reearth/commit/b80a31)
-- Fix padding settings for page ([#823](https://github.com/reearth/reearth/pull/823)) [`f9a7d4`](https://github.com/reearth/reearth/commit/f9a7d4)
-- Reset current page on tab change ([#822](https://github.com/reearth/reearth/pull/822)) [`972fda`](https://github.com/reearth/reearth/commit/972fda)
-- Fix timeline field component&[#39](https://github.com/reearth/reearth/pull/39);s popover ([#821](https://github.com/reearth/reearth/pull/821)) [`a38df1`](https://github.com/reearth/reearth/commit/a38df1)
-- Story block edit Panel layout ([#810](https://github.com/reearth/reearth/pull/810)) [`67a0d6`](https://github.com/reearth/reearth/commit/67a0d6)
-- Double click on page name ([#815](https://github.com/reearth/reearth/pull/815)) [`ccf3c2`](https://github.com/reearth/reearth/commit/ccf3c2)
-- Drag in timeline blog ([#802](https://github.com/reearth/reearth/pull/802)) [`f4fc80`](https://github.com/reearth/reearth/commit/f4fc80)
-- Add an API to get description from entity ([#813](https://github.com/reearth/reearth/pull/813)) [`75c326`](https://github.com/reearth/reearth/commit/75c326)
-- Beta zindexes ([#751](https://github.com/reearth/reearth/pull/751)) [`4b7161`](https://github.com/reearth/reearth/commit/4b7161)
-- Fix overriding layer structure ([#818](https://github.com/reearth/reearth/pull/818)) [`034e98`](https://github.com/reearth/reearth/commit/034e98)
-- Fix layer freezing after feature selection [`030528`](https://github.com/reearth/reearth/commit/030528)
-- Fix feature unselection ([#812](https://github.com/reearth/reearth/pull/812)) [`3e6b7c`](https://github.com/reearth/reearth/commit/3e6b7c)
-- Story page click away ([#806](https://github.com/reearth/reearth/pull/806)) [`b97cd2`](https://github.com/reearth/reearth/commit/b97cd2)
-- Move doubleClick with debounce to utils ([#811](https://github.com/reearth/reearth/pull/811)) [`80b65f`](https://github.com/reearth/reearth/commit/80b65f)
-- Ui and ux fixes ([#809](https://github.com/reearth/reearth/pull/809)) [`770edb`](https://github.com/reearth/reearth/commit/770edb)
-- UI updates ([#805](https://github.com/reearth/reearth/pull/805)) [`621416`](https://github.com/reearth/reearth/commit/621416)
-- Multi layer Select ([#757](https://github.com/reearth/reearth/pull/757)) [`0e75fa`](https://github.com/reearth/reearth/commit/0e75fa)
-- Fix classic notification bar ([#804](https://github.com/reearth/reearth/pull/804)) [`1ca153`](https://github.com/reearth/reearth/commit/1ca153)
-- Fix error in Timeline block [`0b0290`](https://github.com/reearth/reearth/commit/0b0290)
-- Fix story panel bg in published project [`f8df61`](https://github.com/reearth/reearth/commit/f8df61)
-- Handle misfiring of singleClick on doubleClick at layerName and layerStyleName ([#800](https://github.com/reearth/reearth/pull/800)) [`d539d3`](https://github.com/reearth/reearth/commit/d539d3)
-- Bug fixes ([#803](https://github.com/reearth/reearth/pull/803)) [`8e4ada`](https://github.com/reearth/reearth/commit/8e4ada)
-- Fix gap field component ([#801](https://github.com/reearth/reearth/pull/801)) [`f9b18c`](https://github.com/reearth/reearth/commit/f9b18c)
-- Add story background setting ([#775](https://github.com/reearth/reearth/pull/775)) [`f8ea05`](https://github.com/reearth/reearth/commit/f8ea05)
-- Collapse side panels ([#799](https://github.com/reearth/reearth/pull/799)) [`8aa78f`](https://github.com/reearth/reearth/commit/8aa78f)
-- Visualizer clock update  ([#782](https://github.com/reearth/reearth/pull/782)) [`9c4c84`](https://github.com/reearth/reearth/commit/9c4c84)
-- Timeline block ([#750](https://github.com/reearth/reearth/pull/750)) [`f5ab49`](https://github.com/reearth/reearth/commit/f5ab49)
-- Fix text and camera button blocks ([#797](https://github.com/reearth/reearth/pull/797)) [`b97d67`](https://github.com/reearth/reearth/commit/b97d67)
-- New beta notification ([#796](https://github.com/reearth/reearth/pull/796)) [`607773`](https://github.com/reearth/reearth/commit/607773)
-- Slider fixes ([#795](https://github.com/reearth/reearth/pull/795)) [`801396`](https://github.com/reearth/reearth/commit/801396)
-- Auto create page on project creation ([#794](https://github.com/reearth/reearth/pull/794)) [`6d5360`](https://github.com/reearth/reearth/commit/6d5360)
-- Storyblock ux update ([#776](https://github.com/reearth/reearth/pull/776)) [`0c16b4`](https://github.com/reearth/reearth/commit/0c16b4)
-- Misc bug fixes improvements ([#793](https://github.com/reearth/reearth/pull/793)) [`b09909`](https://github.com/reearth/reearth/commit/b09909)
-- 3dtile feature select support in UI ([#792](https://github.com/reearth/reearth/pull/792)) [`be18c6`](https://github.com/reearth/reearth/commit/be18c6)
-- Add scene setting ([#755](https://github.com/reearth/reearth/pull/755)) [`f9e53a`](https://github.com/reearth/reearth/commit/f9e53a)
-- Minor fixes in map editor ([#789](https://github.com/reearth/reearth/pull/789)) [`56c4c0`](https://github.com/reearth/reearth/commit/56c4c0)
+- Handle invalid date in time convert ([#878](https://github.com/reearth/reearth-visualizer/pull/878)) [`c8e825`](https://github.com/reearth/reearth-visualizer/commit/c8e825)
+- Timeline bug fixing ([#876](https://github.com/reearth/reearth-visualizer/pull/876)) [`46593d`](https://github.com/reearth/reearth-visualizer/commit/46593d)
+- Disable PBR when material has texture ([#875](https://github.com/reearth/reearth-visualizer/pull/875)) [`969a63`](https://github.com/reearth/reearth-visualizer/commit/969a63)
+- Add hideIndicator On Selecting ([#866](https://github.com/reearth/reearth-visualizer/pull/866)) [`9a1e32`](https://github.com/reearth/reearth-visualizer/commit/9a1e32)
+- Fix scene undefined bug in heatmap ([#873](https://github.com/reearth/reearth-visualizer/pull/873)) [`ace172`](https://github.com/reearth/reearth-visualizer/commit/ace172)
+- Invoke requestRender before capture screen [`86f666`](https://github.com/reearth/reearth-visualizer/commit/86f666)
+- Sketch layer UI implementation ([#855](https://github.com/reearth/reearth-visualizer/pull/855)) [`9b9d4b`](https://github.com/reearth/reearth-visualizer/commit/9b9d4b)
+- Add flyToBBox ([#865](https://github.com/reearth/reearth-visualizer/pull/865)) [`76ada0`](https://github.com/reearth/reearth-visualizer/commit/76ada0)
+- Timeline with padding ([#853](https://github.com/reearth/reearth-visualizer/pull/853)) [`a16870`](https://github.com/reearth/reearth-visualizer/commit/a16870)
+- Fix frustum instance [`146872`](https://github.com/reearth/reearth-visualizer/commit/146872)
+- Add support for heatMap in beta ([#835](https://github.com/reearth/reearth-visualizer/pull/835)) [`0c4c02`](https://github.com/reearth/reearth-visualizer/commit/0c4c02)
+- Add some functionalities for pedestrian ([#862](https://github.com/reearth/reearth-visualizer/pull/862)) [`293335`](https://github.com/reearth/reearth-visualizer/commit/293335)
+- Remember the editor settings ([#825](https://github.com/reearth/reearth-visualizer/pull/825)) [`02aac2`](https://github.com/reearth/reearth-visualizer/commit/02aac2)
+- Add frustum model ([#861](https://github.com/reearth/reearth-visualizer/pull/861)) [`2b6895`](https://github.com/reearth/reearth-visualizer/commit/2b6895)
+- Add transition appearance ([#860](https://github.com/reearth/reearth-visualizer/pull/860)) [`fb496e`](https://github.com/reearth/reearth-visualizer/commit/fb496e)
+- Refactoring web code ([#858](https://github.com/reearth/reearth-visualizer/pull/858)) [`7f0e76`](https://github.com/reearth/reearth-visualizer/commit/7f0e76)
+- Extend camera and marker APIs for pedestrian ([#859](https://github.com/reearth/reearth-visualizer/pull/859)) [`1d35d9`](https://github.com/reearth/reearth-visualizer/commit/1d35d9)
+- Improve Story Panel UX ([#856](https://github.com/reearth/reearth-visualizer/pull/856)) [`d8d9f3`](https://github.com/reearth/reearth-visualizer/commit/d8d9f3)
+- Multiple bug fixes ([#854](https://github.com/reearth/reearth-visualizer/pull/854)) [`574037`](https://github.com/reearth/reearth-visualizer/commit/574037)
+- Fix assets not refetching ([#852](https://github.com/reearth/reearth-visualizer/pull/852)) [`0b60ec`](https://github.com/reearth/reearth-visualizer/commit/0b60ec)
+- Fix published WAS area padding ([#850](https://github.com/reearth/reearth-visualizer/pull/850)) [`569681`](https://github.com/reearth/reearth-visualizer/commit/569681)
+- Fixing a few bugs ([#849](https://github.com/reearth/reearth-visualizer/pull/849)) [`c8ad89`](https://github.com/reearth/reearth-visualizer/commit/c8ad89)
+- Color bug fix ([#843](https://github.com/reearth/reearth-visualizer/pull/843)) [`76f514`](https://github.com/reearth/reearth-visualizer/commit/76f514)
+- Stringify label text ([#848](https://github.com/reearth/reearth-visualizer/pull/848)) [`17bcc6`](https://github.com/reearth/reearth-visualizer/commit/17bcc6)
+- Next page button story block ([#846](https://github.com/reearth/reearth-visualizer/pull/846)) [`7aa346`](https://github.com/reearth/reearth-visualizer/commit/7aa346)
+- Fix timeline block breaking when time set to current day ([#847](https://github.com/reearth/reearth-visualizer/pull/847)) [`a69d81`](https://github.com/reearth/reearth-visualizer/commit/a69d81)
+- Fix unsafe builtin widget logic to work well on published page ([#845](https://github.com/reearth/reearth-visualizer/pull/845)) [`1b1e83`](https://github.com/reearth/reearth-visualizer/commit/1b1e83)
+- Fix title padding changes updating page padding ([#840](https://github.com/reearth/reearth-visualizer/pull/840)) [`42d9ed`](https://github.com/reearth/reearth-visualizer/commit/42d9ed)
+- Finalize Japanese translations ([#842](https://github.com/reearth/reearth-visualizer/pull/842)) [`1ff1f7`](https://github.com/reearth/reearth-visualizer/commit/1ff1f7)
+- Add page name tag to indicator and fix some small bugs ([#841](https://github.com/reearth/reearth-visualizer/pull/841)) [`968b6b`](https://github.com/reearth/reearth-visualizer/commit/968b6b)
+- Improve asset modal ([#838](https://github.com/reearth/reearth-visualizer/pull/838)) [`68c18d`](https://github.com/reearth/reearth-visualizer/commit/68c18d)
+- Modify zoom level field ([#808](https://github.com/reearth/reearth-visualizer/pull/808)) [`1b79cf`](https://github.com/reearth/reearth-visualizer/commit/1b79cf)
+- Fix story block creation and preview ([#837](https://github.com/reearth/reearth-visualizer/pull/837)) [`ebf99c`](https://github.com/reearth/reearth-visualizer/commit/ebf99c)
+- Update switch layer block functionality  ([#833](https://github.com/reearth/reearth-visualizer/pull/833)) [`ed2931`](https://github.com/reearth/reearth-visualizer/commit/ed2931)
+- Fix story block bugs ([#829](https://github.com/reearth/reearth-visualizer/pull/829)) [`d6bf3e`](https://github.com/reearth/reearth-visualizer/commit/d6bf3e)
+- Timefield bug fix ([#828](https://github.com/reearth/reearth-visualizer/pull/828)) [`df99b1`](https://github.com/reearth/reearth-visualizer/commit/df99b1)
+- Fix story page bugs ([#826](https://github.com/reearth/reearth-visualizer/pull/826)) [`09338f`](https://github.com/reearth/reearth-visualizer/commit/09338f)
+- Fix type errors in align system [`91a821`](https://github.com/reearth/reearth-visualizer/commit/91a821)
+- Fix camera behavior in interaction mode ([#824](https://github.com/reearth/reearth-visualizer/pull/824)) [`912d68`](https://github.com/reearth/reearth-visualizer/commit/912d68)
+- Fix WAS gap [`b80a31`](https://github.com/reearth/reearth-visualizer/commit/b80a31)
+- Fix padding settings for page ([#823](https://github.com/reearth/reearth-visualizer/pull/823)) [`f9a7d4`](https://github.com/reearth/reearth-visualizer/commit/f9a7d4)
+- Reset current page on tab change ([#822](https://github.com/reearth/reearth-visualizer/pull/822)) [`972fda`](https://github.com/reearth/reearth-visualizer/commit/972fda)
+- Fix timeline field component&[#39](https://github.com/reearth/reearth-visualizer/pull/39);s popover ([#821](https://github.com/reearth/reearth-visualizer/pull/821)) [`a38df1`](https://github.com/reearth/reearth-visualizer/commit/a38df1)
+- Story block edit Panel layout ([#810](https://github.com/reearth/reearth-visualizer/pull/810)) [`67a0d6`](https://github.com/reearth/reearth-visualizer/commit/67a0d6)
+- Double click on page name ([#815](https://github.com/reearth/reearth-visualizer/pull/815)) [`ccf3c2`](https://github.com/reearth/reearth-visualizer/commit/ccf3c2)
+- Drag in timeline blog ([#802](https://github.com/reearth/reearth-visualizer/pull/802)) [`f4fc80`](https://github.com/reearth/reearth-visualizer/commit/f4fc80)
+- Add an API to get description from entity ([#813](https://github.com/reearth/reearth-visualizer/pull/813)) [`75c326`](https://github.com/reearth/reearth-visualizer/commit/75c326)
+- Beta zindexes ([#751](https://github.com/reearth/reearth-visualizer/pull/751)) [`4b7161`](https://github.com/reearth/reearth-visualizer/commit/4b7161)
+- Fix overriding layer structure ([#818](https://github.com/reearth/reearth-visualizer/pull/818)) [`034e98`](https://github.com/reearth/reearth-visualizer/commit/034e98)
+- Fix layer freezing after feature selection [`030528`](https://github.com/reearth/reearth-visualizer/commit/030528)
+- Fix feature unselection ([#812](https://github.com/reearth/reearth-visualizer/pull/812)) [`3e6b7c`](https://github.com/reearth/reearth-visualizer/commit/3e6b7c)
+- Story page click away ([#806](https://github.com/reearth/reearth-visualizer/pull/806)) [`b97cd2`](https://github.com/reearth/reearth-visualizer/commit/b97cd2)
+- Move doubleClick with debounce to utils ([#811](https://github.com/reearth/reearth-visualizer/pull/811)) [`80b65f`](https://github.com/reearth/reearth-visualizer/commit/80b65f)
+- Ui and ux fixes ([#809](https://github.com/reearth/reearth-visualizer/pull/809)) [`770edb`](https://github.com/reearth/reearth-visualizer/commit/770edb)
+- UI updates ([#805](https://github.com/reearth/reearth-visualizer/pull/805)) [`621416`](https://github.com/reearth/reearth-visualizer/commit/621416)
+- Multi layer Select ([#757](https://github.com/reearth/reearth-visualizer/pull/757)) [`0e75fa`](https://github.com/reearth/reearth-visualizer/commit/0e75fa)
+- Fix classic notification bar ([#804](https://github.com/reearth/reearth-visualizer/pull/804)) [`1ca153`](https://github.com/reearth/reearth-visualizer/commit/1ca153)
+- Fix error in Timeline block [`0b0290`](https://github.com/reearth/reearth-visualizer/commit/0b0290)
+- Fix story panel bg in published project [`f8df61`](https://github.com/reearth/reearth-visualizer/commit/f8df61)
+- Handle misfiring of singleClick on doubleClick at layerName and layerStyleName ([#800](https://github.com/reearth/reearth-visualizer/pull/800)) [`d539d3`](https://github.com/reearth/reearth-visualizer/commit/d539d3)
+- Bug fixes ([#803](https://github.com/reearth/reearth-visualizer/pull/803)) [`8e4ada`](https://github.com/reearth/reearth-visualizer/commit/8e4ada)
+- Fix gap field component ([#801](https://github.com/reearth/reearth-visualizer/pull/801)) [`f9b18c`](https://github.com/reearth/reearth-visualizer/commit/f9b18c)
+- Add story background setting ([#775](https://github.com/reearth/reearth-visualizer/pull/775)) [`f8ea05`](https://github.com/reearth/reearth-visualizer/commit/f8ea05)
+- Collapse side panels ([#799](https://github.com/reearth/reearth-visualizer/pull/799)) [`8aa78f`](https://github.com/reearth/reearth-visualizer/commit/8aa78f)
+- Visualizer clock update  ([#782](https://github.com/reearth/reearth-visualizer/pull/782)) [`9c4c84`](https://github.com/reearth/reearth-visualizer/commit/9c4c84)
+- Timeline block ([#750](https://github.com/reearth/reearth-visualizer/pull/750)) [`f5ab49`](https://github.com/reearth/reearth-visualizer/commit/f5ab49)
+- Fix text and camera button blocks ([#797](https://github.com/reearth/reearth-visualizer/pull/797)) [`b97d67`](https://github.com/reearth/reearth-visualizer/commit/b97d67)
+- New beta notification ([#796](https://github.com/reearth/reearth-visualizer/pull/796)) [`607773`](https://github.com/reearth/reearth-visualizer/commit/607773)
+- Slider fixes ([#795](https://github.com/reearth/reearth-visualizer/pull/795)) [`801396`](https://github.com/reearth/reearth-visualizer/commit/801396)
+- Auto create page on project creation ([#794](https://github.com/reearth/reearth-visualizer/pull/794)) [`6d5360`](https://github.com/reearth/reearth-visualizer/commit/6d5360)
+- Storyblock ux update ([#776](https://github.com/reearth/reearth-visualizer/pull/776)) [`0c16b4`](https://github.com/reearth/reearth-visualizer/commit/0c16b4)
+- Misc bug fixes improvements ([#793](https://github.com/reearth/reearth-visualizer/pull/793)) [`b09909`](https://github.com/reearth/reearth-visualizer/commit/b09909)
+- 3dtile feature select support in UI ([#792](https://github.com/reearth/reearth-visualizer/pull/792)) [`be18c6`](https://github.com/reearth/reearth-visualizer/commit/be18c6)
+- Add scene setting ([#755](https://github.com/reearth/reearth-visualizer/pull/755)) [`f9e53a`](https://github.com/reearth/reearth-visualizer/commit/f9e53a)
+- Minor fixes in map editor ([#789](https://github.com/reearth/reearth-visualizer/pull/789)) [`56c4c0`](https://github.com/reearth/reearth-visualizer/commit/56c4c0)
 
 ### Server
 
 #### 🔧 Bug Fixes
 
-- Cannot find storytelling by public name [`76b996`](https://github.com/reearth/reearth/commit/76b996)
-- Serve published metadata of storytelling ([#851](https://github.com/reearth/reearth/pull/851)) [`7850d0`](https://github.com/reearth/reearth/commit/7850d0)
-- Repo filter remains between different contexts [`887daf`](https://github.com/reearth/reearth/commit/887daf)
+- Cannot find storytelling by public name [`76b996`](https://github.com/reearth/reearth-visualizer/commit/76b996)
+- Serve published metadata of storytelling ([#851](https://github.com/reearth/reearth-visualizer/pull/851)) [`7850d0`](https://github.com/reearth/reearth-visualizer/commit/7850d0)
+- Repo filter remains between different contexts [`887daf`](https://github.com/reearth/reearth-visualizer/commit/887daf)
 
 #### Miscellaneous Tasks
 
-- Add panel setting to manifest ([#827](https://github.com/reearth/reearth/pull/827)) [`89457b`](https://github.com/reearth/reearth/commit/89457b)
-- Modify zoom level in manifest ([#807](https://github.com/reearth/reearth/pull/807)) [`ae5594`](https://github.com/reearth/reearth/commit/ae5594)
-- Remove empty property group [`7c5587`](https://github.com/reearth/reearth/commit/7c5587)
-- Update convert value in gql [`3bbd0f`](https://github.com/reearth/reearth/commit/3bbd0f)
-- Add array in convert value of gql [`ee5844`](https://github.com/reearth/reearth/commit/ee5844)
-- Add cameraDuration on the cameraButtonStoryBlock [`a69cd6`](https://github.com/reearth/reearth/commit/a69cd6)
-- Remove background setting from manifest [`86cc00`](https://github.com/reearth/reearth/commit/86cc00)
-- Remove debug statements [`a875a2`](https://github.com/reearth/reearth/commit/a875a2)
-- Add bgColor w story in memory, refactors and add test [`df9e95`](https://github.com/reearth/reearth/commit/df9e95)
-- Add position, bgColor &amp; title to story &amp; page json respectively for published story ([#787](https://github.com/reearth/reearth/pull/787)) [`cea0d7`](https://github.com/reearth/reearth/commit/cea0d7)
-- Add bgColor to story mutation resolver [`c158b6`](https://github.com/reearth/reearth/commit/c158b6)
-- Add bgColor to story ([#791](https://github.com/reearth/reearth/pull/791)) [`93aba7`](https://github.com/reearth/reearth/commit/93aba7)
+- Add panel setting to manifest ([#827](https://github.com/reearth/reearth-visualizer/pull/827)) [`89457b`](https://github.com/reearth/reearth-visualizer/commit/89457b)
+- Modify zoom level in manifest ([#807](https://github.com/reearth/reearth-visualizer/pull/807)) [`ae5594`](https://github.com/reearth/reearth-visualizer/commit/ae5594)
+- Remove empty property group [`7c5587`](https://github.com/reearth/reearth-visualizer/commit/7c5587)
+- Update convert value in gql [`3bbd0f`](https://github.com/reearth/reearth-visualizer/commit/3bbd0f)
+- Add array in convert value of gql [`ee5844`](https://github.com/reearth/reearth-visualizer/commit/ee5844)
+- Add cameraDuration on the cameraButtonStoryBlock [`a69cd6`](https://github.com/reearth/reearth-visualizer/commit/a69cd6)
+- Remove background setting from manifest [`86cc00`](https://github.com/reearth/reearth-visualizer/commit/86cc00)
+- Remove debug statements [`a875a2`](https://github.com/reearth/reearth-visualizer/commit/a875a2)
+- Add bgColor w story in memory, refactors and add test [`df9e95`](https://github.com/reearth/reearth-visualizer/commit/df9e95)
+- Add position, bgColor &amp; title to story &amp; page json respectively for published story ([#787](https://github.com/reearth/reearth-visualizer/pull/787)) [`cea0d7`](https://github.com/reearth/reearth-visualizer/commit/cea0d7)
+- Add bgColor to story mutation resolver [`c158b6`](https://github.com/reearth/reearth-visualizer/commit/c158b6)
+- Add bgColor to story ([#791](https://github.com/reearth/reearth-visualizer/pull/791)) [`93aba7`](https://github.com/reearth/reearth-visualizer/commit/93aba7)
 
 ### Misc
 
 #### Miscellaneous Tasks
 
-- Wireframe for globe and tileset ([#870](https://github.com/reearth/reearth/pull/870)) [`75c04f`](https://github.com/reearth/reearth/commit/75c04f)
-- Fix title&[#39](https://github.com/reearth/reearth/pull/39);s panel setting ([#831](https://github.com/reearth/reearth/pull/831)) [`b60713`](https://github.com/reearth/reearth/commit/b60713)
-- Modify the description of zoom level ([#832](https://github.com/reearth/reearth/pull/832)) [`021404`](https://github.com/reearth/reearth/commit/021404)
-- Fix input field popover ([#819](https://github.com/reearth/reearth/pull/819)) [`d42279`](https://github.com/reearth/reearth/commit/d42279)
-- Remove the timeOut from text input ([#814](https://github.com/reearth/reearth/pull/814)) [`4ad7bb`](https://github.com/reearth/reearth/commit/4ad7bb)
+- Wireframe for globe and tileset ([#870](https://github.com/reearth/reearth-visualizer/pull/870)) [`75c04f`](https://github.com/reearth/reearth-visualizer/commit/75c04f)
+- Fix title&[#39](https://github.com/reearth/reearth-visualizer/pull/39);s panel setting ([#831](https://github.com/reearth/reearth-visualizer/pull/831)) [`b60713`](https://github.com/reearth/reearth-visualizer/commit/b60713)
+- Modify the description of zoom level ([#832](https://github.com/reearth/reearth-visualizer/pull/832)) [`021404`](https://github.com/reearth/reearth-visualizer/commit/021404)
+- Fix input field popover ([#819](https://github.com/reearth/reearth-visualizer/pull/819)) [`d42279`](https://github.com/reearth/reearth-visualizer/commit/d42279)
+- Remove the timeOut from text input ([#814](https://github.com/reearth/reearth-visualizer/pull/814)) [`4ad7bb`](https://github.com/reearth/reearth-visualizer/commit/4ad7bb)
 
 #### 
 
-- Fix feature selection...again [`5e3012`](https://github.com/reearth/reearth/commit/5e3012)
+- Fix feature selection...again [`5e3012`](https://github.com/reearth/reearth-visualizer/commit/5e3012)
 
 ### chore
 
 #### 🔧 Bug Fixes
 
-- Invoke requestRender in primitive features whenever component is updated ([#817](https://github.com/reearth/reearth/pull/817)) [`e3ed8c`](https://github.com/reearth/reearth/commit/e3ed8c)
+- Invoke requestRender in primitive features whenever component is updated ([#817](https://github.com/reearth/reearth-visualizer/pull/817)) [`e3ed8c`](https://github.com/reearth/reearth-visualizer/commit/e3ed8c)
 
 ### sever
 
 #### Miscellaneous Tasks
 
-- Fix story publishing for prod ([#844](https://github.com/reearth/reearth/pull/844)) [`c250a2`](https://github.com/reearth/reearth/commit/c250a2)
+- Fix story publishing for prod ([#844](https://github.com/reearth/reearth-visualizer/pull/844)) [`c250a2`](https://github.com/reearth/reearth-visualizer/commit/c250a2)
 
 ### 
 
 #### Miscellaneous Tasks
 
-- Wireframe for globe and tileset ([#870](https://github.com/reearth/reearth/pull/870)) [`75c04f`](https://github.com/reearth/reearth/commit/75c04f)
-- Fix title&[#39](https://github.com/reearth/reearth/pull/39);s panel setting ([#831](https://github.com/reearth/reearth/pull/831)) [`b60713`](https://github.com/reearth/reearth/commit/b60713)
-- Modify the description of zoom level ([#832](https://github.com/reearth/reearth/pull/832)) [`021404`](https://github.com/reearth/reearth/commit/021404)
-- Fix input field popover ([#819](https://github.com/reearth/reearth/pull/819)) [`d42279`](https://github.com/reearth/reearth/commit/d42279)
-- Remove the timeOut from text input ([#814](https://github.com/reearth/reearth/pull/814)) [`4ad7bb`](https://github.com/reearth/reearth/commit/4ad7bb)
+- Wireframe for globe and tileset ([#870](https://github.com/reearth/reearth-visualizer/pull/870)) [`75c04f`](https://github.com/reearth/reearth-visualizer/commit/75c04f)
+- Fix title&[#39](https://github.com/reearth/reearth-visualizer/pull/39);s panel setting ([#831](https://github.com/reearth/reearth-visualizer/pull/831)) [`b60713`](https://github.com/reearth/reearth-visualizer/commit/b60713)
+- Modify the description of zoom level ([#832](https://github.com/reearth/reearth-visualizer/pull/832)) [`021404`](https://github.com/reearth/reearth-visualizer/commit/021404)
+- Fix input field popover ([#819](https://github.com/reearth/reearth-visualizer/pull/819)) [`d42279`](https://github.com/reearth/reearth-visualizer/commit/d42279)
+- Remove the timeOut from text input ([#814](https://github.com/reearth/reearth-visualizer/pull/814)) [`4ad7bb`](https://github.com/reearth/reearth-visualizer/commit/4ad7bb)
 
 #### 
 
-- Fix feature selection...again [`5e3012`](https://github.com/reearth/reearth/commit/5e3012)
+- Fix feature selection...again [`5e3012`](https://github.com/reearth/reearth-visualizer/commit/5e3012)
 
 ## 0.19.0 - 2023-11-06
 
@@ -163,252 +163,252 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Upgrade dependencies which don&[#39](https://github.com/reearth/reearth/pull/39);t include breaking changes ([#783](https://github.com/reearth/reearth/pull/783)) [`930fce`](https://github.com/reearth/reearth/commit/930fce)
-- Story drag and drop ([#689](https://github.com/reearth/reearth/pull/689)) [`f0338c`](https://github.com/reearth/reearth/commit/f0338c)
-- Add layers using wms and mvt ([#694](https://github.com/reearth/reearth/pull/694)) [`5fe512`](https://github.com/reearth/reearth/commit/5fe512)
-- Add spacing input field and number input  ([#636](https://github.com/reearth/reearth/pull/636)) [`f92113`](https://github.com/reearth/reearth/commit/f92113)
-- Toggle Field ([#651](https://github.com/reearth/reearth/pull/651)) [`b13b18`](https://github.com/reearth/reearth/commit/b13b18)
-- Left Panel shows scene.propery.groups titles ([#634](https://github.com/reearth/reearth/pull/634)) [`39b74f`](https://github.com/reearth/reearth/commit/39b74f)
-- Add color field component ([#627](https://github.com/reearth/reearth/pull/627)) [`9e895b`](https://github.com/reearth/reearth/commit/9e895b)
+- Upgrade dependencies which don&[#39](https://github.com/reearth/reearth-visualizer/pull/39);t include breaking changes ([#783](https://github.com/reearth/reearth-visualizer/pull/783)) [`930fce`](https://github.com/reearth/reearth-visualizer/commit/930fce)
+- Story drag and drop ([#689](https://github.com/reearth/reearth-visualizer/pull/689)) [`f0338c`](https://github.com/reearth/reearth-visualizer/commit/f0338c)
+- Add layers using wms and mvt ([#694](https://github.com/reearth/reearth-visualizer/pull/694)) [`5fe512`](https://github.com/reearth/reearth-visualizer/commit/5fe512)
+- Add spacing input field and number input  ([#636](https://github.com/reearth/reearth-visualizer/pull/636)) [`f92113`](https://github.com/reearth/reearth-visualizer/commit/f92113)
+- Toggle Field ([#651](https://github.com/reearth/reearth-visualizer/pull/651)) [`b13b18`](https://github.com/reearth/reearth-visualizer/commit/b13b18)
+- Left Panel shows scene.propery.groups titles ([#634](https://github.com/reearth/reearth-visualizer/pull/634)) [`39b74f`](https://github.com/reearth/reearth-visualizer/commit/39b74f)
+- Add color field component ([#627](https://github.com/reearth/reearth-visualizer/pull/627)) [`9e895b`](https://github.com/reearth/reearth-visualizer/commit/9e895b)
 
 #### 🔧 Bug Fixes
 
-- Disable changing my own role and deleting myself [`e40fe3`](https://github.com/reearth/reearth/commit/e40fe3)
-- Member role cannot be changed [`c11aae`](https://github.com/reearth/reearth/commit/c11aae)
-- Trim leading zeros from number fields ([#724](https://github.com/reearth/reearth/pull/724)) [`410c75`](https://github.com/reearth/reearth/commit/410c75)
-- Remove video URL format verification ([#707](https://github.com/reearth/reearth/pull/707)) [`a74292`](https://github.com/reearth/reearth/commit/a74292)
-- Use ga4 on classic ([#704](https://github.com/reearth/reearth/pull/704)) [`90a46f`](https://github.com/reearth/reearth/commit/90a46f)
-- Allow mouse event for react-dnd ([#638](https://github.com/reearth/reearth/pull/638)) [`2ed816`](https://github.com/reearth/reearth/commit/2ed816)
-- Include single selection to the selection mode ([#643](https://github.com/reearth/reearth/pull/643)) [`864d09`](https://github.com/reearth/reearth/commit/864d09)
-- Suppress error in loading built-in plugin ([#635](https://github.com/reearth/reearth/pull/635)) [`ae83bc`](https://github.com/reearth/reearth/commit/ae83bc)
-- Import builtin plugin from external url ([#625](https://github.com/reearth/reearth/pull/625)) [`17b256`](https://github.com/reearth/reearth/commit/17b256)
+- Disable changing my own role and deleting myself [`e40fe3`](https://github.com/reearth/reearth-visualizer/commit/e40fe3)
+- Member role cannot be changed [`c11aae`](https://github.com/reearth/reearth-visualizer/commit/c11aae)
+- Trim leading zeros from number fields ([#724](https://github.com/reearth/reearth-visualizer/pull/724)) [`410c75`](https://github.com/reearth/reearth-visualizer/commit/410c75)
+- Remove video URL format verification ([#707](https://github.com/reearth/reearth-visualizer/pull/707)) [`a74292`](https://github.com/reearth/reearth-visualizer/commit/a74292)
+- Use ga4 on classic ([#704](https://github.com/reearth/reearth-visualizer/pull/704)) [`90a46f`](https://github.com/reearth/reearth-visualizer/commit/90a46f)
+- Allow mouse event for react-dnd ([#638](https://github.com/reearth/reearth-visualizer/pull/638)) [`2ed816`](https://github.com/reearth/reearth-visualizer/commit/2ed816)
+- Include single selection to the selection mode ([#643](https://github.com/reearth/reearth-visualizer/pull/643)) [`864d09`](https://github.com/reearth/reearth-visualizer/commit/864d09)
+- Suppress error in loading built-in plugin ([#635](https://github.com/reearth/reearth-visualizer/pull/635)) [`ae83bc`](https://github.com/reearth/reearth-visualizer/commit/ae83bc)
+- Import builtin plugin from external url ([#625](https://github.com/reearth/reearth-visualizer/pull/625)) [`17b256`](https://github.com/reearth/reearth-visualizer/commit/17b256)
 
 #### ✨ Refactor
 
-- Remove dropdown component ([#725](https://github.com/reearth/reearth/pull/725)) [`af62fb`](https://github.com/reearth/reearth/commit/af62fb)
+- Remove dropdown component ([#725](https://github.com/reearth/reearth-visualizer/pull/725)) [`af62fb`](https://github.com/reearth/reearth-visualizer/commit/af62fb)
 
 #### Miscellaneous Tasks
 
-- Update reearth&#x2F;web ver [`5ca327`](https://github.com/reearth/reearth/commit/5ca327)
-- Add height to marker appearance ([#790](https://github.com/reearth/reearth/pull/790)) [`8c84c8`](https://github.com/reearth/reearth/commit/8c84c8)
-- Beta story project publishing ([#784](https://github.com/reearth/reearth/pull/784)) [`4e3883`](https://github.com/reearth/reearth/commit/4e3883)
-- Refactor property and revert core ([#788](https://github.com/reearth/reearth/pull/788)) [`e844dd`](https://github.com/reearth/reearth/commit/e844dd)
-- Refactor beta properties ([#786](https://github.com/reearth/reearth/pull/786)) [`a85ca4`](https://github.com/reearth/reearth/commit/a85ca4)
-- Fix layerName random on upload directly ([#781](https://github.com/reearth/reearth/pull/781)) [`2d6962`](https://github.com/reearth/reearth/commit/2d6962)
-- Fix local name is random when added through asset ([#779](https://github.com/reearth/reearth/pull/779)) [`16cbcd`](https://github.com/reearth/reearth/commit/16cbcd)
-- Czml and kml local not working ([#777](https://github.com/reearth/reearth/pull/777)) [`12eddc`](https://github.com/reearth/reearth/commit/12eddc)
-- Fix mvt layer behaviour ([#780](https://github.com/reearth/reearth/pull/780)) [`958178`](https://github.com/reearth/reearth/commit/958178)
-- Add consistency to react imports ([#778](https://github.com/reearth/reearth/pull/778)) [`664139`](https://github.com/reearth/reearth/commit/664139)
-- Timeline field  ([#768](https://github.com/reearth/reearth/pull/768)) [`05bbee`](https://github.com/reearth/reearth/commit/05bbee)
-- Beta publishing ([#744](https://github.com/reearth/reearth/pull/744)) [`7fff78`](https://github.com/reearth/reearth/commit/7fff78)
-- Update layer title default value in beta and update add layerName behaviour for mvt &amp; wms ([#706](https://github.com/reearth/reearth/pull/706)) [`3df69f`](https://github.com/reearth/reearth/commit/3df69f)
-- Refactor story dnd ([#723](https://github.com/reearth/reearth/pull/723)) [`da57ac`](https://github.com/reearth/reearth/commit/da57ac)
-- Layer inspector ([#763](https://github.com/reearth/reearth/pull/763)) [`648152`](https://github.com/reearth/reearth/commit/648152)
-- Date time field input ([#767](https://github.com/reearth/reearth/pull/767)) [`466362`](https://github.com/reearth/reearth/commit/466362)
-- Updated fields in Settings ([#741](https://github.com/reearth/reearth/pull/741)) [`7fa4d5`](https://github.com/reearth/reearth/commit/7fa4d5)
-- StoryBlock isList default fix ([#761](https://github.com/reearth/reearth/pull/761)) [`a8fb53`](https://github.com/reearth/reearth/commit/a8fb53)
-- Fix flyTo giving error in beta ([#760](https://github.com/reearth/reearth/pull/760)) [`b1fd2c`](https://github.com/reearth/reearth/commit/b1fd2c)
-- Fix the date time component ([#752](https://github.com/reearth/reearth/pull/752)) [`615682`](https://github.com/reearth/reearth/commit/615682)
-- Update default layer style ([#754](https://github.com/reearth/reearth/pull/754)) [`c1c3de`](https://github.com/reearth/reearth/commit/c1c3de)
-- Fixes and refactoring to layer style system ([#753](https://github.com/reearth/reearth/pull/753)) [`464674`](https://github.com/reearth/reearth/commit/464674)
-- Add appearance support in beta ([#734](https://github.com/reearth/reearth/pull/734)) [`cd5423`](https://github.com/reearth/reearth/commit/cd5423)
-- Fix visible state ([#747](https://github.com/reearth/reearth/pull/747)) [`ba4382`](https://github.com/reearth/reearth/commit/ba4382)
-- Improve performance of flyTo ([#746](https://github.com/reearth/reearth/pull/746)) [`25359f`](https://github.com/reearth/reearth/commit/25359f)
-- Hide and show layer ([#735](https://github.com/reearth/reearth/pull/735)) [`90e2b9`](https://github.com/reearth/reearth/commit/90e2b9)
-- Fly to layers ([#739](https://github.com/reearth/reearth/pull/739)) [`ce69e7`](https://github.com/reearth/reearth/commit/ce69e7)
-- Add date time field component ([#740](https://github.com/reearth/reearth/pull/740)) [`6c8a42`](https://github.com/reearth/reearth/commit/6c8a42)
-- Story panel refactor ([#715](https://github.com/reearth/reearth/pull/715)) [`86dbb5`](https://github.com/reearth/reearth/commit/86dbb5)
-- Camera block ([#729](https://github.com/reearth/reearth/pull/729)) [`bac4ba`](https://github.com/reearth/reearth/commit/bac4ba)
-- Customize file extension in upload file&[#39](https://github.com/reearth/reearth/pull/39);s window ([#738](https://github.com/reearth/reearth/pull/738)) [`c579c6`](https://github.com/reearth/reearth/commit/c579c6)
-- Add sorting functionality to assets ([#728](https://github.com/reearth/reearth/pull/728)) [`e1edd9`](https://github.com/reearth/reearth/commit/e1edd9)
-- Story page update ([#714](https://github.com/reearth/reearth/pull/714)) [`86d4b9`](https://github.com/reearth/reearth/commit/86d4b9)
-- Fix color field select ([#737](https://github.com/reearth/reearth/pull/737)) [`ead2f5`](https://github.com/reearth/reearth/commit/ead2f5)
-- Refactor assets hooks ([#719](https://github.com/reearth/reearth/pull/719)) [`53aa05`](https://github.com/reearth/reearth/commit/53aa05)
-- Fix some bugs around feature selection functionality ([#736](https://github.com/reearth/reearth/pull/736)) [`2476c3`](https://github.com/reearth/reearth/commit/2476c3)
-- Add timeline manager ([#718](https://github.com/reearth/reearth/pull/718)) [`d4127b`](https://github.com/reearth/reearth/commit/d4127b)
-- Camera issues in storytelling ([#730](https://github.com/reearth/reearth/pull/730)) [`22a0e6`](https://github.com/reearth/reearth/commit/22a0e6)
-- Show installed widgets &amp; fix computed feature property ([#727](https://github.com/reearth/reearth/pull/727)) [`5e9edd`](https://github.com/reearth/reearth/commit/5e9edd)
-- Add multi feature selection APIs ([#716](https://github.com/reearth/reearth/pull/716)) [`124d3c`](https://github.com/reearth/reearth/commit/124d3c)
-- Fix upload file bug ([#717](https://github.com/reearth/reearth/pull/717)) [`984e37`](https://github.com/reearth/reearth/commit/984e37)
-- Update story text block fontsize options ([#720](https://github.com/reearth/reearth/pull/720)) [`55ac86`](https://github.com/reearth/reearth/commit/55ac86)
-- Add layers from local ([#702](https://github.com/reearth/reearth/pull/702)) [`a4a580`](https://github.com/reearth/reearth/commit/a4a580)
-- Image and video blocks ([#708](https://github.com/reearth/reearth/pull/708)) [`97f64a`](https://github.com/reearth/reearth/commit/97f64a)
-- MD Block ([#712](https://github.com/reearth/reearth/pull/712)) [`8fd9d3`](https://github.com/reearth/reearth/commit/8fd9d3)
-- Story page layer UI ([#709](https://github.com/reearth/reearth/pull/709)) [`4a62ab`](https://github.com/reearth/reearth/commit/4a62ab)
-- Various bug fixes and refactoring ([#713](https://github.com/reearth/reearth/pull/713)) [`253641`](https://github.com/reearth/reearth/commit/253641)
-- Fix block creation [`c4cc87`](https://github.com/reearth/reearth/commit/c4cc87)
-- Fix layer update process [`a366ab`](https://github.com/reearth/reearth/commit/a366ab)
-- Fix a layer update process ([#711](https://github.com/reearth/reearth/pull/711)) [`391ef0`](https://github.com/reearth/reearth/commit/391ef0)
-- Disable fxaa ([#710](https://github.com/reearth/reearth/pull/710)) [`c7d071`](https://github.com/reearth/reearth/commit/c7d071)
-- Add line-height option to story text block ([#703](https://github.com/reearth/reearth/pull/703)) [`fcf04f`](https://github.com/reearth/reearth/commit/fcf04f)
-- List field ([#687](https://github.com/reearth/reearth/pull/687)) [`07bc84`](https://github.com/reearth/reearth/commit/07bc84)
-- Add URL field ([#674](https://github.com/reearth/reearth/pull/674)) [`8c4b5b`](https://github.com/reearth/reearth/commit/8c4b5b)
-- Fix story page&#x2F;block ui&#x2F;ux ([#701](https://github.com/reearth/reearth/pull/701)) [`af7d3b`](https://github.com/reearth/reearth/commit/af7d3b)
-- Fix create &amp; remove story block ([#700](https://github.com/reearth/reearth/pull/700)) [`57bbc3`](https://github.com/reearth/reearth/commit/57bbc3)
-- Story page camera transition ([#699](https://github.com/reearth/reearth/pull/699)) [`4afa47`](https://github.com/reearth/reearth/commit/4afa47)
-- Fix value input asset datatype ([#698](https://github.com/reearth/reearth/pull/698)) [`bb362b`](https://github.com/reearth/reearth/commit/bb362b)
-- Refactor storypanel to remove any gql use ([#697](https://github.com/reearth/reearth/pull/697)) [`70d1dd`](https://github.com/reearth/reearth/commit/70d1dd)
-- Select field - Minor fixes ([#696](https://github.com/reearth/reearth/pull/696)) [`6b5db3`](https://github.com/reearth/reearth/commit/6b5db3)
-- Refactor&#x2F;update Camera field ([#692](https://github.com/reearth/reearth/pull/692)) [`b15e42`](https://github.com/reearth/reearth/commit/b15e42)
-- Fix delimited layer input field type ([#695](https://github.com/reearth/reearth/pull/695)) [`fa3627`](https://github.com/reearth/reearth/commit/fa3627)
-- Refactor plugin API camera.getFovInfo ([#691](https://github.com/reearth/reearth/pull/691)) [`b77db4`](https://github.com/reearth/reearth/commit/b77db4)
-- Show scene settings ([#688](https://github.com/reearth/reearth/pull/688)) [`884b76`](https://github.com/reearth/reearth/commit/884b76)
-- Fix default infobox behavior ([#681](https://github.com/reearth/reearth/pull/681)) [`a36415`](https://github.com/reearth/reearth/commit/a36415)
-- Basic layer features API ([#683](https://github.com/reearth/reearth/pull/683)) [`ba4409`](https://github.com/reearth/reearth/commit/ba4409)
-- Refactor storypanel ([#685](https://github.com/reearth/reearth/pull/685)) [`3a35cb`](https://github.com/reearth/reearth/commit/3a35cb)
-- Update select field usage ([#678](https://github.com/reearth/reearth/pull/678)) [`14b446`](https://github.com/reearth/reearth/commit/14b446)
-- Camera field responsiveness ([#686](https://github.com/reearth/reearth/pull/686)) [`39d7c0`](https://github.com/reearth/reearth/commit/39d7c0)
-- Add support for layer name editing in beta ([#665](https://github.com/reearth/reearth/pull/665)) [`02cb8d`](https://github.com/reearth/reearth/commit/02cb8d)
-- Camera field  ([#647](https://github.com/reearth/reearth/pull/647)) [`dfa05b`](https://github.com/reearth/reearth/commit/dfa05b)
-- Fix HBAO error when Cesium is destroyed ([#675](https://github.com/reearth/reearth/pull/675)) [`5e41ba`](https://github.com/reearth/reearth/commit/5e41ba)
-- Add location field ([#660](https://github.com/reearth/reearth/pull/660)) [`65beea`](https://github.com/reearth/reearth/commit/65beea)
-- Add number field ([#669](https://github.com/reearth/reearth/pull/669)) [`d21625`](https://github.com/reearth/reearth/commit/d21625)
-- Radio and radio group field components ([#650](https://github.com/reearth/reearth/pull/650)) [`afaa24`](https://github.com/reearth/reearth/commit/afaa24)
-- Add pluginAPI camera.getFovCenter ([#673](https://github.com/reearth/reearth/pull/673)) [`c2c2b0`](https://github.com/reearth/reearth/commit/c2c2b0)
-- Fix story page gap [`363a03`](https://github.com/reearth/reearth/commit/363a03)
-- Fix inifinite loop while selecting layer ([#672](https://github.com/reearth/reearth/pull/672)) [`3b2295`](https://github.com/reearth/reearth/commit/3b2295)
-- Fix story page gap issue [`cb09be`](https://github.com/reearth/reearth/commit/cb09be)
-- Story page change on user scroll ([#671](https://github.com/reearth/reearth/pull/671)) [`e03a0a`](https://github.com/reearth/reearth/commit/e03a0a)
-- Override default light ([#667](https://github.com/reearth/reearth/pull/667)) [`b3c7e8`](https://github.com/reearth/reearth/commit/b3c7e8)
-- Correct style of story text block ([#668](https://github.com/reearth/reearth/pull/668)) [`422dec`](https://github.com/reearth/reearth/commit/422dec)
-- Fix the layer delete behavior ([#666](https://github.com/reearth/reearth/pull/666)) [`e91a24`](https://github.com/reearth/reearth/commit/e91a24)
-- Publish modal ([#658](https://github.com/reearth/reearth/pull/658)) [`df854f`](https://github.com/reearth/reearth/commit/df854f)
-- Select Field ([#662](https://github.com/reearth/reearth/pull/662)) [`4ee196`](https://github.com/reearth/reearth/commit/4ee196)
-- Publish tab type ([#659](https://github.com/reearth/reearth/pull/659)) [`feca38`](https://github.com/reearth/reearth/commit/feca38)
-- Add some atmosphere properties ([#663](https://github.com/reearth/reearth/pull/663)) [`caee55`](https://github.com/reearth/reearth/commit/caee55)
-- Add dataSource, layerSidePanel component in beta ([#633](https://github.com/reearth/reearth/pull/633)) [`9972e6`](https://github.com/reearth/reearth/commit/9972e6)
-- Limit lexical css ([#664](https://github.com/reearth/reearth/pull/664)) [`f01500`](https://github.com/reearth/reearth/commit/f01500)
-- Slider Field ([#652](https://github.com/reearth/reearth/pull/652)) [`f7fe7f`](https://github.com/reearth/reearth/commit/f7fe7f)
-- Add story text block ([#653](https://github.com/reearth/reearth/pull/653)) [`6abb7b`](https://github.com/reearth/reearth/commit/6abb7b)
-- Story page settings ([#639](https://github.com/reearth/reearth/pull/639)) [`0eaeed`](https://github.com/reearth/reearth/commit/0eaeed)
-- Beta project settings pages ([#645](https://github.com/reearth/reearth/pull/645)) [`d42294`](https://github.com/reearth/reearth/commit/d42294)
-- Revert cesium and resium ([#641](https://github.com/reearth/reearth/pull/641)) [`6f7bab`](https://github.com/reearth/reearth/commit/6f7bab)
-- Add property update support to story blocks ([#629](https://github.com/reearth/reearth/pull/629)) [`fdd4ee`](https://github.com/reearth/reearth/commit/fdd4ee)
-- TabsMenu for switching between tabs  ([#631](https://github.com/reearth/reearth/pull/631)) [`42ad68`](https://github.com/reearth/reearth/commit/42ad68)
-- Upgrade dependencies ([#626](https://github.com/reearth/reearth/pull/626)) [`19e4fd`](https://github.com/reearth/reearth/commit/19e4fd)
-- Story block system ([#619](https://github.com/reearth/reearth/pull/619)) [`8a6ad6`](https://github.com/reearth/reearth/commit/8a6ad6)
-- Add container settings panel for widget area ([#620](https://github.com/reearth/reearth/pull/620)) [`bea668`](https://github.com/reearth/reearth/commit/bea668)
+- Update reearth&#x2F;web ver [`5ca327`](https://github.com/reearth/reearth-visualizer/commit/5ca327)
+- Add height to marker appearance ([#790](https://github.com/reearth/reearth-visualizer/pull/790)) [`8c84c8`](https://github.com/reearth/reearth-visualizer/commit/8c84c8)
+- Beta story project publishing ([#784](https://github.com/reearth/reearth-visualizer/pull/784)) [`4e3883`](https://github.com/reearth/reearth-visualizer/commit/4e3883)
+- Refactor property and revert core ([#788](https://github.com/reearth/reearth-visualizer/pull/788)) [`e844dd`](https://github.com/reearth/reearth-visualizer/commit/e844dd)
+- Refactor beta properties ([#786](https://github.com/reearth/reearth-visualizer/pull/786)) [`a85ca4`](https://github.com/reearth/reearth-visualizer/commit/a85ca4)
+- Fix layerName random on upload directly ([#781](https://github.com/reearth/reearth-visualizer/pull/781)) [`2d6962`](https://github.com/reearth/reearth-visualizer/commit/2d6962)
+- Fix local name is random when added through asset ([#779](https://github.com/reearth/reearth-visualizer/pull/779)) [`16cbcd`](https://github.com/reearth/reearth-visualizer/commit/16cbcd)
+- Czml and kml local not working ([#777](https://github.com/reearth/reearth-visualizer/pull/777)) [`12eddc`](https://github.com/reearth/reearth-visualizer/commit/12eddc)
+- Fix mvt layer behaviour ([#780](https://github.com/reearth/reearth-visualizer/pull/780)) [`958178`](https://github.com/reearth/reearth-visualizer/commit/958178)
+- Add consistency to react imports ([#778](https://github.com/reearth/reearth-visualizer/pull/778)) [`664139`](https://github.com/reearth/reearth-visualizer/commit/664139)
+- Timeline field  ([#768](https://github.com/reearth/reearth-visualizer/pull/768)) [`05bbee`](https://github.com/reearth/reearth-visualizer/commit/05bbee)
+- Beta publishing ([#744](https://github.com/reearth/reearth-visualizer/pull/744)) [`7fff78`](https://github.com/reearth/reearth-visualizer/commit/7fff78)
+- Update layer title default value in beta and update add layerName behaviour for mvt &amp; wms ([#706](https://github.com/reearth/reearth-visualizer/pull/706)) [`3df69f`](https://github.com/reearth/reearth-visualizer/commit/3df69f)
+- Refactor story dnd ([#723](https://github.com/reearth/reearth-visualizer/pull/723)) [`da57ac`](https://github.com/reearth/reearth-visualizer/commit/da57ac)
+- Layer inspector ([#763](https://github.com/reearth/reearth-visualizer/pull/763)) [`648152`](https://github.com/reearth/reearth-visualizer/commit/648152)
+- Date time field input ([#767](https://github.com/reearth/reearth-visualizer/pull/767)) [`466362`](https://github.com/reearth/reearth-visualizer/commit/466362)
+- Updated fields in Settings ([#741](https://github.com/reearth/reearth-visualizer/pull/741)) [`7fa4d5`](https://github.com/reearth/reearth-visualizer/commit/7fa4d5)
+- StoryBlock isList default fix ([#761](https://github.com/reearth/reearth-visualizer/pull/761)) [`a8fb53`](https://github.com/reearth/reearth-visualizer/commit/a8fb53)
+- Fix flyTo giving error in beta ([#760](https://github.com/reearth/reearth-visualizer/pull/760)) [`b1fd2c`](https://github.com/reearth/reearth-visualizer/commit/b1fd2c)
+- Fix the date time component ([#752](https://github.com/reearth/reearth-visualizer/pull/752)) [`615682`](https://github.com/reearth/reearth-visualizer/commit/615682)
+- Update default layer style ([#754](https://github.com/reearth/reearth-visualizer/pull/754)) [`c1c3de`](https://github.com/reearth/reearth-visualizer/commit/c1c3de)
+- Fixes and refactoring to layer style system ([#753](https://github.com/reearth/reearth-visualizer/pull/753)) [`464674`](https://github.com/reearth/reearth-visualizer/commit/464674)
+- Add appearance support in beta ([#734](https://github.com/reearth/reearth-visualizer/pull/734)) [`cd5423`](https://github.com/reearth/reearth-visualizer/commit/cd5423)
+- Fix visible state ([#747](https://github.com/reearth/reearth-visualizer/pull/747)) [`ba4382`](https://github.com/reearth/reearth-visualizer/commit/ba4382)
+- Improve performance of flyTo ([#746](https://github.com/reearth/reearth-visualizer/pull/746)) [`25359f`](https://github.com/reearth/reearth-visualizer/commit/25359f)
+- Hide and show layer ([#735](https://github.com/reearth/reearth-visualizer/pull/735)) [`90e2b9`](https://github.com/reearth/reearth-visualizer/commit/90e2b9)
+- Fly to layers ([#739](https://github.com/reearth/reearth-visualizer/pull/739)) [`ce69e7`](https://github.com/reearth/reearth-visualizer/commit/ce69e7)
+- Add date time field component ([#740](https://github.com/reearth/reearth-visualizer/pull/740)) [`6c8a42`](https://github.com/reearth/reearth-visualizer/commit/6c8a42)
+- Story panel refactor ([#715](https://github.com/reearth/reearth-visualizer/pull/715)) [`86dbb5`](https://github.com/reearth/reearth-visualizer/commit/86dbb5)
+- Camera block ([#729](https://github.com/reearth/reearth-visualizer/pull/729)) [`bac4ba`](https://github.com/reearth/reearth-visualizer/commit/bac4ba)
+- Customize file extension in upload file&[#39](https://github.com/reearth/reearth-visualizer/pull/39);s window ([#738](https://github.com/reearth/reearth-visualizer/pull/738)) [`c579c6`](https://github.com/reearth/reearth-visualizer/commit/c579c6)
+- Add sorting functionality to assets ([#728](https://github.com/reearth/reearth-visualizer/pull/728)) [`e1edd9`](https://github.com/reearth/reearth-visualizer/commit/e1edd9)
+- Story page update ([#714](https://github.com/reearth/reearth-visualizer/pull/714)) [`86d4b9`](https://github.com/reearth/reearth-visualizer/commit/86d4b9)
+- Fix color field select ([#737](https://github.com/reearth/reearth-visualizer/pull/737)) [`ead2f5`](https://github.com/reearth/reearth-visualizer/commit/ead2f5)
+- Refactor assets hooks ([#719](https://github.com/reearth/reearth-visualizer/pull/719)) [`53aa05`](https://github.com/reearth/reearth-visualizer/commit/53aa05)
+- Fix some bugs around feature selection functionality ([#736](https://github.com/reearth/reearth-visualizer/pull/736)) [`2476c3`](https://github.com/reearth/reearth-visualizer/commit/2476c3)
+- Add timeline manager ([#718](https://github.com/reearth/reearth-visualizer/pull/718)) [`d4127b`](https://github.com/reearth/reearth-visualizer/commit/d4127b)
+- Camera issues in storytelling ([#730](https://github.com/reearth/reearth-visualizer/pull/730)) [`22a0e6`](https://github.com/reearth/reearth-visualizer/commit/22a0e6)
+- Show installed widgets &amp; fix computed feature property ([#727](https://github.com/reearth/reearth-visualizer/pull/727)) [`5e9edd`](https://github.com/reearth/reearth-visualizer/commit/5e9edd)
+- Add multi feature selection APIs ([#716](https://github.com/reearth/reearth-visualizer/pull/716)) [`124d3c`](https://github.com/reearth/reearth-visualizer/commit/124d3c)
+- Fix upload file bug ([#717](https://github.com/reearth/reearth-visualizer/pull/717)) [`984e37`](https://github.com/reearth/reearth-visualizer/commit/984e37)
+- Update story text block fontsize options ([#720](https://github.com/reearth/reearth-visualizer/pull/720)) [`55ac86`](https://github.com/reearth/reearth-visualizer/commit/55ac86)
+- Add layers from local ([#702](https://github.com/reearth/reearth-visualizer/pull/702)) [`a4a580`](https://github.com/reearth/reearth-visualizer/commit/a4a580)
+- Image and video blocks ([#708](https://github.com/reearth/reearth-visualizer/pull/708)) [`97f64a`](https://github.com/reearth/reearth-visualizer/commit/97f64a)
+- MD Block ([#712](https://github.com/reearth/reearth-visualizer/pull/712)) [`8fd9d3`](https://github.com/reearth/reearth-visualizer/commit/8fd9d3)
+- Story page layer UI ([#709](https://github.com/reearth/reearth-visualizer/pull/709)) [`4a62ab`](https://github.com/reearth/reearth-visualizer/commit/4a62ab)
+- Various bug fixes and refactoring ([#713](https://github.com/reearth/reearth-visualizer/pull/713)) [`253641`](https://github.com/reearth/reearth-visualizer/commit/253641)
+- Fix block creation [`c4cc87`](https://github.com/reearth/reearth-visualizer/commit/c4cc87)
+- Fix layer update process [`a366ab`](https://github.com/reearth/reearth-visualizer/commit/a366ab)
+- Fix a layer update process ([#711](https://github.com/reearth/reearth-visualizer/pull/711)) [`391ef0`](https://github.com/reearth/reearth-visualizer/commit/391ef0)
+- Disable fxaa ([#710](https://github.com/reearth/reearth-visualizer/pull/710)) [`c7d071`](https://github.com/reearth/reearth-visualizer/commit/c7d071)
+- Add line-height option to story text block ([#703](https://github.com/reearth/reearth-visualizer/pull/703)) [`fcf04f`](https://github.com/reearth/reearth-visualizer/commit/fcf04f)
+- List field ([#687](https://github.com/reearth/reearth-visualizer/pull/687)) [`07bc84`](https://github.com/reearth/reearth-visualizer/commit/07bc84)
+- Add URL field ([#674](https://github.com/reearth/reearth-visualizer/pull/674)) [`8c4b5b`](https://github.com/reearth/reearth-visualizer/commit/8c4b5b)
+- Fix story page&#x2F;block ui&#x2F;ux ([#701](https://github.com/reearth/reearth-visualizer/pull/701)) [`af7d3b`](https://github.com/reearth/reearth-visualizer/commit/af7d3b)
+- Fix create &amp; remove story block ([#700](https://github.com/reearth/reearth-visualizer/pull/700)) [`57bbc3`](https://github.com/reearth/reearth-visualizer/commit/57bbc3)
+- Story page camera transition ([#699](https://github.com/reearth/reearth-visualizer/pull/699)) [`4afa47`](https://github.com/reearth/reearth-visualizer/commit/4afa47)
+- Fix value input asset datatype ([#698](https://github.com/reearth/reearth-visualizer/pull/698)) [`bb362b`](https://github.com/reearth/reearth-visualizer/commit/bb362b)
+- Refactor storypanel to remove any gql use ([#697](https://github.com/reearth/reearth-visualizer/pull/697)) [`70d1dd`](https://github.com/reearth/reearth-visualizer/commit/70d1dd)
+- Select field - Minor fixes ([#696](https://github.com/reearth/reearth-visualizer/pull/696)) [`6b5db3`](https://github.com/reearth/reearth-visualizer/commit/6b5db3)
+- Refactor&#x2F;update Camera field ([#692](https://github.com/reearth/reearth-visualizer/pull/692)) [`b15e42`](https://github.com/reearth/reearth-visualizer/commit/b15e42)
+- Fix delimited layer input field type ([#695](https://github.com/reearth/reearth-visualizer/pull/695)) [`fa3627`](https://github.com/reearth/reearth-visualizer/commit/fa3627)
+- Refactor plugin API camera.getFovInfo ([#691](https://github.com/reearth/reearth-visualizer/pull/691)) [`b77db4`](https://github.com/reearth/reearth-visualizer/commit/b77db4)
+- Show scene settings ([#688](https://github.com/reearth/reearth-visualizer/pull/688)) [`884b76`](https://github.com/reearth/reearth-visualizer/commit/884b76)
+- Fix default infobox behavior ([#681](https://github.com/reearth/reearth-visualizer/pull/681)) [`a36415`](https://github.com/reearth/reearth-visualizer/commit/a36415)
+- Basic layer features API ([#683](https://github.com/reearth/reearth-visualizer/pull/683)) [`ba4409`](https://github.com/reearth/reearth-visualizer/commit/ba4409)
+- Refactor storypanel ([#685](https://github.com/reearth/reearth-visualizer/pull/685)) [`3a35cb`](https://github.com/reearth/reearth-visualizer/commit/3a35cb)
+- Update select field usage ([#678](https://github.com/reearth/reearth-visualizer/pull/678)) [`14b446`](https://github.com/reearth/reearth-visualizer/commit/14b446)
+- Camera field responsiveness ([#686](https://github.com/reearth/reearth-visualizer/pull/686)) [`39d7c0`](https://github.com/reearth/reearth-visualizer/commit/39d7c0)
+- Add support for layer name editing in beta ([#665](https://github.com/reearth/reearth-visualizer/pull/665)) [`02cb8d`](https://github.com/reearth/reearth-visualizer/commit/02cb8d)
+- Camera field  ([#647](https://github.com/reearth/reearth-visualizer/pull/647)) [`dfa05b`](https://github.com/reearth/reearth-visualizer/commit/dfa05b)
+- Fix HBAO error when Cesium is destroyed ([#675](https://github.com/reearth/reearth-visualizer/pull/675)) [`5e41ba`](https://github.com/reearth/reearth-visualizer/commit/5e41ba)
+- Add location field ([#660](https://github.com/reearth/reearth-visualizer/pull/660)) [`65beea`](https://github.com/reearth/reearth-visualizer/commit/65beea)
+- Add number field ([#669](https://github.com/reearth/reearth-visualizer/pull/669)) [`d21625`](https://github.com/reearth/reearth-visualizer/commit/d21625)
+- Radio and radio group field components ([#650](https://github.com/reearth/reearth-visualizer/pull/650)) [`afaa24`](https://github.com/reearth/reearth-visualizer/commit/afaa24)
+- Add pluginAPI camera.getFovCenter ([#673](https://github.com/reearth/reearth-visualizer/pull/673)) [`c2c2b0`](https://github.com/reearth/reearth-visualizer/commit/c2c2b0)
+- Fix story page gap [`363a03`](https://github.com/reearth/reearth-visualizer/commit/363a03)
+- Fix inifinite loop while selecting layer ([#672](https://github.com/reearth/reearth-visualizer/pull/672)) [`3b2295`](https://github.com/reearth/reearth-visualizer/commit/3b2295)
+- Fix story page gap issue [`cb09be`](https://github.com/reearth/reearth-visualizer/commit/cb09be)
+- Story page change on user scroll ([#671](https://github.com/reearth/reearth-visualizer/pull/671)) [`e03a0a`](https://github.com/reearth/reearth-visualizer/commit/e03a0a)
+- Override default light ([#667](https://github.com/reearth/reearth-visualizer/pull/667)) [`b3c7e8`](https://github.com/reearth/reearth-visualizer/commit/b3c7e8)
+- Correct style of story text block ([#668](https://github.com/reearth/reearth-visualizer/pull/668)) [`422dec`](https://github.com/reearth/reearth-visualizer/commit/422dec)
+- Fix the layer delete behavior ([#666](https://github.com/reearth/reearth-visualizer/pull/666)) [`e91a24`](https://github.com/reearth/reearth-visualizer/commit/e91a24)
+- Publish modal ([#658](https://github.com/reearth/reearth-visualizer/pull/658)) [`df854f`](https://github.com/reearth/reearth-visualizer/commit/df854f)
+- Select Field ([#662](https://github.com/reearth/reearth-visualizer/pull/662)) [`4ee196`](https://github.com/reearth/reearth-visualizer/commit/4ee196)
+- Publish tab type ([#659](https://github.com/reearth/reearth-visualizer/pull/659)) [`feca38`](https://github.com/reearth/reearth-visualizer/commit/feca38)
+- Add some atmosphere properties ([#663](https://github.com/reearth/reearth-visualizer/pull/663)) [`caee55`](https://github.com/reearth/reearth-visualizer/commit/caee55)
+- Add dataSource, layerSidePanel component in beta ([#633](https://github.com/reearth/reearth-visualizer/pull/633)) [`9972e6`](https://github.com/reearth/reearth-visualizer/commit/9972e6)
+- Limit lexical css ([#664](https://github.com/reearth/reearth-visualizer/pull/664)) [`f01500`](https://github.com/reearth/reearth-visualizer/commit/f01500)
+- Slider Field ([#652](https://github.com/reearth/reearth-visualizer/pull/652)) [`f7fe7f`](https://github.com/reearth/reearth-visualizer/commit/f7fe7f)
+- Add story text block ([#653](https://github.com/reearth/reearth-visualizer/pull/653)) [`6abb7b`](https://github.com/reearth/reearth-visualizer/commit/6abb7b)
+- Story page settings ([#639](https://github.com/reearth/reearth-visualizer/pull/639)) [`0eaeed`](https://github.com/reearth/reearth-visualizer/commit/0eaeed)
+- Beta project settings pages ([#645](https://github.com/reearth/reearth-visualizer/pull/645)) [`d42294`](https://github.com/reearth/reearth-visualizer/commit/d42294)
+- Revert cesium and resium ([#641](https://github.com/reearth/reearth-visualizer/pull/641)) [`6f7bab`](https://github.com/reearth/reearth-visualizer/commit/6f7bab)
+- Add property update support to story blocks ([#629](https://github.com/reearth/reearth-visualizer/pull/629)) [`fdd4ee`](https://github.com/reearth/reearth-visualizer/commit/fdd4ee)
+- TabsMenu for switching between tabs  ([#631](https://github.com/reearth/reearth-visualizer/pull/631)) [`42ad68`](https://github.com/reearth/reearth-visualizer/commit/42ad68)
+- Upgrade dependencies ([#626](https://github.com/reearth/reearth-visualizer/pull/626)) [`19e4fd`](https://github.com/reearth/reearth-visualizer/commit/19e4fd)
+- Story block system ([#619](https://github.com/reearth/reearth-visualizer/pull/619)) [`8a6ad6`](https://github.com/reearth/reearth-visualizer/commit/8a6ad6)
+- Add container settings panel for widget area ([#620](https://github.com/reearth/reearth-visualizer/pull/620)) [`bea668`](https://github.com/reearth/reearth-visualizer/commit/bea668)
 
 ### Server
 
 #### 🚀 Features
 
-- Add env var to specify account database ([#640](https://github.com/reearth/reearth/pull/640)) [`3b88ad`](https://github.com/reearth/reearth/commit/3b88ad)
+- Add env var to specify account database ([#640](https://github.com/reearth/reearth-visualizer/pull/640)) [`3b88ad`](https://github.com/reearth/reearth-visualizer/commit/3b88ad)
 
 #### 🔧 Bug Fixes
 
-- Typo in timeline value type [`9d33b4`](https://github.com/reearth/reearth/commit/9d33b4)
-- Increase default GraphQL complexity limit [`ade5cd`](https://github.com/reearth/reearth/commit/ade5cd)
-- Maintainer role cannot be handled correctly [`c8a175`](https://github.com/reearth/reearth/commit/c8a175)
-- Check project count to ensure policy on project republication ([#742](https://github.com/reearth/reearth/pull/742)) [`576023`](https://github.com/reearth/reearth/commit/576023)
-- Apply default policy to workspaces [`8b1ef4`](https://github.com/reearth/reearth/commit/8b1ef4)
-- Workspace member count is not limited by policies ([#722](https://github.com/reearth/reearth/pull/722)) [`4c7a8f`](https://github.com/reearth/reearth/commit/4c7a8f)
-- Workspace policy was not loaded from db correctly ([#721](https://github.com/reearth/reearth/pull/721)) [`d8022a`](https://github.com/reearth/reearth/commit/d8022a)
-- Wrong account db name [`db2564`](https://github.com/reearth/reearth/commit/db2564)
-- Disable compat when account db is specified [`ba4555`](https://github.com/reearth/reearth/commit/ba4555)
-- Fix signup panic error [`ace22d`](https://github.com/reearth/reearth/commit/ace22d)
-- Story&#x2F;story page properties were not saved ([#637](https://github.com/reearth/reearth/pull/637)) [`faf5f3`](https://github.com/reearth/reearth/commit/faf5f3)
-- Disable transaction for accountmongo in local [`0ef6a8`](https://github.com/reearth/reearth/commit/0ef6a8)
+- Typo in timeline value type [`9d33b4`](https://github.com/reearth/reearth-visualizer/commit/9d33b4)
+- Increase default GraphQL complexity limit [`ade5cd`](https://github.com/reearth/reearth-visualizer/commit/ade5cd)
+- Maintainer role cannot be handled correctly [`c8a175`](https://github.com/reearth/reearth-visualizer/commit/c8a175)
+- Check project count to ensure policy on project republication ([#742](https://github.com/reearth/reearth-visualizer/pull/742)) [`576023`](https://github.com/reearth/reearth-visualizer/commit/576023)
+- Apply default policy to workspaces [`8b1ef4`](https://github.com/reearth/reearth-visualizer/commit/8b1ef4)
+- Workspace member count is not limited by policies ([#722](https://github.com/reearth/reearth-visualizer/pull/722)) [`4c7a8f`](https://github.com/reearth/reearth-visualizer/commit/4c7a8f)
+- Workspace policy was not loaded from db correctly ([#721](https://github.com/reearth/reearth-visualizer/pull/721)) [`d8022a`](https://github.com/reearth/reearth-visualizer/commit/d8022a)
+- Wrong account db name [`db2564`](https://github.com/reearth/reearth-visualizer/commit/db2564)
+- Disable compat when account db is specified [`ba4555`](https://github.com/reearth/reearth-visualizer/commit/ba4555)
+- Fix signup panic error [`ace22d`](https://github.com/reearth/reearth-visualizer/commit/ace22d)
+- Story&#x2F;story page properties were not saved ([#637](https://github.com/reearth/reearth-visualizer/pull/637)) [`faf5f3`](https://github.com/reearth/reearth-visualizer/commit/faf5f3)
+- Disable transaction for accountmongo in local [`0ef6a8`](https://github.com/reearth/reearth-visualizer/commit/0ef6a8)
 
 #### ✨ Refactor
 
-- Replace user&#x2F;workspace with account in reearthx ([#568](https://github.com/reearth/reearth/pull/568)) [`958a1c`](https://github.com/reearth/reearth/commit/958a1c)
+- Replace user&#x2F;workspace with account in reearthx ([#568](https://github.com/reearth/reearth-visualizer/pull/568)) [`958a1c`](https://github.com/reearth/reearth-visualizer/commit/958a1c)
 
 #### Miscellaneous Tasks
 
-- Add story background setting ([#774](https://github.com/reearth/reearth/pull/774)) [`38f26c`](https://github.com/reearth/reearth/commit/38f26c)
-- Add layers in pageJSON of published story ([#785](https://github.com/reearth/reearth/pull/785)) [`0ba17b`](https://github.com/reearth/reearth/commit/0ba17b)
-- Add play mode to timeline setting in manifest ([#773](https://github.com/reearth/reearth/pull/773)) [`751e28`](https://github.com/reearth/reearth/commit/751e28)
-- Add layerStyles to publishing ([#772](https://github.com/reearth/reearth/pull/772)) [`469f45`](https://github.com/reearth/reearth/commit/469f45)
-- Add array and timeline valuetype to property ([#770](https://github.com/reearth/reearth/pull/770)) [`dcbe9d`](https://github.com/reearth/reearth/commit/dcbe9d)
-- Add nlslayer in project &amp; story publishing ([#769](https://github.com/reearth/reearth/pull/769)) [`4a3d08`](https://github.com/reearth/reearth/commit/4a3d08)
-- Update manifest and plugin_schema to support collection in schemaGroup ([#748](https://github.com/reearth/reearth/pull/748)) [`f70234`](https://github.com/reearth/reearth/commit/f70234)
-- Add cesium-beta viz support in server ([#743](https://github.com/reearth/reearth/pull/743)) [`dcf9f3`](https://github.com/reearth/reearth/commit/dcf9f3)
-- Modify update method for config change in NLSLayer ([#732](https://github.com/reearth/reearth/pull/732)) [`0853ba`](https://github.com/reearth/reearth/commit/0853ba)
-- Refactor and fix issue w style ([#733](https://github.com/reearth/reearth/pull/733)) [`8573df`](https://github.com/reearth/reearth/commit/8573df)
-- Fix NLS simple update ([#705](https://github.com/reearth/reearth/pull/705)) [`3e3549`](https://github.com/reearth/reearth/commit/3e3549)
-- Add extensionId and pluginId in block json of published story ([#693](https://github.com/reearth/reearth/pull/693)) [`b2992d`](https://github.com/reearth/reearth/commit/b2992d)
-- Update layer for appearance support in beta ([#690](https://github.com/reearth/reearth/pull/690)) [`eb82a8`](https://github.com/reearth/reearth/commit/eb82a8)
-- Handle visibility for nls layer  ([#661](https://github.com/reearth/reearth/pull/661)) [`708833`](https://github.com/reearth/reearth/commit/708833)
-- Add e2e test for NLS CRUD ([#649](https://github.com/reearth/reearth/pull/649)) [`69a88d`](https://github.com/reearth/reearth/commit/69a88d)
-- Storytelling publishing ([#648](https://github.com/reearth/reearth/pull/648)) [`edb596`](https://github.com/reearth/reearth/commit/edb596)
-- Update parser.go [`fdc056`](https://github.com/reearth/reearth/commit/fdc056)
-- Revert changes made for debuggin in manifest parser [`178693`](https://github.com/reearth/reearth/commit/178693)
-- Add debug log to parsefromurl [`8834e0`](https://github.com/reearth/reearth/commit/8834e0)
-- Add min&#x2F;max to spacing fields ([#646](https://github.com/reearth/reearth/pull/646)) [`8619e7`](https://github.com/reearth/reearth/commit/8619e7)
-- Add NLS layer support ([#632](https://github.com/reearth/reearth/pull/632)) [`c83248`](https://github.com/reearth/reearth/commit/c83248)
-- Fix lint error from [#644](https://github.com/reearth/reearth/pull/644) [`383ef9`](https://github.com/reearth/reearth/commit/383ef9)
-- Support appearance in server ([#644](https://github.com/reearth/reearth/pull/644)) [`0876ae`](https://github.com/reearth/reearth/commit/0876ae)
-- Upgrade reearthx [`873104`](https://github.com/reearth/reearth/commit/873104)
-- Add test for story block properties ([#630](https://github.com/reearth/reearth/pull/630)) [`562c51`](https://github.com/reearth/reearth/commit/562c51)
-- Add missing fields for story settings ([#628](https://github.com/reearth/reearth/pull/628)) [`75d522`](https://github.com/reearth/reearth/commit/75d522)
+- Add story background setting ([#774](https://github.com/reearth/reearth-visualizer/pull/774)) [`38f26c`](https://github.com/reearth/reearth-visualizer/commit/38f26c)
+- Add layers in pageJSON of published story ([#785](https://github.com/reearth/reearth-visualizer/pull/785)) [`0ba17b`](https://github.com/reearth/reearth-visualizer/commit/0ba17b)
+- Add play mode to timeline setting in manifest ([#773](https://github.com/reearth/reearth-visualizer/pull/773)) [`751e28`](https://github.com/reearth/reearth-visualizer/commit/751e28)
+- Add layerStyles to publishing ([#772](https://github.com/reearth/reearth-visualizer/pull/772)) [`469f45`](https://github.com/reearth/reearth-visualizer/commit/469f45)
+- Add array and timeline valuetype to property ([#770](https://github.com/reearth/reearth-visualizer/pull/770)) [`dcbe9d`](https://github.com/reearth/reearth-visualizer/commit/dcbe9d)
+- Add nlslayer in project &amp; story publishing ([#769](https://github.com/reearth/reearth-visualizer/pull/769)) [`4a3d08`](https://github.com/reearth/reearth-visualizer/commit/4a3d08)
+- Update manifest and plugin_schema to support collection in schemaGroup ([#748](https://github.com/reearth/reearth-visualizer/pull/748)) [`f70234`](https://github.com/reearth/reearth-visualizer/commit/f70234)
+- Add cesium-beta viz support in server ([#743](https://github.com/reearth/reearth-visualizer/pull/743)) [`dcf9f3`](https://github.com/reearth/reearth-visualizer/commit/dcf9f3)
+- Modify update method for config change in NLSLayer ([#732](https://github.com/reearth/reearth-visualizer/pull/732)) [`0853ba`](https://github.com/reearth/reearth-visualizer/commit/0853ba)
+- Refactor and fix issue w style ([#733](https://github.com/reearth/reearth-visualizer/pull/733)) [`8573df`](https://github.com/reearth/reearth-visualizer/commit/8573df)
+- Fix NLS simple update ([#705](https://github.com/reearth/reearth-visualizer/pull/705)) [`3e3549`](https://github.com/reearth/reearth-visualizer/commit/3e3549)
+- Add extensionId and pluginId in block json of published story ([#693](https://github.com/reearth/reearth-visualizer/pull/693)) [`b2992d`](https://github.com/reearth/reearth-visualizer/commit/b2992d)
+- Update layer for appearance support in beta ([#690](https://github.com/reearth/reearth-visualizer/pull/690)) [`eb82a8`](https://github.com/reearth/reearth-visualizer/commit/eb82a8)
+- Handle visibility for nls layer  ([#661](https://github.com/reearth/reearth-visualizer/pull/661)) [`708833`](https://github.com/reearth/reearth-visualizer/commit/708833)
+- Add e2e test for NLS CRUD ([#649](https://github.com/reearth/reearth-visualizer/pull/649)) [`69a88d`](https://github.com/reearth/reearth-visualizer/commit/69a88d)
+- Storytelling publishing ([#648](https://github.com/reearth/reearth-visualizer/pull/648)) [`edb596`](https://github.com/reearth/reearth-visualizer/commit/edb596)
+- Update parser.go [`fdc056`](https://github.com/reearth/reearth-visualizer/commit/fdc056)
+- Revert changes made for debuggin in manifest parser [`178693`](https://github.com/reearth/reearth-visualizer/commit/178693)
+- Add debug log to parsefromurl [`8834e0`](https://github.com/reearth/reearth-visualizer/commit/8834e0)
+- Add min&#x2F;max to spacing fields ([#646](https://github.com/reearth/reearth-visualizer/pull/646)) [`8619e7`](https://github.com/reearth/reearth-visualizer/commit/8619e7)
+- Add NLS layer support ([#632](https://github.com/reearth/reearth-visualizer/pull/632)) [`c83248`](https://github.com/reearth/reearth-visualizer/commit/c83248)
+- Fix lint error from [#644](https://github.com/reearth/reearth-visualizer/pull/644) [`383ef9`](https://github.com/reearth/reearth-visualizer/commit/383ef9)
+- Support appearance in server ([#644](https://github.com/reearth/reearth-visualizer/pull/644)) [`0876ae`](https://github.com/reearth/reearth-visualizer/commit/0876ae)
+- Upgrade reearthx [`873104`](https://github.com/reearth/reearth-visualizer/commit/873104)
+- Add test for story block properties ([#630](https://github.com/reearth/reearth-visualizer/pull/630)) [`562c51`](https://github.com/reearth/reearth-visualizer/commit/562c51)
+- Add missing fields for story settings ([#628](https://github.com/reearth/reearth-visualizer/pull/628)) [`75d522`](https://github.com/reearth/reearth-visualizer/commit/75d522)
 
 ### Misc
 
 #### 📖 Documentation
 
-- Update README.md [`d3335c`](https://github.com/reearth/reearth/commit/d3335c)
+- Update README.md [`d3335c`](https://github.com/reearth/reearth-visualizer/commit/d3335c)
 
 #### ✨ Refactor
 
-- Use radio group in Data source manage ([#680](https://github.com/reearth/reearth/pull/680)) [`72a00b`](https://github.com/reearth/reearth/commit/72a00b)
-- Add assets feature ([#679](https://github.com/reearth/reearth/pull/679)) [`41326d`](https://github.com/reearth/reearth/commit/41326d)
-- Refactor text input component ([#677](https://github.com/reearth/reearth/pull/677)) [`ee4fad`](https://github.com/reearth/reearth/commit/ee4fad)
+- Use radio group in Data source manage ([#680](https://github.com/reearth/reearth-visualizer/pull/680)) [`72a00b`](https://github.com/reearth/reearth-visualizer/commit/72a00b)
+- Add assets feature ([#679](https://github.com/reearth/reearth-visualizer/pull/679)) [`41326d`](https://github.com/reearth/reearth-visualizer/commit/41326d)
+- Refactor text input component ([#677](https://github.com/reearth/reearth-visualizer/pull/677)) [`ee4fad`](https://github.com/reearth/reearth-visualizer/commit/ee4fad)
 
 #### Miscellaneous Tasks
 
-- Fix page title empty string ([#762](https://github.com/reearth/reearth/pull/762)) [`44e573`](https://github.com/reearth/reearth/commit/44e573)
-- Fix delete last page doesn&[#39](https://github.com/reearth/reearth/pull/39);t refresh the right panel ([#771](https://github.com/reearth/reearth/pull/771)) [`66c6f9`](https://github.com/reearth/reearth/commit/66c6f9)
-- Add super admin configuration ([#766](https://github.com/reearth/reearth/pull/766)) [`8bc811`](https://github.com/reearth/reearth/commit/8bc811)
-- Add idProperty to data ([#731](https://github.com/reearth/reearth/pull/731)) [`ef5885`](https://github.com/reearth/reearth/commit/ef5885)
-- Add asset type to data source manager ([#726](https://github.com/reearth/reearth/pull/726)) [`28cfb6`](https://github.com/reearth/reearth/commit/28cfb6)
-- Update CODEOWNERS [`3ed464`](https://github.com/reearth/reearth/commit/3ed464)
+- Fix page title empty string ([#762](https://github.com/reearth/reearth-visualizer/pull/762)) [`44e573`](https://github.com/reearth/reearth-visualizer/commit/44e573)
+- Fix delete last page doesn&[#39](https://github.com/reearth/reearth-visualizer/pull/39);t refresh the right panel ([#771](https://github.com/reearth/reearth-visualizer/pull/771)) [`66c6f9`](https://github.com/reearth/reearth-visualizer/commit/66c6f9)
+- Add super admin configuration ([#766](https://github.com/reearth/reearth-visualizer/pull/766)) [`8bc811`](https://github.com/reearth/reearth-visualizer/commit/8bc811)
+- Add idProperty to data ([#731](https://github.com/reearth/reearth-visualizer/pull/731)) [`ef5885`](https://github.com/reearth/reearth-visualizer/commit/ef5885)
+- Add asset type to data source manager ([#726](https://github.com/reearth/reearth-visualizer/pull/726)) [`28cfb6`](https://github.com/reearth/reearth-visualizer/commit/28cfb6)
+- Update CODEOWNERS [`3ed464`](https://github.com/reearth/reearth-visualizer/commit/3ed464)
 
 ### ci
 
 #### Miscellaneous Tasks
 
-- Update reviewer-lottery.yml [`8fea37`](https://github.com/reearth/reearth/commit/8fea37)
+- Update reviewer-lottery.yml [`8fea37`](https://github.com/reearth/reearth-visualizer/commit/8fea37)
 
 ### server, web
 
 #### Miscellaneous Tasks
 
-- Add collection to property schemaGroup ([#764](https://github.com/reearth/reearth/pull/764)) [`9cab76`](https://github.com/reearth/reearth/commit/9cab76)
-- Add map valueType to property ([#759](https://github.com/reearth/reearth/pull/759)) [`db515b`](https://github.com/reearth/reearth/commit/db515b)
+- Add collection to property schemaGroup ([#764](https://github.com/reearth/reearth-visualizer/pull/764)) [`9cab76`](https://github.com/reearth/reearth-visualizer/commit/9cab76)
+- Add map valueType to property ([#759](https://github.com/reearth/reearth-visualizer/pull/759)) [`db515b`](https://github.com/reearth/reearth-visualizer/commit/db515b)
 
 ### sever
 
 #### Miscellaneous Tasks
 
-- Refactor around NLS layers ([#656](https://github.com/reearth/reearth/pull/656)) [`1405dd`](https://github.com/reearth/reearth/commit/1405dd)
+- Refactor around NLS layers ([#656](https://github.com/reearth/reearth-visualizer/pull/656)) [`1405dd`](https://github.com/reearth/reearth-visualizer/commit/1405dd)
 
 ### web,server
 
 #### 🚀 Features
 
-- Support maintainer role ([#749](https://github.com/reearth/reearth/pull/749)) [`20b086`](https://github.com/reearth/reearth/commit/20b086)
+- Support maintainer role ([#749](https://github.com/reearth/reearth-visualizer/pull/749)) [`20b086`](https://github.com/reearth/reearth-visualizer/commit/20b086)
 
 ### 
 
 #### 📖 Documentation
 
-- Update README.md [`d3335c`](https://github.com/reearth/reearth/commit/d3335c)
+- Update README.md [`d3335c`](https://github.com/reearth/reearth-visualizer/commit/d3335c)
 
 #### ✨ Refactor
 
-- Use radio group in Data source manage ([#680](https://github.com/reearth/reearth/pull/680)) [`72a00b`](https://github.com/reearth/reearth/commit/72a00b)
-- Add assets feature ([#679](https://github.com/reearth/reearth/pull/679)) [`41326d`](https://github.com/reearth/reearth/commit/41326d)
-- Refactor text input component ([#677](https://github.com/reearth/reearth/pull/677)) [`ee4fad`](https://github.com/reearth/reearth/commit/ee4fad)
+- Use radio group in Data source manage ([#680](https://github.com/reearth/reearth-visualizer/pull/680)) [`72a00b`](https://github.com/reearth/reearth-visualizer/commit/72a00b)
+- Add assets feature ([#679](https://github.com/reearth/reearth-visualizer/pull/679)) [`41326d`](https://github.com/reearth/reearth-visualizer/commit/41326d)
+- Refactor text input component ([#677](https://github.com/reearth/reearth-visualizer/pull/677)) [`ee4fad`](https://github.com/reearth/reearth-visualizer/commit/ee4fad)
 
 #### Miscellaneous Tasks
 
-- Fix page title empty string ([#762](https://github.com/reearth/reearth/pull/762)) [`44e573`](https://github.com/reearth/reearth/commit/44e573)
-- Fix delete last page doesn&[#39](https://github.com/reearth/reearth/pull/39);t refresh the right panel ([#771](https://github.com/reearth/reearth/pull/771)) [`66c6f9`](https://github.com/reearth/reearth/commit/66c6f9)
-- Add super admin configuration ([#766](https://github.com/reearth/reearth/pull/766)) [`8bc811`](https://github.com/reearth/reearth/commit/8bc811)
-- Add idProperty to data ([#731](https://github.com/reearth/reearth/pull/731)) [`ef5885`](https://github.com/reearth/reearth/commit/ef5885)
-- Add asset type to data source manager ([#726](https://github.com/reearth/reearth/pull/726)) [`28cfb6`](https://github.com/reearth/reearth/commit/28cfb6)
-- Update CODEOWNERS [`3ed464`](https://github.com/reearth/reearth/commit/3ed464)
+- Fix page title empty string ([#762](https://github.com/reearth/reearth-visualizer/pull/762)) [`44e573`](https://github.com/reearth/reearth-visualizer/commit/44e573)
+- Fix delete last page doesn&[#39](https://github.com/reearth/reearth-visualizer/pull/39);t refresh the right panel ([#771](https://github.com/reearth/reearth-visualizer/pull/771)) [`66c6f9`](https://github.com/reearth/reearth-visualizer/commit/66c6f9)
+- Add super admin configuration ([#766](https://github.com/reearth/reearth-visualizer/pull/766)) [`8bc811`](https://github.com/reearth/reearth-visualizer/commit/8bc811)
+- Add idProperty to data ([#731](https://github.com/reearth/reearth-visualizer/pull/731)) [`ef5885`](https://github.com/reearth/reearth-visualizer/commit/ef5885)
+- Add asset type to data source manager ([#726](https://github.com/reearth/reearth-visualizer/pull/726)) [`28cfb6`](https://github.com/reearth/reearth-visualizer/commit/28cfb6)
+- Update CODEOWNERS [`3ed464`](https://github.com/reearth/reearth-visualizer/commit/3ed464)
 
 ## 0.18.0 - 2023-08-07
 
@@ -416,95 +416,95 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Add VisualizerContext in NLS for beta ([#591](https://github.com/reearth/reearth/pull/591)) [`39811d`](https://github.com/reearth/reearth/commit/39811d)
-- New beta modal design ([#579](https://github.com/reearth/reearth/pull/579)) [`517b1b`](https://github.com/reearth/reearth/commit/517b1b)
-- Support google photorealistic ([#521](https://github.com/reearth/reearth/pull/521)) [`ca71b3`](https://github.com/reearth/reearth/commit/ca71b3)
-- Support IBL for terrain ([#529](https://github.com/reearth/reearth/pull/529)) [`743963`](https://github.com/reearth/reearth/commit/743963)
-- Support HBAO ([#569](https://github.com/reearth/reearth/pull/569)) [`d5b3c9`](https://github.com/reearth/reearth/commit/d5b3c9)
+- Add VisualizerContext in NLS for beta ([#591](https://github.com/reearth/reearth-visualizer/pull/591)) [`39811d`](https://github.com/reearth/reearth-visualizer/commit/39811d)
+- New beta modal design ([#579](https://github.com/reearth/reearth-visualizer/pull/579)) [`517b1b`](https://github.com/reearth/reearth-visualizer/commit/517b1b)
+- Support google photorealistic ([#521](https://github.com/reearth/reearth-visualizer/pull/521)) [`ca71b3`](https://github.com/reearth/reearth-visualizer/commit/ca71b3)
+- Support IBL for terrain ([#529](https://github.com/reearth/reearth-visualizer/pull/529)) [`743963`](https://github.com/reearth/reearth-visualizer/commit/743963)
+- Support HBAO ([#569](https://github.com/reearth/reearth-visualizer/pull/569)) [`d5b3c9`](https://github.com/reearth/reearth-visualizer/commit/d5b3c9)
 
 #### 🔧 Bug Fixes
 
-- Wrong type error [`88ee7e`](https://github.com/reearth/reearth/commit/88ee7e)
-- Unsafe builtin implementation ([#623](https://github.com/reearth/reearth/pull/623)) [`96faac`](https://github.com/reearth/reearth/commit/96faac)
-- Revert small change [`aa8680`](https://github.com/reearth/reearth/commit/aa8680)
-- Pr preview build failing ([#614](https://github.com/reearth/reearth/pull/614)) [`031295`](https://github.com/reearth/reearth/commit/031295)
-- Crash app by ambient occlusion ([#611](https://github.com/reearth/reearth/pull/611)) [`15bd99`](https://github.com/reearth/reearth/commit/15bd99)
-- Gpx parsing not working ([#590](https://github.com/reearth/reearth/pull/590)) [`35d6da`](https://github.com/reearth/reearth/commit/35d6da)
-- Build ci failling [`54354b`](https://github.com/reearth/reearth/commit/54354b)
-- Create workspace  beta modal design ([#597](https://github.com/reearth/reearth/pull/597)) [`141026`](https://github.com/reearth/reearth/commit/141026)
-- Performance issue when generate md5 with large data.url ([#587](https://github.com/reearth/reearth/pull/587)) [`733862`](https://github.com/reearth/reearth/commit/733862)
-- AO invariant error [`b1875e`](https://github.com/reearth/reearth/commit/b1875e)
-- Ambient occlusion ([#574](https://github.com/reearth/reearth/pull/574)) [`9ae1af`](https://github.com/reearth/reearth/commit/9ae1af)
+- Wrong type error [`88ee7e`](https://github.com/reearth/reearth-visualizer/commit/88ee7e)
+- Unsafe builtin implementation ([#623](https://github.com/reearth/reearth-visualizer/pull/623)) [`96faac`](https://github.com/reearth/reearth-visualizer/commit/96faac)
+- Revert small change [`aa8680`](https://github.com/reearth/reearth-visualizer/commit/aa8680)
+- Pr preview build failing ([#614](https://github.com/reearth/reearth-visualizer/pull/614)) [`031295`](https://github.com/reearth/reearth-visualizer/commit/031295)
+- Crash app by ambient occlusion ([#611](https://github.com/reearth/reearth-visualizer/pull/611)) [`15bd99`](https://github.com/reearth/reearth-visualizer/commit/15bd99)
+- Gpx parsing not working ([#590](https://github.com/reearth/reearth-visualizer/pull/590)) [`35d6da`](https://github.com/reearth/reearth-visualizer/commit/35d6da)
+- Build ci failling [`54354b`](https://github.com/reearth/reearth-visualizer/commit/54354b)
+- Create workspace  beta modal design ([#597](https://github.com/reearth/reearth-visualizer/pull/597)) [`141026`](https://github.com/reearth/reearth-visualizer/commit/141026)
+- Performance issue when generate md5 with large data.url ([#587](https://github.com/reearth/reearth-visualizer/pull/587)) [`733862`](https://github.com/reearth/reearth-visualizer/commit/733862)
+- AO invariant error [`b1875e`](https://github.com/reearth/reearth-visualizer/commit/b1875e)
+- Ambient occlusion ([#574](https://github.com/reearth/reearth-visualizer/pull/574)) [`9ae1af`](https://github.com/reearth/reearth-visualizer/commit/9ae1af)
 
 #### ✨ Refactor
 
-- Config ([#575](https://github.com/reearth/reearth/pull/575)) [`2ebdf5`](https://github.com/reearth/reearth/commit/2ebdf5)
-- Services&#x2F;api [`4ec0bc`](https://github.com/reearth/reearth/commit/4ec0bc)
+- Config ([#575](https://github.com/reearth/reearth-visualizer/pull/575)) [`2ebdf5`](https://github.com/reearth/reearth-visualizer/commit/2ebdf5)
+- Services&#x2F;api [`4ec0bc`](https://github.com/reearth/reearth-visualizer/commit/4ec0bc)
 
 #### Miscellaneous Tasks
 
-- Update hexadecimal colors ([#618](https://github.com/reearth/reearth/pull/618)) [`ac2bb9`](https://github.com/reearth/reearth/commit/ac2bb9)
-- Version bump to 0.18.0 [`9c794d`](https://github.com/reearth/reearth/commit/9c794d)
-- Fix several issues around visualizer render ([#612](https://github.com/reearth/reearth/pull/612)) [`62d28e`](https://github.com/reearth/reearth/commit/62d28e)
-- Update button beta design ([#613](https://github.com/reearth/reearth/pull/613)) [`ed4e33`](https://github.com/reearth/reearth/commit/ed4e33)
-- Basic publish tab in beta ([#606](https://github.com/reearth/reearth/pull/606)) [`5f3141`](https://github.com/reearth/reearth/commit/5f3141)
-- Hook up with story page API ([#592](https://github.com/reearth/reearth/pull/592)) [`9eea0f`](https://github.com/reearth/reearth/commit/9eea0f)
-- Add widget and align system update functionality ([#604](https://github.com/reearth/reearth/pull/604)) [`0738b7`](https://github.com/reearth/reearth/commit/0738b7)
-- Update widget tab ([#598](https://github.com/reearth/reearth/pull/598)) [`a40c94`](https://github.com/reearth/reearth/commit/a40c94)
-- Enable visualizer explicit rendering ([#583](https://github.com/reearth/reearth/pull/583)) [`7a2503`](https://github.com/reearth/reearth/commit/7a2503)
-- Unsafe plugin support ([#576](https://github.com/reearth/reearth/pull/576)) [`1ebef7`](https://github.com/reearth/reearth/commit/1ebef7)
-- Add list style common DnD component ([#585](https://github.com/reearth/reearth/pull/585)) [`ad4ae6`](https://github.com/reearth/reearth/commit/ad4ae6)
-- Add popover contents to left panel and related modification ([#581](https://github.com/reearth/reearth/pull/581)) [`ca753c`](https://github.com/reearth/reearth/commit/ca753c)
-- Basic widget page ([#578](https://github.com/reearth/reearth/pull/578)) [`3e8dc0`](https://github.com/reearth/reearth/commit/3e8dc0)
-- Add popover and basic content components ([#580](https://github.com/reearth/reearth/pull/580)) [`53bf82`](https://github.com/reearth/reearth/commit/53bf82)
-- Panel resize functionality improvements ([#572](https://github.com/reearth/reearth/pull/572)) [`99f5ad`](https://github.com/reearth/reearth/commit/99f5ad)
-- Add image-based lighting ([#519](https://github.com/reearth/reearth/pull/519)) [`7622d7`](https://github.com/reearth/reearth/commit/7622d7)
-- Add storytelling static content of left panel  ([#565](https://github.com/reearth/reearth/pull/565)) [`65c1a1`](https://github.com/reearth/reearth/commit/65c1a1)
+- Update hexadecimal colors ([#618](https://github.com/reearth/reearth-visualizer/pull/618)) [`ac2bb9`](https://github.com/reearth/reearth-visualizer/commit/ac2bb9)
+- Version bump to 0.18.0 [`9c794d`](https://github.com/reearth/reearth-visualizer/commit/9c794d)
+- Fix several issues around visualizer render ([#612](https://github.com/reearth/reearth-visualizer/pull/612)) [`62d28e`](https://github.com/reearth/reearth-visualizer/commit/62d28e)
+- Update button beta design ([#613](https://github.com/reearth/reearth-visualizer/pull/613)) [`ed4e33`](https://github.com/reearth/reearth-visualizer/commit/ed4e33)
+- Basic publish tab in beta ([#606](https://github.com/reearth/reearth-visualizer/pull/606)) [`5f3141`](https://github.com/reearth/reearth-visualizer/commit/5f3141)
+- Hook up with story page API ([#592](https://github.com/reearth/reearth-visualizer/pull/592)) [`9eea0f`](https://github.com/reearth/reearth-visualizer/commit/9eea0f)
+- Add widget and align system update functionality ([#604](https://github.com/reearth/reearth-visualizer/pull/604)) [`0738b7`](https://github.com/reearth/reearth-visualizer/commit/0738b7)
+- Update widget tab ([#598](https://github.com/reearth/reearth-visualizer/pull/598)) [`a40c94`](https://github.com/reearth/reearth-visualizer/commit/a40c94)
+- Enable visualizer explicit rendering ([#583](https://github.com/reearth/reearth-visualizer/pull/583)) [`7a2503`](https://github.com/reearth/reearth-visualizer/commit/7a2503)
+- Unsafe plugin support ([#576](https://github.com/reearth/reearth-visualizer/pull/576)) [`1ebef7`](https://github.com/reearth/reearth-visualizer/commit/1ebef7)
+- Add list style common DnD component ([#585](https://github.com/reearth/reearth-visualizer/pull/585)) [`ad4ae6`](https://github.com/reearth/reearth-visualizer/commit/ad4ae6)
+- Add popover contents to left panel and related modification ([#581](https://github.com/reearth/reearth-visualizer/pull/581)) [`ca753c`](https://github.com/reearth/reearth-visualizer/commit/ca753c)
+- Basic widget page ([#578](https://github.com/reearth/reearth-visualizer/pull/578)) [`3e8dc0`](https://github.com/reearth/reearth-visualizer/commit/3e8dc0)
+- Add popover and basic content components ([#580](https://github.com/reearth/reearth-visualizer/pull/580)) [`53bf82`](https://github.com/reearth/reearth-visualizer/commit/53bf82)
+- Panel resize functionality improvements ([#572](https://github.com/reearth/reearth-visualizer/pull/572)) [`99f5ad`](https://github.com/reearth/reearth-visualizer/commit/99f5ad)
+- Add image-based lighting ([#519](https://github.com/reearth/reearth-visualizer/pull/519)) [`7622d7`](https://github.com/reearth/reearth-visualizer/commit/7622d7)
+- Add storytelling static content of left panel  ([#565](https://github.com/reearth/reearth-visualizer/pull/565)) [`65c1a1`](https://github.com/reearth/reearth-visualizer/commit/65c1a1)
 
 ### Server
 
 #### 🚀 Features
 
-- Storytelling blocks CRUD ([#610](https://github.com/reearth/reearth/pull/610)) [`5ac70f`](https://github.com/reearth/reearth/commit/5ac70f)
-- Support storytelling ([#553](https://github.com/reearth/reearth/pull/553)) [`f9b310`](https://github.com/reearth/reearth/commit/f9b310)
-- Extension system ([#584](https://github.com/reearth/reearth/pull/584)) [`847db6`](https://github.com/reearth/reearth/commit/847db6)
+- Storytelling blocks CRUD ([#610](https://github.com/reearth/reearth-visualizer/pull/610)) [`5ac70f`](https://github.com/reearth/reearth-visualizer/commit/5ac70f)
+- Support storytelling ([#553](https://github.com/reearth/reearth-visualizer/pull/553)) [`f9b310`](https://github.com/reearth/reearth-visualizer/commit/f9b310)
+- Extension system ([#584](https://github.com/reearth/reearth-visualizer/pull/584)) [`847db6`](https://github.com/reearth/reearth-visualizer/commit/847db6)
 
 #### 🔧 Bug Fixes
 
-- Add missing plugin extensions types ([#624](https://github.com/reearth/reearth/pull/624)) [`b98084`](https://github.com/reearth/reearth/commit/b98084)
-- Add missing fields to PropertySchema documents. ([#621](https://github.com/reearth/reearth/pull/621)) [`827c0d`](https://github.com/reearth/reearth/commit/827c0d)
+- Add missing plugin extensions types ([#624](https://github.com/reearth/reearth-visualizer/pull/624)) [`b98084`](https://github.com/reearth/reearth-visualizer/commit/b98084)
+- Add missing fields to PropertySchema documents. ([#621](https://github.com/reearth/reearth-visualizer/pull/621)) [`827c0d`](https://github.com/reearth/reearth-visualizer/commit/827c0d)
 
 #### ⚡️ Performance
 
-- Add group.linkeddatasetschema index ([#563](https://github.com/reearth/reearth/pull/563)) [`c4f2c1`](https://github.com/reearth/reearth/commit/c4f2c1)
-- Improve dataset index ([#562](https://github.com/reearth/reearth/pull/562)) [`49ce87`](https://github.com/reearth/reearth/commit/49ce87)
+- Add group.linkeddatasetschema index ([#563](https://github.com/reearth/reearth-visualizer/pull/563)) [`c4f2c1`](https://github.com/reearth/reearth-visualizer/commit/c4f2c1)
+- Improve dataset index ([#562](https://github.com/reearth/reearth-visualizer/pull/562)) [`49ce87`](https://github.com/reearth/reearth-visualizer/commit/49ce87)
 
 #### Miscellaneous Tasks
 
-- Revert changes on ci_server.yml [`fb45e0`](https://github.com/reearth/reearth/commit/fb45e0)
-- Expand sys extensions to support storytelling pages&#x2F;blocks ([#622](https://github.com/reearth/reearth/pull/622)) [`c4c46c`](https://github.com/reearth/reearth/commit/c4c46c)
-- Add JSON schema to built in manifest ([#617](https://github.com/reearth/reearth/pull/617)) [`755931`](https://github.com/reearth/reearth/commit/755931)
-- Add spacing value type with padding and margin UI support ([#616](https://github.com/reearth/reearth/pull/616)) [`99abf5`](https://github.com/reearth/reearth/commit/99abf5)
+- Revert changes on ci_server.yml [`fb45e0`](https://github.com/reearth/reearth-visualizer/commit/fb45e0)
+- Expand sys extensions to support storytelling pages&#x2F;blocks ([#622](https://github.com/reearth/reearth-visualizer/pull/622)) [`c4c46c`](https://github.com/reearth/reearth-visualizer/commit/c4c46c)
+- Add JSON schema to built in manifest ([#617](https://github.com/reearth/reearth-visualizer/pull/617)) [`755931`](https://github.com/reearth/reearth-visualizer/commit/755931)
+- Add spacing value type with padding and margin UI support ([#616](https://github.com/reearth/reearth-visualizer/pull/616)) [`99abf5`](https://github.com/reearth/reearth-visualizer/commit/99abf5)
 
 ### Misc
 
 #### Miscellaneous Tasks
 
-- Revert CHANGELOG.md to same as main [`ac3594`](https://github.com/reearth/reearth/commit/ac3594)
-- Remove prev CHANGELOG changes [`c248fc`](https://github.com/reearth/reearth/commit/c248fc)
-- Update reviewer-lottery.yml [`79aaf0`](https://github.com/reearth/reearth/commit/79aaf0)
-- Update theme&[#39](https://github.com/reearth/reearth/pull/39);s colors ([#589](https://github.com/reearth/reearth/pull/589)) [`714fb9`](https://github.com/reearth/reearth/commit/714fb9)
-- Update CODEOWNERS [`0b8919`](https://github.com/reearth/reearth/commit/0b8919)
+- Revert CHANGELOG.md to same as main [`ac3594`](https://github.com/reearth/reearth-visualizer/commit/ac3594)
+- Remove prev CHANGELOG changes [`c248fc`](https://github.com/reearth/reearth-visualizer/commit/c248fc)
+- Update reviewer-lottery.yml [`79aaf0`](https://github.com/reearth/reearth-visualizer/commit/79aaf0)
+- Update theme&[#39](https://github.com/reearth/reearth-visualizer/pull/39);s colors ([#589](https://github.com/reearth/reearth-visualizer/pull/589)) [`714fb9`](https://github.com/reearth/reearth-visualizer/commit/714fb9)
+- Update CODEOWNERS [`0b8919`](https://github.com/reearth/reearth-visualizer/commit/0b8919)
 
 ### 
 
 #### Miscellaneous Tasks
 
-- Revert CHANGELOG.md to same as main [`ac3594`](https://github.com/reearth/reearth/commit/ac3594)
-- Remove prev CHANGELOG changes [`c248fc`](https://github.com/reearth/reearth/commit/c248fc)
-- Update reviewer-lottery.yml [`79aaf0`](https://github.com/reearth/reearth/commit/79aaf0)
-- Update theme&[#39](https://github.com/reearth/reearth/pull/39);s colors ([#589](https://github.com/reearth/reearth/pull/589)) [`714fb9`](https://github.com/reearth/reearth/commit/714fb9)
-- Update CODEOWNERS [`0b8919`](https://github.com/reearth/reearth/commit/0b8919)
+- Revert CHANGELOG.md to same as main [`ac3594`](https://github.com/reearth/reearth-visualizer/commit/ac3594)
+- Remove prev CHANGELOG changes [`c248fc`](https://github.com/reearth/reearth-visualizer/commit/c248fc)
+- Update reviewer-lottery.yml [`79aaf0`](https://github.com/reearth/reearth-visualizer/commit/79aaf0)
+- Update theme&[#39](https://github.com/reearth/reearth-visualizer/pull/39);s colors ([#589](https://github.com/reearth/reearth-visualizer/pull/589)) [`714fb9`](https://github.com/reearth/reearth-visualizer/commit/714fb9)
+- Update CODEOWNERS [`0b8919`](https://github.com/reearth/reearth-visualizer/commit/0b8919)
 
 ## 0.17.0 - 2023-07-11
 
@@ -512,114 +512,114 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Visualizer antialiasing ([#566](https://github.com/reearth/reearth/pull/566)) [`dd1b39`](https://github.com/reearth/reearth/commit/dd1b39)
-- Visualizer supports shadow map ([#524](https://github.com/reearth/reearth/pull/524)) [`748d9d`](https://github.com/reearth/reearth/commit/748d9d)
-- Add an option to disable default PBR to 3dtiles and model features in NLS ([#517](https://github.com/reearth/reearth/pull/517)) [`29083d`](https://github.com/reearth/reearth/commit/29083d)
-- Interaction mode on beta ([#507](https://github.com/reearth/reearth/pull/507)) [`d4bbd6`](https://github.com/reearth/reearth/commit/d4bbd6)
-- Add aws cognito support in auth ([#449](https://github.com/reearth/reearth/pull/449)) [`414473`](https://github.com/reearth/reearth/commit/414473)
+- Visualizer antialiasing ([#566](https://github.com/reearth/reearth-visualizer/pull/566)) [`dd1b39`](https://github.com/reearth/reearth-visualizer/commit/dd1b39)
+- Visualizer supports shadow map ([#524](https://github.com/reearth/reearth-visualizer/pull/524)) [`748d9d`](https://github.com/reearth/reearth-visualizer/commit/748d9d)
+- Add an option to disable default PBR to 3dtiles and model features in NLS ([#517](https://github.com/reearth/reearth-visualizer/pull/517)) [`29083d`](https://github.com/reearth/reearth-visualizer/commit/29083d)
+- Interaction mode on beta ([#507](https://github.com/reearth/reearth-visualizer/pull/507)) [`d4bbd6`](https://github.com/reearth/reearth-visualizer/commit/d4bbd6)
+- Add aws cognito support in auth ([#449](https://github.com/reearth/reearth-visualizer/pull/449)) [`414473`](https://github.com/reearth/reearth-visualizer/commit/414473)
 
 #### 🔧 Bug Fixes
 
-- Unexpect select undefined when select mvt layer ([#560](https://github.com/reearth/reearth/pull/560)) [`7ec40f`](https://github.com/reearth/reearth/commit/7ec40f)
-- Show OSM buildings [`ac01eb`](https://github.com/reearth/reearth/commit/ac01eb)
-- Selection event for published page ([#549](https://github.com/reearth/reearth/pull/549)) [`b4a111`](https://github.com/reearth/reearth/commit/b4a111)
-- Pass ion token to each layer ([#558](https://github.com/reearth/reearth/pull/558)) [`822d03`](https://github.com/reearth/reearth/commit/822d03)
-- Support with Authentication function support for cognito backend ([#514](https://github.com/reearth/reearth/pull/514)) [`c603f7`](https://github.com/reearth/reearth/commit/c603f7)
-- Skip cache feature for data has updateInterval ([#552](https://github.com/reearth/reearth/pull/552)) [`38489c`](https://github.com/reearth/reearth/commit/38489c)
-- Add id to property group list [`466fac`](https://github.com/reearth/reearth/commit/466fac)
-- Workspace or userId being undefined ([#527](https://github.com/reearth/reearth/pull/527)) [`d676dc`](https://github.com/reearth/reearth/commit/d676dc)
-- Infinite loop on network error ([#525](https://github.com/reearth/reearth/pull/525)) [`fa30bc`](https://github.com/reearth/reearth/commit/fa30bc)
-- Revert functionality to remember last workspace opened ([#523](https://github.com/reearth/reearth/pull/523)) [`05e32d`](https://github.com/reearth/reearth/commit/05e32d)
-- Typing for window in beta ([#518](https://github.com/reearth/reearth/pull/518)) [`b815a9`](https://github.com/reearth/reearth/commit/b815a9)
-- Wrong workspace when sharing link ([#506](https://github.com/reearth/reearth/pull/506)) [`5b939e`](https://github.com/reearth/reearth/commit/5b939e)
-- Revert published page VR layer selection ([#512](https://github.com/reearth/reearth/pull/512)) [`02d7fa`](https://github.com/reearth/reearth/commit/02d7fa)
-- Published page not getting theme [`a797dd`](https://github.com/reearth/reearth/commit/a797dd)
+- Unexpect select undefined when select mvt layer ([#560](https://github.com/reearth/reearth-visualizer/pull/560)) [`7ec40f`](https://github.com/reearth/reearth-visualizer/commit/7ec40f)
+- Show OSM buildings [`ac01eb`](https://github.com/reearth/reearth-visualizer/commit/ac01eb)
+- Selection event for published page ([#549](https://github.com/reearth/reearth-visualizer/pull/549)) [`b4a111`](https://github.com/reearth/reearth-visualizer/commit/b4a111)
+- Pass ion token to each layer ([#558](https://github.com/reearth/reearth-visualizer/pull/558)) [`822d03`](https://github.com/reearth/reearth-visualizer/commit/822d03)
+- Support with Authentication function support for cognito backend ([#514](https://github.com/reearth/reearth-visualizer/pull/514)) [`c603f7`](https://github.com/reearth/reearth-visualizer/commit/c603f7)
+- Skip cache feature for data has updateInterval ([#552](https://github.com/reearth/reearth-visualizer/pull/552)) [`38489c`](https://github.com/reearth/reearth-visualizer/commit/38489c)
+- Add id to property group list [`466fac`](https://github.com/reearth/reearth-visualizer/commit/466fac)
+- Workspace or userId being undefined ([#527](https://github.com/reearth/reearth-visualizer/pull/527)) [`d676dc`](https://github.com/reearth/reearth-visualizer/commit/d676dc)
+- Infinite loop on network error ([#525](https://github.com/reearth/reearth-visualizer/pull/525)) [`fa30bc`](https://github.com/reearth/reearth-visualizer/commit/fa30bc)
+- Revert functionality to remember last workspace opened ([#523](https://github.com/reearth/reearth-visualizer/pull/523)) [`05e32d`](https://github.com/reearth/reearth-visualizer/commit/05e32d)
+- Typing for window in beta ([#518](https://github.com/reearth/reearth-visualizer/pull/518)) [`b815a9`](https://github.com/reearth/reearth-visualizer/commit/b815a9)
+- Wrong workspace when sharing link ([#506](https://github.com/reearth/reearth-visualizer/pull/506)) [`5b939e`](https://github.com/reearth/reearth-visualizer/commit/5b939e)
+- Revert published page VR layer selection ([#512](https://github.com/reearth/reearth-visualizer/pull/512)) [`02d7fa`](https://github.com/reearth/reearth-visualizer/commit/02d7fa)
+- Published page not getting theme [`a797dd`](https://github.com/reearth/reearth-visualizer/commit/a797dd)
 
 #### ⚡️ Performance
 
-- Speed up fetching layers with datasets ([#544](https://github.com/reearth/reearth/pull/544)) [`e12357`](https://github.com/reearth/reearth/commit/e12357)
+- Speed up fetching layers with datasets ([#544](https://github.com/reearth/reearth-visualizer/pull/544)) [`e12357`](https://github.com/reearth/reearth-visualizer/commit/e12357)
 
 #### ✨ Refactor
 
-- Split gql queries, fragments, etc ([#546](https://github.com/reearth/reearth/pull/546)) [`591800`](https://github.com/reearth/reearth/commit/591800)
-- Handle cesium private property of shadow map ([#531](https://github.com/reearth/reearth/pull/531)) [`ae4cdd`](https://github.com/reearth/reearth/commit/ae4cdd)
-- Handle GQL errors w useSetAtom ([#528](https://github.com/reearth/reearth/pull/528)) [`ff2040`](https://github.com/reearth/reearth/commit/ff2040)
-- Update Beta theme ([#504](https://github.com/reearth/reearth/pull/504)) [`248f1a`](https://github.com/reearth/reearth/commit/248f1a)
+- Split gql queries, fragments, etc ([#546](https://github.com/reearth/reearth-visualizer/pull/546)) [`591800`](https://github.com/reearth/reearth-visualizer/commit/591800)
+- Handle cesium private property of shadow map ([#531](https://github.com/reearth/reearth-visualizer/pull/531)) [`ae4cdd`](https://github.com/reearth/reearth-visualizer/commit/ae4cdd)
+- Handle GQL errors w useSetAtom ([#528](https://github.com/reearth/reearth-visualizer/pull/528)) [`ff2040`](https://github.com/reearth/reearth-visualizer/commit/ff2040)
+- Update Beta theme ([#504](https://github.com/reearth/reearth-visualizer/pull/504)) [`248f1a`](https://github.com/reearth/reearth-visualizer/commit/248f1a)
 
 #### Miscellaneous Tasks
 
-- Remove duplication from canvas convert.ts ([#573](https://github.com/reearth/reearth/pull/573)) [`988041`](https://github.com/reearth/reearth/commit/988041)
-- Update package.json to v0.17.0 ([#571](https://github.com/reearth/reearth/pull/571)) [`ac87ec`](https://github.com/reearth/reearth/commit/ac87ec)
-- Update package.json to v0.17.0 ([#570](https://github.com/reearth/reearth/pull/570)) [`215c73`](https://github.com/reearth/reearth/commit/215c73)
-- Refactor graphQL and set new standard ([#536](https://github.com/reearth/reearth/pull/536)) [`a002e6`](https://github.com/reearth/reearth/commit/a002e6)
-- Add story page indicator ([#543](https://github.com/reearth/reearth/pull/543)) [`7b47bb`](https://github.com/reearth/reearth/commit/7b47bb)
-- Add empty StoryPanel ([#541](https://github.com/reearth/reearth/pull/541)) [`65ba8c`](https://github.com/reearth/reearth/commit/65ba8c)
-- Allow reearth_config.json to be set remotely for local development ([#559](https://github.com/reearth/reearth/pull/559)) [`d1cba2`](https://github.com/reearth/reearth/commit/d1cba2)
-- Add SettingsButtons Component ([#513](https://github.com/reearth/reearth/pull/513)) [`6d0ab3`](https://github.com/reearth/reearth/commit/6d0ab3)
-- Add SwitchButtonList Component ([#526](https://github.com/reearth/reearth/pull/526)) [`34c54f`](https://github.com/reearth/reearth/commit/34c54f)
-- Reduce useless console.log on dataset load [`afcde1`](https://github.com/reearth/reearth/commit/afcde1)
-- Add actionItem to beta ([#497](https://github.com/reearth/reearth/pull/497)) [`d48d54`](https://github.com/reearth/reearth/commit/d48d54)
-- Add CheckboxField component ([#508](https://github.com/reearth/reearth/pull/508)) [`3a12f5`](https://github.com/reearth/reearth/commit/3a12f5)
-- Add SubTabButtonList component ([#509](https://github.com/reearth/reearth/pull/509)) [`61c937`](https://github.com/reearth/reearth/commit/61c937)
-- Add SidePanelSectionField component ([#505](https://github.com/reearth/reearth/pull/505)) [`4b7056`](https://github.com/reearth/reearth/commit/4b7056)
-- Update package.json version [`ff1daf`](https://github.com/reearth/reearth/commit/ff1daf)
+- Remove duplication from canvas convert.ts ([#573](https://github.com/reearth/reearth-visualizer/pull/573)) [`988041`](https://github.com/reearth/reearth-visualizer/commit/988041)
+- Update package.json to v0.17.0 ([#571](https://github.com/reearth/reearth-visualizer/pull/571)) [`ac87ec`](https://github.com/reearth/reearth-visualizer/commit/ac87ec)
+- Update package.json to v0.17.0 ([#570](https://github.com/reearth/reearth-visualizer/pull/570)) [`215c73`](https://github.com/reearth/reearth-visualizer/commit/215c73)
+- Refactor graphQL and set new standard ([#536](https://github.com/reearth/reearth-visualizer/pull/536)) [`a002e6`](https://github.com/reearth/reearth-visualizer/commit/a002e6)
+- Add story page indicator ([#543](https://github.com/reearth/reearth-visualizer/pull/543)) [`7b47bb`](https://github.com/reearth/reearth-visualizer/commit/7b47bb)
+- Add empty StoryPanel ([#541](https://github.com/reearth/reearth-visualizer/pull/541)) [`65ba8c`](https://github.com/reearth/reearth-visualizer/commit/65ba8c)
+- Allow reearth_config.json to be set remotely for local development ([#559](https://github.com/reearth/reearth-visualizer/pull/559)) [`d1cba2`](https://github.com/reearth/reearth-visualizer/commit/d1cba2)
+- Add SettingsButtons Component ([#513](https://github.com/reearth/reearth-visualizer/pull/513)) [`6d0ab3`](https://github.com/reearth/reearth-visualizer/commit/6d0ab3)
+- Add SwitchButtonList Component ([#526](https://github.com/reearth/reearth-visualizer/pull/526)) [`34c54f`](https://github.com/reearth/reearth-visualizer/commit/34c54f)
+- Reduce useless console.log on dataset load [`afcde1`](https://github.com/reearth/reearth-visualizer/commit/afcde1)
+- Add actionItem to beta ([#497](https://github.com/reearth/reearth-visualizer/pull/497)) [`d48d54`](https://github.com/reearth/reearth-visualizer/commit/d48d54)
+- Add CheckboxField component ([#508](https://github.com/reearth/reearth-visualizer/pull/508)) [`3a12f5`](https://github.com/reearth/reearth-visualizer/commit/3a12f5)
+- Add SubTabButtonList component ([#509](https://github.com/reearth/reearth-visualizer/pull/509)) [`61c937`](https://github.com/reearth/reearth-visualizer/commit/61c937)
+- Add SidePanelSectionField component ([#505](https://github.com/reearth/reearth-visualizer/pull/505)) [`4b7056`](https://github.com/reearth/reearth-visualizer/commit/4b7056)
+- Update package.json version [`ff1daf`](https://github.com/reearth/reearth-visualizer/commit/ff1daf)
 
 ### Server
 
 #### 🚀 Features
 
-- Add dataset IDs and schema to dataset API ([#539](https://github.com/reearth/reearth/pull/539)) [`765c29`](https://github.com/reearth/reearth/commit/765c29)
-- Dataset REST API ([#537](https://github.com/reearth/reearth/pull/537)) [`62d6f0`](https://github.com/reearth/reearth/commit/62d6f0)
+- Add dataset IDs and schema to dataset API ([#539](https://github.com/reearth/reearth-visualizer/pull/539)) [`765c29`](https://github.com/reearth/reearth-visualizer/commit/765c29)
+- Dataset REST API ([#537](https://github.com/reearth/reearth-visualizer/pull/537)) [`62d6f0`](https://github.com/reearth/reearth-visualizer/commit/62d6f0)
 
 #### 🔧 Bug Fixes
 
-- Reduce size of queries sent to MongoDB ([#550](https://github.com/reearth/reearth/pull/550)) [`56bef2`](https://github.com/reearth/reearth/commit/56bef2)
-- Filter properties in property.FindByIDs ([#548](https://github.com/reearth/reearth/pull/548)) [`842252`](https://github.com/reearth/reearth/commit/842252)
-- Add schema field ID to dataset REST API ([#547](https://github.com/reearth/reearth/pull/547)) [`241011`](https://github.com/reearth/reearth/commit/241011)
-- Use default mongo conn timeout [`f0e5cc`](https://github.com/reearth/reearth/commit/f0e5cc)
+- Reduce size of queries sent to MongoDB ([#550](https://github.com/reearth/reearth-visualizer/pull/550)) [`56bef2`](https://github.com/reearth/reearth-visualizer/commit/56bef2)
+- Filter properties in property.FindByIDs ([#548](https://github.com/reearth/reearth-visualizer/pull/548)) [`842252`](https://github.com/reearth/reearth-visualizer/commit/842252)
+- Add schema field ID to dataset REST API ([#547](https://github.com/reearth/reearth-visualizer/pull/547)) [`241011`](https://github.com/reearth/reearth-visualizer/commit/241011)
+- Use default mongo conn timeout [`f0e5cc`](https://github.com/reearth/reearth-visualizer/commit/f0e5cc)
 
 #### ✨ Refactor
 
-- Replace user&#x2F;workspace with account in reearthx ([#493](https://github.com/reearth/reearth/pull/493)) [`5a612b`](https://github.com/reearth/reearth/commit/5a612b)
+- Replace user&#x2F;workspace with account in reearthx ([#493](https://github.com/reearth/reearth-visualizer/pull/493)) [`5a612b`](https://github.com/reearth/reearth-visualizer/commit/5a612b)
 
 #### Miscellaneous Tasks
 
-- Go mod tidy [`a0d8b0`](https://github.com/reearth/reearth/commit/a0d8b0)
-- Add REEARTH_ASSETBASEURL to &#x2F;server&#x2F;.env.example ([#433](https://github.com/reearth/reearth/pull/433)) [`02e25c`](https://github.com/reearth/reearth/commit/02e25c)
-- Print request ID to logs ([#530](https://github.com/reearth/reearth/pull/530)) [`8081c9`](https://github.com/reearth/reearth/commit/8081c9)
-- Add logs on internal error [`4b79e9`](https://github.com/reearth/reearth/commit/4b79e9)
+- Go mod tidy [`a0d8b0`](https://github.com/reearth/reearth-visualizer/commit/a0d8b0)
+- Add REEARTH_ASSETBASEURL to &#x2F;server&#x2F;.env.example ([#433](https://github.com/reearth/reearth-visualizer/pull/433)) [`02e25c`](https://github.com/reearth/reearth-visualizer/commit/02e25c)
+- Print request ID to logs ([#530](https://github.com/reearth/reearth-visualizer/pull/530)) [`8081c9`](https://github.com/reearth/reearth-visualizer/commit/8081c9)
+- Add logs on internal error [`4b79e9`](https://github.com/reearth/reearth-visualizer/commit/4b79e9)
 
 ### Misc
 
 #### 🔧 Bug Fixes
 
-- Force jpg for watercolor tile ([#564](https://github.com/reearth/reearth/pull/564)) [`45ec8f`](https://github.com/reearth/reearth/commit/45ec8f)
+- Force jpg for watercolor tile ([#564](https://github.com/reearth/reearth-visualizer/pull/564)) [`45ec8f`](https://github.com/reearth/reearth-visualizer/commit/45ec8f)
 
 #### Miscellaneous Tasks
 
-- Update node.js to v18 ([#515](https://github.com/reearth/reearth/pull/515)) [`d34248`](https://github.com/reearth/reearth/commit/d34248)
-- Update CODEOWNERS [`55f82a`](https://github.com/reearth/reearth/commit/55f82a)
+- Update node.js to v18 ([#515](https://github.com/reearth/reearth-visualizer/pull/515)) [`d34248`](https://github.com/reearth/reearth-visualizer/commit/d34248)
+- Update CODEOWNERS [`55f82a`](https://github.com/reearth/reearth-visualizer/commit/55f82a)
 
 #### 
 
-- Chore(web): Add InsertionButton ([#496](https://github.com/reearth/reearth/pull/496)) [`b55cc9`](https://github.com/reearth/reearth/commit/b55cc9)
-- Chore(web): Add StorytellingPageSectionItem ([#495](https://github.com/reearth/reearth/pull/495)) [`36ddb2`](https://github.com/reearth/reearth/commit/36ddb2)
+- Chore(web): Add InsertionButton ([#496](https://github.com/reearth/reearth-visualizer/pull/496)) [`b55cc9`](https://github.com/reearth/reearth-visualizer/commit/b55cc9)
+- Chore(web): Add StorytellingPageSectionItem ([#495](https://github.com/reearth/reearth-visualizer/pull/495)) [`36ddb2`](https://github.com/reearth/reearth-visualizer/commit/36ddb2)
 
 ### 
 
 #### 🔧 Bug Fixes
 
-- Force jpg for watercolor tile ([#564](https://github.com/reearth/reearth/pull/564)) [`45ec8f`](https://github.com/reearth/reearth/commit/45ec8f)
+- Force jpg for watercolor tile ([#564](https://github.com/reearth/reearth-visualizer/pull/564)) [`45ec8f`](https://github.com/reearth/reearth-visualizer/commit/45ec8f)
 
 #### Miscellaneous Tasks
 
-- Update node.js to v18 ([#515](https://github.com/reearth/reearth/pull/515)) [`d34248`](https://github.com/reearth/reearth/commit/d34248)
-- Update CODEOWNERS [`55f82a`](https://github.com/reearth/reearth/commit/55f82a)
+- Update node.js to v18 ([#515](https://github.com/reearth/reearth-visualizer/pull/515)) [`d34248`](https://github.com/reearth/reearth-visualizer/commit/d34248)
+- Update CODEOWNERS [`55f82a`](https://github.com/reearth/reearth-visualizer/commit/55f82a)
 
 #### 
 
-- Chore(web): Add InsertionButton ([#496](https://github.com/reearth/reearth/pull/496)) [`b55cc9`](https://github.com/reearth/reearth/commit/b55cc9)
-- Chore(web): Add StorytellingPageSectionItem ([#495](https://github.com/reearth/reearth/pull/495)) [`36ddb2`](https://github.com/reearth/reearth/commit/36ddb2)
+- Chore(web): Add InsertionButton ([#496](https://github.com/reearth/reearth-visualizer/pull/496)) [`b55cc9`](https://github.com/reearth/reearth-visualizer/commit/b55cc9)
+- Chore(web): Add StorytellingPageSectionItem ([#495](https://github.com/reearth/reearth-visualizer/pull/495)) [`36ddb2`](https://github.com/reearth/reearth-visualizer/commit/36ddb2)
 
 ## 0.16.3 - 2023-06-16
 
@@ -627,39 +627,39 @@ All notable changes to this project will be documented in this file.
 
 #### 🔧 Bug Fixes
 
-- Don&[#39](https://github.com/reearth/reearth/pull/39);t show project select on project creation [`a2def8`](https://github.com/reearth/reearth/commit/a2def8)
-- Published page layer selection ([#503](https://github.com/reearth/reearth/pull/503)) [`2a23f4`](https://github.com/reearth/reearth/commit/2a23f4)
+- Don&[#39](https://github.com/reearth/reearth-visualizer/pull/39);t show project select on project creation [`a2def8`](https://github.com/reearth/reearth-visualizer/commit/a2def8)
+- Published page layer selection ([#503](https://github.com/reearth/reearth-visualizer/pull/503)) [`2a23f4`](https://github.com/reearth/reearth-visualizer/commit/2a23f4)
 
 #### ✨ Refactor
 
-- Theme system ([#498](https://github.com/reearth/reearth/pull/498)) [`b7fa18`](https://github.com/reearth/reearth/commit/b7fa18)
-- Organize stories to classic group ([#488](https://github.com/reearth/reearth/pull/488)) [`0eed12`](https://github.com/reearth/reearth/commit/0eed12)
-- Organize Resizable(beta) hooks ([#467](https://github.com/reearth/reearth/pull/467)) [`449335`](https://github.com/reearth/reearth/commit/449335)
+- Theme system ([#498](https://github.com/reearth/reearth-visualizer/pull/498)) [`b7fa18`](https://github.com/reearth/reearth-visualizer/commit/b7fa18)
+- Organize stories to classic group ([#488](https://github.com/reearth/reearth-visualizer/pull/488)) [`0eed12`](https://github.com/reearth/reearth-visualizer/commit/0eed12)
+- Organize Resizable(beta) hooks ([#467](https://github.com/reearth/reearth-visualizer/pull/467)) [`449335`](https://github.com/reearth/reearth-visualizer/commit/449335)
 
 #### Miscellaneous Tasks
 
-- Update package.json for v0.16.3 [`116936`](https://github.com/reearth/reearth/commit/116936)
-- Design beta navBar ([#486](https://github.com/reearth/reearth/pull/486)) [`e07837`](https://github.com/reearth/reearth/commit/e07837)
-- Add useManageSwitchState ([#471](https://github.com/reearth/reearth/pull/471)) [`97f7f2`](https://github.com/reearth/reearth/commit/97f7f2)
+- Update package.json for v0.16.3 [`116936`](https://github.com/reearth/reearth-visualizer/commit/116936)
+- Design beta navBar ([#486](https://github.com/reearth/reearth-visualizer/pull/486)) [`e07837`](https://github.com/reearth/reearth-visualizer/commit/e07837)
+- Add useManageSwitchState ([#471](https://github.com/reearth/reearth-visualizer/pull/471)) [`97f7f2`](https://github.com/reearth/reearth-visualizer/commit/97f7f2)
 
 ### Server
 
 #### 🔧 Bug Fixes
 
-- Ignore filter for project repo findByPublicName ([#499](https://github.com/reearth/reearth/pull/499)) [`612e78`](https://github.com/reearth/reearth/commit/612e78)
-- Published metadata api should return error correctly [`073b30`](https://github.com/reearth/reearth/commit/073b30)
+- Ignore filter for project repo findByPublicName ([#499](https://github.com/reearth/reearth-visualizer/pull/499)) [`612e78`](https://github.com/reearth/reearth-visualizer/commit/612e78)
+- Published metadata api should return error correctly [`073b30`](https://github.com/reearth/reearth-visualizer/commit/073b30)
 
 ### Misc
 
 #### Miscellaneous Tasks
 
-- Update CODEOWNERS [`338c7a`](https://github.com/reearth/reearth/commit/338c7a)
+- Update CODEOWNERS [`338c7a`](https://github.com/reearth/reearth-visualizer/commit/338c7a)
 
 ### 
 
 #### Miscellaneous Tasks
 
-- Update CODEOWNERS [`338c7a`](https://github.com/reearth/reearth/commit/338c7a)
+- Update CODEOWNERS [`338c7a`](https://github.com/reearth/reearth-visualizer/commit/338c7a)
 
 ## 0.16.2 - 2023-06-08
 
@@ -667,7 +667,7 @@ All notable changes to this project will be documented in this file.
 
 #### Miscellaneous Tasks
 
-- Update package.json [`4051be`](https://github.com/reearth/reearth/commit/4051be)
+- Update package.json [`4051be`](https://github.com/reearth/reearth-visualizer/commit/4051be)
 
 ### web, server
 
@@ -680,7 +680,7 @@ All notable changes to this project will be documented in this file.
 
 #### Miscellaneous Tasks
 
-- Update to 0.16.1 for the fix release [`707942`](https://github.com/reearth/reearth/commit/707942)
+- Update to 0.16.1 for the fix release [`707942`](https://github.com/reearth/reearth-visualizer/commit/707942)
 
 ### server, web
 
@@ -692,7 +692,7 @@ All notable changes to this project will be documented in this file.
 
 #### Miscellaneous Tasks
 
-- Update to 0.16.1 for the fix release [`707942`](https://github.com/reearth/reearth/commit/707942)
+- Update to 0.16.1 for the fix release [`707942`](https://github.com/reearth/reearth-visualizer/commit/707942)
 
 ## 0.16.0 - 2023-06-08
 
@@ -700,103 +700,103 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Support create beta project ([#451](https://github.com/reearth/reearth/pull/451)) [`7c89bf`](https://github.com/reearth/reearth/commit/7c89bf)
-- Re:Earth Beta routing and basic component structure ([#444](https://github.com/reearth/reearth/pull/444)) [`75b7bb`](https://github.com/reearth/reearth/commit/75b7bb)
-- Split code between beta and classic ([#434](https://github.com/reearth/reearth/pull/434)) [`a8a680`](https://github.com/reearth/reearth/commit/a8a680)
+- Support create beta project ([#451](https://github.com/reearth/reearth-visualizer/pull/451)) [`7c89bf`](https://github.com/reearth/reearth-visualizer/commit/7c89bf)
+- Re:Earth Beta routing and basic component structure ([#444](https://github.com/reearth/reearth-visualizer/pull/444)) [`75b7bb`](https://github.com/reearth/reearth-visualizer/commit/75b7bb)
+- Split code between beta and classic ([#434](https://github.com/reearth/reearth-visualizer/pull/434)) [`a8a680`](https://github.com/reearth/reearth-visualizer/commit/a8a680)
 
 #### 🔧 Bug Fixes
 
-- Infobox showing [object object] on click ([#487](https://github.com/reearth/reearth/pull/487)) [`90c38e`](https://github.com/reearth/reearth/commit/90c38e)
-- Parse properties(feature) recursively before using in evaluator at core ([#479](https://github.com/reearth/reearth/pull/479)) [`20635b`](https://github.com/reearth/reearth/commit/20635b)
-- UpdateClockLoad deafault true in beta-core ([#480](https://github.com/reearth/reearth/pull/480)) [`6e27b8`](https://github.com/reearth/reearth/commit/6e27b8)
-- Set updateClockOnLoad default value as true ([#470](https://github.com/reearth/reearth/pull/470)) [`b61d6e`](https://github.com/reearth/reearth/commit/b61d6e)
-- Use error boundary in core Visualizer ([#442](https://github.com/reearth/reearth/pull/442)) [`c3bca4`](https://github.com/reearth/reearth/commit/c3bca4)
-- Stories name conflicts ([#439](https://github.com/reearth/reearth/pull/439)) [`e59e2a`](https://github.com/reearth/reearth/commit/e59e2a)
-- Storybook v7 setup ([#438](https://github.com/reearth/reearth/pull/438)) [`77fe8e`](https://github.com/reearth/reearth/commit/77fe8e)
-- Auth0 error when refresh token ([#436](https://github.com/reearth/reearth/pull/436)) [`db7b69`](https://github.com/reearth/reearth/commit/db7b69)
+- Infobox showing [object object] on click ([#487](https://github.com/reearth/reearth-visualizer/pull/487)) [`90c38e`](https://github.com/reearth/reearth-visualizer/commit/90c38e)
+- Parse properties(feature) recursively before using in evaluator at core ([#479](https://github.com/reearth/reearth-visualizer/pull/479)) [`20635b`](https://github.com/reearth/reearth-visualizer/commit/20635b)
+- UpdateClockLoad deafault true in beta-core ([#480](https://github.com/reearth/reearth-visualizer/pull/480)) [`6e27b8`](https://github.com/reearth/reearth-visualizer/commit/6e27b8)
+- Set updateClockOnLoad default value as true ([#470](https://github.com/reearth/reearth-visualizer/pull/470)) [`b61d6e`](https://github.com/reearth/reearth-visualizer/commit/b61d6e)
+- Use error boundary in core Visualizer ([#442](https://github.com/reearth/reearth-visualizer/pull/442)) [`c3bca4`](https://github.com/reearth/reearth-visualizer/commit/c3bca4)
+- Stories name conflicts ([#439](https://github.com/reearth/reearth-visualizer/pull/439)) [`e59e2a`](https://github.com/reearth/reearth-visualizer/commit/e59e2a)
+- Storybook v7 setup ([#438](https://github.com/reearth/reearth-visualizer/pull/438)) [`77fe8e`](https://github.com/reearth/reearth-visualizer/commit/77fe8e)
+- Auth0 error when refresh token ([#436](https://github.com/reearth/reearth-visualizer/pull/436)) [`db7b69`](https://github.com/reearth/reearth-visualizer/commit/db7b69)
 
 #### ✨ Refactor
 
-- Beta visualizer ([#469](https://github.com/reearth/reearth/pull/469)) [`332db7`](https://github.com/reearth/reearth/commit/332db7)
-- Storybook setup ([#457](https://github.com/reearth/reearth/pull/457)) [`4b0c52`](https://github.com/reearth/reearth/commit/4b0c52)
-- Beta tab routing ([#448](https://github.com/reearth/reearth/pull/448)) [`4f1678`](https://github.com/reearth/reearth/commit/4f1678)
-- Routing ([#447](https://github.com/reearth/reearth/pull/447)) [`ca7216`](https://github.com/reearth/reearth/commit/ca7216)
+- Beta visualizer ([#469](https://github.com/reearth/reearth-visualizer/pull/469)) [`332db7`](https://github.com/reearth/reearth-visualizer/commit/332db7)
+- Storybook setup ([#457](https://github.com/reearth/reearth-visualizer/pull/457)) [`4b0c52`](https://github.com/reearth/reearth-visualizer/commit/4b0c52)
+- Beta tab routing ([#448](https://github.com/reearth/reearth-visualizer/pull/448)) [`4f1678`](https://github.com/reearth/reearth-visualizer/commit/4f1678)
+- Routing ([#447](https://github.com/reearth/reearth-visualizer/pull/447)) [`ca7216`](https://github.com/reearth/reearth-visualizer/commit/ca7216)
 
 #### Miscellaneous Tasks
 
-- Add theming support for components in storybook ([#481](https://github.com/reearth/reearth/pull/481)) [`7cdea3`](https://github.com/reearth/reearth/commit/7cdea3)
-- Add TabButton component ([#464](https://github.com/reearth/reearth/pull/464)) [`342a03`](https://github.com/reearth/reearth/commit/342a03)
-- Add beta editor layout ([#463](https://github.com/reearth/reearth/pull/463)) [`96c473`](https://github.com/reearth/reearth/commit/96c473)
-- Move visualizer to beta ([#460](https://github.com/reearth/reearth/pull/460)) [`5ed819`](https://github.com/reearth/reearth/commit/5ed819)
-- Copy Icon component from classic ([#455](https://github.com/reearth/reearth/pull/455)) [`994287`](https://github.com/reearth/reearth/commit/994287)
-- Upgrade vite version ([#458](https://github.com/reearth/reearth/pull/458)) [`3e3cb9`](https://github.com/reearth/reearth/commit/3e3cb9)
-- Improve storybook preview setting ([#456](https://github.com/reearth/reearth/pull/456)) [`16d7ac`](https://github.com/reearth/reearth/commit/16d7ac)
-- Update eslint and tsconfig to include &#x60;any&#x60; use ([#452](https://github.com/reearth/reearth/pull/452)) [`13ae38`](https://github.com/reearth/reearth/commit/13ae38)
+- Add theming support for components in storybook ([#481](https://github.com/reearth/reearth-visualizer/pull/481)) [`7cdea3`](https://github.com/reearth/reearth-visualizer/commit/7cdea3)
+- Add TabButton component ([#464](https://github.com/reearth/reearth-visualizer/pull/464)) [`342a03`](https://github.com/reearth/reearth-visualizer/commit/342a03)
+- Add beta editor layout ([#463](https://github.com/reearth/reearth-visualizer/pull/463)) [`96c473`](https://github.com/reearth/reearth-visualizer/commit/96c473)
+- Move visualizer to beta ([#460](https://github.com/reearth/reearth-visualizer/pull/460)) [`5ed819`](https://github.com/reearth/reearth-visualizer/commit/5ed819)
+- Copy Icon component from classic ([#455](https://github.com/reearth/reearth-visualizer/pull/455)) [`994287`](https://github.com/reearth/reearth-visualizer/commit/994287)
+- Upgrade vite version ([#458](https://github.com/reearth/reearth-visualizer/pull/458)) [`3e3cb9`](https://github.com/reearth/reearth-visualizer/commit/3e3cb9)
+- Improve storybook preview setting ([#456](https://github.com/reearth/reearth-visualizer/pull/456)) [`16d7ac`](https://github.com/reearth/reearth-visualizer/commit/16d7ac)
+- Update eslint and tsconfig to include &#x60;any&#x60; use ([#452](https://github.com/reearth/reearth-visualizer/pull/452)) [`13ae38`](https://github.com/reearth/reearth-visualizer/commit/13ae38)
 
 ### Server
 
 #### 🚀 Features
 
-- Support AWS S3 storage ([#440](https://github.com/reearth/reearth/pull/440)) [`8c56c7`](https://github.com/reearth/reearth/commit/8c56c7)
-- Support AWS Cognito auth server ([#450](https://github.com/reearth/reearth/pull/450)) [`2002db`](https://github.com/reearth/reearth/commit/2002db)
-- Support AWS SES mailer ([#441](https://github.com/reearth/reearth/pull/441)) [`23be7b`](https://github.com/reearth/reearth/commit/23be7b)
-- Add coreSupport flag to project ([#424](https://github.com/reearth/reearth/pull/424)) [`dacc3d`](https://github.com/reearth/reearth/commit/dacc3d)
+- Support AWS S3 storage ([#440](https://github.com/reearth/reearth-visualizer/pull/440)) [`8c56c7`](https://github.com/reearth/reearth-visualizer/commit/8c56c7)
+- Support AWS Cognito auth server ([#450](https://github.com/reearth/reearth-visualizer/pull/450)) [`2002db`](https://github.com/reearth/reearth-visualizer/commit/2002db)
+- Support AWS SES mailer ([#441](https://github.com/reearth/reearth-visualizer/pull/441)) [`23be7b`](https://github.com/reearth/reearth-visualizer/commit/23be7b)
+- Add coreSupport flag to project ([#424](https://github.com/reearth/reearth-visualizer/pull/424)) [`dacc3d`](https://github.com/reearth/reearth-visualizer/commit/dacc3d)
 
 #### 🔧 Bug Fixes
 
-- Plugin migrator did not update layers [`d0524e`](https://github.com/reearth/reearth/commit/d0524e)
-- Plugin update cause layer corruption ([#431](https://github.com/reearth/reearth/pull/431)) [`f2dd7b`](https://github.com/reearth/reearth/commit/f2dd7b)
-- Fs does not work on windows ([#430](https://github.com/reearth/reearth/pull/430)) [`189039`](https://github.com/reearth/reearth/commit/189039)
+- Plugin migrator did not update layers [`d0524e`](https://github.com/reearth/reearth-visualizer/commit/d0524e)
+- Plugin update cause layer corruption ([#431](https://github.com/reearth/reearth-visualizer/pull/431)) [`f2dd7b`](https://github.com/reearth/reearth-visualizer/commit/f2dd7b)
+- Fs does not work on windows ([#430](https://github.com/reearth/reearth-visualizer/pull/430)) [`189039`](https://github.com/reearth/reearth-visualizer/commit/189039)
 
 #### ✨ Refactor
 
-- Use reearthx auth middleware ([#468](https://github.com/reearth/reearth/pull/468)) [`e9e4c6`](https://github.com/reearth/reearth/commit/e9e4c6)
-- Graphql schema ([#446](https://github.com/reearth/reearth/pull/446)) [`ee0710`](https://github.com/reearth/reearth/commit/ee0710)
-- Use reearthx mailer ([#445](https://github.com/reearth/reearth/pull/445)) [`f27b78`](https://github.com/reearth/reearth/commit/f27b78)
+- Use reearthx auth middleware ([#468](https://github.com/reearth/reearth-visualizer/pull/468)) [`e9e4c6`](https://github.com/reearth/reearth-visualizer/commit/e9e4c6)
+- Graphql schema ([#446](https://github.com/reearth/reearth-visualizer/pull/446)) [`ee0710`](https://github.com/reearth/reearth-visualizer/commit/ee0710)
+- Use reearthx mailer ([#445](https://github.com/reearth/reearth-visualizer/pull/445)) [`f27b78`](https://github.com/reearth/reearth-visualizer/commit/f27b78)
 
 #### 🧪 Testing
 
-- Fix project created at in unit test ([#477](https://github.com/reearth/reearth/pull/477)) [`640c7e`](https://github.com/reearth/reearth/commit/640c7e)
+- Fix project created at in unit test ([#477](https://github.com/reearth/reearth-visualizer/pull/477)) [`640c7e`](https://github.com/reearth/reearth-visualizer/commit/640c7e)
 
 #### Miscellaneous Tasks
 
-- Upgrade go to v1.20 [`e0790f`](https://github.com/reearth/reearth/commit/e0790f)
+- Upgrade go to v1.20 [`e0790f`](https://github.com/reearth/reearth-visualizer/commit/e0790f)
 
 ### Misc
 
 #### 📖 Documentation
 
-- Add badges to server and web READMEs ([#454](https://github.com/reearth/reearth/pull/454)) [`7cbce1`](https://github.com/reearth/reearth/commit/7cbce1)
+- Add badges to server and web READMEs ([#454](https://github.com/reearth/reearth-visualizer/pull/454)) [`7cbce1`](https://github.com/reearth/reearth-visualizer/commit/7cbce1)
 
 #### Miscellaneous Tasks
 
-- Update to 0.16.0 for the release [`561ed8`](https://github.com/reearth/reearth/commit/561ed8)
-- Update CODEOWNERS ([#482](https://github.com/reearth/reearth/pull/482)) [`dbac02`](https://github.com/reearth/reearth/commit/dbac02)
-- Add ActionButton icon ([#461](https://github.com/reearth/reearth/pull/461)) [`ef30ad`](https://github.com/reearth/reearth/commit/ef30ad)
-- Remove netlify.toml ([#435](https://github.com/reearth/reearth/pull/435)) [`48a8cf`](https://github.com/reearth/reearth/commit/48a8cf)
+- Update to 0.16.0 for the release [`561ed8`](https://github.com/reearth/reearth-visualizer/commit/561ed8)
+- Update CODEOWNERS ([#482](https://github.com/reearth/reearth-visualizer/pull/482)) [`dbac02`](https://github.com/reearth/reearth-visualizer/commit/dbac02)
+- Add ActionButton icon ([#461](https://github.com/reearth/reearth-visualizer/pull/461)) [`ef30ad`](https://github.com/reearth/reearth-visualizer/commit/ef30ad)
+- Remove netlify.toml ([#435](https://github.com/reearth/reearth-visualizer/pull/435)) [`48a8cf`](https://github.com/reearth/reearth-visualizer/commit/48a8cf)
 
 #### 
 
-- Update readmes [`976835`](https://github.com/reearth/reearth/commit/976835)
-- Update for v0.15.1 [`a4ada6`](https://github.com/reearth/reearth/commit/a4ada6)
+- Update readmes [`976835`](https://github.com/reearth/reearth-visualizer/commit/976835)
+- Update for v0.15.1 [`a4ada6`](https://github.com/reearth/reearth-visualizer/commit/a4ada6)
 
 ### 
 
 #### 📖 Documentation
 
-- Add badges to server and web READMEs ([#454](https://github.com/reearth/reearth/pull/454)) [`7cbce1`](https://github.com/reearth/reearth/commit/7cbce1)
+- Add badges to server and web READMEs ([#454](https://github.com/reearth/reearth-visualizer/pull/454)) [`7cbce1`](https://github.com/reearth/reearth-visualizer/commit/7cbce1)
 
 #### Miscellaneous Tasks
 
-- Update to 0.16.0 for the release [`561ed8`](https://github.com/reearth/reearth/commit/561ed8)
-- Update CODEOWNERS ([#482](https://github.com/reearth/reearth/pull/482)) [`dbac02`](https://github.com/reearth/reearth/commit/dbac02)
-- Add ActionButton icon ([#461](https://github.com/reearth/reearth/pull/461)) [`ef30ad`](https://github.com/reearth/reearth/commit/ef30ad)
-- Remove netlify.toml ([#435](https://github.com/reearth/reearth/pull/435)) [`48a8cf`](https://github.com/reearth/reearth/commit/48a8cf)
+- Update to 0.16.0 for the release [`561ed8`](https://github.com/reearth/reearth-visualizer/commit/561ed8)
+- Update CODEOWNERS ([#482](https://github.com/reearth/reearth-visualizer/pull/482)) [`dbac02`](https://github.com/reearth/reearth-visualizer/commit/dbac02)
+- Add ActionButton icon ([#461](https://github.com/reearth/reearth-visualizer/pull/461)) [`ef30ad`](https://github.com/reearth/reearth-visualizer/commit/ef30ad)
+- Remove netlify.toml ([#435](https://github.com/reearth/reearth-visualizer/pull/435)) [`48a8cf`](https://github.com/reearth/reearth-visualizer/commit/48a8cf)
 
 #### 
 
-- Update readmes [`976835`](https://github.com/reearth/reearth/commit/976835)
-- Update for v0.15.1 [`a4ada6`](https://github.com/reearth/reearth/commit/a4ada6)
+- Update readmes [`976835`](https://github.com/reearth/reearth-visualizer/commit/976835)
+- Update for v0.15.1 [`a4ada6`](https://github.com/reearth/reearth-visualizer/commit/a4ada6)
 
 ## 0.15.0 - 2023-05-18
 
@@ -804,600 +804,600 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Support nested style expression object in style evaluator ([#423](https://github.com/reearth/reearth/pull/423)) [`60b52c`](https://github.com/reearth/reearth/commit/60b52c)
-- Add reearth ver support in profile header ([#428](https://github.com/reearth/reearth/pull/428)) [`d1125e`](https://github.com/reearth/reearth/commit/d1125e)
-- Sandbox plugin iframe - alpha ([#399](https://github.com/reearth/reearth/pull/399)) [`d77fcb`](https://github.com/reearth/reearth/commit/d77fcb)
-- Add netlify to web ([#413](https://github.com/reearth/reearth/pull/413)) [`ce6935`](https://github.com/reearth/reearth/commit/ce6935)
-- Support csv download for Dataset in setting page  ([#410](https://github.com/reearth/reearth/pull/410)) [`3bb0a0`](https://github.com/reearth/reearth/commit/3bb0a0)
-- Properties for widget areas ([#427](https://github.com/reearth/reearth/pull/427)) [`e6e805`](https://github.com/reearth/reearth/commit/e6e805)
+- Support nested style expression object in style evaluator ([#423](https://github.com/reearth/reearth-visualizer/pull/423)) [`60b52c`](https://github.com/reearth/reearth-visualizer/commit/60b52c)
+- Add reearth ver support in profile header ([#428](https://github.com/reearth/reearth-visualizer/pull/428)) [`d1125e`](https://github.com/reearth/reearth-visualizer/commit/d1125e)
+- Sandbox plugin iframe - alpha ([#399](https://github.com/reearth/reearth-visualizer/pull/399)) [`d77fcb`](https://github.com/reearth/reearth-visualizer/commit/d77fcb)
+- Add netlify to web ([#413](https://github.com/reearth/reearth-visualizer/pull/413)) [`ce6935`](https://github.com/reearth/reearth-visualizer/commit/ce6935)
+- Support csv download for Dataset in setting page  ([#410](https://github.com/reearth/reearth-visualizer/pull/410)) [`3bb0a0`](https://github.com/reearth/reearth-visualizer/commit/3bb0a0)
+- Properties for widget areas ([#427](https://github.com/reearth/reearth-visualizer/pull/427)) [`e6e805`](https://github.com/reearth/reearth-visualizer/commit/e6e805)
 
 #### 🔧 Bug Fixes
 
-- Add data url to componentId for better tracking of component in core ([#421](https://github.com/reearth/reearth/pull/421)) [`c3ab03`](https://github.com/reearth/reearth/commit/c3ab03)
-- Update cesium version to 1.105.2 from 1.105.1 ([#425](https://github.com/reearth/reearth/pull/425)) [`de8896`](https://github.com/reearth/reearth/commit/de8896)
-- Create new workspace doesn&[#39](https://github.com/reearth/reearth/pull/39);t save session ([#417](https://github.com/reearth/reearth/pull/417)) [`2c36e7`](https://github.com/reearth/reearth/commit/2c36e7)
-- Classic infobox always shown for 3d tiles ([#416](https://github.com/reearth/reearth/pull/416)) [`a7a944`](https://github.com/reearth/reearth/commit/a7a944)
-- Wrong last workspace value when multiple tabs ([#405](https://github.com/reearth/reearth/pull/405)) [`d68440`](https://github.com/reearth/reearth/commit/d68440)
-- Feature containing layer show hide not working ([#412](https://github.com/reearth/reearth/pull/412)) [`2a97ef`](https://github.com/reearth/reearth/commit/2a97ef)
-- Point cloud style converse error with undefined ([#398](https://github.com/reearth/reearth/pull/398)) [`9bf955`](https://github.com/reearth/reearth/commit/9bf955)
-- Remove package.json yarn.lock from root ([#395](https://github.com/reearth/reearth/pull/395)) [`a87a2c`](https://github.com/reearth/reearth/commit/a87a2c)
-- Pre-commit hook with husky [`b96641`](https://github.com/reearth/reearth/commit/b96641)
-- Widget align system ([#436](https://github.com/reearth/reearth/pull/436)) [`0b8c85`](https://github.com/reearth/reearth/commit/0b8c85)
+- Add data url to componentId for better tracking of component in core ([#421](https://github.com/reearth/reearth-visualizer/pull/421)) [`c3ab03`](https://github.com/reearth/reearth-visualizer/commit/c3ab03)
+- Update cesium version to 1.105.2 from 1.105.1 ([#425](https://github.com/reearth/reearth-visualizer/pull/425)) [`de8896`](https://github.com/reearth/reearth-visualizer/commit/de8896)
+- Create new workspace doesn&[#39](https://github.com/reearth/reearth-visualizer/pull/39);t save session ([#417](https://github.com/reearth/reearth-visualizer/pull/417)) [`2c36e7`](https://github.com/reearth/reearth-visualizer/commit/2c36e7)
+- Classic infobox always shown for 3d tiles ([#416](https://github.com/reearth/reearth-visualizer/pull/416)) [`a7a944`](https://github.com/reearth/reearth-visualizer/commit/a7a944)
+- Wrong last workspace value when multiple tabs ([#405](https://github.com/reearth/reearth-visualizer/pull/405)) [`d68440`](https://github.com/reearth/reearth-visualizer/commit/d68440)
+- Feature containing layer show hide not working ([#412](https://github.com/reearth/reearth-visualizer/pull/412)) [`2a97ef`](https://github.com/reearth/reearth-visualizer/commit/2a97ef)
+- Point cloud style converse error with undefined ([#398](https://github.com/reearth/reearth-visualizer/pull/398)) [`9bf955`](https://github.com/reearth/reearth-visualizer/commit/9bf955)
+- Remove package.json yarn.lock from root ([#395](https://github.com/reearth/reearth-visualizer/pull/395)) [`a87a2c`](https://github.com/reearth/reearth-visualizer/commit/a87a2c)
+- Pre-commit hook with husky [`b96641`](https://github.com/reearth/reearth-visualizer/commit/b96641)
+- Widget align system ([#436](https://github.com/reearth/reearth-visualizer/pull/436)) [`0b8c85`](https://github.com/reearth/reearth-visualizer/commit/0b8c85)
 
 #### Miscellaneous Tasks
 
-- Upgrade auth0 to version 2 ([#420](https://github.com/reearth/reearth/pull/420)) [`abfb4d`](https://github.com/reearth/reearth/commit/abfb4d)
-- Update dependencies ([#411](https://github.com/reearth/reearth/pull/411)) [`58632a`](https://github.com/reearth/reearth/commit/58632a)
-- Remove redundant comments [`57aa3c`](https://github.com/reearth/reearth/commit/57aa3c)
-- Purge reearth-web of reference to team-Setting page ([#394](https://github.com/reearth/reearth/pull/394)) [`bc6d01`](https://github.com/reearth/reearth/commit/bc6d01)
+- Upgrade auth0 to version 2 ([#420](https://github.com/reearth/reearth-visualizer/pull/420)) [`abfb4d`](https://github.com/reearth/reearth-visualizer/commit/abfb4d)
+- Update dependencies ([#411](https://github.com/reearth/reearth-visualizer/pull/411)) [`58632a`](https://github.com/reearth/reearth-visualizer/commit/58632a)
+- Remove redundant comments [`57aa3c`](https://github.com/reearth/reearth-visualizer/commit/57aa3c)
+- Purge reearth-web of reference to team-Setting page ([#394](https://github.com/reearth/reearth-visualizer/pull/394)) [`bc6d01`](https://github.com/reearth/reearth-visualizer/commit/bc6d01)
 
 ### Server
 
 #### 🚀 Features
 
-- Export dataset as csv ([#409](https://github.com/reearth/reearth/pull/409)) [`79077b`](https://github.com/reearth/reearth/commit/79077b)
-- Add experimental_sandbox option to scene settings [`8d688c`](https://github.com/reearth/reearth/commit/8d688c)
-- REEARTH_WEB_CONFIG envvar [`e6e79e`](https://github.com/reearth/reearth/commit/e6e79e)
-- Vr mode in scene property [`53030d`](https://github.com/reearth/reearth/commit/53030d)
-- Add config to disable web feature [`654758`](https://github.com/reearth/reearth/commit/654758)
-- Serve published pages on root path ([#386](https://github.com/reearth/reearth/pull/386)) [`845531`](https://github.com/reearth/reearth/commit/845531)
-- Label background padding for markers [`160944`](https://github.com/reearth/reearth/commit/160944)
-- Label background color property field for markers [`ac10b4`](https://github.com/reearth/reearth/commit/ac10b4)
-- Add padding properties to widget align system area ([#381](https://github.com/reearth/reearth/pull/381)) [`d5dbcf`](https://github.com/reearth/reearth/commit/d5dbcf)
-- Add Visible field to built-in widgets ([#380](https://github.com/reearth/reearth/pull/380)) [`8c1d82`](https://github.com/reearth/reearth/commit/8c1d82)
+- Export dataset as csv ([#409](https://github.com/reearth/reearth-visualizer/pull/409)) [`79077b`](https://github.com/reearth/reearth-visualizer/commit/79077b)
+- Add experimental_sandbox option to scene settings [`8d688c`](https://github.com/reearth/reearth-visualizer/commit/8d688c)
+- REEARTH_WEB_CONFIG envvar [`e6e79e`](https://github.com/reearth/reearth-visualizer/commit/e6e79e)
+- Vr mode in scene property [`53030d`](https://github.com/reearth/reearth-visualizer/commit/53030d)
+- Add config to disable web feature [`654758`](https://github.com/reearth/reearth-visualizer/commit/654758)
+- Serve published pages on root path ([#386](https://github.com/reearth/reearth-visualizer/pull/386)) [`845531`](https://github.com/reearth/reearth-visualizer/commit/845531)
+- Label background padding for markers [`160944`](https://github.com/reearth/reearth-visualizer/commit/160944)
+- Label background color property field for markers [`ac10b4`](https://github.com/reearth/reearth-visualizer/commit/ac10b4)
+- Add padding properties to widget align system area ([#381](https://github.com/reearth/reearth-visualizer/pull/381)) [`d5dbcf`](https://github.com/reearth/reearth-visualizer/commit/d5dbcf)
+- Add Visible field to built-in widgets ([#380](https://github.com/reearth/reearth-visualizer/pull/380)) [`8c1d82`](https://github.com/reearth/reearth-visualizer/commit/8c1d82)
 
 #### 🔧 Bug Fixes
 
-- Fix favicon url [`12dafb`](https://github.com/reearth/reearth/commit/12dafb)
-- Rewrite title and favicon for published html [`03b5be`](https://github.com/reearth/reearth/commit/03b5be)
-- Env vars to change html title and favicon ([#390](https://github.com/reearth/reearth/pull/390)) [`a9910c`](https://github.com/reearth/reearth/commit/a9910c)
-- Upload assets outside transaction [`afc7e2`](https://github.com/reearth/reearth/commit/afc7e2)
-- Handle transaction correctly [`4b164b`](https://github.com/reearth/reearth/commit/4b164b)
-- Prefer dataset values when merging properties ([#388](https://github.com/reearth/reearth/pull/388)) [`8112f7`](https://github.com/reearth/reearth/commit/8112f7)
-- Add schema to published field in web config [`b17807`](https://github.com/reearth/reearth/commit/b17807)
-- Add published field to web config [`18fdf7`](https://github.com/reearth/reearth/commit/18fdf7)
-- Description of experimental flag in scene property [`b04157`](https://github.com/reearth/reearth/commit/b04157)
-- Htmlblock order ([#385](https://github.com/reearth/reearth/pull/385)) [`bb1b9c`](https://github.com/reearth/reearth/commit/bb1b9c)
-- Use auth0 web client id for reearth_config.json [`634799`](https://github.com/reearth/reearth/commit/634799)
-- Make widget area gap optional ([#383](https://github.com/reearth/reearth/pull/383)) [`1e00ca`](https://github.com/reearth/reearth/commit/1e00ca)
-- Widget padding fixes ([#382](https://github.com/reearth/reearth/pull/382)) [`a019c5`](https://github.com/reearth/reearth/commit/a019c5)
-- Widget area could not be saved and loaded to mongo [`3f3adf`](https://github.com/reearth/reearth/commit/3f3adf)
-- Public plugin was deleted on installing privte plugin that has same name [`d24034`](https://github.com/reearth/reearth/commit/d24034)
+- Fix favicon url [`12dafb`](https://github.com/reearth/reearth-visualizer/commit/12dafb)
+- Rewrite title and favicon for published html [`03b5be`](https://github.com/reearth/reearth-visualizer/commit/03b5be)
+- Env vars to change html title and favicon ([#390](https://github.com/reearth/reearth-visualizer/pull/390)) [`a9910c`](https://github.com/reearth/reearth-visualizer/commit/a9910c)
+- Upload assets outside transaction [`afc7e2`](https://github.com/reearth/reearth-visualizer/commit/afc7e2)
+- Handle transaction correctly [`4b164b`](https://github.com/reearth/reearth-visualizer/commit/4b164b)
+- Prefer dataset values when merging properties ([#388](https://github.com/reearth/reearth-visualizer/pull/388)) [`8112f7`](https://github.com/reearth/reearth-visualizer/commit/8112f7)
+- Add schema to published field in web config [`b17807`](https://github.com/reearth/reearth-visualizer/commit/b17807)
+- Add published field to web config [`18fdf7`](https://github.com/reearth/reearth-visualizer/commit/18fdf7)
+- Description of experimental flag in scene property [`b04157`](https://github.com/reearth/reearth-visualizer/commit/b04157)
+- Htmlblock order ([#385](https://github.com/reearth/reearth-visualizer/pull/385)) [`bb1b9c`](https://github.com/reearth/reearth-visualizer/commit/bb1b9c)
+- Use auth0 web client id for reearth_config.json [`634799`](https://github.com/reearth/reearth-visualizer/commit/634799)
+- Make widget area gap optional ([#383](https://github.com/reearth/reearth-visualizer/pull/383)) [`1e00ca`](https://github.com/reearth/reearth-visualizer/commit/1e00ca)
+- Widget padding fixes ([#382](https://github.com/reearth/reearth-visualizer/pull/382)) [`a019c5`](https://github.com/reearth/reearth-visualizer/commit/a019c5)
+- Widget area could not be saved and loaded to mongo [`3f3adf`](https://github.com/reearth/reearth-visualizer/commit/3f3adf)
+- Public plugin was deleted on installing privte plugin that has same name [`d24034`](https://github.com/reearth/reearth-visualizer/commit/d24034)
 
 #### ✨ Refactor
 
-- Use reearthx cache ([#401](https://github.com/reearth/reearth/pull/401)) [`c4811d`](https://github.com/reearth/reearth/commit/c4811d)
+- Use reearthx cache ([#401](https://github.com/reearth/reearth-visualizer/pull/401)) [`c4811d`](https://github.com/reearth/reearth-visualizer/commit/c4811d)
 
 #### 🧪 Testing
 
-- Some unit test fails on windows ([#392](https://github.com/reearth/reearth/pull/392)) [`bc89f3`](https://github.com/reearth/reearth/commit/bc89f3)
+- Some unit test fails on windows ([#392](https://github.com/reearth/reearth-visualizer/pull/392)) [`bc89f3`](https://github.com/reearth/reearth-visualizer/commit/bc89f3)
 
 #### Miscellaneous Tasks
 
-- Lowercase the error message [`c22565`](https://github.com/reearth/reearth/commit/c22565)
-- Upgrade ci go linter to 1.52.* ([#402](https://github.com/reearth/reearth/pull/402)) [`2a87bb`](https://github.com/reearth/reearth/commit/2a87bb)
-- Advanced option to scene settings [`707601`](https://github.com/reearth/reearth/commit/707601)
-- Upgrade deps [`bed3f2`](https://github.com/reearth/reearth/commit/bed3f2)
-- Add logs to plugin download from marketplace [`436b68`](https://github.com/reearth/reearth/commit/436b68)
+- Lowercase the error message [`c22565`](https://github.com/reearth/reearth-visualizer/commit/c22565)
+- Upgrade ci go linter to 1.52.* ([#402](https://github.com/reearth/reearth-visualizer/pull/402)) [`2a87bb`](https://github.com/reearth/reearth-visualizer/commit/2a87bb)
+- Advanced option to scene settings [`707601`](https://github.com/reearth/reearth-visualizer/commit/707601)
+- Upgrade deps [`bed3f2`](https://github.com/reearth/reearth-visualizer/commit/bed3f2)
+- Add logs to plugin download from marketplace [`436b68`](https://github.com/reearth/reearth-visualizer/commit/436b68)
 
 ### Misc
 
 #### 🚀 Features
 
-- Support polyline and point on reearth&#x2F;core ([#606](https://github.com/reearth/reearth/pull/606)) [`abd9a3`](https://github.com/reearth/reearth/commit/abd9a3)
-- Add remembering last open workspace functionality ([#598](https://github.com/reearth/reearth/pull/598)) [`968a9d`](https://github.com/reearth/reearth/commit/968a9d)
-- Support TileMapService(TMS) on reearth&#x2F;core ([#604](https://github.com/reearth/reearth/pull/604)) [`284b35`](https://github.com/reearth/reearth/commit/284b35)
-- Support styling color &amp; show for 3dtiles model ([#599](https://github.com/reearth/reearth/pull/599)) [`a82ca2`](https://github.com/reearth/reearth/commit/a82ca2)
-- Support tiles data type on reearth&#x2F;core ([#597](https://github.com/reearth/reearth/pull/597) [`ae5c49`](https://github.com/reearth/reearth/commit/ae5c49)
-- Support classificationType property in some feature on reearth&#x2F;core ([#593](https://github.com/reearth/reearth/pull/593)) [`897868`](https://github.com/reearth/reearth/commit/897868)
-- Upgrade cesium-mvt-imagery-provider ([#591](https://github.com/reearth/reearth/pull/591)) [`d01d01`](https://github.com/reearth/reearth/commit/d01d01)
-- Upgrade cesium-mvt-imagery-provider ([#588](https://github.com/reearth/reearth/pull/588)) [`e138bd`](https://github.com/reearth/reearth/commit/e138bd)
-- Add more styling properties to resource appearance in reearth&#x2F;core ([#586](https://github.com/reearth/reearth/pull/586)) [`8f3625`](https://github.com/reearth/reearth/commit/8f3625)
-- Add built field in scene in plugin api ([#584](https://github.com/reearth/reearth/pull/584)) [`e8050c`](https://github.com/reearth/reearth/commit/e8050c)
-- Add scene light ([#576](https://github.com/reearth/reearth/pull/576)) [`43c2b8`](https://github.com/reearth/reearth/commit/43c2b8)
-- Upgrade mvt lib ([#575](https://github.com/reearth/reearth/pull/575)) [`584cee`](https://github.com/reearth/reearth/commit/584cee)
-- Option to unselect layer when click infobox close ([#564](https://github.com/reearth/reearth/pull/564)) [`f2b2f2`](https://github.com/reearth/reearth/commit/f2b2f2)
-- Add alpha property to raster appearance on reearth&#x2F;core ([#555](https://github.com/reearth/reearth/pull/555)) [`541f30`](https://github.com/reearth/reearth/commit/541f30)
-- Support styling for point cloud on reearth&#x2F;core ([#549](https://github.com/reearth/reearth/pull/549)) [`f410d6`](https://github.com/reearth/reearth/commit/f410d6)
-- Add defaultContent property for infobox in plugin API on reearth&#x2F;core ([#538](https://github.com/reearth/reearth/pull/538)) [`31ba31`](https://github.com/reearth/reearth/commit/31ba31)
-- Add updateClockOnLoad  to data on reearth&#x2F;core ([#539](https://github.com/reearth/reearth/pull/539)) [`3653e2`](https://github.com/reearth/reearth/commit/3653e2)
-- Support gltf data type on reearth&#x2F;core ([#535](https://github.com/reearth/reearth/pull/535)) [`e086be`](https://github.com/reearth/reearth/commit/e086be)
-- Support ga4 ([#509](https://github.com/reearth/reearth/pull/509)) [`39bfb0`](https://github.com/reearth/reearth/commit/39bfb0)
-- Select MVT feature on reearth&#x2F;core ([#527](https://github.com/reearth/reearth/pull/527)) [`de605d`](https://github.com/reearth/reearth/commit/de605d)
-- Add parameters property to data on reearth&#x2F;core ([#520](https://github.com/reearth/reearth/pull/520)) [`c698eb`](https://github.com/reearth/reearth/commit/c698eb)
-- Layer select event in reearth&#x2F;core ([#470](https://github.com/reearth/reearth/pull/470)) [`fb22e6`](https://github.com/reearth/reearth/commit/fb22e6)
-- Show field in appearances of reearth&#x2F;core ([#469](https://github.com/reearth/reearth/pull/469)) [`819eb6`](https://github.com/reearth/reearth/commit/819eb6)
-- ImageSizeInMeters field in marker proeperty ([#511](https://github.com/reearth/reearth/pull/511)) [`290cb7`](https://github.com/reearth/reearth/commit/290cb7)
-- Override clock from scene setting on reearth&#x2F;core ([#505](https://github.com/reearth/reearth/pull/505)) [`01bffd`](https://github.com/reearth/reearth/commit/01bffd)
-- Support features for CZML on reearth&#x2F;core ([#506](https://github.com/reearth/reearth/pull/506)) [`e5c160`](https://github.com/reearth/reearth/commit/e5c160)
-- Update cesium ([#503](https://github.com/reearth/reearth/pull/503)) [`5a649f`](https://github.com/reearth/reearth/commit/5a649f)
-- Color blend mode in tileset on reearth&#x2F;core ([#496](https://github.com/reearth/reearth/pull/496)) [`ca43dc`](https://github.com/reearth/reearth/commit/ca43dc)
-- Change brand images and colors at the root page ([#495](https://github.com/reearth/reearth/pull/495))Co-authored-by: rot1024 &lt;aayhrot@gmail.com&gt; [`4f07b9`](https://github.com/reearth/reearth/commit/4f07b9)
-- Add builtin clipping box on reearth&#x2F;core ([#487](https://github.com/reearth/reearth/pull/487)) [`63bd4f`](https://github.com/reearth/reearth/commit/63bd4f)
-- ExtrudedHeight for polygon on reearth&#x2F;core ([#486](https://github.com/reearth/reearth/pull/486)) [`523d35`](https://github.com/reearth/reearth/commit/523d35)
-- Support resource entity layerId on reearth&#x2F;core ([#485](https://github.com/reearth/reearth/pull/485)) [`7bd7c5`](https://github.com/reearth/reearth/commit/7bd7c5)
-- Support distanceDisplayCondition on reearth&#x2F;core ([#475](https://github.com/reearth/reearth/pull/475)) [`ce8270`](https://github.com/reearth/reearth/commit/ce8270)
-- Support GeoRSS and gml in reearth&#x2F;core ([#455](https://github.com/reearth/reearth/pull/455)) [`58c25b`](https://github.com/reearth/reearth/commit/58c25b)
-- Add htmlblock on reearth&#x2F;core ([#454](https://github.com/reearth/reearth/pull/454)) [`1b37e0`](https://github.com/reearth/reearth/commit/1b37e0)
-- Support clipping box direction on reearth&#x2F;core ([#467](https://github.com/reearth/reearth/pull/467)) [`70f74e`](https://github.com/reearth/reearth/commit/70f74e)
-- Add sampleTerrainHeight on reearht&#x2F;core ([#466](https://github.com/reearth/reearth/pull/466)) [`55334e`](https://github.com/reearth/reearth/commit/55334e)
-- Get brand from config ([#457](https://github.com/reearth/reearth/pull/457)) [`d35361`](https://github.com/reearth/reearth/commit/d35361)
-- Support timeline on mobile on reearth&#x2F;core ([#462](https://github.com/reearth/reearth/pull/462)) [`efeaf4`](https://github.com/reearth/reearth/commit/efeaf4)
-- Use visible field on reearth&#x2F;core ([#456](https://github.com/reearth/reearth/pull/456)) [`333610`](https://github.com/reearth/reearth/commit/333610)
-- Add htmlblock to built-in plugin ([#384](https://github.com/reearth/reearth/pull/384)) [`51c79a`](https://github.com/reearth/reearth/commit/51c79a)
-- Add override, replace and delete plugin API on reearth&#x2F;core ([#451](https://github.com/reearth/reearth/pull/451)) [`2e1c41`](https://github.com/reearth/reearth/commit/2e1c41)
-- Selecting imagery features ([#450](https://github.com/reearth/reearth/pull/450)) [`f24ef5`](https://github.com/reearth/reearth/commit/f24ef5)
-- Support interval fetching data on reearth&#x2F;core ([#449](https://github.com/reearth/reearth/pull/449)) [`406174`](https://github.com/reearth/reearth/commit/406174)
-- Support select feature on reearth&#x2F;core ([#445](https://github.com/reearth/reearth/pull/445)) [`3174b1`](https://github.com/reearth/reearth/commit/3174b1)
-- Use experimental core flag ([#448](https://github.com/reearth/reearth/pull/448)) [`b04294`](https://github.com/reearth/reearth/commit/b04294)
-- Support time series features on reearth&#x2F;core ([#446](https://github.com/reearth/reearth/pull/446)) [`8fc9b6`](https://github.com/reearth/reearth/commit/8fc9b6)
-- Scene property to enable VR mode ([#444](https://github.com/reearth/reearth/pull/444)) [`3d35aa`](https://github.com/reearth/reearth/commit/3d35aa)
-- Support general transit feed ([#408](https://github.com/reearth/reearth/pull/408)) [`49b4a4`](https://github.com/reearth/reearth/commit/49b4a4)
-- Support osm data type on reearth&#x2F;core ([#431](https://github.com/reearth/reearth/pull/431)) [`0d4e0b`](https://github.com/reearth/reearth/commit/0d4e0b)
-- Label background color and padding property for markers ([#426](https://github.com/reearth/reearth/pull/426) [`72cd0d`](https://github.com/reearth/reearth/commit/72cd0d)
-- Support entity base flyTo on reearth&#x2F;core ([#419](https://github.com/reearth/reearth/pull/419)) [`3060cf`](https://github.com/reearth/reearth/commit/3060cf)
-- Support overriding czml appearance on reearth&#x2F;core ([#421](https://github.com/reearth/reearth/pull/421)) [`e62f4d`](https://github.com/reearth/reearth/commit/e62f4d)
-- Support kml on reearth&#x2F;core ([#422](https://github.com/reearth/reearth/pull/422)) [`052daf`](https://github.com/reearth/reearth/commit/052daf)
-- Support json properties on reearth&#x2F;core ([#412](https://github.com/reearth/reearth/pull/412)) [`ac7986`](https://github.com/reearth/reearth/commit/ac7986)
-- Connect reearth&#x2F;core with existence pages ([#401](https://github.com/reearth/reearth/pull/401)) [`0735c0`](https://github.com/reearth/reearth/commit/0735c0)
-- Add runTimes property to PluginInstance ([#404](https://github.com/reearth/reearth/pull/404)) [`17d787`](https://github.com/reearth/reearth/commit/17d787)
-- Support plugin system on reearth&#x2F;core ([#399](https://github.com/reearth/reearth/pull/399)) [`bab9e6`](https://github.com/reearth/reearth/commit/bab9e6)
-- Add selectedFeature and selectedComputedFeature on reearth&#x2F;core ([#398](https://github.com/reearth/reearth/pull/398)) [`474b34`](https://github.com/reearth/reearth/commit/474b34)
-- Set modal above popup ([#397](https://github.com/reearth/reearth/pull/397)) [`ff47c5`](https://github.com/reearth/reearth/commit/ff47c5)
-- Port 2d navigator to reearth&#x2F;core ([#394](https://github.com/reearth/reearth/pull/394)) [`07a6b4`](https://github.com/reearth/reearth/commit/07a6b4)
-- Core&#x2F;Visualizer without plugins ([#372](https://github.com/reearth/reearth/pull/372)) [`f97c38`](https://github.com/reearth/reearth/commit/f97c38)
-- Reearth style language ([#384](https://github.com/reearth/reearth/pull/384)) [`a828ac`](https://github.com/reearth/reearth/commit/a828ac)
-- Support 3dtiles on reearth&#x2F;core ([#392](https://github.com/reearth/reearth/pull/392)) [`e8068f`](https://github.com/reearth/reearth/commit/e8068f)
-- Support MVT on reearth&#x2F;core ([#388](https://github.com/reearth/reearth/pull/388)) [`cac89c`](https://github.com/reearth/reearth/commit/cac89c)
-- Support WMS on reearth&#x2F;core ([#387](https://github.com/reearth/reearth/pull/387)) [`666c1b`](https://github.com/reearth/reearth/commit/666c1b)
-- Support CZML in reearth&#x2F;core ([#383](https://github.com/reearth/reearth/pull/383)) [`f44d98`](https://github.com/reearth/reearth/commit/f44d98)
-- Plugin api client storage ([#376](https://github.com/reearth/reearth/pull/376)) [`4f36ad`](https://github.com/reearth/reearth/commit/4f36ad)
-- Support csv on the reearth&#x2F;core ([#382](https://github.com/reearth/reearth/pull/382)) [`a8f5bf`](https://github.com/reearth/reearth/commit/a8f5bf)
+- Support polyline and point on reearth&#x2F;core ([#606](https://github.com/reearth/reearth-visualizer/pull/606)) [`abd9a3`](https://github.com/reearth/reearth-visualizer/commit/abd9a3)
+- Add remembering last open workspace functionality ([#598](https://github.com/reearth/reearth-visualizer/pull/598)) [`968a9d`](https://github.com/reearth/reearth-visualizer/commit/968a9d)
+- Support TileMapService(TMS) on reearth&#x2F;core ([#604](https://github.com/reearth/reearth-visualizer/pull/604)) [`284b35`](https://github.com/reearth/reearth-visualizer/commit/284b35)
+- Support styling color &amp; show for 3dtiles model ([#599](https://github.com/reearth/reearth-visualizer/pull/599)) [`a82ca2`](https://github.com/reearth/reearth-visualizer/commit/a82ca2)
+- Support tiles data type on reearth&#x2F;core ([#597](https://github.com/reearth/reearth-visualizer/pull/597) [`ae5c49`](https://github.com/reearth/reearth-visualizer/commit/ae5c49)
+- Support classificationType property in some feature on reearth&#x2F;core ([#593](https://github.com/reearth/reearth-visualizer/pull/593)) [`897868`](https://github.com/reearth/reearth-visualizer/commit/897868)
+- Upgrade cesium-mvt-imagery-provider ([#591](https://github.com/reearth/reearth-visualizer/pull/591)) [`d01d01`](https://github.com/reearth/reearth-visualizer/commit/d01d01)
+- Upgrade cesium-mvt-imagery-provider ([#588](https://github.com/reearth/reearth-visualizer/pull/588)) [`e138bd`](https://github.com/reearth/reearth-visualizer/commit/e138bd)
+- Add more styling properties to resource appearance in reearth&#x2F;core ([#586](https://github.com/reearth/reearth-visualizer/pull/586)) [`8f3625`](https://github.com/reearth/reearth-visualizer/commit/8f3625)
+- Add built field in scene in plugin api ([#584](https://github.com/reearth/reearth-visualizer/pull/584)) [`e8050c`](https://github.com/reearth/reearth-visualizer/commit/e8050c)
+- Add scene light ([#576](https://github.com/reearth/reearth-visualizer/pull/576)) [`43c2b8`](https://github.com/reearth/reearth-visualizer/commit/43c2b8)
+- Upgrade mvt lib ([#575](https://github.com/reearth/reearth-visualizer/pull/575)) [`584cee`](https://github.com/reearth/reearth-visualizer/commit/584cee)
+- Option to unselect layer when click infobox close ([#564](https://github.com/reearth/reearth-visualizer/pull/564)) [`f2b2f2`](https://github.com/reearth/reearth-visualizer/commit/f2b2f2)
+- Add alpha property to raster appearance on reearth&#x2F;core ([#555](https://github.com/reearth/reearth-visualizer/pull/555)) [`541f30`](https://github.com/reearth/reearth-visualizer/commit/541f30)
+- Support styling for point cloud on reearth&#x2F;core ([#549](https://github.com/reearth/reearth-visualizer/pull/549)) [`f410d6`](https://github.com/reearth/reearth-visualizer/commit/f410d6)
+- Add defaultContent property for infobox in plugin API on reearth&#x2F;core ([#538](https://github.com/reearth/reearth-visualizer/pull/538)) [`31ba31`](https://github.com/reearth/reearth-visualizer/commit/31ba31)
+- Add updateClockOnLoad  to data on reearth&#x2F;core ([#539](https://github.com/reearth/reearth-visualizer/pull/539)) [`3653e2`](https://github.com/reearth/reearth-visualizer/commit/3653e2)
+- Support gltf data type on reearth&#x2F;core ([#535](https://github.com/reearth/reearth-visualizer/pull/535)) [`e086be`](https://github.com/reearth/reearth-visualizer/commit/e086be)
+- Support ga4 ([#509](https://github.com/reearth/reearth-visualizer/pull/509)) [`39bfb0`](https://github.com/reearth/reearth-visualizer/commit/39bfb0)
+- Select MVT feature on reearth&#x2F;core ([#527](https://github.com/reearth/reearth-visualizer/pull/527)) [`de605d`](https://github.com/reearth/reearth-visualizer/commit/de605d)
+- Add parameters property to data on reearth&#x2F;core ([#520](https://github.com/reearth/reearth-visualizer/pull/520)) [`c698eb`](https://github.com/reearth/reearth-visualizer/commit/c698eb)
+- Layer select event in reearth&#x2F;core ([#470](https://github.com/reearth/reearth-visualizer/pull/470)) [`fb22e6`](https://github.com/reearth/reearth-visualizer/commit/fb22e6)
+- Show field in appearances of reearth&#x2F;core ([#469](https://github.com/reearth/reearth-visualizer/pull/469)) [`819eb6`](https://github.com/reearth/reearth-visualizer/commit/819eb6)
+- ImageSizeInMeters field in marker proeperty ([#511](https://github.com/reearth/reearth-visualizer/pull/511)) [`290cb7`](https://github.com/reearth/reearth-visualizer/commit/290cb7)
+- Override clock from scene setting on reearth&#x2F;core ([#505](https://github.com/reearth/reearth-visualizer/pull/505)) [`01bffd`](https://github.com/reearth/reearth-visualizer/commit/01bffd)
+- Support features for CZML on reearth&#x2F;core ([#506](https://github.com/reearth/reearth-visualizer/pull/506)) [`e5c160`](https://github.com/reearth/reearth-visualizer/commit/e5c160)
+- Update cesium ([#503](https://github.com/reearth/reearth-visualizer/pull/503)) [`5a649f`](https://github.com/reearth/reearth-visualizer/commit/5a649f)
+- Color blend mode in tileset on reearth&#x2F;core ([#496](https://github.com/reearth/reearth-visualizer/pull/496)) [`ca43dc`](https://github.com/reearth/reearth-visualizer/commit/ca43dc)
+- Change brand images and colors at the root page ([#495](https://github.com/reearth/reearth-visualizer/pull/495))Co-authored-by: rot1024 &lt;aayhrot@gmail.com&gt; [`4f07b9`](https://github.com/reearth/reearth-visualizer/commit/4f07b9)
+- Add builtin clipping box on reearth&#x2F;core ([#487](https://github.com/reearth/reearth-visualizer/pull/487)) [`63bd4f`](https://github.com/reearth/reearth-visualizer/commit/63bd4f)
+- ExtrudedHeight for polygon on reearth&#x2F;core ([#486](https://github.com/reearth/reearth-visualizer/pull/486)) [`523d35`](https://github.com/reearth/reearth-visualizer/commit/523d35)
+- Support resource entity layerId on reearth&#x2F;core ([#485](https://github.com/reearth/reearth-visualizer/pull/485)) [`7bd7c5`](https://github.com/reearth/reearth-visualizer/commit/7bd7c5)
+- Support distanceDisplayCondition on reearth&#x2F;core ([#475](https://github.com/reearth/reearth-visualizer/pull/475)) [`ce8270`](https://github.com/reearth/reearth-visualizer/commit/ce8270)
+- Support GeoRSS and gml in reearth&#x2F;core ([#455](https://github.com/reearth/reearth-visualizer/pull/455)) [`58c25b`](https://github.com/reearth/reearth-visualizer/commit/58c25b)
+- Add htmlblock on reearth&#x2F;core ([#454](https://github.com/reearth/reearth-visualizer/pull/454)) [`1b37e0`](https://github.com/reearth/reearth-visualizer/commit/1b37e0)
+- Support clipping box direction on reearth&#x2F;core ([#467](https://github.com/reearth/reearth-visualizer/pull/467)) [`70f74e`](https://github.com/reearth/reearth-visualizer/commit/70f74e)
+- Add sampleTerrainHeight on reearht&#x2F;core ([#466](https://github.com/reearth/reearth-visualizer/pull/466)) [`55334e`](https://github.com/reearth/reearth-visualizer/commit/55334e)
+- Get brand from config ([#457](https://github.com/reearth/reearth-visualizer/pull/457)) [`d35361`](https://github.com/reearth/reearth-visualizer/commit/d35361)
+- Support timeline on mobile on reearth&#x2F;core ([#462](https://github.com/reearth/reearth-visualizer/pull/462)) [`efeaf4`](https://github.com/reearth/reearth-visualizer/commit/efeaf4)
+- Use visible field on reearth&#x2F;core ([#456](https://github.com/reearth/reearth-visualizer/pull/456)) [`333610`](https://github.com/reearth/reearth-visualizer/commit/333610)
+- Add htmlblock to built-in plugin ([#384](https://github.com/reearth/reearth-visualizer/pull/384)) [`51c79a`](https://github.com/reearth/reearth-visualizer/commit/51c79a)
+- Add override, replace and delete plugin API on reearth&#x2F;core ([#451](https://github.com/reearth/reearth-visualizer/pull/451)) [`2e1c41`](https://github.com/reearth/reearth-visualizer/commit/2e1c41)
+- Selecting imagery features ([#450](https://github.com/reearth/reearth-visualizer/pull/450)) [`f24ef5`](https://github.com/reearth/reearth-visualizer/commit/f24ef5)
+- Support interval fetching data on reearth&#x2F;core ([#449](https://github.com/reearth/reearth-visualizer/pull/449)) [`406174`](https://github.com/reearth/reearth-visualizer/commit/406174)
+- Support select feature on reearth&#x2F;core ([#445](https://github.com/reearth/reearth-visualizer/pull/445)) [`3174b1`](https://github.com/reearth/reearth-visualizer/commit/3174b1)
+- Use experimental core flag ([#448](https://github.com/reearth/reearth-visualizer/pull/448)) [`b04294`](https://github.com/reearth/reearth-visualizer/commit/b04294)
+- Support time series features on reearth&#x2F;core ([#446](https://github.com/reearth/reearth-visualizer/pull/446)) [`8fc9b6`](https://github.com/reearth/reearth-visualizer/commit/8fc9b6)
+- Scene property to enable VR mode ([#444](https://github.com/reearth/reearth-visualizer/pull/444)) [`3d35aa`](https://github.com/reearth/reearth-visualizer/commit/3d35aa)
+- Support general transit feed ([#408](https://github.com/reearth/reearth-visualizer/pull/408)) [`49b4a4`](https://github.com/reearth/reearth-visualizer/commit/49b4a4)
+- Support osm data type on reearth&#x2F;core ([#431](https://github.com/reearth/reearth-visualizer/pull/431)) [`0d4e0b`](https://github.com/reearth/reearth-visualizer/commit/0d4e0b)
+- Label background color and padding property for markers ([#426](https://github.com/reearth/reearth-visualizer/pull/426) [`72cd0d`](https://github.com/reearth/reearth-visualizer/commit/72cd0d)
+- Support entity base flyTo on reearth&#x2F;core ([#419](https://github.com/reearth/reearth-visualizer/pull/419)) [`3060cf`](https://github.com/reearth/reearth-visualizer/commit/3060cf)
+- Support overriding czml appearance on reearth&#x2F;core ([#421](https://github.com/reearth/reearth-visualizer/pull/421)) [`e62f4d`](https://github.com/reearth/reearth-visualizer/commit/e62f4d)
+- Support kml on reearth&#x2F;core ([#422](https://github.com/reearth/reearth-visualizer/pull/422)) [`052daf`](https://github.com/reearth/reearth-visualizer/commit/052daf)
+- Support json properties on reearth&#x2F;core ([#412](https://github.com/reearth/reearth-visualizer/pull/412)) [`ac7986`](https://github.com/reearth/reearth-visualizer/commit/ac7986)
+- Connect reearth&#x2F;core with existence pages ([#401](https://github.com/reearth/reearth-visualizer/pull/401)) [`0735c0`](https://github.com/reearth/reearth-visualizer/commit/0735c0)
+- Add runTimes property to PluginInstance ([#404](https://github.com/reearth/reearth-visualizer/pull/404)) [`17d787`](https://github.com/reearth/reearth-visualizer/commit/17d787)
+- Support plugin system on reearth&#x2F;core ([#399](https://github.com/reearth/reearth-visualizer/pull/399)) [`bab9e6`](https://github.com/reearth/reearth-visualizer/commit/bab9e6)
+- Add selectedFeature and selectedComputedFeature on reearth&#x2F;core ([#398](https://github.com/reearth/reearth-visualizer/pull/398)) [`474b34`](https://github.com/reearth/reearth-visualizer/commit/474b34)
+- Set modal above popup ([#397](https://github.com/reearth/reearth-visualizer/pull/397)) [`ff47c5`](https://github.com/reearth/reearth-visualizer/commit/ff47c5)
+- Port 2d navigator to reearth&#x2F;core ([#394](https://github.com/reearth/reearth-visualizer/pull/394)) [`07a6b4`](https://github.com/reearth/reearth-visualizer/commit/07a6b4)
+- Core&#x2F;Visualizer without plugins ([#372](https://github.com/reearth/reearth-visualizer/pull/372)) [`f97c38`](https://github.com/reearth/reearth-visualizer/commit/f97c38)
+- Reearth style language ([#384](https://github.com/reearth/reearth-visualizer/pull/384)) [`a828ac`](https://github.com/reearth/reearth-visualizer/commit/a828ac)
+- Support 3dtiles on reearth&#x2F;core ([#392](https://github.com/reearth/reearth-visualizer/pull/392)) [`e8068f`](https://github.com/reearth/reearth-visualizer/commit/e8068f)
+- Support MVT on reearth&#x2F;core ([#388](https://github.com/reearth/reearth-visualizer/pull/388)) [`cac89c`](https://github.com/reearth/reearth-visualizer/commit/cac89c)
+- Support WMS on reearth&#x2F;core ([#387](https://github.com/reearth/reearth-visualizer/pull/387)) [`666c1b`](https://github.com/reearth/reearth-visualizer/commit/666c1b)
+- Support CZML in reearth&#x2F;core ([#383](https://github.com/reearth/reearth-visualizer/pull/383)) [`f44d98`](https://github.com/reearth/reearth-visualizer/commit/f44d98)
+- Plugin api client storage ([#376](https://github.com/reearth/reearth-visualizer/pull/376)) [`4f36ad`](https://github.com/reearth/reearth-visualizer/commit/4f36ad)
+- Support csv on the reearth&#x2F;core ([#382](https://github.com/reearth/reearth-visualizer/pull/382)) [`a8f5bf`](https://github.com/reearth/reearth-visualizer/commit/a8f5bf)
 
 #### 🔧 Bug Fixes
 
-- Merge conflict resolved [`39a37a`](https://github.com/reearth/reearth/commit/39a37a)
-- Use core hook may get value incorrectly ([#609](https://github.com/reearth/reearth/pull/609)) [`d87e90`](https://github.com/reearth/reearth/commit/d87e90)
-- Resolve endsWith is not a function error with style in reearth&#x2F;core ([#603](https://github.com/reearth/reearth/pull/603)) [`15fec3`](https://github.com/reearth/reearth/commit/15fec3)
-- Add % as special case for &#x60;Number()&#x60; in style lang of reearth&#x2F;core ([#601](https://github.com/reearth/reearth/pull/601)) [`5a4a3d`](https://github.com/reearth/reearth/commit/5a4a3d)
-- Rename moveWidget to onMoveWidget on reearth&#x2F;core ([#600](https://github.com/reearth/reearth/pull/600)) [`6c06ab`](https://github.com/reearth/reearth/commit/6c06ab)
-- Enable splash screen in preview page ([#596](https://github.com/reearth/reearth/pull/596) [`e1f5ac`](https://github.com/reearth/reearth/commit/e1f5ac)
-- Timeline scroll should be fixed in initial render ([#571](https://github.com/reearth/reearth/pull/571)) [`6a0aed`](https://github.com/reearth/reearth/commit/6a0aed)
-- Remove default height reference for modelGraphics in reearth&#x2F;core ([#592](https://github.com/reearth/reearth/pull/592)) [`961b46`](https://github.com/reearth/reearth/commit/961b46)
-- Remove duplication of feature entity in reearth&#x2F;core ([#590](https://github.com/reearth/reearth/pull/590)) [`8cc03e`](https://github.com/reearth/reearth/commit/8cc03e)
-- Prevent selecting not shown feature for MVT on reearth&#x2F;core ([#589](https://github.com/reearth/reearth/pull/589)) [`41816d`](https://github.com/reearth/reearth/commit/41816d)
-- Infobox for 3dtiles feature ([#587](https://github.com/reearth/reearth/pull/587)) [`70cfdb`](https://github.com/reearth/reearth/commit/70cfdb)
-- Use layer id with feature id for entity id on reearth&#x2F;core ([#585](https://github.com/reearth/reearth/pull/585)) [`24cc88`](https://github.com/reearth/reearth/commit/24cc88)
-- Can&[#39](https://github.com/reearth/reearth/pull/39);t set iframe&[#39](https://github.com/reearth/reearth/pull/39);s width or height individually in crust  ([#583](https://github.com/reearth/reearth/pull/583)) [`3494b4`](https://github.com/reearth/reearth/commit/3494b4)
-- MVT isn&[#39](https://github.com/reearth/reearth/pull/39);t render correctly on reearth&#x2F;core ([#582](https://github.com/reearth/reearth/pull/582)) [`988d1a`](https://github.com/reearth/reearth/commit/988d1a)
-- Sample terrain height API cannot properly return promise ([#581](https://github.com/reearth/reearth/pull/581)) [`72eafd`](https://github.com/reearth/reearth/commit/72eafd)
-- Change logical operator evaluation behaviour in reearth&#x2F;core ([#580](https://github.com/reearth/reearth/pull/580)) [`3d23ce`](https://github.com/reearth/reearth/commit/3d23ce)
-- Infobox style collapse for long names ([#578](https://github.com/reearth/reearth/pull/578)) [`04775d`](https://github.com/reearth/reearth/commit/04775d)
-- Override currentTime on timeline widget when time is updated by CZML on reearth&#x2F;core ([#579](https://github.com/reearth/reearth/pull/579)) [`dbe2e1`](https://github.com/reearth/reearth/commit/dbe2e1)
-- Rename scene light properties [`8b3a18`](https://github.com/reearth/reearth/commit/8b3a18)
-- Add none cesium value for heightReference ([#577](https://github.com/reearth/reearth/pull/577)) [`2c92e3`](https://github.com/reearth/reearth/commit/2c92e3)
-- JSON Path condition on reearth&#x2F;core ([#572](https://github.com/reearth/reearth/pull/572)) [`5f7024`](https://github.com/reearth/reearth/commit/5f7024)
-- Update html head [`f1780f`](https://github.com/reearth/reearth/commit/f1780f)
-- Sync selected feature with layer api on reearth&#x2F;core ([#570](https://github.com/reearth/reearth/pull/570)) [`ded6b0`](https://github.com/reearth/reearth/commit/ded6b0)
-- Imagery index on reearth&#x2F;core ([#569](https://github.com/reearth/reearth/pull/569)) [`6b233f`](https://github.com/reearth/reearth/commit/6b233f)
-- Revert add height to polygon in reearth&#x2F;core ([#566](https://github.com/reearth/reearth/pull/566)) [`1f2f74`](https://github.com/reearth/reearth/commit/1f2f74)
-- Add clamp as default height reference for model in reearth&#x2F;core ([#567](https://github.com/reearth/reearth/pull/567)) [`517386`](https://github.com/reearth/reearth/commit/517386)
-- Minimum timeline range on reearth&#x2F;core ([#565](https://github.com/reearth/reearth/pull/565)) [`975c79`](https://github.com/reearth/reearth/commit/975c79)
-- Infobox html block styling ([#562](https://github.com/reearth/reearth/pull/562)) [`32b248`](https://github.com/reearth/reearth/commit/32b248)
-- Imagery layer tile index on reearth&#x2F;core ([#561](https://github.com/reearth/reearth/pull/561) [`25bdff`](https://github.com/reearth/reearth/commit/25bdff)
-- Add &quot;disabled&quot; as shadow mode on reearth&#x2F;core ([#560](https://github.com/reearth/reearth/pull/560)) [`1632ea`](https://github.com/reearth/reearth/commit/1632ea)
-- Support multi layers in MVT on reearth&#x2F;core ([#559](https://github.com/reearth/reearth/pull/559)) [`9c8c88`](https://github.com/reearth/reearth/commit/9c8c88)
-- Html block margin and height [`09f6ef`](https://github.com/reearth/reearth/commit/09f6ef)
-- UpdateClockOnLoad condition on reearth&#x2F;core ([#558](https://github.com/reearth/reearth/pull/558)) [`f9076a`](https://github.com/reearth/reearth/commit/f9076a)
-- Add height to polygon in reearth&#x2F;core ([#557](https://github.com/reearth/reearth/pull/557)) [`a84dbe`](https://github.com/reearth/reearth/commit/a84dbe)
-- Use computed feature on resource on reearth&#x2F;core ([#556](https://github.com/reearth/reearth/pull/556)) [`006f40`](https://github.com/reearth/reearth/commit/006f40)
-- Point cloud dirty check on reearth&#x2F;core ([#554](https://github.com/reearth/reearth/pull/554)) [`f95d27`](https://github.com/reearth/reearth/commit/f95d27)
-- Support default infobox and selection indicator on imagery layer on reearth&#x2F;core ([#553](https://github.com/reearth/reearth/pull/553)) [`1946b3`](https://github.com/reearth/reearth/commit/1946b3)
-- Scrollbar in timeline widget always showing ([#550](https://github.com/reearth/reearth/pull/550)) [`84d63d`](https://github.com/reearth/reearth/commit/84d63d)
-- Clipping box on point cloud on reearth&#x2F;core ([#552](https://github.com/reearth/reearth/pull/552)) [`fb4455`](https://github.com/reearth/reearth/commit/fb4455)
-- Htmlblock on safari ([#548](https://github.com/reearth/reearth/pull/548)) [`392fc7`](https://github.com/reearth/reearth/commit/392fc7)
-- Use attributes as default content for infobox on reearth&#x2F;core ([#547](https://github.com/reearth/reearth/pull/547)) [`be3718`](https://github.com/reearth/reearth/commit/be3718)
-- Deleting feature process on reearth&#x2F;core ([#546](https://github.com/reearth/reearth/pull/546)) [`39ecaf`](https://github.com/reearth/reearth/commit/39ecaf)
-- Trigger select event when featureId is changed on reearth&#x2F;core ([#545](https://github.com/reearth/reearth/pull/545)) [`6f5401`](https://github.com/reearth/reearth/commit/6f5401)
-- Draw polylines on polygon on reearth&#x2F;core ([#544](https://github.com/reearth/reearth/pull/544)) [`d35329`](https://github.com/reearth/reearth/commit/d35329)
-- Infobox html color ([#534](https://github.com/reearth/reearth/pull/534)) [`c0e0a6`](https://github.com/reearth/reearth/commit/c0e0a6)
-- Use overriddenLayers to get infobox on reearth&#x2F;core ([#541](https://github.com/reearth/reearth/pull/541)) [`c4e9db`](https://github.com/reearth/reearth/commit/c4e9db)
-- Fly to multiple entities added by a layer on reearth&#x2F;core ([#540](https://github.com/reearth/reearth/pull/540)) [`95b3d3`](https://github.com/reearth/reearth/commit/95b3d3)
-- Add polyfill for requestIdleCallback in reearth&#x2F;core ([#537](https://github.com/reearth/reearth/pull/537)) [`c4722f`](https://github.com/reearth/reearth/commit/c4722f)
-- Overriding timeline behavior on reearth&#x2F;core ([#532](https://github.com/reearth/reearth/pull/532)) [`890dae`](https://github.com/reearth/reearth/commit/890dae)
-- Timeline bug on reearth&#x2F;core ([#531](https://github.com/reearth/reearth/pull/531)) [`572678`](https://github.com/reearth/reearth/commit/572678)
-- Some error on reearth&#x2F;core ([#530](https://github.com/reearth/reearth/pull/530)) [`4ee0b6`](https://github.com/reearth/reearth/commit/4ee0b6)
-- Abort fetching on data atom on reearth&#x2F;core ([#529](https://github.com/reearth/reearth/pull/529)) [`e82c88`](https://github.com/reearth/reearth/commit/e82c88)
-- Timeline behavior on reearth&#x2F;core ([#528](https://github.com/reearth/reearth/pull/528)) [`461d06`](https://github.com/reearth/reearth/commit/461d06)
-- Parse csv numeric strings as numbers in reearth&#x2F;core ([#526](https://github.com/reearth/reearth/pull/526)) [`9c890f`](https://github.com/reearth/reearth/commit/9c890f)
-- Parse hyphen as reserved word in property key on reearth&#x2F;core ([#525](https://github.com/reearth/reearth/pull/525)) [`d49058`](https://github.com/reearth/reearth/commit/d49058)
-- Condition for CZML on reearth&#x2F;core ([#524](https://github.com/reearth/reearth/pull/524)) [`3c61ca`](https://github.com/reearth/reearth/commit/3c61ca)
-- Czml style for marker on reearth&#x2F;core ([#523](https://github.com/reearth/reearth/pull/523)) [`67dccb`](https://github.com/reearth/reearth/commit/67dccb)
-- Use default block for entity on reearth&#x2F;core ([#522](https://github.com/reearth/reearth/pull/522)) [`ecd09a`](https://github.com/reearth/reearth/commit/ecd09a)
-- Remove copyLazyLayer on reearth&#x2F;core ([#519](https://github.com/reearth/reearth/pull/519)) [`e17218`](https://github.com/reearth/reearth/commit/e17218)
-- Copying lazy layers undefined behavior on reearth&#x2F;core ([#516](https://github.com/reearth/reearth/pull/516)) [`7b2c5e`](https://github.com/reearth/reearth/commit/7b2c5e)
-- Copy lazy layer on plugin on reearth&#x2F;core ([#515](https://github.com/reearth/reearth/pull/515)) [`046a3d`](https://github.com/reearth/reearth/commit/046a3d)
-- Attach style dynamically in resource on reearth&#x2F;core ([#514](https://github.com/reearth/reearth/pull/514)) [`81d291`](https://github.com/reearth/reearth/commit/81d291)
-- Infinite infobox in CZML on reearth&#x2F;core ([#513](https://github.com/reearth/reearth/pull/513)) [`3e49a1`](https://github.com/reearth/reearth/commit/3e49a1)
-- Selecting resource feature behavior on reearth&#x2F;core ([#512](https://github.com/reearth/reearth/pull/512)) [`35f2c2`](https://github.com/reearth/reearth/commit/35f2c2)
-- Prevent unnecessary render on timeline on reearth&#x2F;core ([#510](https://github.com/reearth/reearth/pull/510)) [`7cb9d5`](https://github.com/reearth/reearth/commit/7cb9d5)
-- Parse reserved word when property name includes reserved word on reearth&#x2F;core ([#508](https://github.com/reearth/reearth/pull/508)) [`aa247e`](https://github.com/reearth/reearth/commit/aa247e)
-- Pass engine meta on plugin editor ([#507](https://github.com/reearth/reearth/pull/507)) [`9cd1b5`](https://github.com/reearth/reearth/commit/9cd1b5)
-- Mvt line width on reearth&#x2F;core ([#504](https://github.com/reearth/reearth/pull/504)) [`c1a939`](https://github.com/reearth/reearth/commit/c1a939)
-- It should not render entity when coordinate is undefined on reearth&#x2F;core [`23b6c6`](https://github.com/reearth/reearth/commit/23b6c6)
-- Allow enter ground option for clipping box on reearth&#x2F;core ([#500](https://github.com/reearth/reearth/pull/500)) [`f8e129`](https://github.com/reearth/reearth/commit/f8e129)
-- Clip area with clipping box on reearth&#x2F;core ([#498](https://github.com/reearth/reearth/pull/498)) [`4f647f`](https://github.com/reearth/reearth/commit/4f647f)
-- Mvt cache on reearth&#x2F;core ([#497](https://github.com/reearth/reearth/pull/497)) [`ba2c7e`](https://github.com/reearth/reearth/commit/ba2c7e)
-- Recreate no feature component when data url is changed on reearth&#x2F;core ([#494](https://github.com/reearth/reearth/pull/494)) [`93c805`](https://github.com/reearth/reearth/commit/93c805)
-- Ignore cesium ion token when it is empty [`6648be`](https://github.com/reearth/reearth/commit/6648be)
-- Feature type fix gpx on reearth&#x2F;core ([#493](https://github.com/reearth/reearth/pull/493)) [`51b8e8`](https://github.com/reearth/reearth/commit/51b8e8)
-- Infobox error after layer delete ([#492](https://github.com/reearth/reearth/pull/492)) [`8a59dd`](https://github.com/reearth/reearth/commit/8a59dd)
-- Delete bug that deletes necessary layer on reearth&#x2F;core ([#484](https://github.com/reearth/reearth/pull/484)) [`a0f48f`](https://github.com/reearth/reearth/commit/a0f48f)
-- Force update when some data properties are updated on reearth&#x2F;core ([#483](https://github.com/reearth/reearth/pull/483)) [`867238`](https://github.com/reearth/reearth/commit/867238)
-- Revert appearance to initial value when appearance is undefined on reearth&#x2F;core ([#482](https://github.com/reearth/reearth/pull/482)) [`76b6f4`](https://github.com/reearth/reearth/commit/76b6f4)
-- Entity id is duplicated error on reearth&#x2F;core ([#481](https://github.com/reearth/reearth/pull/481)) [`a2b0b6`](https://github.com/reearth/reearth/commit/a2b0b6)
-- Infobox property is undefined error on reearth&#x2F;core ([#480](https://github.com/reearth/reearth/pull/480)) [`2b8b07`](https://github.com/reearth/reearth/commit/2b8b07)
-- Layers override behavior on rearth&#x2F;core ([#479](https://github.com/reearth/reearth/pull/479)) [`faff37`](https://github.com/reearth/reearth/commit/faff37)
-- Error handling for time interval on reearth&#x2F;core ([#478](https://github.com/reearth/reearth/pull/478)) [`edf546`](https://github.com/reearth/reearth/commit/edf546)
-- Overridden layers api on reearth&#x2F;core ([#477](https://github.com/reearth/reearth/pull/477)) [`abaade`](https://github.com/reearth/reearth/commit/abaade)
-- Add properties in vehicle point for gtfs ([#476](https://github.com/reearth/reearth/pull/476)) [`1058ab`](https://github.com/reearth/reearth/commit/1058ab)
-- Color function on reearth&#x2F;core ([#474](https://github.com/reearth/reearth/pull/474)) [`7d9fca`](https://github.com/reearth/reearth/commit/7d9fca)
-- Errors when many functions are created in plugins ([#471](https://github.com/reearth/reearth/pull/471)) [`ebb50d`](https://github.com/reearth/reearth/commit/ebb50d)
-- Coordinates for csv on reearth&#x2F;core ([#472](https://github.com/reearth/reearth/pull/472)) [`4a6473`](https://github.com/reearth/reearth/commit/4a6473)
-- Lint and type error [`d00b9b`](https://github.com/reearth/reearth/commit/d00b9b)
-- Suppress screen flicker when judging useCore [`b1852d`](https://github.com/reearth/reearth/commit/b1852d)
-- Widget area has margin even if no widgets, disable widget area transition in built scene [`b51569`](https://github.com/reearth/reearth/commit/b51569)
-- Cesium crashes when VR mode is false [`efa3fd`](https://github.com/reearth/reearth/commit/efa3fd)
-- 3dtiles overriding appearance behavior on reearth&#x2F;core ([#468](https://github.com/reearth/reearth/pull/468)) [`8c48bc`](https://github.com/reearth/reearth/commit/8c48bc)
-- Support visible and dynamic plane in clipping box on reearth&#x2F;core ([#465](https://github.com/reearth/reearth/pull/465)) [`4c89aa`](https://github.com/reearth/reearth/commit/4c89aa)
-- SelectedFeature for 3dtiles on reearth&#x2F;core ([#463](https://github.com/reearth/reearth/pull/463)) [`cd1777`](https://github.com/reearth/reearth/commit/cd1777)
-- Express undefined visible field on reearth&#x2F;core ([#461](https://github.com/reearth/reearth/pull/461)) [`c74630`](https://github.com/reearth/reearth/commit/c74630)
-- Undefined behavior for visible field ([#460](https://github.com/reearth/reearth/pull/460)) [`c41d70`](https://github.com/reearth/reearth/commit/c41d70)
-- Select entity on reearth&#x2F;core ([#458](https://github.com/reearth/reearth/pull/458)) [`bc1824`](https://github.com/reearth/reearth/commit/bc1824)
-- Use default infobox on reearth&#x2F;core ([#453](https://github.com/reearth/reearth/pull/453)) [`d3fec8`](https://github.com/reearth/reearth/commit/d3fec8)
-- Select event behavior on reearth&#x2F;core ([#452](https://github.com/reearth/reearth/pull/452)) [`384488`](https://github.com/reearth/reearth/commit/384488)
-- Error in published page on reearth&#x2F;core ([#447](https://github.com/reearth/reearth/pull/447)) [`4c8805`](https://github.com/reearth/reearth/commit/4c8805)
-- Expand timeline in initial load ([#443](https://github.com/reearth/reearth/pull/443)) [`d6a742`](https://github.com/reearth/reearth/commit/d6a742)
-- Replace globe image when cesium ion token is updated ([#442](https://github.com/reearth/reearth/pull/442)) [`64ffae`](https://github.com/reearth/reearth/commit/64ffae)
-- Layer fetch on reearth&#x2F;core ([#441](https://github.com/reearth/reearth/pull/441)) [`597b82`](https://github.com/reearth/reearth/commit/597b82)
-- Dnd layer on reearth&#x2F;core ([#440](https://github.com/reearth/reearth/pull/440)) [`a5a2b4`](https://github.com/reearth/reearth/commit/a5a2b4)
-- Disable requestRenderMode depends on widget on reearth&#x2F;core ([#439](https://github.com/reearth/reearth/pull/439)) [`12ce63`](https://github.com/reearth/reearth/commit/12ce63)
-- Selected layer id is not propagated on reearth&#x2F;core ([#438](https://github.com/reearth/reearth/pull/438)) [`24993b`](https://github.com/reearth/reearth/commit/24993b)
-- Handle featureId for 3dtiles and compat select plugin api on reearth&#x2F;core ([#417](https://github.com/reearth/reearth/pull/417)) [`9144ad`](https://github.com/reearth/reearth/commit/9144ad)
-- Undefined behavior for resource on reearth&#x2F;core ([#437](https://github.com/reearth/reearth/pull/437)) [`3f51f2`](https://github.com/reearth/reearth/commit/3f51f2)
-- Blocks cannot be displayed and updated as expected on reearth&#x2F;core ([#434](https://github.com/reearth/reearth/pull/434)) [`b5f921`](https://github.com/reearth/reearth/commit/b5f921)
-- Layer appearances are not evaluated as expected ([#418](https://github.com/reearth/reearth/pull/418)) [`20382c`](https://github.com/reearth/reearth/commit/20382c)
-- Support resource auto on reearth&#x2F;core ([#435](https://github.com/reearth/reearth/pull/435)) [`595c66`](https://github.com/reearth/reearth/commit/595c66)
-- Cluster features on reearth&#x2F;core ([#430](https://github.com/reearth/reearth/pull/430)) [`92dd47`](https://github.com/reearth/reearth/commit/92dd47)
-- 3D Tiles infobox on reearth&#x2F;core ([#433](https://github.com/reearth/reearth/pull/433)) [`b4afd7`](https://github.com/reearth/reearth/commit/b4afd7)
-- GeoJSON with resource appearance on reearth&#x2F;core ([#432](https://github.com/reearth/reearth/pull/432)) [`464d67`](https://github.com/reearth/reearth/commit/464d67)
-- Dnd layer on reearth&#x2F;core ([#424](https://github.com/reearth/reearth/pull/424)) [`75e6a7`](https://github.com/reearth/reearth/commit/75e6a7)
-- WAS bug on reearth&#x2F;core ([#416](https://github.com/reearth/reearth/pull/416)) [`045274`](https://github.com/reearth/reearth/commit/045274)
-- Cannot select features on reearth&#x2F;core ([#414](https://github.com/reearth/reearth/pull/414)) [`f1a8dd`](https://github.com/reearth/reearth/commit/f1a8dd)
-- Support csv value string on reearth&#x2F;core ([#415](https://github.com/reearth/reearth/pull/415)) [`4033f7`](https://github.com/reearth/reearth/commit/4033f7)
-- MoveTo widget to empty page on mobile on reearth&#x2F;core ([#413](https://github.com/reearth/reearth/pull/413)) [`07a935`](https://github.com/reearth/reearth/commit/07a935)
-- Widget align system on mobile ([#409](https://github.com/reearth/reearth/pull/409)) [`fce1ad`](https://github.com/reearth/reearth/commit/fce1ad)
-- Increment runTimes on preinit ([#410](https://github.com/reearth/reearth/pull/410)) [`797020`](https://github.com/reearth/reearth/commit/797020)
-- Plugin instance runTimes property ([#405](https://github.com/reearth/reearth/pull/405)) [`a06434`](https://github.com/reearth/reearth/commit/a06434)
-- Make iframe width or height assignable without the other ([#403](https://github.com/reearth/reearth/pull/403)) [`e8647a`](https://github.com/reearth/reearth/commit/e8647a)
-- Cache ComputedFeature on reearth&#x2F;core ([#396](https://github.com/reearth/reearth/pull/396)) [`775a8a`](https://github.com/reearth/reearth/commit/775a8a)
-- Missing type of API modal &amp; popup options.  ([#400](https://github.com/reearth/reearth/pull/400)) [`a68b24`](https://github.com/reearth/reearth/commit/a68b24)
-- Visualizer on reearth&#x2F;core ([#395](https://github.com/reearth/reearth/pull/395)) [`7ba0db`](https://github.com/reearth/reearth/commit/7ba0db)
-- Update mvt dynamically when appearance is updated ([#393](https://github.com/reearth/reearth/pull/393)) [`7ca5d1`](https://github.com/reearth/reearth/commit/7ca5d1)
+- Merge conflict resolved [`39a37a`](https://github.com/reearth/reearth-visualizer/commit/39a37a)
+- Use core hook may get value incorrectly ([#609](https://github.com/reearth/reearth-visualizer/pull/609)) [`d87e90`](https://github.com/reearth/reearth-visualizer/commit/d87e90)
+- Resolve endsWith is not a function error with style in reearth&#x2F;core ([#603](https://github.com/reearth/reearth-visualizer/pull/603)) [`15fec3`](https://github.com/reearth/reearth-visualizer/commit/15fec3)
+- Add % as special case for &#x60;Number()&#x60; in style lang of reearth&#x2F;core ([#601](https://github.com/reearth/reearth-visualizer/pull/601)) [`5a4a3d`](https://github.com/reearth/reearth-visualizer/commit/5a4a3d)
+- Rename moveWidget to onMoveWidget on reearth&#x2F;core ([#600](https://github.com/reearth/reearth-visualizer/pull/600)) [`6c06ab`](https://github.com/reearth/reearth-visualizer/commit/6c06ab)
+- Enable splash screen in preview page ([#596](https://github.com/reearth/reearth-visualizer/pull/596) [`e1f5ac`](https://github.com/reearth/reearth-visualizer/commit/e1f5ac)
+- Timeline scroll should be fixed in initial render ([#571](https://github.com/reearth/reearth-visualizer/pull/571)) [`6a0aed`](https://github.com/reearth/reearth-visualizer/commit/6a0aed)
+- Remove default height reference for modelGraphics in reearth&#x2F;core ([#592](https://github.com/reearth/reearth-visualizer/pull/592)) [`961b46`](https://github.com/reearth/reearth-visualizer/commit/961b46)
+- Remove duplication of feature entity in reearth&#x2F;core ([#590](https://github.com/reearth/reearth-visualizer/pull/590)) [`8cc03e`](https://github.com/reearth/reearth-visualizer/commit/8cc03e)
+- Prevent selecting not shown feature for MVT on reearth&#x2F;core ([#589](https://github.com/reearth/reearth-visualizer/pull/589)) [`41816d`](https://github.com/reearth/reearth-visualizer/commit/41816d)
+- Infobox for 3dtiles feature ([#587](https://github.com/reearth/reearth-visualizer/pull/587)) [`70cfdb`](https://github.com/reearth/reearth-visualizer/commit/70cfdb)
+- Use layer id with feature id for entity id on reearth&#x2F;core ([#585](https://github.com/reearth/reearth-visualizer/pull/585)) [`24cc88`](https://github.com/reearth/reearth-visualizer/commit/24cc88)
+- Can&[#39](https://github.com/reearth/reearth-visualizer/pull/39);t set iframe&[#39](https://github.com/reearth/reearth-visualizer/pull/39);s width or height individually in crust  ([#583](https://github.com/reearth/reearth-visualizer/pull/583)) [`3494b4`](https://github.com/reearth/reearth-visualizer/commit/3494b4)
+- MVT isn&[#39](https://github.com/reearth/reearth-visualizer/pull/39);t render correctly on reearth&#x2F;core ([#582](https://github.com/reearth/reearth-visualizer/pull/582)) [`988d1a`](https://github.com/reearth/reearth-visualizer/commit/988d1a)
+- Sample terrain height API cannot properly return promise ([#581](https://github.com/reearth/reearth-visualizer/pull/581)) [`72eafd`](https://github.com/reearth/reearth-visualizer/commit/72eafd)
+- Change logical operator evaluation behaviour in reearth&#x2F;core ([#580](https://github.com/reearth/reearth-visualizer/pull/580)) [`3d23ce`](https://github.com/reearth/reearth-visualizer/commit/3d23ce)
+- Infobox style collapse for long names ([#578](https://github.com/reearth/reearth-visualizer/pull/578)) [`04775d`](https://github.com/reearth/reearth-visualizer/commit/04775d)
+- Override currentTime on timeline widget when time is updated by CZML on reearth&#x2F;core ([#579](https://github.com/reearth/reearth-visualizer/pull/579)) [`dbe2e1`](https://github.com/reearth/reearth-visualizer/commit/dbe2e1)
+- Rename scene light properties [`8b3a18`](https://github.com/reearth/reearth-visualizer/commit/8b3a18)
+- Add none cesium value for heightReference ([#577](https://github.com/reearth/reearth-visualizer/pull/577)) [`2c92e3`](https://github.com/reearth/reearth-visualizer/commit/2c92e3)
+- JSON Path condition on reearth&#x2F;core ([#572](https://github.com/reearth/reearth-visualizer/pull/572)) [`5f7024`](https://github.com/reearth/reearth-visualizer/commit/5f7024)
+- Update html head [`f1780f`](https://github.com/reearth/reearth-visualizer/commit/f1780f)
+- Sync selected feature with layer api on reearth&#x2F;core ([#570](https://github.com/reearth/reearth-visualizer/pull/570)) [`ded6b0`](https://github.com/reearth/reearth-visualizer/commit/ded6b0)
+- Imagery index on reearth&#x2F;core ([#569](https://github.com/reearth/reearth-visualizer/pull/569)) [`6b233f`](https://github.com/reearth/reearth-visualizer/commit/6b233f)
+- Revert add height to polygon in reearth&#x2F;core ([#566](https://github.com/reearth/reearth-visualizer/pull/566)) [`1f2f74`](https://github.com/reearth/reearth-visualizer/commit/1f2f74)
+- Add clamp as default height reference for model in reearth&#x2F;core ([#567](https://github.com/reearth/reearth-visualizer/pull/567)) [`517386`](https://github.com/reearth/reearth-visualizer/commit/517386)
+- Minimum timeline range on reearth&#x2F;core ([#565](https://github.com/reearth/reearth-visualizer/pull/565)) [`975c79`](https://github.com/reearth/reearth-visualizer/commit/975c79)
+- Infobox html block styling ([#562](https://github.com/reearth/reearth-visualizer/pull/562)) [`32b248`](https://github.com/reearth/reearth-visualizer/commit/32b248)
+- Imagery layer tile index on reearth&#x2F;core ([#561](https://github.com/reearth/reearth-visualizer/pull/561) [`25bdff`](https://github.com/reearth/reearth-visualizer/commit/25bdff)
+- Add &quot;disabled&quot; as shadow mode on reearth&#x2F;core ([#560](https://github.com/reearth/reearth-visualizer/pull/560)) [`1632ea`](https://github.com/reearth/reearth-visualizer/commit/1632ea)
+- Support multi layers in MVT on reearth&#x2F;core ([#559](https://github.com/reearth/reearth-visualizer/pull/559)) [`9c8c88`](https://github.com/reearth/reearth-visualizer/commit/9c8c88)
+- Html block margin and height [`09f6ef`](https://github.com/reearth/reearth-visualizer/commit/09f6ef)
+- UpdateClockOnLoad condition on reearth&#x2F;core ([#558](https://github.com/reearth/reearth-visualizer/pull/558)) [`f9076a`](https://github.com/reearth/reearth-visualizer/commit/f9076a)
+- Add height to polygon in reearth&#x2F;core ([#557](https://github.com/reearth/reearth-visualizer/pull/557)) [`a84dbe`](https://github.com/reearth/reearth-visualizer/commit/a84dbe)
+- Use computed feature on resource on reearth&#x2F;core ([#556](https://github.com/reearth/reearth-visualizer/pull/556)) [`006f40`](https://github.com/reearth/reearth-visualizer/commit/006f40)
+- Point cloud dirty check on reearth&#x2F;core ([#554](https://github.com/reearth/reearth-visualizer/pull/554)) [`f95d27`](https://github.com/reearth/reearth-visualizer/commit/f95d27)
+- Support default infobox and selection indicator on imagery layer on reearth&#x2F;core ([#553](https://github.com/reearth/reearth-visualizer/pull/553)) [`1946b3`](https://github.com/reearth/reearth-visualizer/commit/1946b3)
+- Scrollbar in timeline widget always showing ([#550](https://github.com/reearth/reearth-visualizer/pull/550)) [`84d63d`](https://github.com/reearth/reearth-visualizer/commit/84d63d)
+- Clipping box on point cloud on reearth&#x2F;core ([#552](https://github.com/reearth/reearth-visualizer/pull/552)) [`fb4455`](https://github.com/reearth/reearth-visualizer/commit/fb4455)
+- Htmlblock on safari ([#548](https://github.com/reearth/reearth-visualizer/pull/548)) [`392fc7`](https://github.com/reearth/reearth-visualizer/commit/392fc7)
+- Use attributes as default content for infobox on reearth&#x2F;core ([#547](https://github.com/reearth/reearth-visualizer/pull/547)) [`be3718`](https://github.com/reearth/reearth-visualizer/commit/be3718)
+- Deleting feature process on reearth&#x2F;core ([#546](https://github.com/reearth/reearth-visualizer/pull/546)) [`39ecaf`](https://github.com/reearth/reearth-visualizer/commit/39ecaf)
+- Trigger select event when featureId is changed on reearth&#x2F;core ([#545](https://github.com/reearth/reearth-visualizer/pull/545)) [`6f5401`](https://github.com/reearth/reearth-visualizer/commit/6f5401)
+- Draw polylines on polygon on reearth&#x2F;core ([#544](https://github.com/reearth/reearth-visualizer/pull/544)) [`d35329`](https://github.com/reearth/reearth-visualizer/commit/d35329)
+- Infobox html color ([#534](https://github.com/reearth/reearth-visualizer/pull/534)) [`c0e0a6`](https://github.com/reearth/reearth-visualizer/commit/c0e0a6)
+- Use overriddenLayers to get infobox on reearth&#x2F;core ([#541](https://github.com/reearth/reearth-visualizer/pull/541)) [`c4e9db`](https://github.com/reearth/reearth-visualizer/commit/c4e9db)
+- Fly to multiple entities added by a layer on reearth&#x2F;core ([#540](https://github.com/reearth/reearth-visualizer/pull/540)) [`95b3d3`](https://github.com/reearth/reearth-visualizer/commit/95b3d3)
+- Add polyfill for requestIdleCallback in reearth&#x2F;core ([#537](https://github.com/reearth/reearth-visualizer/pull/537)) [`c4722f`](https://github.com/reearth/reearth-visualizer/commit/c4722f)
+- Overriding timeline behavior on reearth&#x2F;core ([#532](https://github.com/reearth/reearth-visualizer/pull/532)) [`890dae`](https://github.com/reearth/reearth-visualizer/commit/890dae)
+- Timeline bug on reearth&#x2F;core ([#531](https://github.com/reearth/reearth-visualizer/pull/531)) [`572678`](https://github.com/reearth/reearth-visualizer/commit/572678)
+- Some error on reearth&#x2F;core ([#530](https://github.com/reearth/reearth-visualizer/pull/530)) [`4ee0b6`](https://github.com/reearth/reearth-visualizer/commit/4ee0b6)
+- Abort fetching on data atom on reearth&#x2F;core ([#529](https://github.com/reearth/reearth-visualizer/pull/529)) [`e82c88`](https://github.com/reearth/reearth-visualizer/commit/e82c88)
+- Timeline behavior on reearth&#x2F;core ([#528](https://github.com/reearth/reearth-visualizer/pull/528)) [`461d06`](https://github.com/reearth/reearth-visualizer/commit/461d06)
+- Parse csv numeric strings as numbers in reearth&#x2F;core ([#526](https://github.com/reearth/reearth-visualizer/pull/526)) [`9c890f`](https://github.com/reearth/reearth-visualizer/commit/9c890f)
+- Parse hyphen as reserved word in property key on reearth&#x2F;core ([#525](https://github.com/reearth/reearth-visualizer/pull/525)) [`d49058`](https://github.com/reearth/reearth-visualizer/commit/d49058)
+- Condition for CZML on reearth&#x2F;core ([#524](https://github.com/reearth/reearth-visualizer/pull/524)) [`3c61ca`](https://github.com/reearth/reearth-visualizer/commit/3c61ca)
+- Czml style for marker on reearth&#x2F;core ([#523](https://github.com/reearth/reearth-visualizer/pull/523)) [`67dccb`](https://github.com/reearth/reearth-visualizer/commit/67dccb)
+- Use default block for entity on reearth&#x2F;core ([#522](https://github.com/reearth/reearth-visualizer/pull/522)) [`ecd09a`](https://github.com/reearth/reearth-visualizer/commit/ecd09a)
+- Remove copyLazyLayer on reearth&#x2F;core ([#519](https://github.com/reearth/reearth-visualizer/pull/519)) [`e17218`](https://github.com/reearth/reearth-visualizer/commit/e17218)
+- Copying lazy layers undefined behavior on reearth&#x2F;core ([#516](https://github.com/reearth/reearth-visualizer/pull/516)) [`7b2c5e`](https://github.com/reearth/reearth-visualizer/commit/7b2c5e)
+- Copy lazy layer on plugin on reearth&#x2F;core ([#515](https://github.com/reearth/reearth-visualizer/pull/515)) [`046a3d`](https://github.com/reearth/reearth-visualizer/commit/046a3d)
+- Attach style dynamically in resource on reearth&#x2F;core ([#514](https://github.com/reearth/reearth-visualizer/pull/514)) [`81d291`](https://github.com/reearth/reearth-visualizer/commit/81d291)
+- Infinite infobox in CZML on reearth&#x2F;core ([#513](https://github.com/reearth/reearth-visualizer/pull/513)) [`3e49a1`](https://github.com/reearth/reearth-visualizer/commit/3e49a1)
+- Selecting resource feature behavior on reearth&#x2F;core ([#512](https://github.com/reearth/reearth-visualizer/pull/512)) [`35f2c2`](https://github.com/reearth/reearth-visualizer/commit/35f2c2)
+- Prevent unnecessary render on timeline on reearth&#x2F;core ([#510](https://github.com/reearth/reearth-visualizer/pull/510)) [`7cb9d5`](https://github.com/reearth/reearth-visualizer/commit/7cb9d5)
+- Parse reserved word when property name includes reserved word on reearth&#x2F;core ([#508](https://github.com/reearth/reearth-visualizer/pull/508)) [`aa247e`](https://github.com/reearth/reearth-visualizer/commit/aa247e)
+- Pass engine meta on plugin editor ([#507](https://github.com/reearth/reearth-visualizer/pull/507)) [`9cd1b5`](https://github.com/reearth/reearth-visualizer/commit/9cd1b5)
+- Mvt line width on reearth&#x2F;core ([#504](https://github.com/reearth/reearth-visualizer/pull/504)) [`c1a939`](https://github.com/reearth/reearth-visualizer/commit/c1a939)
+- It should not render entity when coordinate is undefined on reearth&#x2F;core [`23b6c6`](https://github.com/reearth/reearth-visualizer/commit/23b6c6)
+- Allow enter ground option for clipping box on reearth&#x2F;core ([#500](https://github.com/reearth/reearth-visualizer/pull/500)) [`f8e129`](https://github.com/reearth/reearth-visualizer/commit/f8e129)
+- Clip area with clipping box on reearth&#x2F;core ([#498](https://github.com/reearth/reearth-visualizer/pull/498)) [`4f647f`](https://github.com/reearth/reearth-visualizer/commit/4f647f)
+- Mvt cache on reearth&#x2F;core ([#497](https://github.com/reearth/reearth-visualizer/pull/497)) [`ba2c7e`](https://github.com/reearth/reearth-visualizer/commit/ba2c7e)
+- Recreate no feature component when data url is changed on reearth&#x2F;core ([#494](https://github.com/reearth/reearth-visualizer/pull/494)) [`93c805`](https://github.com/reearth/reearth-visualizer/commit/93c805)
+- Ignore cesium ion token when it is empty [`6648be`](https://github.com/reearth/reearth-visualizer/commit/6648be)
+- Feature type fix gpx on reearth&#x2F;core ([#493](https://github.com/reearth/reearth-visualizer/pull/493)) [`51b8e8`](https://github.com/reearth/reearth-visualizer/commit/51b8e8)
+- Infobox error after layer delete ([#492](https://github.com/reearth/reearth-visualizer/pull/492)) [`8a59dd`](https://github.com/reearth/reearth-visualizer/commit/8a59dd)
+- Delete bug that deletes necessary layer on reearth&#x2F;core ([#484](https://github.com/reearth/reearth-visualizer/pull/484)) [`a0f48f`](https://github.com/reearth/reearth-visualizer/commit/a0f48f)
+- Force update when some data properties are updated on reearth&#x2F;core ([#483](https://github.com/reearth/reearth-visualizer/pull/483)) [`867238`](https://github.com/reearth/reearth-visualizer/commit/867238)
+- Revert appearance to initial value when appearance is undefined on reearth&#x2F;core ([#482](https://github.com/reearth/reearth-visualizer/pull/482)) [`76b6f4`](https://github.com/reearth/reearth-visualizer/commit/76b6f4)
+- Entity id is duplicated error on reearth&#x2F;core ([#481](https://github.com/reearth/reearth-visualizer/pull/481)) [`a2b0b6`](https://github.com/reearth/reearth-visualizer/commit/a2b0b6)
+- Infobox property is undefined error on reearth&#x2F;core ([#480](https://github.com/reearth/reearth-visualizer/pull/480)) [`2b8b07`](https://github.com/reearth/reearth-visualizer/commit/2b8b07)
+- Layers override behavior on rearth&#x2F;core ([#479](https://github.com/reearth/reearth-visualizer/pull/479)) [`faff37`](https://github.com/reearth/reearth-visualizer/commit/faff37)
+- Error handling for time interval on reearth&#x2F;core ([#478](https://github.com/reearth/reearth-visualizer/pull/478)) [`edf546`](https://github.com/reearth/reearth-visualizer/commit/edf546)
+- Overridden layers api on reearth&#x2F;core ([#477](https://github.com/reearth/reearth-visualizer/pull/477)) [`abaade`](https://github.com/reearth/reearth-visualizer/commit/abaade)
+- Add properties in vehicle point for gtfs ([#476](https://github.com/reearth/reearth-visualizer/pull/476)) [`1058ab`](https://github.com/reearth/reearth-visualizer/commit/1058ab)
+- Color function on reearth&#x2F;core ([#474](https://github.com/reearth/reearth-visualizer/pull/474)) [`7d9fca`](https://github.com/reearth/reearth-visualizer/commit/7d9fca)
+- Errors when many functions are created in plugins ([#471](https://github.com/reearth/reearth-visualizer/pull/471)) [`ebb50d`](https://github.com/reearth/reearth-visualizer/commit/ebb50d)
+- Coordinates for csv on reearth&#x2F;core ([#472](https://github.com/reearth/reearth-visualizer/pull/472)) [`4a6473`](https://github.com/reearth/reearth-visualizer/commit/4a6473)
+- Lint and type error [`d00b9b`](https://github.com/reearth/reearth-visualizer/commit/d00b9b)
+- Suppress screen flicker when judging useCore [`b1852d`](https://github.com/reearth/reearth-visualizer/commit/b1852d)
+- Widget area has margin even if no widgets, disable widget area transition in built scene [`b51569`](https://github.com/reearth/reearth-visualizer/commit/b51569)
+- Cesium crashes when VR mode is false [`efa3fd`](https://github.com/reearth/reearth-visualizer/commit/efa3fd)
+- 3dtiles overriding appearance behavior on reearth&#x2F;core ([#468](https://github.com/reearth/reearth-visualizer/pull/468)) [`8c48bc`](https://github.com/reearth/reearth-visualizer/commit/8c48bc)
+- Support visible and dynamic plane in clipping box on reearth&#x2F;core ([#465](https://github.com/reearth/reearth-visualizer/pull/465)) [`4c89aa`](https://github.com/reearth/reearth-visualizer/commit/4c89aa)
+- SelectedFeature for 3dtiles on reearth&#x2F;core ([#463](https://github.com/reearth/reearth-visualizer/pull/463)) [`cd1777`](https://github.com/reearth/reearth-visualizer/commit/cd1777)
+- Express undefined visible field on reearth&#x2F;core ([#461](https://github.com/reearth/reearth-visualizer/pull/461)) [`c74630`](https://github.com/reearth/reearth-visualizer/commit/c74630)
+- Undefined behavior for visible field ([#460](https://github.com/reearth/reearth-visualizer/pull/460)) [`c41d70`](https://github.com/reearth/reearth-visualizer/commit/c41d70)
+- Select entity on reearth&#x2F;core ([#458](https://github.com/reearth/reearth-visualizer/pull/458)) [`bc1824`](https://github.com/reearth/reearth-visualizer/commit/bc1824)
+- Use default infobox on reearth&#x2F;core ([#453](https://github.com/reearth/reearth-visualizer/pull/453)) [`d3fec8`](https://github.com/reearth/reearth-visualizer/commit/d3fec8)
+- Select event behavior on reearth&#x2F;core ([#452](https://github.com/reearth/reearth-visualizer/pull/452)) [`384488`](https://github.com/reearth/reearth-visualizer/commit/384488)
+- Error in published page on reearth&#x2F;core ([#447](https://github.com/reearth/reearth-visualizer/pull/447)) [`4c8805`](https://github.com/reearth/reearth-visualizer/commit/4c8805)
+- Expand timeline in initial load ([#443](https://github.com/reearth/reearth-visualizer/pull/443)) [`d6a742`](https://github.com/reearth/reearth-visualizer/commit/d6a742)
+- Replace globe image when cesium ion token is updated ([#442](https://github.com/reearth/reearth-visualizer/pull/442)) [`64ffae`](https://github.com/reearth/reearth-visualizer/commit/64ffae)
+- Layer fetch on reearth&#x2F;core ([#441](https://github.com/reearth/reearth-visualizer/pull/441)) [`597b82`](https://github.com/reearth/reearth-visualizer/commit/597b82)
+- Dnd layer on reearth&#x2F;core ([#440](https://github.com/reearth/reearth-visualizer/pull/440)) [`a5a2b4`](https://github.com/reearth/reearth-visualizer/commit/a5a2b4)
+- Disable requestRenderMode depends on widget on reearth&#x2F;core ([#439](https://github.com/reearth/reearth-visualizer/pull/439)) [`12ce63`](https://github.com/reearth/reearth-visualizer/commit/12ce63)
+- Selected layer id is not propagated on reearth&#x2F;core ([#438](https://github.com/reearth/reearth-visualizer/pull/438)) [`24993b`](https://github.com/reearth/reearth-visualizer/commit/24993b)
+- Handle featureId for 3dtiles and compat select plugin api on reearth&#x2F;core ([#417](https://github.com/reearth/reearth-visualizer/pull/417)) [`9144ad`](https://github.com/reearth/reearth-visualizer/commit/9144ad)
+- Undefined behavior for resource on reearth&#x2F;core ([#437](https://github.com/reearth/reearth-visualizer/pull/437)) [`3f51f2`](https://github.com/reearth/reearth-visualizer/commit/3f51f2)
+- Blocks cannot be displayed and updated as expected on reearth&#x2F;core ([#434](https://github.com/reearth/reearth-visualizer/pull/434)) [`b5f921`](https://github.com/reearth/reearth-visualizer/commit/b5f921)
+- Layer appearances are not evaluated as expected ([#418](https://github.com/reearth/reearth-visualizer/pull/418)) [`20382c`](https://github.com/reearth/reearth-visualizer/commit/20382c)
+- Support resource auto on reearth&#x2F;core ([#435](https://github.com/reearth/reearth-visualizer/pull/435)) [`595c66`](https://github.com/reearth/reearth-visualizer/commit/595c66)
+- Cluster features on reearth&#x2F;core ([#430](https://github.com/reearth/reearth-visualizer/pull/430)) [`92dd47`](https://github.com/reearth/reearth-visualizer/commit/92dd47)
+- 3D Tiles infobox on reearth&#x2F;core ([#433](https://github.com/reearth/reearth-visualizer/pull/433)) [`b4afd7`](https://github.com/reearth/reearth-visualizer/commit/b4afd7)
+- GeoJSON with resource appearance on reearth&#x2F;core ([#432](https://github.com/reearth/reearth-visualizer/pull/432)) [`464d67`](https://github.com/reearth/reearth-visualizer/commit/464d67)
+- Dnd layer on reearth&#x2F;core ([#424](https://github.com/reearth/reearth-visualizer/pull/424)) [`75e6a7`](https://github.com/reearth/reearth-visualizer/commit/75e6a7)
+- WAS bug on reearth&#x2F;core ([#416](https://github.com/reearth/reearth-visualizer/pull/416)) [`045274`](https://github.com/reearth/reearth-visualizer/commit/045274)
+- Cannot select features on reearth&#x2F;core ([#414](https://github.com/reearth/reearth-visualizer/pull/414)) [`f1a8dd`](https://github.com/reearth/reearth-visualizer/commit/f1a8dd)
+- Support csv value string on reearth&#x2F;core ([#415](https://github.com/reearth/reearth-visualizer/pull/415)) [`4033f7`](https://github.com/reearth/reearth-visualizer/commit/4033f7)
+- MoveTo widget to empty page on mobile on reearth&#x2F;core ([#413](https://github.com/reearth/reearth-visualizer/pull/413)) [`07a935`](https://github.com/reearth/reearth-visualizer/commit/07a935)
+- Widget align system on mobile ([#409](https://github.com/reearth/reearth-visualizer/pull/409)) [`fce1ad`](https://github.com/reearth/reearth-visualizer/commit/fce1ad)
+- Increment runTimes on preinit ([#410](https://github.com/reearth/reearth-visualizer/pull/410)) [`797020`](https://github.com/reearth/reearth-visualizer/commit/797020)
+- Plugin instance runTimes property ([#405](https://github.com/reearth/reearth-visualizer/pull/405)) [`a06434`](https://github.com/reearth/reearth-visualizer/commit/a06434)
+- Make iframe width or height assignable without the other ([#403](https://github.com/reearth/reearth-visualizer/pull/403)) [`e8647a`](https://github.com/reearth/reearth-visualizer/commit/e8647a)
+- Cache ComputedFeature on reearth&#x2F;core ([#396](https://github.com/reearth/reearth-visualizer/pull/396)) [`775a8a`](https://github.com/reearth/reearth-visualizer/commit/775a8a)
+- Missing type of API modal &amp; popup options.  ([#400](https://github.com/reearth/reearth-visualizer/pull/400)) [`a68b24`](https://github.com/reearth/reearth-visualizer/commit/a68b24)
+- Visualizer on reearth&#x2F;core ([#395](https://github.com/reearth/reearth-visualizer/pull/395)) [`7ba0db`](https://github.com/reearth/reearth-visualizer/commit/7ba0db)
+- Update mvt dynamically when appearance is updated ([#393](https://github.com/reearth/reearth-visualizer/pull/393)) [`7ca5d1`](https://github.com/reearth/reearth-visualizer/commit/7ca5d1)
 
 #### 📖 Documentation
 
-- Add diagrams of core architecture ([#396](https://github.com/reearth/reearth/pull/396)) [`2dfa6b`](https://github.com/reearth/reearth/commit/2dfa6b)
+- Add diagrams of core architecture ([#396](https://github.com/reearth/reearth-visualizer/pull/396)) [`2dfa6b`](https://github.com/reearth/reearth-visualizer/commit/2dfa6b)
 
 #### ⚡️ Performance
 
-- Consider geojson as both delegate and active data type in reearth&#x2F;core ([#608](https://github.com/reearth/reearth/pull/608)) [`94bc59`](https://github.com/reearth/reearth/commit/94bc59)
-- Improve styling in MVT on reearth&#x2F;core ([#574](https://github.com/reearth/reearth/pull/574)) [`8ced77`](https://github.com/reearth/reearth/commit/8ced77)
-- Improve 3dtiles performance and disable requestRenderMode on reearth&#x2F;core ([#568](https://github.com/reearth/reearth/pull/568)) [`e645ec`](https://github.com/reearth/reearth/commit/e645ec)
-- Reduce style evaluator memory signature in reearth&#x2F;core ([#563](https://github.com/reearth/reearth/pull/563)) [`f74b56`](https://github.com/reearth/reearth/commit/f74b56)
-- Use private modifier on evaluator on reearth&#x2F;core ([#543](https://github.com/reearth/reearth/pull/543)) [`532c66`](https://github.com/reearth/reearth/commit/532c66)
-- Improve regexp on reearth&#x2F;core ([#533](https://github.com/reearth/reearth/pull/533)) [`ca7b05`](https://github.com/reearth/reearth/commit/ca7b05)
-- Stop synchronizing features in MVT on reearth&#x2F;core ([#521](https://github.com/reearth/reearth/pull/521)) [`82ae2c`](https://github.com/reearth/reearth/commit/82ae2c)
-- Copy lazy layer lazily ([#517](https://github.com/reearth/reearth/pull/517)) [`4a5ba4`](https://github.com/reearth/reearth/commit/4a5ba4)
-- Improve mvt rendering on reearth&#x2F;core ([#501](https://github.com/reearth/reearth/pull/501)) [`8a681d`](https://github.com/reearth/reearth/commit/8a681d)
-- Compute features concurrently on reearth&#x2F;core ([#499](https://github.com/reearth/reearth/pull/499)) [`6448ba`](https://github.com/reearth/reearth/commit/6448ba)
-- Improve skipping computing process for 3dtiles on reearth&#x2F;core ([#491](https://github.com/reearth/reearth/pull/491)) [`253b58`](https://github.com/reearth/reearth/commit/253b58)
-- Improve 3dtiles features calculation on reearth&#x2F;core ([#489](https://github.com/reearth/reearth/pull/489)) [`1204a6`](https://github.com/reearth/reearth/commit/1204a6)
-- Improve expression cache strategy on reearth&#x2F;core ([#488](https://github.com/reearth/reearth/pull/488)) [`324e28`](https://github.com/reearth/reearth/commit/324e28)
-- Cache AST for evaluator on reearth&#x2F;core ([#473](https://github.com/reearth/reearth/pull/473)) [`da6bb3`](https://github.com/reearth/reearth/commit/da6bb3)
-- Improve blink when feature is updated on reearth&#x2F;core ([#429](https://github.com/reearth/reearth/pull/429)) [`c10a67`](https://github.com/reearth/reearth/commit/c10a67)
+- Consider geojson as both delegate and active data type in reearth&#x2F;core ([#608](https://github.com/reearth/reearth-visualizer/pull/608)) [`94bc59`](https://github.com/reearth/reearth-visualizer/commit/94bc59)
+- Improve styling in MVT on reearth&#x2F;core ([#574](https://github.com/reearth/reearth-visualizer/pull/574)) [`8ced77`](https://github.com/reearth/reearth-visualizer/commit/8ced77)
+- Improve 3dtiles performance and disable requestRenderMode on reearth&#x2F;core ([#568](https://github.com/reearth/reearth-visualizer/pull/568)) [`e645ec`](https://github.com/reearth/reearth-visualizer/commit/e645ec)
+- Reduce style evaluator memory signature in reearth&#x2F;core ([#563](https://github.com/reearth/reearth-visualizer/pull/563)) [`f74b56`](https://github.com/reearth/reearth-visualizer/commit/f74b56)
+- Use private modifier on evaluator on reearth&#x2F;core ([#543](https://github.com/reearth/reearth-visualizer/pull/543)) [`532c66`](https://github.com/reearth/reearth-visualizer/commit/532c66)
+- Improve regexp on reearth&#x2F;core ([#533](https://github.com/reearth/reearth-visualizer/pull/533)) [`ca7b05`](https://github.com/reearth/reearth-visualizer/commit/ca7b05)
+- Stop synchronizing features in MVT on reearth&#x2F;core ([#521](https://github.com/reearth/reearth-visualizer/pull/521)) [`82ae2c`](https://github.com/reearth/reearth-visualizer/commit/82ae2c)
+- Copy lazy layer lazily ([#517](https://github.com/reearth/reearth-visualizer/pull/517)) [`4a5ba4`](https://github.com/reearth/reearth-visualizer/commit/4a5ba4)
+- Improve mvt rendering on reearth&#x2F;core ([#501](https://github.com/reearth/reearth-visualizer/pull/501)) [`8a681d`](https://github.com/reearth/reearth-visualizer/commit/8a681d)
+- Compute features concurrently on reearth&#x2F;core ([#499](https://github.com/reearth/reearth-visualizer/pull/499)) [`6448ba`](https://github.com/reearth/reearth-visualizer/commit/6448ba)
+- Improve skipping computing process for 3dtiles on reearth&#x2F;core ([#491](https://github.com/reearth/reearth-visualizer/pull/491)) [`253b58`](https://github.com/reearth/reearth-visualizer/commit/253b58)
+- Improve 3dtiles features calculation on reearth&#x2F;core ([#489](https://github.com/reearth/reearth-visualizer/pull/489)) [`1204a6`](https://github.com/reearth/reearth-visualizer/commit/1204a6)
+- Improve expression cache strategy on reearth&#x2F;core ([#488](https://github.com/reearth/reearth-visualizer/pull/488)) [`324e28`](https://github.com/reearth/reearth-visualizer/commit/324e28)
+- Cache AST for evaluator on reearth&#x2F;core ([#473](https://github.com/reearth/reearth-visualizer/pull/473)) [`da6bb3`](https://github.com/reearth/reearth-visualizer/commit/da6bb3)
+- Improve blink when feature is updated on reearth&#x2F;core ([#429](https://github.com/reearth/reearth-visualizer/pull/429)) [`c10a67`](https://github.com/reearth/reearth-visualizer/commit/c10a67)
 
 #### ✨ Refactor
 
-- Replace &quot;team&quot; word  related to Team state with &quot;workspace&quot; ([#607](https://github.com/reearth/reearth/pull/607)) [`fb254b`](https://github.com/reearth/reearth/commit/fb254b)
+- Replace &quot;team&quot; word  related to Team state with &quot;workspace&quot; ([#607](https://github.com/reearth/reearth-visualizer/pull/607)) [`fb254b`](https://github.com/reearth/reearth-visualizer/commit/fb254b)
 
 #### Miscellaneous Tasks
 
-- Remove redundant workflows [`f2685d`](https://github.com/reearth/reearth/commit/f2685d)
-- Remove inter-dependency of web and server workflows [`999e73`](https://github.com/reearth/reearth/commit/999e73)
-- Change codeowner [`bffa05`](https://github.com/reearth/reearth/commit/bffa05)
-- Upgrade eslint [`d55795`](https://github.com/reearth/reearth/commit/d55795)
-- Update dependency cesium to v1.104.0 ([#594](https://github.com/reearth/reearth/pull/594)) [`c57839`](https://github.com/reearth/reearth/commit/c57839)
-- Fix storybook is not working ([#536](https://github.com/reearth/reearth/pull/536) [`d52124`](https://github.com/reearth/reearth/commit/d52124)
-- Rename asset dir to avoid conflicts with backend API endpoints [`1d9455`](https://github.com/reearth/reearth/commit/1d9455)
-- Add offline_access auth scope to support refresh tokens with built-in auth server ([#425](https://github.com/reearth/reearth/pull/425) [`2a2af1`](https://github.com/reearth/reearth/commit/2a2af1)
-- Upgrade dependencies ([#391](https://github.com/reearth/reearth/pull/391)) [`7280af`](https://github.com/reearth/reearth/commit/7280af)
+- Remove redundant workflows [`f2685d`](https://github.com/reearth/reearth-visualizer/commit/f2685d)
+- Remove inter-dependency of web and server workflows [`999e73`](https://github.com/reearth/reearth-visualizer/commit/999e73)
+- Change codeowner [`bffa05`](https://github.com/reearth/reearth-visualizer/commit/bffa05)
+- Upgrade eslint [`d55795`](https://github.com/reearth/reearth-visualizer/commit/d55795)
+- Update dependency cesium to v1.104.0 ([#594](https://github.com/reearth/reearth-visualizer/pull/594)) [`c57839`](https://github.com/reearth/reearth-visualizer/commit/c57839)
+- Fix storybook is not working ([#536](https://github.com/reearth/reearth-visualizer/pull/536) [`d52124`](https://github.com/reearth/reearth-visualizer/commit/d52124)
+- Rename asset dir to avoid conflicts with backend API endpoints [`1d9455`](https://github.com/reearth/reearth-visualizer/commit/1d9455)
+- Add offline_access auth scope to support refresh tokens with built-in auth server ([#425](https://github.com/reearth/reearth-visualizer/pull/425) [`2a2af1`](https://github.com/reearth/reearth-visualizer/commit/2a2af1)
+- Upgrade dependencies ([#391](https://github.com/reearth/reearth-visualizer/pull/391)) [`7280af`](https://github.com/reearth/reearth-visualizer/commit/7280af)
 
 #### 
 
-- Add updated SECURITY.md [`bc31ce`](https://github.com/reearth/reearth/commit/bc31ce)
-- Update to 0.15.0 for the release [`d9b693`](https://github.com/reearth/reearth/commit/d9b693)
-- Mono repo — moving reearth-web [`3b1d8d`](https://github.com/reearth/reearth/commit/3b1d8d)
-- Chore(server(: upgrade golangci-lint to v1.51 [`9c8714`](https://github.com/reearth/reearth/commit/9c8714)
+- Add updated SECURITY.md [`bc31ce`](https://github.com/reearth/reearth-visualizer/commit/bc31ce)
+- Update to 0.15.0 for the release [`d9b693`](https://github.com/reearth/reearth-visualizer/commit/d9b693)
+- Mono repo — moving reearth-web [`3b1d8d`](https://github.com/reearth/reearth-visualizer/commit/3b1d8d)
+- Chore(server(: upgrade golangci-lint to v1.51 [`9c8714`](https://github.com/reearth/reearth-visualizer/commit/9c8714)
 
 ### ci
 
 #### 🔧 Bug Fixes
 
-- Set deafault working directory in build-docker-image [`c57909`](https://github.com/reearth/reearth/commit/c57909)
-- Path director fix on docker build and refactor on deply web nightly [`7c72ea`](https://github.com/reearth/reearth/commit/7c72ea)
+- Set deafault working directory in build-docker-image [`c57909`](https://github.com/reearth/reearth-visualizer/commit/c57909)
+- Path director fix on docker build and refactor on deply web nightly [`7c72ea`](https://github.com/reearth/reearth-visualizer/commit/7c72ea)
 
 #### Miscellaneous Tasks
 
-- Add conditional in ci-web and ci-server for renovate commits ([#406](https://github.com/reearth/reearth/pull/406)) [`cc024b`](https://github.com/reearth/reearth/commit/cc024b)
-- Invoke workflows with their name [`fbbb76`](https://github.com/reearth/reearth/commit/fbbb76)
+- Add conditional in ci-web and ci-server for renovate commits ([#406](https://github.com/reearth/reearth-visualizer/pull/406)) [`cc024b`](https://github.com/reearth/reearth-visualizer/commit/cc024b)
+- Invoke workflows with their name [`fbbb76`](https://github.com/reearth/reearth-visualizer/commit/fbbb76)
 
 ### core
 
 #### 🚀 Features
 
-- Support shapefile in reearth&#x2F;core ([#420](https://github.com/reearth/reearth/pull/420)) [`508502`](https://github.com/reearth/reearth/commit/508502)
-- Support gpx in reearth&#x2F;core ([#423](https://github.com/reearth/reearth/pull/423)) [`b4b04b`](https://github.com/reearth/reearth/commit/b4b04b)
+- Support shapefile in reearth&#x2F;core ([#420](https://github.com/reearth/reearth-visualizer/pull/420)) [`508502`](https://github.com/reearth/reearth-visualizer/commit/508502)
+- Support gpx in reearth&#x2F;core ([#423](https://github.com/reearth/reearth-visualizer/pull/423)) [`b4b04b`](https://github.com/reearth/reearth-visualizer/commit/b4b04b)
 
 ### 
 
 #### 🚀 Features
 
-- Support polyline and point on reearth&#x2F;core ([#606](https://github.com/reearth/reearth/pull/606)) [`abd9a3`](https://github.com/reearth/reearth/commit/abd9a3)
-- Add remembering last open workspace functionality ([#598](https://github.com/reearth/reearth/pull/598)) [`968a9d`](https://github.com/reearth/reearth/commit/968a9d)
-- Support TileMapService(TMS) on reearth&#x2F;core ([#604](https://github.com/reearth/reearth/pull/604)) [`284b35`](https://github.com/reearth/reearth/commit/284b35)
-- Support styling color &amp; show for 3dtiles model ([#599](https://github.com/reearth/reearth/pull/599)) [`a82ca2`](https://github.com/reearth/reearth/commit/a82ca2)
-- Support tiles data type on reearth&#x2F;core ([#597](https://github.com/reearth/reearth/pull/597) [`ae5c49`](https://github.com/reearth/reearth/commit/ae5c49)
-- Support classificationType property in some feature on reearth&#x2F;core ([#593](https://github.com/reearth/reearth/pull/593)) [`897868`](https://github.com/reearth/reearth/commit/897868)
-- Upgrade cesium-mvt-imagery-provider ([#591](https://github.com/reearth/reearth/pull/591)) [`d01d01`](https://github.com/reearth/reearth/commit/d01d01)
-- Upgrade cesium-mvt-imagery-provider ([#588](https://github.com/reearth/reearth/pull/588)) [`e138bd`](https://github.com/reearth/reearth/commit/e138bd)
-- Add more styling properties to resource appearance in reearth&#x2F;core ([#586](https://github.com/reearth/reearth/pull/586)) [`8f3625`](https://github.com/reearth/reearth/commit/8f3625)
-- Add built field in scene in plugin api ([#584](https://github.com/reearth/reearth/pull/584)) [`e8050c`](https://github.com/reearth/reearth/commit/e8050c)
-- Add scene light ([#576](https://github.com/reearth/reearth/pull/576)) [`43c2b8`](https://github.com/reearth/reearth/commit/43c2b8)
-- Upgrade mvt lib ([#575](https://github.com/reearth/reearth/pull/575)) [`584cee`](https://github.com/reearth/reearth/commit/584cee)
-- Option to unselect layer when click infobox close ([#564](https://github.com/reearth/reearth/pull/564)) [`f2b2f2`](https://github.com/reearth/reearth/commit/f2b2f2)
-- Add alpha property to raster appearance on reearth&#x2F;core ([#555](https://github.com/reearth/reearth/pull/555)) [`541f30`](https://github.com/reearth/reearth/commit/541f30)
-- Support styling for point cloud on reearth&#x2F;core ([#549](https://github.com/reearth/reearth/pull/549)) [`f410d6`](https://github.com/reearth/reearth/commit/f410d6)
-- Add defaultContent property for infobox in plugin API on reearth&#x2F;core ([#538](https://github.com/reearth/reearth/pull/538)) [`31ba31`](https://github.com/reearth/reearth/commit/31ba31)
-- Add updateClockOnLoad  to data on reearth&#x2F;core ([#539](https://github.com/reearth/reearth/pull/539)) [`3653e2`](https://github.com/reearth/reearth/commit/3653e2)
-- Support gltf data type on reearth&#x2F;core ([#535](https://github.com/reearth/reearth/pull/535)) [`e086be`](https://github.com/reearth/reearth/commit/e086be)
-- Support ga4 ([#509](https://github.com/reearth/reearth/pull/509)) [`39bfb0`](https://github.com/reearth/reearth/commit/39bfb0)
-- Select MVT feature on reearth&#x2F;core ([#527](https://github.com/reearth/reearth/pull/527)) [`de605d`](https://github.com/reearth/reearth/commit/de605d)
-- Add parameters property to data on reearth&#x2F;core ([#520](https://github.com/reearth/reearth/pull/520)) [`c698eb`](https://github.com/reearth/reearth/commit/c698eb)
-- Layer select event in reearth&#x2F;core ([#470](https://github.com/reearth/reearth/pull/470)) [`fb22e6`](https://github.com/reearth/reearth/commit/fb22e6)
-- Show field in appearances of reearth&#x2F;core ([#469](https://github.com/reearth/reearth/pull/469)) [`819eb6`](https://github.com/reearth/reearth/commit/819eb6)
-- ImageSizeInMeters field in marker proeperty ([#511](https://github.com/reearth/reearth/pull/511)) [`290cb7`](https://github.com/reearth/reearth/commit/290cb7)
-- Override clock from scene setting on reearth&#x2F;core ([#505](https://github.com/reearth/reearth/pull/505)) [`01bffd`](https://github.com/reearth/reearth/commit/01bffd)
-- Support features for CZML on reearth&#x2F;core ([#506](https://github.com/reearth/reearth/pull/506)) [`e5c160`](https://github.com/reearth/reearth/commit/e5c160)
-- Update cesium ([#503](https://github.com/reearth/reearth/pull/503)) [`5a649f`](https://github.com/reearth/reearth/commit/5a649f)
-- Color blend mode in tileset on reearth&#x2F;core ([#496](https://github.com/reearth/reearth/pull/496)) [`ca43dc`](https://github.com/reearth/reearth/commit/ca43dc)
-- Change brand images and colors at the root page ([#495](https://github.com/reearth/reearth/pull/495))Co-authored-by: rot1024 &lt;aayhrot@gmail.com&gt; [`4f07b9`](https://github.com/reearth/reearth/commit/4f07b9)
-- Add builtin clipping box on reearth&#x2F;core ([#487](https://github.com/reearth/reearth/pull/487)) [`63bd4f`](https://github.com/reearth/reearth/commit/63bd4f)
-- ExtrudedHeight for polygon on reearth&#x2F;core ([#486](https://github.com/reearth/reearth/pull/486)) [`523d35`](https://github.com/reearth/reearth/commit/523d35)
-- Support resource entity layerId on reearth&#x2F;core ([#485](https://github.com/reearth/reearth/pull/485)) [`7bd7c5`](https://github.com/reearth/reearth/commit/7bd7c5)
-- Support distanceDisplayCondition on reearth&#x2F;core ([#475](https://github.com/reearth/reearth/pull/475)) [`ce8270`](https://github.com/reearth/reearth/commit/ce8270)
-- Support GeoRSS and gml in reearth&#x2F;core ([#455](https://github.com/reearth/reearth/pull/455)) [`58c25b`](https://github.com/reearth/reearth/commit/58c25b)
-- Add htmlblock on reearth&#x2F;core ([#454](https://github.com/reearth/reearth/pull/454)) [`1b37e0`](https://github.com/reearth/reearth/commit/1b37e0)
-- Support clipping box direction on reearth&#x2F;core ([#467](https://github.com/reearth/reearth/pull/467)) [`70f74e`](https://github.com/reearth/reearth/commit/70f74e)
-- Add sampleTerrainHeight on reearht&#x2F;core ([#466](https://github.com/reearth/reearth/pull/466)) [`55334e`](https://github.com/reearth/reearth/commit/55334e)
-- Get brand from config ([#457](https://github.com/reearth/reearth/pull/457)) [`d35361`](https://github.com/reearth/reearth/commit/d35361)
-- Support timeline on mobile on reearth&#x2F;core ([#462](https://github.com/reearth/reearth/pull/462)) [`efeaf4`](https://github.com/reearth/reearth/commit/efeaf4)
-- Use visible field on reearth&#x2F;core ([#456](https://github.com/reearth/reearth/pull/456)) [`333610`](https://github.com/reearth/reearth/commit/333610)
-- Add htmlblock to built-in plugin ([#384](https://github.com/reearth/reearth/pull/384)) [`51c79a`](https://github.com/reearth/reearth/commit/51c79a)
-- Add override, replace and delete plugin API on reearth&#x2F;core ([#451](https://github.com/reearth/reearth/pull/451)) [`2e1c41`](https://github.com/reearth/reearth/commit/2e1c41)
-- Selecting imagery features ([#450](https://github.com/reearth/reearth/pull/450)) [`f24ef5`](https://github.com/reearth/reearth/commit/f24ef5)
-- Support interval fetching data on reearth&#x2F;core ([#449](https://github.com/reearth/reearth/pull/449)) [`406174`](https://github.com/reearth/reearth/commit/406174)
-- Support select feature on reearth&#x2F;core ([#445](https://github.com/reearth/reearth/pull/445)) [`3174b1`](https://github.com/reearth/reearth/commit/3174b1)
-- Use experimental core flag ([#448](https://github.com/reearth/reearth/pull/448)) [`b04294`](https://github.com/reearth/reearth/commit/b04294)
-- Support time series features on reearth&#x2F;core ([#446](https://github.com/reearth/reearth/pull/446)) [`8fc9b6`](https://github.com/reearth/reearth/commit/8fc9b6)
-- Scene property to enable VR mode ([#444](https://github.com/reearth/reearth/pull/444)) [`3d35aa`](https://github.com/reearth/reearth/commit/3d35aa)
-- Support general transit feed ([#408](https://github.com/reearth/reearth/pull/408)) [`49b4a4`](https://github.com/reearth/reearth/commit/49b4a4)
-- Support osm data type on reearth&#x2F;core ([#431](https://github.com/reearth/reearth/pull/431)) [`0d4e0b`](https://github.com/reearth/reearth/commit/0d4e0b)
-- Label background color and padding property for markers ([#426](https://github.com/reearth/reearth/pull/426) [`72cd0d`](https://github.com/reearth/reearth/commit/72cd0d)
-- Support entity base flyTo on reearth&#x2F;core ([#419](https://github.com/reearth/reearth/pull/419)) [`3060cf`](https://github.com/reearth/reearth/commit/3060cf)
-- Support overriding czml appearance on reearth&#x2F;core ([#421](https://github.com/reearth/reearth/pull/421)) [`e62f4d`](https://github.com/reearth/reearth/commit/e62f4d)
-- Support kml on reearth&#x2F;core ([#422](https://github.com/reearth/reearth/pull/422)) [`052daf`](https://github.com/reearth/reearth/commit/052daf)
-- Support json properties on reearth&#x2F;core ([#412](https://github.com/reearth/reearth/pull/412)) [`ac7986`](https://github.com/reearth/reearth/commit/ac7986)
-- Connect reearth&#x2F;core with existence pages ([#401](https://github.com/reearth/reearth/pull/401)) [`0735c0`](https://github.com/reearth/reearth/commit/0735c0)
-- Add runTimes property to PluginInstance ([#404](https://github.com/reearth/reearth/pull/404)) [`17d787`](https://github.com/reearth/reearth/commit/17d787)
-- Support plugin system on reearth&#x2F;core ([#399](https://github.com/reearth/reearth/pull/399)) [`bab9e6`](https://github.com/reearth/reearth/commit/bab9e6)
-- Add selectedFeature and selectedComputedFeature on reearth&#x2F;core ([#398](https://github.com/reearth/reearth/pull/398)) [`474b34`](https://github.com/reearth/reearth/commit/474b34)
-- Set modal above popup ([#397](https://github.com/reearth/reearth/pull/397)) [`ff47c5`](https://github.com/reearth/reearth/commit/ff47c5)
-- Port 2d navigator to reearth&#x2F;core ([#394](https://github.com/reearth/reearth/pull/394)) [`07a6b4`](https://github.com/reearth/reearth/commit/07a6b4)
-- Core&#x2F;Visualizer without plugins ([#372](https://github.com/reearth/reearth/pull/372)) [`f97c38`](https://github.com/reearth/reearth/commit/f97c38)
-- Reearth style language ([#384](https://github.com/reearth/reearth/pull/384)) [`a828ac`](https://github.com/reearth/reearth/commit/a828ac)
-- Support 3dtiles on reearth&#x2F;core ([#392](https://github.com/reearth/reearth/pull/392)) [`e8068f`](https://github.com/reearth/reearth/commit/e8068f)
-- Support MVT on reearth&#x2F;core ([#388](https://github.com/reearth/reearth/pull/388)) [`cac89c`](https://github.com/reearth/reearth/commit/cac89c)
-- Support WMS on reearth&#x2F;core ([#387](https://github.com/reearth/reearth/pull/387)) [`666c1b`](https://github.com/reearth/reearth/commit/666c1b)
-- Support CZML in reearth&#x2F;core ([#383](https://github.com/reearth/reearth/pull/383)) [`f44d98`](https://github.com/reearth/reearth/commit/f44d98)
-- Plugin api client storage ([#376](https://github.com/reearth/reearth/pull/376)) [`4f36ad`](https://github.com/reearth/reearth/commit/4f36ad)
-- Support csv on the reearth&#x2F;core ([#382](https://github.com/reearth/reearth/pull/382)) [`a8f5bf`](https://github.com/reearth/reearth/commit/a8f5bf)
+- Support polyline and point on reearth&#x2F;core ([#606](https://github.com/reearth/reearth-visualizer/pull/606)) [`abd9a3`](https://github.com/reearth/reearth-visualizer/commit/abd9a3)
+- Add remembering last open workspace functionality ([#598](https://github.com/reearth/reearth-visualizer/pull/598)) [`968a9d`](https://github.com/reearth/reearth-visualizer/commit/968a9d)
+- Support TileMapService(TMS) on reearth&#x2F;core ([#604](https://github.com/reearth/reearth-visualizer/pull/604)) [`284b35`](https://github.com/reearth/reearth-visualizer/commit/284b35)
+- Support styling color &amp; show for 3dtiles model ([#599](https://github.com/reearth/reearth-visualizer/pull/599)) [`a82ca2`](https://github.com/reearth/reearth-visualizer/commit/a82ca2)
+- Support tiles data type on reearth&#x2F;core ([#597](https://github.com/reearth/reearth-visualizer/pull/597) [`ae5c49`](https://github.com/reearth/reearth-visualizer/commit/ae5c49)
+- Support classificationType property in some feature on reearth&#x2F;core ([#593](https://github.com/reearth/reearth-visualizer/pull/593)) [`897868`](https://github.com/reearth/reearth-visualizer/commit/897868)
+- Upgrade cesium-mvt-imagery-provider ([#591](https://github.com/reearth/reearth-visualizer/pull/591)) [`d01d01`](https://github.com/reearth/reearth-visualizer/commit/d01d01)
+- Upgrade cesium-mvt-imagery-provider ([#588](https://github.com/reearth/reearth-visualizer/pull/588)) [`e138bd`](https://github.com/reearth/reearth-visualizer/commit/e138bd)
+- Add more styling properties to resource appearance in reearth&#x2F;core ([#586](https://github.com/reearth/reearth-visualizer/pull/586)) [`8f3625`](https://github.com/reearth/reearth-visualizer/commit/8f3625)
+- Add built field in scene in plugin api ([#584](https://github.com/reearth/reearth-visualizer/pull/584)) [`e8050c`](https://github.com/reearth/reearth-visualizer/commit/e8050c)
+- Add scene light ([#576](https://github.com/reearth/reearth-visualizer/pull/576)) [`43c2b8`](https://github.com/reearth/reearth-visualizer/commit/43c2b8)
+- Upgrade mvt lib ([#575](https://github.com/reearth/reearth-visualizer/pull/575)) [`584cee`](https://github.com/reearth/reearth-visualizer/commit/584cee)
+- Option to unselect layer when click infobox close ([#564](https://github.com/reearth/reearth-visualizer/pull/564)) [`f2b2f2`](https://github.com/reearth/reearth-visualizer/commit/f2b2f2)
+- Add alpha property to raster appearance on reearth&#x2F;core ([#555](https://github.com/reearth/reearth-visualizer/pull/555)) [`541f30`](https://github.com/reearth/reearth-visualizer/commit/541f30)
+- Support styling for point cloud on reearth&#x2F;core ([#549](https://github.com/reearth/reearth-visualizer/pull/549)) [`f410d6`](https://github.com/reearth/reearth-visualizer/commit/f410d6)
+- Add defaultContent property for infobox in plugin API on reearth&#x2F;core ([#538](https://github.com/reearth/reearth-visualizer/pull/538)) [`31ba31`](https://github.com/reearth/reearth-visualizer/commit/31ba31)
+- Add updateClockOnLoad  to data on reearth&#x2F;core ([#539](https://github.com/reearth/reearth-visualizer/pull/539)) [`3653e2`](https://github.com/reearth/reearth-visualizer/commit/3653e2)
+- Support gltf data type on reearth&#x2F;core ([#535](https://github.com/reearth/reearth-visualizer/pull/535)) [`e086be`](https://github.com/reearth/reearth-visualizer/commit/e086be)
+- Support ga4 ([#509](https://github.com/reearth/reearth-visualizer/pull/509)) [`39bfb0`](https://github.com/reearth/reearth-visualizer/commit/39bfb0)
+- Select MVT feature on reearth&#x2F;core ([#527](https://github.com/reearth/reearth-visualizer/pull/527)) [`de605d`](https://github.com/reearth/reearth-visualizer/commit/de605d)
+- Add parameters property to data on reearth&#x2F;core ([#520](https://github.com/reearth/reearth-visualizer/pull/520)) [`c698eb`](https://github.com/reearth/reearth-visualizer/commit/c698eb)
+- Layer select event in reearth&#x2F;core ([#470](https://github.com/reearth/reearth-visualizer/pull/470)) [`fb22e6`](https://github.com/reearth/reearth-visualizer/commit/fb22e6)
+- Show field in appearances of reearth&#x2F;core ([#469](https://github.com/reearth/reearth-visualizer/pull/469)) [`819eb6`](https://github.com/reearth/reearth-visualizer/commit/819eb6)
+- ImageSizeInMeters field in marker proeperty ([#511](https://github.com/reearth/reearth-visualizer/pull/511)) [`290cb7`](https://github.com/reearth/reearth-visualizer/commit/290cb7)
+- Override clock from scene setting on reearth&#x2F;core ([#505](https://github.com/reearth/reearth-visualizer/pull/505)) [`01bffd`](https://github.com/reearth/reearth-visualizer/commit/01bffd)
+- Support features for CZML on reearth&#x2F;core ([#506](https://github.com/reearth/reearth-visualizer/pull/506)) [`e5c160`](https://github.com/reearth/reearth-visualizer/commit/e5c160)
+- Update cesium ([#503](https://github.com/reearth/reearth-visualizer/pull/503)) [`5a649f`](https://github.com/reearth/reearth-visualizer/commit/5a649f)
+- Color blend mode in tileset on reearth&#x2F;core ([#496](https://github.com/reearth/reearth-visualizer/pull/496)) [`ca43dc`](https://github.com/reearth/reearth-visualizer/commit/ca43dc)
+- Change brand images and colors at the root page ([#495](https://github.com/reearth/reearth-visualizer/pull/495))Co-authored-by: rot1024 &lt;aayhrot@gmail.com&gt; [`4f07b9`](https://github.com/reearth/reearth-visualizer/commit/4f07b9)
+- Add builtin clipping box on reearth&#x2F;core ([#487](https://github.com/reearth/reearth-visualizer/pull/487)) [`63bd4f`](https://github.com/reearth/reearth-visualizer/commit/63bd4f)
+- ExtrudedHeight for polygon on reearth&#x2F;core ([#486](https://github.com/reearth/reearth-visualizer/pull/486)) [`523d35`](https://github.com/reearth/reearth-visualizer/commit/523d35)
+- Support resource entity layerId on reearth&#x2F;core ([#485](https://github.com/reearth/reearth-visualizer/pull/485)) [`7bd7c5`](https://github.com/reearth/reearth-visualizer/commit/7bd7c5)
+- Support distanceDisplayCondition on reearth&#x2F;core ([#475](https://github.com/reearth/reearth-visualizer/pull/475)) [`ce8270`](https://github.com/reearth/reearth-visualizer/commit/ce8270)
+- Support GeoRSS and gml in reearth&#x2F;core ([#455](https://github.com/reearth/reearth-visualizer/pull/455)) [`58c25b`](https://github.com/reearth/reearth-visualizer/commit/58c25b)
+- Add htmlblock on reearth&#x2F;core ([#454](https://github.com/reearth/reearth-visualizer/pull/454)) [`1b37e0`](https://github.com/reearth/reearth-visualizer/commit/1b37e0)
+- Support clipping box direction on reearth&#x2F;core ([#467](https://github.com/reearth/reearth-visualizer/pull/467)) [`70f74e`](https://github.com/reearth/reearth-visualizer/commit/70f74e)
+- Add sampleTerrainHeight on reearht&#x2F;core ([#466](https://github.com/reearth/reearth-visualizer/pull/466)) [`55334e`](https://github.com/reearth/reearth-visualizer/commit/55334e)
+- Get brand from config ([#457](https://github.com/reearth/reearth-visualizer/pull/457)) [`d35361`](https://github.com/reearth/reearth-visualizer/commit/d35361)
+- Support timeline on mobile on reearth&#x2F;core ([#462](https://github.com/reearth/reearth-visualizer/pull/462)) [`efeaf4`](https://github.com/reearth/reearth-visualizer/commit/efeaf4)
+- Use visible field on reearth&#x2F;core ([#456](https://github.com/reearth/reearth-visualizer/pull/456)) [`333610`](https://github.com/reearth/reearth-visualizer/commit/333610)
+- Add htmlblock to built-in plugin ([#384](https://github.com/reearth/reearth-visualizer/pull/384)) [`51c79a`](https://github.com/reearth/reearth-visualizer/commit/51c79a)
+- Add override, replace and delete plugin API on reearth&#x2F;core ([#451](https://github.com/reearth/reearth-visualizer/pull/451)) [`2e1c41`](https://github.com/reearth/reearth-visualizer/commit/2e1c41)
+- Selecting imagery features ([#450](https://github.com/reearth/reearth-visualizer/pull/450)) [`f24ef5`](https://github.com/reearth/reearth-visualizer/commit/f24ef5)
+- Support interval fetching data on reearth&#x2F;core ([#449](https://github.com/reearth/reearth-visualizer/pull/449)) [`406174`](https://github.com/reearth/reearth-visualizer/commit/406174)
+- Support select feature on reearth&#x2F;core ([#445](https://github.com/reearth/reearth-visualizer/pull/445)) [`3174b1`](https://github.com/reearth/reearth-visualizer/commit/3174b1)
+- Use experimental core flag ([#448](https://github.com/reearth/reearth-visualizer/pull/448)) [`b04294`](https://github.com/reearth/reearth-visualizer/commit/b04294)
+- Support time series features on reearth&#x2F;core ([#446](https://github.com/reearth/reearth-visualizer/pull/446)) [`8fc9b6`](https://github.com/reearth/reearth-visualizer/commit/8fc9b6)
+- Scene property to enable VR mode ([#444](https://github.com/reearth/reearth-visualizer/pull/444)) [`3d35aa`](https://github.com/reearth/reearth-visualizer/commit/3d35aa)
+- Support general transit feed ([#408](https://github.com/reearth/reearth-visualizer/pull/408)) [`49b4a4`](https://github.com/reearth/reearth-visualizer/commit/49b4a4)
+- Support osm data type on reearth&#x2F;core ([#431](https://github.com/reearth/reearth-visualizer/pull/431)) [`0d4e0b`](https://github.com/reearth/reearth-visualizer/commit/0d4e0b)
+- Label background color and padding property for markers ([#426](https://github.com/reearth/reearth-visualizer/pull/426) [`72cd0d`](https://github.com/reearth/reearth-visualizer/commit/72cd0d)
+- Support entity base flyTo on reearth&#x2F;core ([#419](https://github.com/reearth/reearth-visualizer/pull/419)) [`3060cf`](https://github.com/reearth/reearth-visualizer/commit/3060cf)
+- Support overriding czml appearance on reearth&#x2F;core ([#421](https://github.com/reearth/reearth-visualizer/pull/421)) [`e62f4d`](https://github.com/reearth/reearth-visualizer/commit/e62f4d)
+- Support kml on reearth&#x2F;core ([#422](https://github.com/reearth/reearth-visualizer/pull/422)) [`052daf`](https://github.com/reearth/reearth-visualizer/commit/052daf)
+- Support json properties on reearth&#x2F;core ([#412](https://github.com/reearth/reearth-visualizer/pull/412)) [`ac7986`](https://github.com/reearth/reearth-visualizer/commit/ac7986)
+- Connect reearth&#x2F;core with existence pages ([#401](https://github.com/reearth/reearth-visualizer/pull/401)) [`0735c0`](https://github.com/reearth/reearth-visualizer/commit/0735c0)
+- Add runTimes property to PluginInstance ([#404](https://github.com/reearth/reearth-visualizer/pull/404)) [`17d787`](https://github.com/reearth/reearth-visualizer/commit/17d787)
+- Support plugin system on reearth&#x2F;core ([#399](https://github.com/reearth/reearth-visualizer/pull/399)) [`bab9e6`](https://github.com/reearth/reearth-visualizer/commit/bab9e6)
+- Add selectedFeature and selectedComputedFeature on reearth&#x2F;core ([#398](https://github.com/reearth/reearth-visualizer/pull/398)) [`474b34`](https://github.com/reearth/reearth-visualizer/commit/474b34)
+- Set modal above popup ([#397](https://github.com/reearth/reearth-visualizer/pull/397)) [`ff47c5`](https://github.com/reearth/reearth-visualizer/commit/ff47c5)
+- Port 2d navigator to reearth&#x2F;core ([#394](https://github.com/reearth/reearth-visualizer/pull/394)) [`07a6b4`](https://github.com/reearth/reearth-visualizer/commit/07a6b4)
+- Core&#x2F;Visualizer without plugins ([#372](https://github.com/reearth/reearth-visualizer/pull/372)) [`f97c38`](https://github.com/reearth/reearth-visualizer/commit/f97c38)
+- Reearth style language ([#384](https://github.com/reearth/reearth-visualizer/pull/384)) [`a828ac`](https://github.com/reearth/reearth-visualizer/commit/a828ac)
+- Support 3dtiles on reearth&#x2F;core ([#392](https://github.com/reearth/reearth-visualizer/pull/392)) [`e8068f`](https://github.com/reearth/reearth-visualizer/commit/e8068f)
+- Support MVT on reearth&#x2F;core ([#388](https://github.com/reearth/reearth-visualizer/pull/388)) [`cac89c`](https://github.com/reearth/reearth-visualizer/commit/cac89c)
+- Support WMS on reearth&#x2F;core ([#387](https://github.com/reearth/reearth-visualizer/pull/387)) [`666c1b`](https://github.com/reearth/reearth-visualizer/commit/666c1b)
+- Support CZML in reearth&#x2F;core ([#383](https://github.com/reearth/reearth-visualizer/pull/383)) [`f44d98`](https://github.com/reearth/reearth-visualizer/commit/f44d98)
+- Plugin api client storage ([#376](https://github.com/reearth/reearth-visualizer/pull/376)) [`4f36ad`](https://github.com/reearth/reearth-visualizer/commit/4f36ad)
+- Support csv on the reearth&#x2F;core ([#382](https://github.com/reearth/reearth-visualizer/pull/382)) [`a8f5bf`](https://github.com/reearth/reearth-visualizer/commit/a8f5bf)
 
 #### 🔧 Bug Fixes
 
-- Merge conflict resolved [`39a37a`](https://github.com/reearth/reearth/commit/39a37a)
-- Use core hook may get value incorrectly ([#609](https://github.com/reearth/reearth/pull/609)) [`d87e90`](https://github.com/reearth/reearth/commit/d87e90)
-- Resolve endsWith is not a function error with style in reearth&#x2F;core ([#603](https://github.com/reearth/reearth/pull/603)) [`15fec3`](https://github.com/reearth/reearth/commit/15fec3)
-- Add % as special case for &#x60;Number()&#x60; in style lang of reearth&#x2F;core ([#601](https://github.com/reearth/reearth/pull/601)) [`5a4a3d`](https://github.com/reearth/reearth/commit/5a4a3d)
-- Rename moveWidget to onMoveWidget on reearth&#x2F;core ([#600](https://github.com/reearth/reearth/pull/600)) [`6c06ab`](https://github.com/reearth/reearth/commit/6c06ab)
-- Enable splash screen in preview page ([#596](https://github.com/reearth/reearth/pull/596) [`e1f5ac`](https://github.com/reearth/reearth/commit/e1f5ac)
-- Timeline scroll should be fixed in initial render ([#571](https://github.com/reearth/reearth/pull/571)) [`6a0aed`](https://github.com/reearth/reearth/commit/6a0aed)
-- Remove default height reference for modelGraphics in reearth&#x2F;core ([#592](https://github.com/reearth/reearth/pull/592)) [`961b46`](https://github.com/reearth/reearth/commit/961b46)
-- Remove duplication of feature entity in reearth&#x2F;core ([#590](https://github.com/reearth/reearth/pull/590)) [`8cc03e`](https://github.com/reearth/reearth/commit/8cc03e)
-- Prevent selecting not shown feature for MVT on reearth&#x2F;core ([#589](https://github.com/reearth/reearth/pull/589)) [`41816d`](https://github.com/reearth/reearth/commit/41816d)
-- Infobox for 3dtiles feature ([#587](https://github.com/reearth/reearth/pull/587)) [`70cfdb`](https://github.com/reearth/reearth/commit/70cfdb)
-- Use layer id with feature id for entity id on reearth&#x2F;core ([#585](https://github.com/reearth/reearth/pull/585)) [`24cc88`](https://github.com/reearth/reearth/commit/24cc88)
-- Can&[#39](https://github.com/reearth/reearth/pull/39);t set iframe&[#39](https://github.com/reearth/reearth/pull/39);s width or height individually in crust  ([#583](https://github.com/reearth/reearth/pull/583)) [`3494b4`](https://github.com/reearth/reearth/commit/3494b4)
-- MVT isn&[#39](https://github.com/reearth/reearth/pull/39);t render correctly on reearth&#x2F;core ([#582](https://github.com/reearth/reearth/pull/582)) [`988d1a`](https://github.com/reearth/reearth/commit/988d1a)
-- Sample terrain height API cannot properly return promise ([#581](https://github.com/reearth/reearth/pull/581)) [`72eafd`](https://github.com/reearth/reearth/commit/72eafd)
-- Change logical operator evaluation behaviour in reearth&#x2F;core ([#580](https://github.com/reearth/reearth/pull/580)) [`3d23ce`](https://github.com/reearth/reearth/commit/3d23ce)
-- Infobox style collapse for long names ([#578](https://github.com/reearth/reearth/pull/578)) [`04775d`](https://github.com/reearth/reearth/commit/04775d)
-- Override currentTime on timeline widget when time is updated by CZML on reearth&#x2F;core ([#579](https://github.com/reearth/reearth/pull/579)) [`dbe2e1`](https://github.com/reearth/reearth/commit/dbe2e1)
-- Rename scene light properties [`8b3a18`](https://github.com/reearth/reearth/commit/8b3a18)
-- Add none cesium value for heightReference ([#577](https://github.com/reearth/reearth/pull/577)) [`2c92e3`](https://github.com/reearth/reearth/commit/2c92e3)
-- JSON Path condition on reearth&#x2F;core ([#572](https://github.com/reearth/reearth/pull/572)) [`5f7024`](https://github.com/reearth/reearth/commit/5f7024)
-- Update html head [`f1780f`](https://github.com/reearth/reearth/commit/f1780f)
-- Sync selected feature with layer api on reearth&#x2F;core ([#570](https://github.com/reearth/reearth/pull/570)) [`ded6b0`](https://github.com/reearth/reearth/commit/ded6b0)
-- Imagery index on reearth&#x2F;core ([#569](https://github.com/reearth/reearth/pull/569)) [`6b233f`](https://github.com/reearth/reearth/commit/6b233f)
-- Revert add height to polygon in reearth&#x2F;core ([#566](https://github.com/reearth/reearth/pull/566)) [`1f2f74`](https://github.com/reearth/reearth/commit/1f2f74)
-- Add clamp as default height reference for model in reearth&#x2F;core ([#567](https://github.com/reearth/reearth/pull/567)) [`517386`](https://github.com/reearth/reearth/commit/517386)
-- Minimum timeline range on reearth&#x2F;core ([#565](https://github.com/reearth/reearth/pull/565)) [`975c79`](https://github.com/reearth/reearth/commit/975c79)
-- Infobox html block styling ([#562](https://github.com/reearth/reearth/pull/562)) [`32b248`](https://github.com/reearth/reearth/commit/32b248)
-- Imagery layer tile index on reearth&#x2F;core ([#561](https://github.com/reearth/reearth/pull/561) [`25bdff`](https://github.com/reearth/reearth/commit/25bdff)
-- Add &quot;disabled&quot; as shadow mode on reearth&#x2F;core ([#560](https://github.com/reearth/reearth/pull/560)) [`1632ea`](https://github.com/reearth/reearth/commit/1632ea)
-- Support multi layers in MVT on reearth&#x2F;core ([#559](https://github.com/reearth/reearth/pull/559)) [`9c8c88`](https://github.com/reearth/reearth/commit/9c8c88)
-- Html block margin and height [`09f6ef`](https://github.com/reearth/reearth/commit/09f6ef)
-- UpdateClockOnLoad condition on reearth&#x2F;core ([#558](https://github.com/reearth/reearth/pull/558)) [`f9076a`](https://github.com/reearth/reearth/commit/f9076a)
-- Add height to polygon in reearth&#x2F;core ([#557](https://github.com/reearth/reearth/pull/557)) [`a84dbe`](https://github.com/reearth/reearth/commit/a84dbe)
-- Use computed feature on resource on reearth&#x2F;core ([#556](https://github.com/reearth/reearth/pull/556)) [`006f40`](https://github.com/reearth/reearth/commit/006f40)
-- Point cloud dirty check on reearth&#x2F;core ([#554](https://github.com/reearth/reearth/pull/554)) [`f95d27`](https://github.com/reearth/reearth/commit/f95d27)
-- Support default infobox and selection indicator on imagery layer on reearth&#x2F;core ([#553](https://github.com/reearth/reearth/pull/553)) [`1946b3`](https://github.com/reearth/reearth/commit/1946b3)
-- Scrollbar in timeline widget always showing ([#550](https://github.com/reearth/reearth/pull/550)) [`84d63d`](https://github.com/reearth/reearth/commit/84d63d)
-- Clipping box on point cloud on reearth&#x2F;core ([#552](https://github.com/reearth/reearth/pull/552)) [`fb4455`](https://github.com/reearth/reearth/commit/fb4455)
-- Htmlblock on safari ([#548](https://github.com/reearth/reearth/pull/548)) [`392fc7`](https://github.com/reearth/reearth/commit/392fc7)
-- Use attributes as default content for infobox on reearth&#x2F;core ([#547](https://github.com/reearth/reearth/pull/547)) [`be3718`](https://github.com/reearth/reearth/commit/be3718)
-- Deleting feature process on reearth&#x2F;core ([#546](https://github.com/reearth/reearth/pull/546)) [`39ecaf`](https://github.com/reearth/reearth/commit/39ecaf)
-- Trigger select event when featureId is changed on reearth&#x2F;core ([#545](https://github.com/reearth/reearth/pull/545)) [`6f5401`](https://github.com/reearth/reearth/commit/6f5401)
-- Draw polylines on polygon on reearth&#x2F;core ([#544](https://github.com/reearth/reearth/pull/544)) [`d35329`](https://github.com/reearth/reearth/commit/d35329)
-- Infobox html color ([#534](https://github.com/reearth/reearth/pull/534)) [`c0e0a6`](https://github.com/reearth/reearth/commit/c0e0a6)
-- Use overriddenLayers to get infobox on reearth&#x2F;core ([#541](https://github.com/reearth/reearth/pull/541)) [`c4e9db`](https://github.com/reearth/reearth/commit/c4e9db)
-- Fly to multiple entities added by a layer on reearth&#x2F;core ([#540](https://github.com/reearth/reearth/pull/540)) [`95b3d3`](https://github.com/reearth/reearth/commit/95b3d3)
-- Add polyfill for requestIdleCallback in reearth&#x2F;core ([#537](https://github.com/reearth/reearth/pull/537)) [`c4722f`](https://github.com/reearth/reearth/commit/c4722f)
-- Overriding timeline behavior on reearth&#x2F;core ([#532](https://github.com/reearth/reearth/pull/532)) [`890dae`](https://github.com/reearth/reearth/commit/890dae)
-- Timeline bug on reearth&#x2F;core ([#531](https://github.com/reearth/reearth/pull/531)) [`572678`](https://github.com/reearth/reearth/commit/572678)
-- Some error on reearth&#x2F;core ([#530](https://github.com/reearth/reearth/pull/530)) [`4ee0b6`](https://github.com/reearth/reearth/commit/4ee0b6)
-- Abort fetching on data atom on reearth&#x2F;core ([#529](https://github.com/reearth/reearth/pull/529)) [`e82c88`](https://github.com/reearth/reearth/commit/e82c88)
-- Timeline behavior on reearth&#x2F;core ([#528](https://github.com/reearth/reearth/pull/528)) [`461d06`](https://github.com/reearth/reearth/commit/461d06)
-- Parse csv numeric strings as numbers in reearth&#x2F;core ([#526](https://github.com/reearth/reearth/pull/526)) [`9c890f`](https://github.com/reearth/reearth/commit/9c890f)
-- Parse hyphen as reserved word in property key on reearth&#x2F;core ([#525](https://github.com/reearth/reearth/pull/525)) [`d49058`](https://github.com/reearth/reearth/commit/d49058)
-- Condition for CZML on reearth&#x2F;core ([#524](https://github.com/reearth/reearth/pull/524)) [`3c61ca`](https://github.com/reearth/reearth/commit/3c61ca)
-- Czml style for marker on reearth&#x2F;core ([#523](https://github.com/reearth/reearth/pull/523)) [`67dccb`](https://github.com/reearth/reearth/commit/67dccb)
-- Use default block for entity on reearth&#x2F;core ([#522](https://github.com/reearth/reearth/pull/522)) [`ecd09a`](https://github.com/reearth/reearth/commit/ecd09a)
-- Remove copyLazyLayer on reearth&#x2F;core ([#519](https://github.com/reearth/reearth/pull/519)) [`e17218`](https://github.com/reearth/reearth/commit/e17218)
-- Copying lazy layers undefined behavior on reearth&#x2F;core ([#516](https://github.com/reearth/reearth/pull/516)) [`7b2c5e`](https://github.com/reearth/reearth/commit/7b2c5e)
-- Copy lazy layer on plugin on reearth&#x2F;core ([#515](https://github.com/reearth/reearth/pull/515)) [`046a3d`](https://github.com/reearth/reearth/commit/046a3d)
-- Attach style dynamically in resource on reearth&#x2F;core ([#514](https://github.com/reearth/reearth/pull/514)) [`81d291`](https://github.com/reearth/reearth/commit/81d291)
-- Infinite infobox in CZML on reearth&#x2F;core ([#513](https://github.com/reearth/reearth/pull/513)) [`3e49a1`](https://github.com/reearth/reearth/commit/3e49a1)
-- Selecting resource feature behavior on reearth&#x2F;core ([#512](https://github.com/reearth/reearth/pull/512)) [`35f2c2`](https://github.com/reearth/reearth/commit/35f2c2)
-- Prevent unnecessary render on timeline on reearth&#x2F;core ([#510](https://github.com/reearth/reearth/pull/510)) [`7cb9d5`](https://github.com/reearth/reearth/commit/7cb9d5)
-- Parse reserved word when property name includes reserved word on reearth&#x2F;core ([#508](https://github.com/reearth/reearth/pull/508)) [`aa247e`](https://github.com/reearth/reearth/commit/aa247e)
-- Pass engine meta on plugin editor ([#507](https://github.com/reearth/reearth/pull/507)) [`9cd1b5`](https://github.com/reearth/reearth/commit/9cd1b5)
-- Mvt line width on reearth&#x2F;core ([#504](https://github.com/reearth/reearth/pull/504)) [`c1a939`](https://github.com/reearth/reearth/commit/c1a939)
-- It should not render entity when coordinate is undefined on reearth&#x2F;core [`23b6c6`](https://github.com/reearth/reearth/commit/23b6c6)
-- Allow enter ground option for clipping box on reearth&#x2F;core ([#500](https://github.com/reearth/reearth/pull/500)) [`f8e129`](https://github.com/reearth/reearth/commit/f8e129)
-- Clip area with clipping box on reearth&#x2F;core ([#498](https://github.com/reearth/reearth/pull/498)) [`4f647f`](https://github.com/reearth/reearth/commit/4f647f)
-- Mvt cache on reearth&#x2F;core ([#497](https://github.com/reearth/reearth/pull/497)) [`ba2c7e`](https://github.com/reearth/reearth/commit/ba2c7e)
-- Recreate no feature component when data url is changed on reearth&#x2F;core ([#494](https://github.com/reearth/reearth/pull/494)) [`93c805`](https://github.com/reearth/reearth/commit/93c805)
-- Ignore cesium ion token when it is empty [`6648be`](https://github.com/reearth/reearth/commit/6648be)
-- Feature type fix gpx on reearth&#x2F;core ([#493](https://github.com/reearth/reearth/pull/493)) [`51b8e8`](https://github.com/reearth/reearth/commit/51b8e8)
-- Infobox error after layer delete ([#492](https://github.com/reearth/reearth/pull/492)) [`8a59dd`](https://github.com/reearth/reearth/commit/8a59dd)
-- Delete bug that deletes necessary layer on reearth&#x2F;core ([#484](https://github.com/reearth/reearth/pull/484)) [`a0f48f`](https://github.com/reearth/reearth/commit/a0f48f)
-- Force update when some data properties are updated on reearth&#x2F;core ([#483](https://github.com/reearth/reearth/pull/483)) [`867238`](https://github.com/reearth/reearth/commit/867238)
-- Revert appearance to initial value when appearance is undefined on reearth&#x2F;core ([#482](https://github.com/reearth/reearth/pull/482)) [`76b6f4`](https://github.com/reearth/reearth/commit/76b6f4)
-- Entity id is duplicated error on reearth&#x2F;core ([#481](https://github.com/reearth/reearth/pull/481)) [`a2b0b6`](https://github.com/reearth/reearth/commit/a2b0b6)
-- Infobox property is undefined error on reearth&#x2F;core ([#480](https://github.com/reearth/reearth/pull/480)) [`2b8b07`](https://github.com/reearth/reearth/commit/2b8b07)
-- Layers override behavior on rearth&#x2F;core ([#479](https://github.com/reearth/reearth/pull/479)) [`faff37`](https://github.com/reearth/reearth/commit/faff37)
-- Error handling for time interval on reearth&#x2F;core ([#478](https://github.com/reearth/reearth/pull/478)) [`edf546`](https://github.com/reearth/reearth/commit/edf546)
-- Overridden layers api on reearth&#x2F;core ([#477](https://github.com/reearth/reearth/pull/477)) [`abaade`](https://github.com/reearth/reearth/commit/abaade)
-- Add properties in vehicle point for gtfs ([#476](https://github.com/reearth/reearth/pull/476)) [`1058ab`](https://github.com/reearth/reearth/commit/1058ab)
-- Color function on reearth&#x2F;core ([#474](https://github.com/reearth/reearth/pull/474)) [`7d9fca`](https://github.com/reearth/reearth/commit/7d9fca)
-- Errors when many functions are created in plugins ([#471](https://github.com/reearth/reearth/pull/471)) [`ebb50d`](https://github.com/reearth/reearth/commit/ebb50d)
-- Coordinates for csv on reearth&#x2F;core ([#472](https://github.com/reearth/reearth/pull/472)) [`4a6473`](https://github.com/reearth/reearth/commit/4a6473)
-- Lint and type error [`d00b9b`](https://github.com/reearth/reearth/commit/d00b9b)
-- Suppress screen flicker when judging useCore [`b1852d`](https://github.com/reearth/reearth/commit/b1852d)
-- Widget area has margin even if no widgets, disable widget area transition in built scene [`b51569`](https://github.com/reearth/reearth/commit/b51569)
-- Cesium crashes when VR mode is false [`efa3fd`](https://github.com/reearth/reearth/commit/efa3fd)
-- 3dtiles overriding appearance behavior on reearth&#x2F;core ([#468](https://github.com/reearth/reearth/pull/468)) [`8c48bc`](https://github.com/reearth/reearth/commit/8c48bc)
-- Support visible and dynamic plane in clipping box on reearth&#x2F;core ([#465](https://github.com/reearth/reearth/pull/465)) [`4c89aa`](https://github.com/reearth/reearth/commit/4c89aa)
-- SelectedFeature for 3dtiles on reearth&#x2F;core ([#463](https://github.com/reearth/reearth/pull/463)) [`cd1777`](https://github.com/reearth/reearth/commit/cd1777)
-- Express undefined visible field on reearth&#x2F;core ([#461](https://github.com/reearth/reearth/pull/461)) [`c74630`](https://github.com/reearth/reearth/commit/c74630)
-- Undefined behavior for visible field ([#460](https://github.com/reearth/reearth/pull/460)) [`c41d70`](https://github.com/reearth/reearth/commit/c41d70)
-- Select entity on reearth&#x2F;core ([#458](https://github.com/reearth/reearth/pull/458)) [`bc1824`](https://github.com/reearth/reearth/commit/bc1824)
-- Use default infobox on reearth&#x2F;core ([#453](https://github.com/reearth/reearth/pull/453)) [`d3fec8`](https://github.com/reearth/reearth/commit/d3fec8)
-- Select event behavior on reearth&#x2F;core ([#452](https://github.com/reearth/reearth/pull/452)) [`384488`](https://github.com/reearth/reearth/commit/384488)
-- Error in published page on reearth&#x2F;core ([#447](https://github.com/reearth/reearth/pull/447)) [`4c8805`](https://github.com/reearth/reearth/commit/4c8805)
-- Expand timeline in initial load ([#443](https://github.com/reearth/reearth/pull/443)) [`d6a742`](https://github.com/reearth/reearth/commit/d6a742)
-- Replace globe image when cesium ion token is updated ([#442](https://github.com/reearth/reearth/pull/442)) [`64ffae`](https://github.com/reearth/reearth/commit/64ffae)
-- Layer fetch on reearth&#x2F;core ([#441](https://github.com/reearth/reearth/pull/441)) [`597b82`](https://github.com/reearth/reearth/commit/597b82)
-- Dnd layer on reearth&#x2F;core ([#440](https://github.com/reearth/reearth/pull/440)) [`a5a2b4`](https://github.com/reearth/reearth/commit/a5a2b4)
-- Disable requestRenderMode depends on widget on reearth&#x2F;core ([#439](https://github.com/reearth/reearth/pull/439)) [`12ce63`](https://github.com/reearth/reearth/commit/12ce63)
-- Selected layer id is not propagated on reearth&#x2F;core ([#438](https://github.com/reearth/reearth/pull/438)) [`24993b`](https://github.com/reearth/reearth/commit/24993b)
-- Handle featureId for 3dtiles and compat select plugin api on reearth&#x2F;core ([#417](https://github.com/reearth/reearth/pull/417)) [`9144ad`](https://github.com/reearth/reearth/commit/9144ad)
-- Undefined behavior for resource on reearth&#x2F;core ([#437](https://github.com/reearth/reearth/pull/437)) [`3f51f2`](https://github.com/reearth/reearth/commit/3f51f2)
-- Blocks cannot be displayed and updated as expected on reearth&#x2F;core ([#434](https://github.com/reearth/reearth/pull/434)) [`b5f921`](https://github.com/reearth/reearth/commit/b5f921)
-- Layer appearances are not evaluated as expected ([#418](https://github.com/reearth/reearth/pull/418)) [`20382c`](https://github.com/reearth/reearth/commit/20382c)
-- Support resource auto on reearth&#x2F;core ([#435](https://github.com/reearth/reearth/pull/435)) [`595c66`](https://github.com/reearth/reearth/commit/595c66)
-- Cluster features on reearth&#x2F;core ([#430](https://github.com/reearth/reearth/pull/430)) [`92dd47`](https://github.com/reearth/reearth/commit/92dd47)
-- 3D Tiles infobox on reearth&#x2F;core ([#433](https://github.com/reearth/reearth/pull/433)) [`b4afd7`](https://github.com/reearth/reearth/commit/b4afd7)
-- GeoJSON with resource appearance on reearth&#x2F;core ([#432](https://github.com/reearth/reearth/pull/432)) [`464d67`](https://github.com/reearth/reearth/commit/464d67)
-- Dnd layer on reearth&#x2F;core ([#424](https://github.com/reearth/reearth/pull/424)) [`75e6a7`](https://github.com/reearth/reearth/commit/75e6a7)
-- WAS bug on reearth&#x2F;core ([#416](https://github.com/reearth/reearth/pull/416)) [`045274`](https://github.com/reearth/reearth/commit/045274)
-- Cannot select features on reearth&#x2F;core ([#414](https://github.com/reearth/reearth/pull/414)) [`f1a8dd`](https://github.com/reearth/reearth/commit/f1a8dd)
-- Support csv value string on reearth&#x2F;core ([#415](https://github.com/reearth/reearth/pull/415)) [`4033f7`](https://github.com/reearth/reearth/commit/4033f7)
-- MoveTo widget to empty page on mobile on reearth&#x2F;core ([#413](https://github.com/reearth/reearth/pull/413)) [`07a935`](https://github.com/reearth/reearth/commit/07a935)
-- Widget align system on mobile ([#409](https://github.com/reearth/reearth/pull/409)) [`fce1ad`](https://github.com/reearth/reearth/commit/fce1ad)
-- Increment runTimes on preinit ([#410](https://github.com/reearth/reearth/pull/410)) [`797020`](https://github.com/reearth/reearth/commit/797020)
-- Plugin instance runTimes property ([#405](https://github.com/reearth/reearth/pull/405)) [`a06434`](https://github.com/reearth/reearth/commit/a06434)
-- Make iframe width or height assignable without the other ([#403](https://github.com/reearth/reearth/pull/403)) [`e8647a`](https://github.com/reearth/reearth/commit/e8647a)
-- Cache ComputedFeature on reearth&#x2F;core ([#396](https://github.com/reearth/reearth/pull/396)) [`775a8a`](https://github.com/reearth/reearth/commit/775a8a)
-- Missing type of API modal &amp; popup options.  ([#400](https://github.com/reearth/reearth/pull/400)) [`a68b24`](https://github.com/reearth/reearth/commit/a68b24)
-- Visualizer on reearth&#x2F;core ([#395](https://github.com/reearth/reearth/pull/395)) [`7ba0db`](https://github.com/reearth/reearth/commit/7ba0db)
-- Update mvt dynamically when appearance is updated ([#393](https://github.com/reearth/reearth/pull/393)) [`7ca5d1`](https://github.com/reearth/reearth/commit/7ca5d1)
+- Merge conflict resolved [`39a37a`](https://github.com/reearth/reearth-visualizer/commit/39a37a)
+- Use core hook may get value incorrectly ([#609](https://github.com/reearth/reearth-visualizer/pull/609)) [`d87e90`](https://github.com/reearth/reearth-visualizer/commit/d87e90)
+- Resolve endsWith is not a function error with style in reearth&#x2F;core ([#603](https://github.com/reearth/reearth-visualizer/pull/603)) [`15fec3`](https://github.com/reearth/reearth-visualizer/commit/15fec3)
+- Add % as special case for &#x60;Number()&#x60; in style lang of reearth&#x2F;core ([#601](https://github.com/reearth/reearth-visualizer/pull/601)) [`5a4a3d`](https://github.com/reearth/reearth-visualizer/commit/5a4a3d)
+- Rename moveWidget to onMoveWidget on reearth&#x2F;core ([#600](https://github.com/reearth/reearth-visualizer/pull/600)) [`6c06ab`](https://github.com/reearth/reearth-visualizer/commit/6c06ab)
+- Enable splash screen in preview page ([#596](https://github.com/reearth/reearth-visualizer/pull/596) [`e1f5ac`](https://github.com/reearth/reearth-visualizer/commit/e1f5ac)
+- Timeline scroll should be fixed in initial render ([#571](https://github.com/reearth/reearth-visualizer/pull/571)) [`6a0aed`](https://github.com/reearth/reearth-visualizer/commit/6a0aed)
+- Remove default height reference for modelGraphics in reearth&#x2F;core ([#592](https://github.com/reearth/reearth-visualizer/pull/592)) [`961b46`](https://github.com/reearth/reearth-visualizer/commit/961b46)
+- Remove duplication of feature entity in reearth&#x2F;core ([#590](https://github.com/reearth/reearth-visualizer/pull/590)) [`8cc03e`](https://github.com/reearth/reearth-visualizer/commit/8cc03e)
+- Prevent selecting not shown feature for MVT on reearth&#x2F;core ([#589](https://github.com/reearth/reearth-visualizer/pull/589)) [`41816d`](https://github.com/reearth/reearth-visualizer/commit/41816d)
+- Infobox for 3dtiles feature ([#587](https://github.com/reearth/reearth-visualizer/pull/587)) [`70cfdb`](https://github.com/reearth/reearth-visualizer/commit/70cfdb)
+- Use layer id with feature id for entity id on reearth&#x2F;core ([#585](https://github.com/reearth/reearth-visualizer/pull/585)) [`24cc88`](https://github.com/reearth/reearth-visualizer/commit/24cc88)
+- Can&[#39](https://github.com/reearth/reearth-visualizer/pull/39);t set iframe&[#39](https://github.com/reearth/reearth-visualizer/pull/39);s width or height individually in crust  ([#583](https://github.com/reearth/reearth-visualizer/pull/583)) [`3494b4`](https://github.com/reearth/reearth-visualizer/commit/3494b4)
+- MVT isn&[#39](https://github.com/reearth/reearth-visualizer/pull/39);t render correctly on reearth&#x2F;core ([#582](https://github.com/reearth/reearth-visualizer/pull/582)) [`988d1a`](https://github.com/reearth/reearth-visualizer/commit/988d1a)
+- Sample terrain height API cannot properly return promise ([#581](https://github.com/reearth/reearth-visualizer/pull/581)) [`72eafd`](https://github.com/reearth/reearth-visualizer/commit/72eafd)
+- Change logical operator evaluation behaviour in reearth&#x2F;core ([#580](https://github.com/reearth/reearth-visualizer/pull/580)) [`3d23ce`](https://github.com/reearth/reearth-visualizer/commit/3d23ce)
+- Infobox style collapse for long names ([#578](https://github.com/reearth/reearth-visualizer/pull/578)) [`04775d`](https://github.com/reearth/reearth-visualizer/commit/04775d)
+- Override currentTime on timeline widget when time is updated by CZML on reearth&#x2F;core ([#579](https://github.com/reearth/reearth-visualizer/pull/579)) [`dbe2e1`](https://github.com/reearth/reearth-visualizer/commit/dbe2e1)
+- Rename scene light properties [`8b3a18`](https://github.com/reearth/reearth-visualizer/commit/8b3a18)
+- Add none cesium value for heightReference ([#577](https://github.com/reearth/reearth-visualizer/pull/577)) [`2c92e3`](https://github.com/reearth/reearth-visualizer/commit/2c92e3)
+- JSON Path condition on reearth&#x2F;core ([#572](https://github.com/reearth/reearth-visualizer/pull/572)) [`5f7024`](https://github.com/reearth/reearth-visualizer/commit/5f7024)
+- Update html head [`f1780f`](https://github.com/reearth/reearth-visualizer/commit/f1780f)
+- Sync selected feature with layer api on reearth&#x2F;core ([#570](https://github.com/reearth/reearth-visualizer/pull/570)) [`ded6b0`](https://github.com/reearth/reearth-visualizer/commit/ded6b0)
+- Imagery index on reearth&#x2F;core ([#569](https://github.com/reearth/reearth-visualizer/pull/569)) [`6b233f`](https://github.com/reearth/reearth-visualizer/commit/6b233f)
+- Revert add height to polygon in reearth&#x2F;core ([#566](https://github.com/reearth/reearth-visualizer/pull/566)) [`1f2f74`](https://github.com/reearth/reearth-visualizer/commit/1f2f74)
+- Add clamp as default height reference for model in reearth&#x2F;core ([#567](https://github.com/reearth/reearth-visualizer/pull/567)) [`517386`](https://github.com/reearth/reearth-visualizer/commit/517386)
+- Minimum timeline range on reearth&#x2F;core ([#565](https://github.com/reearth/reearth-visualizer/pull/565)) [`975c79`](https://github.com/reearth/reearth-visualizer/commit/975c79)
+- Infobox html block styling ([#562](https://github.com/reearth/reearth-visualizer/pull/562)) [`32b248`](https://github.com/reearth/reearth-visualizer/commit/32b248)
+- Imagery layer tile index on reearth&#x2F;core ([#561](https://github.com/reearth/reearth-visualizer/pull/561) [`25bdff`](https://github.com/reearth/reearth-visualizer/commit/25bdff)
+- Add &quot;disabled&quot; as shadow mode on reearth&#x2F;core ([#560](https://github.com/reearth/reearth-visualizer/pull/560)) [`1632ea`](https://github.com/reearth/reearth-visualizer/commit/1632ea)
+- Support multi layers in MVT on reearth&#x2F;core ([#559](https://github.com/reearth/reearth-visualizer/pull/559)) [`9c8c88`](https://github.com/reearth/reearth-visualizer/commit/9c8c88)
+- Html block margin and height [`09f6ef`](https://github.com/reearth/reearth-visualizer/commit/09f6ef)
+- UpdateClockOnLoad condition on reearth&#x2F;core ([#558](https://github.com/reearth/reearth-visualizer/pull/558)) [`f9076a`](https://github.com/reearth/reearth-visualizer/commit/f9076a)
+- Add height to polygon in reearth&#x2F;core ([#557](https://github.com/reearth/reearth-visualizer/pull/557)) [`a84dbe`](https://github.com/reearth/reearth-visualizer/commit/a84dbe)
+- Use computed feature on resource on reearth&#x2F;core ([#556](https://github.com/reearth/reearth-visualizer/pull/556)) [`006f40`](https://github.com/reearth/reearth-visualizer/commit/006f40)
+- Point cloud dirty check on reearth&#x2F;core ([#554](https://github.com/reearth/reearth-visualizer/pull/554)) [`f95d27`](https://github.com/reearth/reearth-visualizer/commit/f95d27)
+- Support default infobox and selection indicator on imagery layer on reearth&#x2F;core ([#553](https://github.com/reearth/reearth-visualizer/pull/553)) [`1946b3`](https://github.com/reearth/reearth-visualizer/commit/1946b3)
+- Scrollbar in timeline widget always showing ([#550](https://github.com/reearth/reearth-visualizer/pull/550)) [`84d63d`](https://github.com/reearth/reearth-visualizer/commit/84d63d)
+- Clipping box on point cloud on reearth&#x2F;core ([#552](https://github.com/reearth/reearth-visualizer/pull/552)) [`fb4455`](https://github.com/reearth/reearth-visualizer/commit/fb4455)
+- Htmlblock on safari ([#548](https://github.com/reearth/reearth-visualizer/pull/548)) [`392fc7`](https://github.com/reearth/reearth-visualizer/commit/392fc7)
+- Use attributes as default content for infobox on reearth&#x2F;core ([#547](https://github.com/reearth/reearth-visualizer/pull/547)) [`be3718`](https://github.com/reearth/reearth-visualizer/commit/be3718)
+- Deleting feature process on reearth&#x2F;core ([#546](https://github.com/reearth/reearth-visualizer/pull/546)) [`39ecaf`](https://github.com/reearth/reearth-visualizer/commit/39ecaf)
+- Trigger select event when featureId is changed on reearth&#x2F;core ([#545](https://github.com/reearth/reearth-visualizer/pull/545)) [`6f5401`](https://github.com/reearth/reearth-visualizer/commit/6f5401)
+- Draw polylines on polygon on reearth&#x2F;core ([#544](https://github.com/reearth/reearth-visualizer/pull/544)) [`d35329`](https://github.com/reearth/reearth-visualizer/commit/d35329)
+- Infobox html color ([#534](https://github.com/reearth/reearth-visualizer/pull/534)) [`c0e0a6`](https://github.com/reearth/reearth-visualizer/commit/c0e0a6)
+- Use overriddenLayers to get infobox on reearth&#x2F;core ([#541](https://github.com/reearth/reearth-visualizer/pull/541)) [`c4e9db`](https://github.com/reearth/reearth-visualizer/commit/c4e9db)
+- Fly to multiple entities added by a layer on reearth&#x2F;core ([#540](https://github.com/reearth/reearth-visualizer/pull/540)) [`95b3d3`](https://github.com/reearth/reearth-visualizer/commit/95b3d3)
+- Add polyfill for requestIdleCallback in reearth&#x2F;core ([#537](https://github.com/reearth/reearth-visualizer/pull/537)) [`c4722f`](https://github.com/reearth/reearth-visualizer/commit/c4722f)
+- Overriding timeline behavior on reearth&#x2F;core ([#532](https://github.com/reearth/reearth-visualizer/pull/532)) [`890dae`](https://github.com/reearth/reearth-visualizer/commit/890dae)
+- Timeline bug on reearth&#x2F;core ([#531](https://github.com/reearth/reearth-visualizer/pull/531)) [`572678`](https://github.com/reearth/reearth-visualizer/commit/572678)
+- Some error on reearth&#x2F;core ([#530](https://github.com/reearth/reearth-visualizer/pull/530)) [`4ee0b6`](https://github.com/reearth/reearth-visualizer/commit/4ee0b6)
+- Abort fetching on data atom on reearth&#x2F;core ([#529](https://github.com/reearth/reearth-visualizer/pull/529)) [`e82c88`](https://github.com/reearth/reearth-visualizer/commit/e82c88)
+- Timeline behavior on reearth&#x2F;core ([#528](https://github.com/reearth/reearth-visualizer/pull/528)) [`461d06`](https://github.com/reearth/reearth-visualizer/commit/461d06)
+- Parse csv numeric strings as numbers in reearth&#x2F;core ([#526](https://github.com/reearth/reearth-visualizer/pull/526)) [`9c890f`](https://github.com/reearth/reearth-visualizer/commit/9c890f)
+- Parse hyphen as reserved word in property key on reearth&#x2F;core ([#525](https://github.com/reearth/reearth-visualizer/pull/525)) [`d49058`](https://github.com/reearth/reearth-visualizer/commit/d49058)
+- Condition for CZML on reearth&#x2F;core ([#524](https://github.com/reearth/reearth-visualizer/pull/524)) [`3c61ca`](https://github.com/reearth/reearth-visualizer/commit/3c61ca)
+- Czml style for marker on reearth&#x2F;core ([#523](https://github.com/reearth/reearth-visualizer/pull/523)) [`67dccb`](https://github.com/reearth/reearth-visualizer/commit/67dccb)
+- Use default block for entity on reearth&#x2F;core ([#522](https://github.com/reearth/reearth-visualizer/pull/522)) [`ecd09a`](https://github.com/reearth/reearth-visualizer/commit/ecd09a)
+- Remove copyLazyLayer on reearth&#x2F;core ([#519](https://github.com/reearth/reearth-visualizer/pull/519)) [`e17218`](https://github.com/reearth/reearth-visualizer/commit/e17218)
+- Copying lazy layers undefined behavior on reearth&#x2F;core ([#516](https://github.com/reearth/reearth-visualizer/pull/516)) [`7b2c5e`](https://github.com/reearth/reearth-visualizer/commit/7b2c5e)
+- Copy lazy layer on plugin on reearth&#x2F;core ([#515](https://github.com/reearth/reearth-visualizer/pull/515)) [`046a3d`](https://github.com/reearth/reearth-visualizer/commit/046a3d)
+- Attach style dynamically in resource on reearth&#x2F;core ([#514](https://github.com/reearth/reearth-visualizer/pull/514)) [`81d291`](https://github.com/reearth/reearth-visualizer/commit/81d291)
+- Infinite infobox in CZML on reearth&#x2F;core ([#513](https://github.com/reearth/reearth-visualizer/pull/513)) [`3e49a1`](https://github.com/reearth/reearth-visualizer/commit/3e49a1)
+- Selecting resource feature behavior on reearth&#x2F;core ([#512](https://github.com/reearth/reearth-visualizer/pull/512)) [`35f2c2`](https://github.com/reearth/reearth-visualizer/commit/35f2c2)
+- Prevent unnecessary render on timeline on reearth&#x2F;core ([#510](https://github.com/reearth/reearth-visualizer/pull/510)) [`7cb9d5`](https://github.com/reearth/reearth-visualizer/commit/7cb9d5)
+- Parse reserved word when property name includes reserved word on reearth&#x2F;core ([#508](https://github.com/reearth/reearth-visualizer/pull/508)) [`aa247e`](https://github.com/reearth/reearth-visualizer/commit/aa247e)
+- Pass engine meta on plugin editor ([#507](https://github.com/reearth/reearth-visualizer/pull/507)) [`9cd1b5`](https://github.com/reearth/reearth-visualizer/commit/9cd1b5)
+- Mvt line width on reearth&#x2F;core ([#504](https://github.com/reearth/reearth-visualizer/pull/504)) [`c1a939`](https://github.com/reearth/reearth-visualizer/commit/c1a939)
+- It should not render entity when coordinate is undefined on reearth&#x2F;core [`23b6c6`](https://github.com/reearth/reearth-visualizer/commit/23b6c6)
+- Allow enter ground option for clipping box on reearth&#x2F;core ([#500](https://github.com/reearth/reearth-visualizer/pull/500)) [`f8e129`](https://github.com/reearth/reearth-visualizer/commit/f8e129)
+- Clip area with clipping box on reearth&#x2F;core ([#498](https://github.com/reearth/reearth-visualizer/pull/498)) [`4f647f`](https://github.com/reearth/reearth-visualizer/commit/4f647f)
+- Mvt cache on reearth&#x2F;core ([#497](https://github.com/reearth/reearth-visualizer/pull/497)) [`ba2c7e`](https://github.com/reearth/reearth-visualizer/commit/ba2c7e)
+- Recreate no feature component when data url is changed on reearth&#x2F;core ([#494](https://github.com/reearth/reearth-visualizer/pull/494)) [`93c805`](https://github.com/reearth/reearth-visualizer/commit/93c805)
+- Ignore cesium ion token when it is empty [`6648be`](https://github.com/reearth/reearth-visualizer/commit/6648be)
+- Feature type fix gpx on reearth&#x2F;core ([#493](https://github.com/reearth/reearth-visualizer/pull/493)) [`51b8e8`](https://github.com/reearth/reearth-visualizer/commit/51b8e8)
+- Infobox error after layer delete ([#492](https://github.com/reearth/reearth-visualizer/pull/492)) [`8a59dd`](https://github.com/reearth/reearth-visualizer/commit/8a59dd)
+- Delete bug that deletes necessary layer on reearth&#x2F;core ([#484](https://github.com/reearth/reearth-visualizer/pull/484)) [`a0f48f`](https://github.com/reearth/reearth-visualizer/commit/a0f48f)
+- Force update when some data properties are updated on reearth&#x2F;core ([#483](https://github.com/reearth/reearth-visualizer/pull/483)) [`867238`](https://github.com/reearth/reearth-visualizer/commit/867238)
+- Revert appearance to initial value when appearance is undefined on reearth&#x2F;core ([#482](https://github.com/reearth/reearth-visualizer/pull/482)) [`76b6f4`](https://github.com/reearth/reearth-visualizer/commit/76b6f4)
+- Entity id is duplicated error on reearth&#x2F;core ([#481](https://github.com/reearth/reearth-visualizer/pull/481)) [`a2b0b6`](https://github.com/reearth/reearth-visualizer/commit/a2b0b6)
+- Infobox property is undefined error on reearth&#x2F;core ([#480](https://github.com/reearth/reearth-visualizer/pull/480)) [`2b8b07`](https://github.com/reearth/reearth-visualizer/commit/2b8b07)
+- Layers override behavior on rearth&#x2F;core ([#479](https://github.com/reearth/reearth-visualizer/pull/479)) [`faff37`](https://github.com/reearth/reearth-visualizer/commit/faff37)
+- Error handling for time interval on reearth&#x2F;core ([#478](https://github.com/reearth/reearth-visualizer/pull/478)) [`edf546`](https://github.com/reearth/reearth-visualizer/commit/edf546)
+- Overridden layers api on reearth&#x2F;core ([#477](https://github.com/reearth/reearth-visualizer/pull/477)) [`abaade`](https://github.com/reearth/reearth-visualizer/commit/abaade)
+- Add properties in vehicle point for gtfs ([#476](https://github.com/reearth/reearth-visualizer/pull/476)) [`1058ab`](https://github.com/reearth/reearth-visualizer/commit/1058ab)
+- Color function on reearth&#x2F;core ([#474](https://github.com/reearth/reearth-visualizer/pull/474)) [`7d9fca`](https://github.com/reearth/reearth-visualizer/commit/7d9fca)
+- Errors when many functions are created in plugins ([#471](https://github.com/reearth/reearth-visualizer/pull/471)) [`ebb50d`](https://github.com/reearth/reearth-visualizer/commit/ebb50d)
+- Coordinates for csv on reearth&#x2F;core ([#472](https://github.com/reearth/reearth-visualizer/pull/472)) [`4a6473`](https://github.com/reearth/reearth-visualizer/commit/4a6473)
+- Lint and type error [`d00b9b`](https://github.com/reearth/reearth-visualizer/commit/d00b9b)
+- Suppress screen flicker when judging useCore [`b1852d`](https://github.com/reearth/reearth-visualizer/commit/b1852d)
+- Widget area has margin even if no widgets, disable widget area transition in built scene [`b51569`](https://github.com/reearth/reearth-visualizer/commit/b51569)
+- Cesium crashes when VR mode is false [`efa3fd`](https://github.com/reearth/reearth-visualizer/commit/efa3fd)
+- 3dtiles overriding appearance behavior on reearth&#x2F;core ([#468](https://github.com/reearth/reearth-visualizer/pull/468)) [`8c48bc`](https://github.com/reearth/reearth-visualizer/commit/8c48bc)
+- Support visible and dynamic plane in clipping box on reearth&#x2F;core ([#465](https://github.com/reearth/reearth-visualizer/pull/465)) [`4c89aa`](https://github.com/reearth/reearth-visualizer/commit/4c89aa)
+- SelectedFeature for 3dtiles on reearth&#x2F;core ([#463](https://github.com/reearth/reearth-visualizer/pull/463)) [`cd1777`](https://github.com/reearth/reearth-visualizer/commit/cd1777)
+- Express undefined visible field on reearth&#x2F;core ([#461](https://github.com/reearth/reearth-visualizer/pull/461)) [`c74630`](https://github.com/reearth/reearth-visualizer/commit/c74630)
+- Undefined behavior for visible field ([#460](https://github.com/reearth/reearth-visualizer/pull/460)) [`c41d70`](https://github.com/reearth/reearth-visualizer/commit/c41d70)
+- Select entity on reearth&#x2F;core ([#458](https://github.com/reearth/reearth-visualizer/pull/458)) [`bc1824`](https://github.com/reearth/reearth-visualizer/commit/bc1824)
+- Use default infobox on reearth&#x2F;core ([#453](https://github.com/reearth/reearth-visualizer/pull/453)) [`d3fec8`](https://github.com/reearth/reearth-visualizer/commit/d3fec8)
+- Select event behavior on reearth&#x2F;core ([#452](https://github.com/reearth/reearth-visualizer/pull/452)) [`384488`](https://github.com/reearth/reearth-visualizer/commit/384488)
+- Error in published page on reearth&#x2F;core ([#447](https://github.com/reearth/reearth-visualizer/pull/447)) [`4c8805`](https://github.com/reearth/reearth-visualizer/commit/4c8805)
+- Expand timeline in initial load ([#443](https://github.com/reearth/reearth-visualizer/pull/443)) [`d6a742`](https://github.com/reearth/reearth-visualizer/commit/d6a742)
+- Replace globe image when cesium ion token is updated ([#442](https://github.com/reearth/reearth-visualizer/pull/442)) [`64ffae`](https://github.com/reearth/reearth-visualizer/commit/64ffae)
+- Layer fetch on reearth&#x2F;core ([#441](https://github.com/reearth/reearth-visualizer/pull/441)) [`597b82`](https://github.com/reearth/reearth-visualizer/commit/597b82)
+- Dnd layer on reearth&#x2F;core ([#440](https://github.com/reearth/reearth-visualizer/pull/440)) [`a5a2b4`](https://github.com/reearth/reearth-visualizer/commit/a5a2b4)
+- Disable requestRenderMode depends on widget on reearth&#x2F;core ([#439](https://github.com/reearth/reearth-visualizer/pull/439)) [`12ce63`](https://github.com/reearth/reearth-visualizer/commit/12ce63)
+- Selected layer id is not propagated on reearth&#x2F;core ([#438](https://github.com/reearth/reearth-visualizer/pull/438)) [`24993b`](https://github.com/reearth/reearth-visualizer/commit/24993b)
+- Handle featureId for 3dtiles and compat select plugin api on reearth&#x2F;core ([#417](https://github.com/reearth/reearth-visualizer/pull/417)) [`9144ad`](https://github.com/reearth/reearth-visualizer/commit/9144ad)
+- Undefined behavior for resource on reearth&#x2F;core ([#437](https://github.com/reearth/reearth-visualizer/pull/437)) [`3f51f2`](https://github.com/reearth/reearth-visualizer/commit/3f51f2)
+- Blocks cannot be displayed and updated as expected on reearth&#x2F;core ([#434](https://github.com/reearth/reearth-visualizer/pull/434)) [`b5f921`](https://github.com/reearth/reearth-visualizer/commit/b5f921)
+- Layer appearances are not evaluated as expected ([#418](https://github.com/reearth/reearth-visualizer/pull/418)) [`20382c`](https://github.com/reearth/reearth-visualizer/commit/20382c)
+- Support resource auto on reearth&#x2F;core ([#435](https://github.com/reearth/reearth-visualizer/pull/435)) [`595c66`](https://github.com/reearth/reearth-visualizer/commit/595c66)
+- Cluster features on reearth&#x2F;core ([#430](https://github.com/reearth/reearth-visualizer/pull/430)) [`92dd47`](https://github.com/reearth/reearth-visualizer/commit/92dd47)
+- 3D Tiles infobox on reearth&#x2F;core ([#433](https://github.com/reearth/reearth-visualizer/pull/433)) [`b4afd7`](https://github.com/reearth/reearth-visualizer/commit/b4afd7)
+- GeoJSON with resource appearance on reearth&#x2F;core ([#432](https://github.com/reearth/reearth-visualizer/pull/432)) [`464d67`](https://github.com/reearth/reearth-visualizer/commit/464d67)
+- Dnd layer on reearth&#x2F;core ([#424](https://github.com/reearth/reearth-visualizer/pull/424)) [`75e6a7`](https://github.com/reearth/reearth-visualizer/commit/75e6a7)
+- WAS bug on reearth&#x2F;core ([#416](https://github.com/reearth/reearth-visualizer/pull/416)) [`045274`](https://github.com/reearth/reearth-visualizer/commit/045274)
+- Cannot select features on reearth&#x2F;core ([#414](https://github.com/reearth/reearth-visualizer/pull/414)) [`f1a8dd`](https://github.com/reearth/reearth-visualizer/commit/f1a8dd)
+- Support csv value string on reearth&#x2F;core ([#415](https://github.com/reearth/reearth-visualizer/pull/415)) [`4033f7`](https://github.com/reearth/reearth-visualizer/commit/4033f7)
+- MoveTo widget to empty page on mobile on reearth&#x2F;core ([#413](https://github.com/reearth/reearth-visualizer/pull/413)) [`07a935`](https://github.com/reearth/reearth-visualizer/commit/07a935)
+- Widget align system on mobile ([#409](https://github.com/reearth/reearth-visualizer/pull/409)) [`fce1ad`](https://github.com/reearth/reearth-visualizer/commit/fce1ad)
+- Increment runTimes on preinit ([#410](https://github.com/reearth/reearth-visualizer/pull/410)) [`797020`](https://github.com/reearth/reearth-visualizer/commit/797020)
+- Plugin instance runTimes property ([#405](https://github.com/reearth/reearth-visualizer/pull/405)) [`a06434`](https://github.com/reearth/reearth-visualizer/commit/a06434)
+- Make iframe width or height assignable without the other ([#403](https://github.com/reearth/reearth-visualizer/pull/403)) [`e8647a`](https://github.com/reearth/reearth-visualizer/commit/e8647a)
+- Cache ComputedFeature on reearth&#x2F;core ([#396](https://github.com/reearth/reearth-visualizer/pull/396)) [`775a8a`](https://github.com/reearth/reearth-visualizer/commit/775a8a)
+- Missing type of API modal &amp; popup options.  ([#400](https://github.com/reearth/reearth-visualizer/pull/400)) [`a68b24`](https://github.com/reearth/reearth-visualizer/commit/a68b24)
+- Visualizer on reearth&#x2F;core ([#395](https://github.com/reearth/reearth-visualizer/pull/395)) [`7ba0db`](https://github.com/reearth/reearth-visualizer/commit/7ba0db)
+- Update mvt dynamically when appearance is updated ([#393](https://github.com/reearth/reearth-visualizer/pull/393)) [`7ca5d1`](https://github.com/reearth/reearth-visualizer/commit/7ca5d1)
 
 #### 📖 Documentation
 
-- Add diagrams of core architecture ([#396](https://github.com/reearth/reearth/pull/396)) [`2dfa6b`](https://github.com/reearth/reearth/commit/2dfa6b)
+- Add diagrams of core architecture ([#396](https://github.com/reearth/reearth-visualizer/pull/396)) [`2dfa6b`](https://github.com/reearth/reearth-visualizer/commit/2dfa6b)
 
 #### ⚡️ Performance
 
-- Consider geojson as both delegate and active data type in reearth&#x2F;core ([#608](https://github.com/reearth/reearth/pull/608)) [`94bc59`](https://github.com/reearth/reearth/commit/94bc59)
-- Improve styling in MVT on reearth&#x2F;core ([#574](https://github.com/reearth/reearth/pull/574)) [`8ced77`](https://github.com/reearth/reearth/commit/8ced77)
-- Improve 3dtiles performance and disable requestRenderMode on reearth&#x2F;core ([#568](https://github.com/reearth/reearth/pull/568)) [`e645ec`](https://github.com/reearth/reearth/commit/e645ec)
-- Reduce style evaluator memory signature in reearth&#x2F;core ([#563](https://github.com/reearth/reearth/pull/563)) [`f74b56`](https://github.com/reearth/reearth/commit/f74b56)
-- Use private modifier on evaluator on reearth&#x2F;core ([#543](https://github.com/reearth/reearth/pull/543)) [`532c66`](https://github.com/reearth/reearth/commit/532c66)
-- Improve regexp on reearth&#x2F;core ([#533](https://github.com/reearth/reearth/pull/533)) [`ca7b05`](https://github.com/reearth/reearth/commit/ca7b05)
-- Stop synchronizing features in MVT on reearth&#x2F;core ([#521](https://github.com/reearth/reearth/pull/521)) [`82ae2c`](https://github.com/reearth/reearth/commit/82ae2c)
-- Copy lazy layer lazily ([#517](https://github.com/reearth/reearth/pull/517)) [`4a5ba4`](https://github.com/reearth/reearth/commit/4a5ba4)
-- Improve mvt rendering on reearth&#x2F;core ([#501](https://github.com/reearth/reearth/pull/501)) [`8a681d`](https://github.com/reearth/reearth/commit/8a681d)
-- Compute features concurrently on reearth&#x2F;core ([#499](https://github.com/reearth/reearth/pull/499)) [`6448ba`](https://github.com/reearth/reearth/commit/6448ba)
-- Improve skipping computing process for 3dtiles on reearth&#x2F;core ([#491](https://github.com/reearth/reearth/pull/491)) [`253b58`](https://github.com/reearth/reearth/commit/253b58)
-- Improve 3dtiles features calculation on reearth&#x2F;core ([#489](https://github.com/reearth/reearth/pull/489)) [`1204a6`](https://github.com/reearth/reearth/commit/1204a6)
-- Improve expression cache strategy on reearth&#x2F;core ([#488](https://github.com/reearth/reearth/pull/488)) [`324e28`](https://github.com/reearth/reearth/commit/324e28)
-- Cache AST for evaluator on reearth&#x2F;core ([#473](https://github.com/reearth/reearth/pull/473)) [`da6bb3`](https://github.com/reearth/reearth/commit/da6bb3)
-- Improve blink when feature is updated on reearth&#x2F;core ([#429](https://github.com/reearth/reearth/pull/429)) [`c10a67`](https://github.com/reearth/reearth/commit/c10a67)
+- Consider geojson as both delegate and active data type in reearth&#x2F;core ([#608](https://github.com/reearth/reearth-visualizer/pull/608)) [`94bc59`](https://github.com/reearth/reearth-visualizer/commit/94bc59)
+- Improve styling in MVT on reearth&#x2F;core ([#574](https://github.com/reearth/reearth-visualizer/pull/574)) [`8ced77`](https://github.com/reearth/reearth-visualizer/commit/8ced77)
+- Improve 3dtiles performance and disable requestRenderMode on reearth&#x2F;core ([#568](https://github.com/reearth/reearth-visualizer/pull/568)) [`e645ec`](https://github.com/reearth/reearth-visualizer/commit/e645ec)
+- Reduce style evaluator memory signature in reearth&#x2F;core ([#563](https://github.com/reearth/reearth-visualizer/pull/563)) [`f74b56`](https://github.com/reearth/reearth-visualizer/commit/f74b56)
+- Use private modifier on evaluator on reearth&#x2F;core ([#543](https://github.com/reearth/reearth-visualizer/pull/543)) [`532c66`](https://github.com/reearth/reearth-visualizer/commit/532c66)
+- Improve regexp on reearth&#x2F;core ([#533](https://github.com/reearth/reearth-visualizer/pull/533)) [`ca7b05`](https://github.com/reearth/reearth-visualizer/commit/ca7b05)
+- Stop synchronizing features in MVT on reearth&#x2F;core ([#521](https://github.com/reearth/reearth-visualizer/pull/521)) [`82ae2c`](https://github.com/reearth/reearth-visualizer/commit/82ae2c)
+- Copy lazy layer lazily ([#517](https://github.com/reearth/reearth-visualizer/pull/517)) [`4a5ba4`](https://github.com/reearth/reearth-visualizer/commit/4a5ba4)
+- Improve mvt rendering on reearth&#x2F;core ([#501](https://github.com/reearth/reearth-visualizer/pull/501)) [`8a681d`](https://github.com/reearth/reearth-visualizer/commit/8a681d)
+- Compute features concurrently on reearth&#x2F;core ([#499](https://github.com/reearth/reearth-visualizer/pull/499)) [`6448ba`](https://github.com/reearth/reearth-visualizer/commit/6448ba)
+- Improve skipping computing process for 3dtiles on reearth&#x2F;core ([#491](https://github.com/reearth/reearth-visualizer/pull/491)) [`253b58`](https://github.com/reearth/reearth-visualizer/commit/253b58)
+- Improve 3dtiles features calculation on reearth&#x2F;core ([#489](https://github.com/reearth/reearth-visualizer/pull/489)) [`1204a6`](https://github.com/reearth/reearth-visualizer/commit/1204a6)
+- Improve expression cache strategy on reearth&#x2F;core ([#488](https://github.com/reearth/reearth-visualizer/pull/488)) [`324e28`](https://github.com/reearth/reearth-visualizer/commit/324e28)
+- Cache AST for evaluator on reearth&#x2F;core ([#473](https://github.com/reearth/reearth-visualizer/pull/473)) [`da6bb3`](https://github.com/reearth/reearth-visualizer/commit/da6bb3)
+- Improve blink when feature is updated on reearth&#x2F;core ([#429](https://github.com/reearth/reearth-visualizer/pull/429)) [`c10a67`](https://github.com/reearth/reearth-visualizer/commit/c10a67)
 
 #### ✨ Refactor
 
-- Replace &quot;team&quot; word  related to Team state with &quot;workspace&quot; ([#607](https://github.com/reearth/reearth/pull/607)) [`fb254b`](https://github.com/reearth/reearth/commit/fb254b)
+- Replace &quot;team&quot; word  related to Team state with &quot;workspace&quot; ([#607](https://github.com/reearth/reearth-visualizer/pull/607)) [`fb254b`](https://github.com/reearth/reearth-visualizer/commit/fb254b)
 
 #### Miscellaneous Tasks
 
-- Remove redundant workflows [`f2685d`](https://github.com/reearth/reearth/commit/f2685d)
-- Remove inter-dependency of web and server workflows [`999e73`](https://github.com/reearth/reearth/commit/999e73)
-- Change codeowner [`bffa05`](https://github.com/reearth/reearth/commit/bffa05)
-- Upgrade eslint [`d55795`](https://github.com/reearth/reearth/commit/d55795)
-- Update dependency cesium to v1.104.0 ([#594](https://github.com/reearth/reearth/pull/594)) [`c57839`](https://github.com/reearth/reearth/commit/c57839)
-- Fix storybook is not working ([#536](https://github.com/reearth/reearth/pull/536) [`d52124`](https://github.com/reearth/reearth/commit/d52124)
-- Rename asset dir to avoid conflicts with backend API endpoints [`1d9455`](https://github.com/reearth/reearth/commit/1d9455)
-- Add offline_access auth scope to support refresh tokens with built-in auth server ([#425](https://github.com/reearth/reearth/pull/425) [`2a2af1`](https://github.com/reearth/reearth/commit/2a2af1)
-- Upgrade dependencies ([#391](https://github.com/reearth/reearth/pull/391)) [`7280af`](https://github.com/reearth/reearth/commit/7280af)
+- Remove redundant workflows [`f2685d`](https://github.com/reearth/reearth-visualizer/commit/f2685d)
+- Remove inter-dependency of web and server workflows [`999e73`](https://github.com/reearth/reearth-visualizer/commit/999e73)
+- Change codeowner [`bffa05`](https://github.com/reearth/reearth-visualizer/commit/bffa05)
+- Upgrade eslint [`d55795`](https://github.com/reearth/reearth-visualizer/commit/d55795)
+- Update dependency cesium to v1.104.0 ([#594](https://github.com/reearth/reearth-visualizer/pull/594)) [`c57839`](https://github.com/reearth/reearth-visualizer/commit/c57839)
+- Fix storybook is not working ([#536](https://github.com/reearth/reearth-visualizer/pull/536) [`d52124`](https://github.com/reearth/reearth-visualizer/commit/d52124)
+- Rename asset dir to avoid conflicts with backend API endpoints [`1d9455`](https://github.com/reearth/reearth-visualizer/commit/1d9455)
+- Add offline_access auth scope to support refresh tokens with built-in auth server ([#425](https://github.com/reearth/reearth-visualizer/pull/425) [`2a2af1`](https://github.com/reearth/reearth-visualizer/commit/2a2af1)
+- Upgrade dependencies ([#391](https://github.com/reearth/reearth-visualizer/pull/391)) [`7280af`](https://github.com/reearth/reearth-visualizer/commit/7280af)
 
 #### 
 
-- Add updated SECURITY.md [`bc31ce`](https://github.com/reearth/reearth/commit/bc31ce)
-- Update to 0.15.0 for the release [`d9b693`](https://github.com/reearth/reearth/commit/d9b693)
-- Mono repo — moving reearth-web [`3b1d8d`](https://github.com/reearth/reearth/commit/3b1d8d)
-- Chore(server(: upgrade golangci-lint to v1.51 [`9c8714`](https://github.com/reearth/reearth/commit/9c8714)
+- Add updated SECURITY.md [`bc31ce`](https://github.com/reearth/reearth-visualizer/commit/bc31ce)
+- Update to 0.15.0 for the release [`d9b693`](https://github.com/reearth/reearth-visualizer/commit/d9b693)
+- Mono repo — moving reearth-web [`3b1d8d`](https://github.com/reearth/reearth-visualizer/commit/3b1d8d)
+- Chore(server(: upgrade golangci-lint to v1.51 [`9c8714`](https://github.com/reearth/reearth-visualizer/commit/9c8714)
 
 ## 0.14.1 - 2022-12-21
 
@@ -1409,119 +1409,119 @@ All notable changes to this project will be documented in this file.
 
 ### 🔧 Bug Fixes
 
-- Plugin API viewport.query destroys published pages ([#385](https://github.com/reearth/reearth-web/pull/385)) [`de8c01`](https://github.com/reearth/reearth-web/commit/de8c01)
+- Plugin API viewport.query destroys published pages ([#385](https://github.com/reearth/reearth-visualizer-web/pull/385)) [`de8c01`](https://github.com/reearth/reearth-visualizer-web/commit/de8c01)
 
 ### Web
 
 ### 🚀 Features
 
-- Port the Box layer into the reearth&#x2F;core ([#377](https://github.com/reearth/reearth-web/pull/377)) [`f235f1`](https://github.com/reearth/reearth-web/commit/f235f1)
-- Support multi feature for geojson ([#380](https://github.com/reearth/reearth-web/pull/380)) [`d1ee59`](https://github.com/reearth/reearth-web/commit/d1ee59)
-- Extend plugin API supports get query ([#374](https://github.com/reearth/reearth-web/pull/374)) [`ccae02`](https://github.com/reearth/reearth-web/commit/ccae02)
-- Extend plugin API supports communication ([#364](https://github.com/reearth/reearth-web/pull/364)) [`61e67e`](https://github.com/reearth/reearth-web/commit/61e67e)
-- Support 2d mode in navigator ([#360](https://github.com/reearth/reearth-web/pull/360)) [`595dd5`](https://github.com/reearth/reearth-web/commit/595dd5)
-- Main logic of the new layer system ([#370](https://github.com/reearth/reearth-web/pull/370)) [`0dd63e`](https://github.com/reearth/reearth-web/commit/0dd63e)
+- Port the Box layer into the reearth&#x2F;core ([#377](https://github.com/reearth/reearth-visualizer-web/pull/377)) [`f235f1`](https://github.com/reearth/reearth-visualizer-web/commit/f235f1)
+- Support multi feature for geojson ([#380](https://github.com/reearth/reearth-visualizer-web/pull/380)) [`d1ee59`](https://github.com/reearth/reearth-visualizer-web/commit/d1ee59)
+- Extend plugin API supports get query ([#374](https://github.com/reearth/reearth-visualizer-web/pull/374)) [`ccae02`](https://github.com/reearth/reearth-visualizer-web/commit/ccae02)
+- Extend plugin API supports communication ([#364](https://github.com/reearth/reearth-visualizer-web/pull/364)) [`61e67e`](https://github.com/reearth/reearth-visualizer-web/commit/61e67e)
+- Support 2d mode in navigator ([#360](https://github.com/reearth/reearth-visualizer-web/pull/360)) [`595dd5`](https://github.com/reearth/reearth-visualizer-web/commit/595dd5)
+- Main logic of the new layer system ([#370](https://github.com/reearth/reearth-visualizer-web/pull/370)) [`0dd63e`](https://github.com/reearth/reearth-visualizer-web/commit/0dd63e)
 
 ### 🔧 Bug Fixes
 
-- Cache logic for feature ([#379](https://github.com/reearth/reearth-web/pull/379)) [`67bc52`](https://github.com/reearth/reearth-web/commit/67bc52)
-- Rendering bug in new layer system ([#375](https://github.com/reearth/reearth-web/pull/375)) [`172988`](https://github.com/reearth/reearth-web/commit/172988)
+- Cache logic for feature ([#379](https://github.com/reearth/reearth-visualizer-web/pull/379)) [`67bc52`](https://github.com/reearth/reearth-visualizer-web/commit/67bc52)
+- Rendering bug in new layer system ([#375](https://github.com/reearth/reearth-visualizer-web/pull/375)) [`172988`](https://github.com/reearth/reearth-visualizer-web/commit/172988)
 
 ### ⚡️ Performance
 
-- Improve unnecessary loading the globe image ([#378](https://github.com/reearth/reearth-web/pull/378)) [`4abbba`](https://github.com/reearth/reearth-web/commit/4abbba)
+- Improve unnecessary loading the globe image ([#378](https://github.com/reearth/reearth-visualizer-web/pull/378)) [`4abbba`](https://github.com/reearth/reearth-visualizer-web/commit/4abbba)
 
 ### ✨ Refactor
 
-- Move feature context ([#381](https://github.com/reearth/reearth-web/pull/381)) [`7e18b8`](https://github.com/reearth/reearth-web/commit/7e18b8)
+- Move feature context ([#381](https://github.com/reearth/reearth-visualizer-web/pull/381)) [`7e18b8`](https://github.com/reearth/reearth-visualizer-web/commit/7e18b8)
 
 ### Miscellaneous Tasks
 
-- Upgrade dependencies ([#373](https://github.com/reearth/reearth-web/pull/373)) [`1fcc75`](https://github.com/reearth/reearth-web/commit/1fcc75)
+- Upgrade dependencies ([#373](https://github.com/reearth/reearth-visualizer-web/pull/373)) [`1fcc75`](https://github.com/reearth/reearth-visualizer-web/commit/1fcc75)
 
 ### Web
 
 ### 🚀 Features
 
-- Support Cesium Ion terrain ([#331](https://github.com/reearth/reearth-web/pull/331)) [`e0b99a`](https://github.com/reearth/reearth-web/commit/e0b99a)
-- Set Cesium Ion default access token via config ([#365](https://github.com/reearth/reearth-web/pull/365)) [`a257b1`](https://github.com/reearth/reearth-web/commit/a257b1)
-- Display policy name on workspace title ([#362](https://github.com/reearth/reearth-web/pull/362)) [`c1c632`](https://github.com/reearth/reearth-web/commit/c1c632)
-- Editable box ([#357](https://github.com/reearth/reearth-web/pull/357)) [`92a159`](https://github.com/reearth/reearth-web/commit/92a159)
-- Extend plugin API supports move widget ([#346](https://github.com/reearth/reearth-web/pull/346)) [`c82825`](https://github.com/reearth/reearth-web/commit/c82825)
-- Extend plugin API supports close widget ([#355](https://github.com/reearth/reearth-web/pull/355)) [`d02578`](https://github.com/reearth/reearth-web/commit/d02578)
-- Extend plugin API supports get scene inEditor ([#351](https://github.com/reearth/reearth-web/pull/351)) [`ec0b81`](https://github.com/reearth/reearth-web/commit/ec0b81)
-- Add clipping box ([#338](https://github.com/reearth/reearth-web/pull/338)) [`af55f1`](https://github.com/reearth/reearth-web/commit/af55f1)
-- Extend plugin API event with modalclose popupclose ([#354](https://github.com/reearth/reearth-web/pull/354)) [`9be75a`](https://github.com/reearth/reearth-web/commit/9be75a)
-- Extend plugin API supports get location from screen position ([#350](https://github.com/reearth/reearth-web/pull/350)) [`9a826f`](https://github.com/reearth/reearth-web/commit/9a826f)
-- Extend plugin API supports get viewport&[#39](https://github.com/reearth/reearth-web/pull/39);s size ([#342](https://github.com/reearth/reearth-web/pull/342)) [`7b268b`](https://github.com/reearth/reearth-web/commit/7b268b)
-- Add Re:Earth favicon ([#349](https://github.com/reearth/reearth-web/pull/349)) [`0395d2`](https://github.com/reearth/reearth-web/commit/0395d2)
-- Support acquiring locations with terrain ([#343](https://github.com/reearth/reearth-web/pull/343)) [`596543`](https://github.com/reearth/reearth-web/commit/596543)
+- Support Cesium Ion terrain ([#331](https://github.com/reearth/reearth-visualizer-web/pull/331)) [`e0b99a`](https://github.com/reearth/reearth-visualizer-web/commit/e0b99a)
+- Set Cesium Ion default access token via config ([#365](https://github.com/reearth/reearth-visualizer-web/pull/365)) [`a257b1`](https://github.com/reearth/reearth-visualizer-web/commit/a257b1)
+- Display policy name on workspace title ([#362](https://github.com/reearth/reearth-visualizer-web/pull/362)) [`c1c632`](https://github.com/reearth/reearth-visualizer-web/commit/c1c632)
+- Editable box ([#357](https://github.com/reearth/reearth-visualizer-web/pull/357)) [`92a159`](https://github.com/reearth/reearth-visualizer-web/commit/92a159)
+- Extend plugin API supports move widget ([#346](https://github.com/reearth/reearth-visualizer-web/pull/346)) [`c82825`](https://github.com/reearth/reearth-visualizer-web/commit/c82825)
+- Extend plugin API supports close widget ([#355](https://github.com/reearth/reearth-visualizer-web/pull/355)) [`d02578`](https://github.com/reearth/reearth-visualizer-web/commit/d02578)
+- Extend plugin API supports get scene inEditor ([#351](https://github.com/reearth/reearth-visualizer-web/pull/351)) [`ec0b81`](https://github.com/reearth/reearth-visualizer-web/commit/ec0b81)
+- Add clipping box ([#338](https://github.com/reearth/reearth-visualizer-web/pull/338)) [`af55f1`](https://github.com/reearth/reearth-visualizer-web/commit/af55f1)
+- Extend plugin API event with modalclose popupclose ([#354](https://github.com/reearth/reearth-visualizer-web/pull/354)) [`9be75a`](https://github.com/reearth/reearth-visualizer-web/commit/9be75a)
+- Extend plugin API supports get location from screen position ([#350](https://github.com/reearth/reearth-visualizer-web/pull/350)) [`9a826f`](https://github.com/reearth/reearth-visualizer-web/commit/9a826f)
+- Extend plugin API supports get viewport&[#39](https://github.com/reearth/reearth-visualizer-web/pull/39);s size ([#342](https://github.com/reearth/reearth-visualizer-web/pull/342)) [`7b268b`](https://github.com/reearth/reearth-visualizer-web/commit/7b268b)
+- Add Re:Earth favicon ([#349](https://github.com/reearth/reearth-visualizer-web/pull/349)) [`0395d2`](https://github.com/reearth/reearth-visualizer-web/commit/0395d2)
+- Support acquiring locations with terrain ([#343](https://github.com/reearth/reearth-visualizer-web/pull/343)) [`596543`](https://github.com/reearth/reearth-visualizer-web/commit/596543)
 
 ### 🔧 Bug Fixes
 
-- Policy messages not aligning with policy ([#368](https://github.com/reearth/reearth-web/pull/368)) [`2871ed`](https://github.com/reearth/reearth-web/commit/2871ed)
-- Widget align system alignment issue with installed widgets [`e302cc`](https://github.com/reearth/reearth-web/commit/e302cc)
-- Rename animation option to withoutAnimation in lookAt ([#361](https://github.com/reearth/reearth-web/pull/361)) [`846a6e`](https://github.com/reearth/reearth-web/commit/846a6e)
-- Post message queue doesn&[#39](https://github.com/reearth/reearth-web/pull/39);t work for modal&#x2F;popup ([#359](https://github.com/reearth/reearth-web/pull/359)) [`abb4ed`](https://github.com/reearth/reearth-web/commit/abb4ed)
-- Correct flyToGround destination camera ([#356](https://github.com/reearth/reearth-web/pull/356)) [`225758`](https://github.com/reearth/reearth-web/commit/225758)
-- Navigator styles ([#353](https://github.com/reearth/reearth-web/pull/353)) [`971323`](https://github.com/reearth/reearth-web/commit/971323)
-- Timeline styles ([#352](https://github.com/reearth/reearth-web/pull/352)) [`c76d36`](https://github.com/reearth/reearth-web/commit/c76d36)
-- Alignment issues in Widget Align System ([#344](https://github.com/reearth/reearth-web/pull/344)) [`0e12ea`](https://github.com/reearth/reearth-web/commit/0e12ea)
-- Cannot input camera altitude less than 500 with camera pane ([#339](https://github.com/reearth/reearth-web/pull/339)) [`76a169`](https://github.com/reearth/reearth-web/commit/76a169)
-- Type error from apollo-client [`7dd2b3`](https://github.com/reearth/reearth-web/commit/7dd2b3)
-- Fix the camera offset when keep press on zoom to layer ([#335](https://github.com/reearth/reearth-web/pull/335)) [`ccec33`](https://github.com/reearth/reearth-web/commit/ccec33)
+- Policy messages not aligning with policy ([#368](https://github.com/reearth/reearth-visualizer-web/pull/368)) [`2871ed`](https://github.com/reearth/reearth-visualizer-web/commit/2871ed)
+- Widget align system alignment issue with installed widgets [`e302cc`](https://github.com/reearth/reearth-visualizer-web/commit/e302cc)
+- Rename animation option to withoutAnimation in lookAt ([#361](https://github.com/reearth/reearth-visualizer-web/pull/361)) [`846a6e`](https://github.com/reearth/reearth-visualizer-web/commit/846a6e)
+- Post message queue doesn&[#39](https://github.com/reearth/reearth-visualizer-web/pull/39);t work for modal&#x2F;popup ([#359](https://github.com/reearth/reearth-visualizer-web/pull/359)) [`abb4ed`](https://github.com/reearth/reearth-visualizer-web/commit/abb4ed)
+- Correct flyToGround destination camera ([#356](https://github.com/reearth/reearth-visualizer-web/pull/356)) [`225758`](https://github.com/reearth/reearth-visualizer-web/commit/225758)
+- Navigator styles ([#353](https://github.com/reearth/reearth-visualizer-web/pull/353)) [`971323`](https://github.com/reearth/reearth-visualizer-web/commit/971323)
+- Timeline styles ([#352](https://github.com/reearth/reearth-visualizer-web/pull/352)) [`c76d36`](https://github.com/reearth/reearth-visualizer-web/commit/c76d36)
+- Alignment issues in Widget Align System ([#344](https://github.com/reearth/reearth-visualizer-web/pull/344)) [`0e12ea`](https://github.com/reearth/reearth-visualizer-web/commit/0e12ea)
+- Cannot input camera altitude less than 500 with camera pane ([#339](https://github.com/reearth/reearth-visualizer-web/pull/339)) [`76a169`](https://github.com/reearth/reearth-visualizer-web/commit/76a169)
+- Type error from apollo-client [`7dd2b3`](https://github.com/reearth/reearth-visualizer-web/commit/7dd2b3)
+- Fix the camera offset when keep press on zoom to layer ([#335](https://github.com/reearth/reearth-visualizer-web/pull/335)) [`ccec33`](https://github.com/reearth/reearth-visualizer-web/commit/ccec33)
 
 ### ⚡️ Performance
 
-- Use lodash-es rather than lodash [`731e54`](https://github.com/reearth/reearth-web/commit/731e54)
+- Use lodash-es rather than lodash [`731e54`](https://github.com/reearth/reearth-visualizer-web/commit/731e54)
 
 ### 🧪 Testing
 
-- Gql func to e2e reearth page [`593780`](https://github.com/reearth/reearth-web/commit/593780)
-- Introduce playwright to run e2e tests ([#336](https://github.com/reearth/reearth-web/pull/336)) [`3af520`](https://github.com/reearth/reearth-web/commit/3af520)
+- Gql func to e2e reearth page [`593780`](https://github.com/reearth/reearth-visualizer-web/commit/593780)
+- Introduce playwright to run e2e tests ([#336](https://github.com/reearth/reearth-visualizer-web/pull/336)) [`3af520`](https://github.com/reearth/reearth-visualizer-web/commit/3af520)
 
 ### Miscellaneous Tasks
 
-- Suppress errors output to the console by Icon [`bd9dc5`](https://github.com/reearth/reearth-web/commit/bd9dc5)
-- Upgrade cesium to v1.100.0 [`ec05a0`](https://github.com/reearth/reearth-web/commit/ec05a0)
-- Upgrade cesium to v1.99 [`be5b22`](https://github.com/reearth/reearth-web/commit/be5b22)
-- Upgrade dependencies ([#345](https://github.com/reearth/reearth-web/pull/345)) [`1efe8c`](https://github.com/reearth/reearth-web/commit/1efe8c)
-- Remove eslint-plugin-graphql, add eslint-plugin-playwright, refresh yarn.lock [`28c846`](https://github.com/reearth/reearth-web/commit/28c846)
-- Use node 16 to avoid storybook build error with node 18 [`64819e`](https://github.com/reearth/reearth-web/commit/64819e)
+- Suppress errors output to the console by Icon [`bd9dc5`](https://github.com/reearth/reearth-visualizer-web/commit/bd9dc5)
+- Upgrade cesium to v1.100.0 [`ec05a0`](https://github.com/reearth/reearth-visualizer-web/commit/ec05a0)
+- Upgrade cesium to v1.99 [`be5b22`](https://github.com/reearth/reearth-visualizer-web/commit/be5b22)
+- Upgrade dependencies ([#345](https://github.com/reearth/reearth-visualizer-web/pull/345)) [`1efe8c`](https://github.com/reearth/reearth-visualizer-web/commit/1efe8c)
+- Remove eslint-plugin-graphql, add eslint-plugin-playwright, refresh yarn.lock [`28c846`](https://github.com/reearth/reearth-visualizer-web/commit/28c846)
+- Use node 16 to avoid storybook build error with node 18 [`64819e`](https://github.com/reearth/reearth-visualizer-web/commit/64819e)
 
 ### Server
 
 #### 🚀 Features
 
-- Remove gsi terrain [`232b78`](https://github.com/reearth/reearth/commit/232b78)
-- Suppprt h2c [`ca0626`](https://github.com/reearth/reearth/commit/ca0626)
-- Add Cesium Ion and GSI terrain, transfer terrain properties ([#369](https://github.com/reearth/reearth/pull/369)) [`104e59`](https://github.com/reearth/reearth/commit/104e59)
+- Remove gsi terrain [`232b78`](https://github.com/reearth/reearth-visualizer/commit/232b78)
+- Suppprt h2c [`ca0626`](https://github.com/reearth/reearth-visualizer/commit/ca0626)
+- Add Cesium Ion and GSI terrain, transfer terrain properties ([#369](https://github.com/reearth/reearth-visualizer/pull/369)) [`104e59`](https://github.com/reearth/reearth-visualizer/commit/104e59)
 
 #### 🔧 Bug Fixes
 
-- Enforce policy of layer count on layer group creation correctly [`193c37`](https://github.com/reearth/reearth/commit/193c37)
-- Dataset limitation by policies, asset size calc [`e07b78`](https://github.com/reearth/reearth/commit/e07b78)
-- Apply default policy to workspaces [`2f7fb9`](https://github.com/reearth/reearth/commit/2f7fb9)
+- Enforce policy of layer count on layer group creation correctly [`193c37`](https://github.com/reearth/reearth-visualizer/commit/193c37)
+- Dataset limitation by policies, asset size calc [`e07b78`](https://github.com/reearth/reearth-visualizer/commit/e07b78)
+- Apply default policy to workspaces [`2f7fb9`](https://github.com/reearth/reearth-visualizer/commit/2f7fb9)
 
 ### Misc
 
 #### 🚀 Features
 
-- Policy name, dataset limitation by policies [`b72132`](https://github.com/reearth/reearth/commit/b72132)
+- Policy name, dataset limitation by policies [`b72132`](https://github.com/reearth/reearth-visualizer/commit/b72132)
 
 #### 🔧 Bug Fixes
 
-- Bugs with incorrectly applied policies ([#377](https://github.com/reearth/reearth/pull/377)) [`67e79f`](https://github.com/reearth/reearth/commit/67e79f)
+- Bugs with incorrectly applied policies ([#377](https://github.com/reearth/reearth-visualizer/pull/377)) [`67e79f`](https://github.com/reearth/reearth-visualizer/commit/67e79f)
 
 ### 
 
 #### 🚀 Features
 
-- Policy name, dataset limitation by policies [`b72132`](https://github.com/reearth/reearth/commit/b72132)
+- Policy name, dataset limitation by policies [`b72132`](https://github.com/reearth/reearth-visualizer/commit/b72132)
 
 #### 🔧 Bug Fixes
 
-- Bugs with incorrectly applied policies ([#377](https://github.com/reearth/reearth/pull/377)) [`67e79f`](https://github.com/reearth/reearth/commit/67e79f)
+- Bugs with incorrectly applied policies ([#377](https://github.com/reearth/reearth-visualizer/pull/377)) [`67e79f`](https://github.com/reearth/reearth-visualizer/commit/67e79f)
 
 ## 0.12.0 - 2022-10-28
 
@@ -1529,49 +1529,49 @@ All notable changes to this project will be documented in this file.
 
 ### Miscellaneous Tasks
 
-- Update eslint-config-reearth to 0.2.1 ([#326](https://github.com/reearth/reearth-web/pull/326)) [`25acdd`](https://github.com/reearth/reearth-web/commit/25acdd)
+- Update eslint-config-reearth to 0.2.1 ([#326](https://github.com/reearth/reearth-visualizer-web/pull/326)) [`25acdd`](https://github.com/reearth/reearth-visualizer-web/commit/25acdd)
 
 ### 🚀 Features
 
-- Add plugin api modal &amp; popup ([#328](https://github.com/reearth/reearth-web/pull/328)) [`27cd7a`](https://github.com/reearth/reearth-web/commit/27cd7a)
-- Zoom to layer ([#301](https://github.com/reearth/reearth-web/pull/301)) [`1f5296`](https://github.com/reearth/reearth-web/commit/1f5296)
-- Fix layer(marker) extrdue line disapear  ([#330](https://github.com/reearth/reearth-web/pull/330)) [`7c304f`](https://github.com/reearth/reearth-web/commit/7c304f)
-- Add option to allow camera to enter the earth&[#39](https://github.com/reearth/reearth-web/pull/39);s surface ([#329](https://github.com/reearth/reearth-web/pull/329)) [`6255ad`](https://github.com/reearth/reearth-web/commit/6255ad)
-- Add navigator as a built-in widget ([#323](https://github.com/reearth/reearth-web/pull/323)) [`3befd4`](https://github.com/reearth/reearth-web/commit/3befd4)
+- Add plugin api modal &amp; popup ([#328](https://github.com/reearth/reearth-visualizer-web/pull/328)) [`27cd7a`](https://github.com/reearth/reearth-visualizer-web/commit/27cd7a)
+- Zoom to layer ([#301](https://github.com/reearth/reearth-visualizer-web/pull/301)) [`1f5296`](https://github.com/reearth/reearth-visualizer-web/commit/1f5296)
+- Fix layer(marker) extrdue line disapear  ([#330](https://github.com/reearth/reearth-visualizer-web/pull/330)) [`7c304f`](https://github.com/reearth/reearth-visualizer-web/commit/7c304f)
+- Add option to allow camera to enter the earth&[#39](https://github.com/reearth/reearth-visualizer-web/pull/39);s surface ([#329](https://github.com/reearth/reearth-visualizer-web/pull/329)) [`6255ad`](https://github.com/reearth/reearth-visualizer-web/commit/6255ad)
+- Add navigator as a built-in widget ([#323](https://github.com/reearth/reearth-visualizer-web/pull/323)) [`3befd4`](https://github.com/reearth/reearth-visualizer-web/commit/3befd4)
 
 ### 🔧 Bug Fixes
 
-- Fix the story telling icon size when the layer name is too long  ([#334](https://github.com/reearth/reearth-web/pull/334)) [`c70121`](https://github.com/reearth/reearth-web/commit/c70121)
-- Polyfill event target for old Safari [`227d64`](https://github.com/reearth/reearth-web/commit/227d64)
-- Zoom to layer functionality ([#332](https://github.com/reearth/reearth-web/pull/332)) [`79b0dd`](https://github.com/reearth/reearth-web/commit/79b0dd)
-- Camera popup icon is too small and the icon on storytelling ([#324](https://github.com/reearth/reearth-web/pull/324)) [`e676c3`](https://github.com/reearth/reearth-web/commit/e676c3)
+- Fix the story telling icon size when the layer name is too long  ([#334](https://github.com/reearth/reearth-visualizer-web/pull/334)) [`c70121`](https://github.com/reearth/reearth-visualizer-web/commit/c70121)
+- Polyfill event target for old Safari [`227d64`](https://github.com/reearth/reearth-visualizer-web/commit/227d64)
+- Zoom to layer functionality ([#332](https://github.com/reearth/reearth-visualizer-web/pull/332)) [`79b0dd`](https://github.com/reearth/reearth-visualizer-web/commit/79b0dd)
+- Camera popup icon is too small and the icon on storytelling ([#324](https://github.com/reearth/reearth-visualizer-web/pull/324)) [`e676c3`](https://github.com/reearth/reearth-visualizer-web/commit/e676c3)
 
 ### Miscellaneous Tasks
 
-- Update yarn.lock [`ae4660`](https://github.com/reearth/reearth-web/commit/ae4660)
-- Fix wdyr [`d4075a`](https://github.com/reearth/reearth-web/commit/d4075a)
-- Update dependency cesium to v1.98.1 ([#325](https://github.com/reearth/reearth-web/pull/325)) [`16e38c`](https://github.com/reearth/reearth-web/commit/16e38c)
+- Update yarn.lock [`ae4660`](https://github.com/reearth/reearth-visualizer-web/commit/ae4660)
+- Fix wdyr [`d4075a`](https://github.com/reearth/reearth-visualizer-web/commit/d4075a)
+- Update dependency cesium to v1.98.1 ([#325](https://github.com/reearth/reearth-visualizer-web/pull/325)) [`16e38c`](https://github.com/reearth/reearth-visualizer-web/commit/16e38c)
 
 ### Server
 
 #### 🚀 Features
 
-- Add field to manifest to allow for entering the ground ([#353](https://github.com/reearth/reearth/pull/353)) [`6a56ce`](https://github.com/reearth/reearth/commit/6a56ce)
-- Add builtint navigator widget manifest ([#342](https://github.com/reearth/reearth/pull/342)) [`f6834f`](https://github.com/reearth/reearth/commit/f6834f)
+- Add field to manifest to allow for entering the ground ([#353](https://github.com/reearth/reearth-visualizer/pull/353)) [`6a56ce`](https://github.com/reearth/reearth-visualizer/commit/6a56ce)
+- Add builtint navigator widget manifest ([#342](https://github.com/reearth/reearth-visualizer/pull/342)) [`f6834f`](https://github.com/reearth/reearth-visualizer/commit/f6834f)
 
 #### 🔧 Bug Fixes
 
-- Tiles typo error ([#360](https://github.com/reearth/reearth/pull/360)) [`ddf7d5`](https://github.com/reearth/reearth/commit/ddf7d5)
-- Japanese typo error ([#351](https://github.com/reearth/reearth/pull/351)) [`d0292c`](https://github.com/reearth/reearth/commit/d0292c)
-- Mongo indexes deleted unexpectedly [`4a323b`](https://github.com/reearth/reearth/commit/4a323b)
+- Tiles typo error ([#360](https://github.com/reearth/reearth-visualizer/pull/360)) [`ddf7d5`](https://github.com/reearth/reearth-visualizer/commit/ddf7d5)
+- Japanese typo error ([#351](https://github.com/reearth/reearth-visualizer/pull/351)) [`d0292c`](https://github.com/reearth/reearth-visualizer/commit/d0292c)
+- Mongo indexes deleted unexpectedly [`4a323b`](https://github.com/reearth/reearth-visualizer/commit/4a323b)
 
 #### ⚡️ Performance
 
-- Add mongo indexes [`cee2b2`](https://github.com/reearth/reearth/commit/cee2b2)
+- Add mongo indexes [`cee2b2`](https://github.com/reearth/reearth-visualizer/commit/cee2b2)
 
 #### Miscellaneous Tasks
 
-- Fix make run-db [`944c0d`](https://github.com/reearth/reearth/commit/944c0d)
+- Fix make run-db [`944c0d`](https://github.com/reearth/reearth-visualizer/commit/944c0d)
 
 ## 0.11.0 - 2022-10-04
 
@@ -1579,134 +1579,134 @@ All notable changes to this project will be documented in this file.
 
 ### 🔧 Bug Fixes
 
-- Installed plugins are not displayed expectedly [`12d546`](https://github.com/reearth/reearth-web/commit/12d546)
+- Installed plugins are not displayed expectedly [`12d546`](https://github.com/reearth/reearth-visualizer-web/commit/12d546)
 
 ### 🚀 Features
 
-- Add 3D OSM building tiles ([#315](https://github.com/reearth/reearth-web/pull/315)) [`2eb89a`](https://github.com/reearth/reearth-web/commit/2eb89a)
-- Extend plugin API with camera control ([#311](https://github.com/reearth/reearth-web/pull/311)) [`c1190b`](https://github.com/reearth/reearth-web/commit/c1190b)
-- Extend plugin api with captureScreen ([#310](https://github.com/reearth/reearth-web/pull/310)) [`f03022`](https://github.com/reearth/reearth-web/commit/f03022)
-- Small update to dashboard UI&#x2F;UX and add marketplace button [`f580e6`](https://github.com/reearth/reearth-web/commit/f580e6)
-- Add global modal component and extension location ([#302](https://github.com/reearth/reearth-web/pull/302)) [`7362aa`](https://github.com/reearth/reearth-web/commit/7362aa)
-- Add overlay warning to earth editor if browser width is too narrow ([#304](https://github.com/reearth/reearth-web/pull/304)) [`7f5f91`](https://github.com/reearth/reearth-web/commit/7f5f91)
-- Add builtin timeline widget ([#285](https://github.com/reearth/reearth-web/pull/285)) [`f774ee`](https://github.com/reearth/reearth-web/commit/f774ee)
-- Add plugin settings extension support ([#293](https://github.com/reearth/reearth-web/pull/293)) [`abd1c2`](https://github.com/reearth/reearth-web/commit/abd1c2)
+- Add 3D OSM building tiles ([#315](https://github.com/reearth/reearth-visualizer-web/pull/315)) [`2eb89a`](https://github.com/reearth/reearth-visualizer-web/commit/2eb89a)
+- Extend plugin API with camera control ([#311](https://github.com/reearth/reearth-visualizer-web/pull/311)) [`c1190b`](https://github.com/reearth/reearth-visualizer-web/commit/c1190b)
+- Extend plugin api with captureScreen ([#310](https://github.com/reearth/reearth-visualizer-web/pull/310)) [`f03022`](https://github.com/reearth/reearth-visualizer-web/commit/f03022)
+- Small update to dashboard UI&#x2F;UX and add marketplace button [`f580e6`](https://github.com/reearth/reearth-visualizer-web/commit/f580e6)
+- Add global modal component and extension location ([#302](https://github.com/reearth/reearth-visualizer-web/pull/302)) [`7362aa`](https://github.com/reearth/reearth-visualizer-web/commit/7362aa)
+- Add overlay warning to earth editor if browser width is too narrow ([#304](https://github.com/reearth/reearth-visualizer-web/pull/304)) [`7f5f91`](https://github.com/reearth/reearth-visualizer-web/commit/7f5f91)
+- Add builtin timeline widget ([#285](https://github.com/reearth/reearth-visualizer-web/pull/285)) [`f774ee`](https://github.com/reearth/reearth-visualizer-web/commit/f774ee)
+- Add plugin settings extension support ([#293](https://github.com/reearth/reearth-visualizer-web/pull/293)) [`abd1c2`](https://github.com/reearth/reearth-visualizer-web/commit/abd1c2)
 
 ### 🔧 Bug Fixes
 
-- Remove &#x60;show&#x60; props from modal extension ([#321](https://github.com/reearth/reearth-web/pull/321)) [`62eb73`](https://github.com/reearth/reearth-web/commit/62eb73)
-- Styles not working as expected in plugin ([#322](https://github.com/reearth/reearth-web/pull/322)) [`21329d`](https://github.com/reearth/reearth-web/commit/21329d)
-- Small type error [`21c8bc`](https://github.com/reearth/reearth-web/commit/21c8bc)
-- Stop redirect when an error occurs on top page [`236354`](https://github.com/reearth/reearth-web/commit/236354)
-- Installed plugins are not correctly listed [`ec305d`](https://github.com/reearth/reearth-web/commit/ec305d)
-- Exposed plugin api add layer does not return layer id ([#320](https://github.com/reearth/reearth-web/pull/320)) [`f504d2`](https://github.com/reearth/reearth-web/commit/f504d2)
-- Cannot to upgrade marketplace plugins ([#319](https://github.com/reearth/reearth-web/pull/319)) [`444fce`](https://github.com/reearth/reearth-web/commit/444fce)
-- Timeline width exceeding browser width ([#316](https://github.com/reearth/reearth-web/pull/316)) [`c6dbb3`](https://github.com/reearth/reearth-web/commit/c6dbb3)
-- 3d tile not updating until source type is selected ([#318](https://github.com/reearth/reearth-web/pull/318)) [`49a07b`](https://github.com/reearth/reearth-web/commit/49a07b)
-- Wrapper styles in plugin section for plugin extension ([#317](https://github.com/reearth/reearth-web/pull/317)) [`235440`](https://github.com/reearth/reearth-web/commit/235440)
-- Timeline speed bug ([#314](https://github.com/reearth/reearth-web/pull/314)) [`984be8`](https://github.com/reearth/reearth-web/commit/984be8)
-- Pass extensions to a plugin library extension [`744154`](https://github.com/reearth/reearth-web/commit/744154)
-- Print errors when failed to load extensions [`35a63f`](https://github.com/reearth/reearth-web/commit/35a63f)
-- Icon button transition happening when undesired ([#313](https://github.com/reearth/reearth-web/pull/313)) [`6a6d98`](https://github.com/reearth/reearth-web/commit/6a6d98)
-- Icon size being too small ([#309](https://github.com/reearth/reearth-web/pull/309)) [`3574f0`](https://github.com/reearth/reearth-web/commit/3574f0)
-- Change query param used by marketplace to be more concise [`9ba28c`](https://github.com/reearth/reearth-web/commit/9ba28c)
-- Dashboard project name not showing ([#307](https://github.com/reearth/reearth-web/pull/307)) [`6a30f5`](https://github.com/reearth/reearth-web/commit/6a30f5)
-- Plugin API update event gets called repeatedly, missing hook deps ([#306](https://github.com/reearth/reearth-web/pull/306)) [`47ec24`](https://github.com/reearth/reearth-web/commit/47ec24)
-- Update cesium to 1.97.0 [`4d993a`](https://github.com/reearth/reearth-web/commit/4d993a)
-- Play button does not work and some unexpected style on timeline widget ([#305](https://github.com/reearth/reearth-web/pull/305)) [`ce29a5`](https://github.com/reearth/reearth-web/commit/ce29a5)
-- Development error occurs when updating or DnD layers ([#299](https://github.com/reearth/reearth-web/pull/299)) [`efd079`](https://github.com/reearth/reearth-web/commit/efd079)
-- Project creation not creating a scene before earth editor becoming accessible [`a0a03e`](https://github.com/reearth/reearth-web/commit/a0a03e)
-- Device settings menu icon getting squished ([#298](https://github.com/reearth/reearth-web/pull/298)) [`91c312`](https://github.com/reearth/reearth-web/commit/91c312)
-- Remove unused GraphQL calls [`59f402`](https://github.com/reearth/reearth-web/commit/59f402)
+- Remove &#x60;show&#x60; props from modal extension ([#321](https://github.com/reearth/reearth-visualizer-web/pull/321)) [`62eb73`](https://github.com/reearth/reearth-visualizer-web/commit/62eb73)
+- Styles not working as expected in plugin ([#322](https://github.com/reearth/reearth-visualizer-web/pull/322)) [`21329d`](https://github.com/reearth/reearth-visualizer-web/commit/21329d)
+- Small type error [`21c8bc`](https://github.com/reearth/reearth-visualizer-web/commit/21c8bc)
+- Stop redirect when an error occurs on top page [`236354`](https://github.com/reearth/reearth-visualizer-web/commit/236354)
+- Installed plugins are not correctly listed [`ec305d`](https://github.com/reearth/reearth-visualizer-web/commit/ec305d)
+- Exposed plugin api add layer does not return layer id ([#320](https://github.com/reearth/reearth-visualizer-web/pull/320)) [`f504d2`](https://github.com/reearth/reearth-visualizer-web/commit/f504d2)
+- Cannot to upgrade marketplace plugins ([#319](https://github.com/reearth/reearth-visualizer-web/pull/319)) [`444fce`](https://github.com/reearth/reearth-visualizer-web/commit/444fce)
+- Timeline width exceeding browser width ([#316](https://github.com/reearth/reearth-visualizer-web/pull/316)) [`c6dbb3`](https://github.com/reearth/reearth-visualizer-web/commit/c6dbb3)
+- 3d tile not updating until source type is selected ([#318](https://github.com/reearth/reearth-visualizer-web/pull/318)) [`49a07b`](https://github.com/reearth/reearth-visualizer-web/commit/49a07b)
+- Wrapper styles in plugin section for plugin extension ([#317](https://github.com/reearth/reearth-visualizer-web/pull/317)) [`235440`](https://github.com/reearth/reearth-visualizer-web/commit/235440)
+- Timeline speed bug ([#314](https://github.com/reearth/reearth-visualizer-web/pull/314)) [`984be8`](https://github.com/reearth/reearth-visualizer-web/commit/984be8)
+- Pass extensions to a plugin library extension [`744154`](https://github.com/reearth/reearth-visualizer-web/commit/744154)
+- Print errors when failed to load extensions [`35a63f`](https://github.com/reearth/reearth-visualizer-web/commit/35a63f)
+- Icon button transition happening when undesired ([#313](https://github.com/reearth/reearth-visualizer-web/pull/313)) [`6a6d98`](https://github.com/reearth/reearth-visualizer-web/commit/6a6d98)
+- Icon size being too small ([#309](https://github.com/reearth/reearth-visualizer-web/pull/309)) [`3574f0`](https://github.com/reearth/reearth-visualizer-web/commit/3574f0)
+- Change query param used by marketplace to be more concise [`9ba28c`](https://github.com/reearth/reearth-visualizer-web/commit/9ba28c)
+- Dashboard project name not showing ([#307](https://github.com/reearth/reearth-visualizer-web/pull/307)) [`6a30f5`](https://github.com/reearth/reearth-visualizer-web/commit/6a30f5)
+- Plugin API update event gets called repeatedly, missing hook deps ([#306](https://github.com/reearth/reearth-visualizer-web/pull/306)) [`47ec24`](https://github.com/reearth/reearth-visualizer-web/commit/47ec24)
+- Update cesium to 1.97.0 [`4d993a`](https://github.com/reearth/reearth-visualizer-web/commit/4d993a)
+- Play button does not work and some unexpected style on timeline widget ([#305](https://github.com/reearth/reearth-visualizer-web/pull/305)) [`ce29a5`](https://github.com/reearth/reearth-visualizer-web/commit/ce29a5)
+- Development error occurs when updating or DnD layers ([#299](https://github.com/reearth/reearth-visualizer-web/pull/299)) [`efd079`](https://github.com/reearth/reearth-visualizer-web/commit/efd079)
+- Project creation not creating a scene before earth editor becoming accessible [`a0a03e`](https://github.com/reearth/reearth-visualizer-web/commit/a0a03e)
+- Device settings menu icon getting squished ([#298](https://github.com/reearth/reearth-visualizer-web/pull/298)) [`91c312`](https://github.com/reearth/reearth-visualizer-web/commit/91c312)
+- Remove unused GraphQL calls [`59f402`](https://github.com/reearth/reearth-visualizer-web/commit/59f402)
 
 ### 🎨 Styling
 
-- Update button and icon UX [`75e6f4`](https://github.com/reearth/reearth-web/commit/75e6f4)
+- Update button and icon UX [`75e6f4`](https://github.com/reearth/reearth-visualizer-web/commit/75e6f4)
 
 ### Miscellaneous Tasks
 
-- Update dependency cesium to v1.97.0 ([#291](https://github.com/reearth/reearth-web/pull/291)) [`dcdf93`](https://github.com/reearth/reearth-web/commit/dcdf93)
-- Add remaining props to plugin settings extensions ([#312](https://github.com/reearth/reearth-web/pull/312)) [`893d32`](https://github.com/reearth/reearth-web/commit/893d32)
-- Plugin component supports modalContainer and popupContainer props ([#300](https://github.com/reearth/reearth-web/pull/300)) [`fc5f58`](https://github.com/reearth/reearth-web/commit/fc5f58)
-- Update cesium to v1.96 ([#303](https://github.com/reearth/reearth-web/pull/303)) [`4fc241`](https://github.com/reearth/reearth-web/commit/4fc241)
+- Update dependency cesium to v1.97.0 ([#291](https://github.com/reearth/reearth-visualizer-web/pull/291)) [`dcdf93`](https://github.com/reearth/reearth-visualizer-web/commit/dcdf93)
+- Add remaining props to plugin settings extensions ([#312](https://github.com/reearth/reearth-visualizer-web/pull/312)) [`893d32`](https://github.com/reearth/reearth-visualizer-web/commit/893d32)
+- Plugin component supports modalContainer and popupContainer props ([#300](https://github.com/reearth/reearth-visualizer-web/pull/300)) [`fc5f58`](https://github.com/reearth/reearth-visualizer-web/commit/fc5f58)
+- Update cesium to v1.96 ([#303](https://github.com/reearth/reearth-visualizer-web/pull/303)) [`4fc241`](https://github.com/reearth/reearth-visualizer-web/commit/4fc241)
 
 ### Server
 
 #### 🚀 Features
 
-- Notify plugin donwload to marketplace ([#341](https://github.com/reearth/reearth/pull/341)) [`59f8a8`](https://github.com/reearth/reearth/commit/59f8a8)
-- Add 3D OSM building tiles ([#340](https://github.com/reearth/reearth/pull/340)) [`b52132`](https://github.com/reearth/reearth/commit/b52132)
-- Allow defining policies to limit functionality on workspaces ([#325](https://github.com/reearth/reearth/pull/325)) [`91ace0`](https://github.com/reearth/reearth/commit/91ace0)
+- Notify plugin donwload to marketplace ([#341](https://github.com/reearth/reearth-visualizer/pull/341)) [`59f8a8`](https://github.com/reearth/reearth-visualizer/commit/59f8a8)
+- Add 3D OSM building tiles ([#340](https://github.com/reearth/reearth-visualizer/pull/340)) [`b52132`](https://github.com/reearth/reearth-visualizer/commit/b52132)
+- Allow defining policies to limit functionality on workspaces ([#325](https://github.com/reearth/reearth-visualizer/pull/325)) [`91ace0`](https://github.com/reearth/reearth-visualizer/commit/91ace0)
 
 #### 🔧 Bug Fixes
 
-- Prevent API caching [`76405b`](https://github.com/reearth/reearth/commit/76405b)
-- Auth server request indexes [`430da0`](https://github.com/reearth/reearth/commit/430da0)
-- Marketplace http client bug [`b652c8`](https://github.com/reearth/reearth/commit/b652c8)
-- Marketplace http client [`ce982d`](https://github.com/reearth/reearth/commit/ce982d)
-- Print marketplace donwload url [`6e1d50`](https://github.com/reearth/reearth/commit/6e1d50)
-- Marketplace client init [`752872`](https://github.com/reearth/reearth/commit/752872)
-- Support marketplace without auth [`4afe99`](https://github.com/reearth/reearth/commit/4afe99)
+- Prevent API caching [`76405b`](https://github.com/reearth/reearth-visualizer/commit/76405b)
+- Auth server request indexes [`430da0`](https://github.com/reearth/reearth-visualizer/commit/430da0)
+- Marketplace http client bug [`b652c8`](https://github.com/reearth/reearth-visualizer/commit/b652c8)
+- Marketplace http client [`ce982d`](https://github.com/reearth/reearth-visualizer/commit/ce982d)
+- Print marketplace donwload url [`6e1d50`](https://github.com/reearth/reearth-visualizer/commit/6e1d50)
+- Marketplace client init [`752872`](https://github.com/reearth/reearth-visualizer/commit/752872)
+- Support marketplace without auth [`4afe99`](https://github.com/reearth/reearth-visualizer/commit/4afe99)
 
 #### ✨ Refactor
 
-- Use mongox, update go to 1.19 ([#334](https://github.com/reearth/reearth/pull/334)) [`cfff17`](https://github.com/reearth/reearth/commit/cfff17)
-- Separate Team from User, rename Team to Workspace ([#324](https://github.com/reearth/reearth/pull/324)) [`03a94a`](https://github.com/reearth/reearth/commit/03a94a)
-- Replace some packages with reearthx ([#322](https://github.com/reearth/reearth/pull/322)) [`3813a9`](https://github.com/reearth/reearth/commit/3813a9)
+- Use mongox, update go to 1.19 ([#334](https://github.com/reearth/reearth-visualizer/pull/334)) [`cfff17`](https://github.com/reearth/reearth-visualizer/commit/cfff17)
+- Separate Team from User, rename Team to Workspace ([#324](https://github.com/reearth/reearth-visualizer/pull/324)) [`03a94a`](https://github.com/reearth/reearth-visualizer/commit/03a94a)
+- Replace some packages with reearthx ([#322](https://github.com/reearth/reearth-visualizer/pull/322)) [`3813a9`](https://github.com/reearth/reearth-visualizer/commit/3813a9)
 
 #### 🧪 Testing
 
-- Add package for e2e tests [`cf7ca5`](https://github.com/reearth/reearth/commit/cf7ca5)
+- Add package for e2e tests [`cf7ca5`](https://github.com/reearth/reearth-visualizer/commit/cf7ca5)
 
 #### Miscellaneous Tasks
 
-- Use reearthx logger [`6b6b21`](https://github.com/reearth/reearth/commit/6b6b21)
-- Upgrade mongo to v5 [`9d231d`](https://github.com/reearth/reearth/commit/9d231d)
-- Replace package name [`bc1ffe`](https://github.com/reearth/reearth/commit/bc1ffe)
+- Use reearthx logger [`6b6b21`](https://github.com/reearth/reearth-visualizer/commit/6b6b21)
+- Upgrade mongo to v5 [`9d231d`](https://github.com/reearth/reearth-visualizer/commit/9d231d)
+- Replace package name [`bc1ffe`](https://github.com/reearth/reearth-visualizer/commit/bc1ffe)
 
 ### Misc
 
 #### 🚀 Features
 
-- Installing plugins from marketplace ([#162](https://github.com/reearth/reearth/pull/162)) [`276ef5`](https://github.com/reearth/reearth/commit/276ef5)
+- Installing plugins from marketplace ([#162](https://github.com/reearth/reearth-visualizer/pull/162)) [`276ef5`](https://github.com/reearth/reearth-visualizer/commit/276ef5)
 
 #### 🔧 Bug Fixes
 
-- Dataset fails to be loaded [`518f03`](https://github.com/reearth/reearth/commit/518f03)
+- Dataset fails to be loaded [`518f03`](https://github.com/reearth/reearth-visualizer/commit/518f03)
 
 #### 📖 Documentation
 
-- Update readme [`c8d2ec`](https://github.com/reearth/reearth/commit/c8d2ec)
+- Update readme [`c8d2ec`](https://github.com/reearth/reearth-visualizer/commit/c8d2ec)
 
 #### ✨ Refactor
 
-- Use reearthx.authserver ([#335](https://github.com/reearth/reearth/pull/335)) [`83dea5`](https://github.com/reearth/reearth/commit/83dea5)
+- Use reearthx.authserver ([#335](https://github.com/reearth/reearth-visualizer/pull/335)) [`83dea5`](https://github.com/reearth/reearth-visualizer/commit/83dea5)
 
 #### Miscellaneous Tasks
 
-- Merge &#x60;reearth&#x2F;reearth-backend&#x60; ([#318](https://github.com/reearth/reearth/pull/318)) [`98514b`](https://github.com/reearth/reearth/commit/98514b)
+- Merge &#x60;reearth&#x2F;reearth-backend&#x60; ([#318](https://github.com/reearth/reearth-visualizer/pull/318)) [`98514b`](https://github.com/reearth/reearth-visualizer/commit/98514b)
 
 ### 
 
 #### 🚀 Features
 
-- Installing plugins from marketplace ([#162](https://github.com/reearth/reearth/pull/162)) [`276ef5`](https://github.com/reearth/reearth/commit/276ef5)
+- Installing plugins from marketplace ([#162](https://github.com/reearth/reearth-visualizer/pull/162)) [`276ef5`](https://github.com/reearth/reearth-visualizer/commit/276ef5)
 
 #### 🔧 Bug Fixes
 
-- Dataset fails to be loaded [`518f03`](https://github.com/reearth/reearth/commit/518f03)
+- Dataset fails to be loaded [`518f03`](https://github.com/reearth/reearth-visualizer/commit/518f03)
 
 #### 📖 Documentation
 
-- Update readme [`c8d2ec`](https://github.com/reearth/reearth/commit/c8d2ec)
+- Update readme [`c8d2ec`](https://github.com/reearth/reearth-visualizer/commit/c8d2ec)
 
 #### ✨ Refactor
 
-- Use reearthx.authserver ([#335](https://github.com/reearth/reearth/pull/335)) [`83dea5`](https://github.com/reearth/reearth/commit/83dea5)
+- Use reearthx.authserver ([#335](https://github.com/reearth/reearth-visualizer/pull/335)) [`83dea5`](https://github.com/reearth/reearth-visualizer/commit/83dea5)
 
 #### Miscellaneous Tasks
 
-- Merge &#x60;reearth&#x2F;reearth-backend&#x60; ([#318](https://github.com/reearth/reearth/pull/318)) [`98514b`](https://github.com/reearth/reearth/commit/98514b)
+- Merge &#x60;reearth&#x2F;reearth-backend&#x60; ([#318](https://github.com/reearth/reearth-visualizer/pull/318)) [`98514b`](https://github.com/reearth/reearth-visualizer/commit/98514b)
 
 ## 0.10.0 - 2022-08-10
 
@@ -1714,41 +1714,41 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Add mouse events to plugin API ([#280](https://github.com/reearth/reearth-web/pull/280)) [`9445f0`](https://github.com/reearth/reearth-web/commit/9445f0)
+- Add mouse events to plugin API ([#280](https://github.com/reearth/reearth-visualizer-web/pull/280)) [`9445f0`](https://github.com/reearth/reearth-visualizer-web/commit/9445f0)
 
 #### 🔧 Bug Fixes
 
-- Select not working after pinch event on ipad ([#290](https://github.com/reearth/reearth-web/pull/290)) [`821504`](https://github.com/reearth/reearth-web/commit/821504)
-- Translation for modal buttons [`7eead9`](https://github.com/reearth/reearth-web/commit/7eead9)
-- Plugin widget&[#39](https://github.com/reearth/reearth-web/pull/39);s width using iframe&[#39](https://github.com/reearth/reearth-web/pull/39);s default ([#283](https://github.com/reearth/reearth-web/pull/283)) [`572da0`](https://github.com/reearth/reearth-web/commit/572da0)
-- Pointer events issues around widgets ([#279](https://github.com/reearth/reearth-web/pull/279)) [`219ea4`](https://github.com/reearth/reearth-web/commit/219ea4)
+- Select not working after pinch event on ipad ([#290](https://github.com/reearth/reearth-visualizer-web/pull/290)) [`821504`](https://github.com/reearth/reearth-visualizer-web/commit/821504)
+- Translation for modal buttons [`7eead9`](https://github.com/reearth/reearth-visualizer-web/commit/7eead9)
+- Plugin widget&[#39](https://github.com/reearth/reearth-visualizer-web/pull/39);s width using iframe&[#39](https://github.com/reearth/reearth-visualizer-web/pull/39);s default ([#283](https://github.com/reearth/reearth-visualizer-web/pull/283)) [`572da0`](https://github.com/reearth/reearth-visualizer-web/commit/572da0)
+- Pointer events issues around widgets ([#279](https://github.com/reearth/reearth-visualizer-web/pull/279)) [`219ea4`](https://github.com/reearth/reearth-visualizer-web/commit/219ea4)
 
 #### 🎨 Styling
 
-- Fix icons of plugin install buttons ([#289](https://github.com/reearth/reearth-web/pull/289)) [`af7a1b`](https://github.com/reearth/reearth-web/commit/af7a1b)
+- Fix icons of plugin install buttons ([#289](https://github.com/reearth/reearth-visualizer-web/pull/289)) [`af7a1b`](https://github.com/reearth/reearth-visualizer-web/commit/af7a1b)
 
 #### 🧪 Testing
 
-- Introduce vitest ([#284](https://github.com/reearth/reearth-web/pull/284)) [`2152e0`](https://github.com/reearth/reearth-web/commit/2152e0)
+- Introduce vitest ([#284](https://github.com/reearth/reearth-visualizer-web/pull/284)) [`2152e0`](https://github.com/reearth/reearth-visualizer-web/commit/2152e0)
 
 #### Miscellaneous Tasks
 
-- Migrate to Vite, upgrade Cypress to v10 ([#287](https://github.com/reearth/reearth-web/pull/287)) [`50f2b6`](https://github.com/reearth/reearth-web/commit/50f2b6)
-- Simplify ESLint config ([#282](https://github.com/reearth/reearth-web/pull/282)) [`b3570a`](https://github.com/reearth/reearth-web/commit/b3570a)
-- Upgrade resium to v1.15.0 ([#281](https://github.com/reearth/reearth-web/pull/281)) [`bd3968`](https://github.com/reearth/reearth-web/commit/bd3968)
-- Cosme changelog [`05084e`](https://github.com/reearth/reearth-web/commit/05084e)
-- Fix changelog [`48de86`](https://github.com/reearth/reearth-web/commit/48de86)
+- Migrate to Vite, upgrade Cypress to v10 ([#287](https://github.com/reearth/reearth-visualizer-web/pull/287)) [`50f2b6`](https://github.com/reearth/reearth-visualizer-web/commit/50f2b6)
+- Simplify ESLint config ([#282](https://github.com/reearth/reearth-visualizer-web/pull/282)) [`b3570a`](https://github.com/reearth/reearth-visualizer-web/commit/b3570a)
+- Upgrade resium to v1.15.0 ([#281](https://github.com/reearth/reearth-visualizer-web/pull/281)) [`bd3968`](https://github.com/reearth/reearth-visualizer-web/commit/bd3968)
+- Cosme changelog [`05084e`](https://github.com/reearth/reearth-visualizer-web/commit/05084e)
+- Fix changelog [`48de86`](https://github.com/reearth/reearth-visualizer-web/commit/48de86)
 
 ### reearth-backend
 
 #### 🚀 Features
 
-- Configurable server host [`61b03a`](https://github.com/reearth/reearth-backend/commit/61b03a)
+- Configurable server host [`61b03a`](https://github.com/reearth/reearth-visualizer-backend/commit/61b03a)
 
 #### Miscellaneous Tasks
 
-- Add new frontend endpoint (for Vite@3) [`70fed0`](https://github.com/reearth/reearth-backend/commit/70fed0)
-- Fix changelog [skip ci] [`895a64`](https://github.com/reearth/reearth-backend/commit/895a64)
+- Add new frontend endpoint (for Vite@3) [`70fed0`](https://github.com/reearth/reearth-visualizer-backend/commit/70fed0)
+- Fix changelog [skip ci] [`895a64`](https://github.com/reearth/reearth-visualizer-backend/commit/895a64)
 
 ## 0.9.0 - 2022-07-20
 
@@ -1756,59 +1756,59 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Plugin API to add layers ([#258](https://github.com/reearth/reearth-web/pull/258)) [`6468e2`](https://github.com/reearth/reearth-web/commit/6468e2)
-- Change layer indicators from preset list ([#245](https://github.com/reearth/reearth-web/pull/245)) [`db185e`](https://github.com/reearth/reearth-web/commit/db185e)
+- Plugin API to add layers ([#258](https://github.com/reearth/reearth-visualizer-web/pull/258)) [`6468e2`](https://github.com/reearth/reearth-visualizer-web/commit/6468e2)
+- Change layer indicators from preset list ([#245](https://github.com/reearth/reearth-visualizer-web/pull/245)) [`db185e`](https://github.com/reearth/reearth-visualizer-web/commit/db185e)
 
 #### 🔧 Bug Fixes
 
-- Some menu not displayed at sidebar in proejct setting page [`7c0705`](https://github.com/reearth/reearth-web/commit/7c0705)
-- Nothing displayed at project setting page when there are many projects [`0a6744`](https://github.com/reearth/reearth-web/commit/0a6744)
-- Plugins do not work as expected, update quickjs-emscripten ([#276](https://github.com/reearth/reearth-web/pull/276)) [`9336e6`](https://github.com/reearth/reearth-web/commit/9336e6)
-- Plugin editor changes do not take effect until run button is clicked ([#274](https://github.com/reearth/reearth-web/pull/274)) [`39fdb2`](https://github.com/reearth/reearth-web/commit/39fdb2)
-- Storytelling widget does not get layers&[#39](https://github.com/reearth/reearth-web/pull/39); title ([#273](https://github.com/reearth/reearth-web/pull/273)) [`5ff72b`](https://github.com/reearth/reearth-web/commit/5ff72b)
-- Dataset icon not showing in layer list ([#275](https://github.com/reearth/reearth-web/pull/275)) [`8dbc88`](https://github.com/reearth/reearth-web/commit/8dbc88)
-- Show full camera values in camera property field popup ([#270](https://github.com/reearth/reearth-web/pull/270)) [`7d3eac`](https://github.com/reearth/reearth-web/commit/7d3eac)
-- Plugin dimensions and iframe issues ([#271](https://github.com/reearth/reearth-web/pull/271)) [`f3a52a`](https://github.com/reearth/reearth-web/commit/f3a52a)
-- Camera jump not working ([#269](https://github.com/reearth/reearth-web/pull/269)) [`48bbfe`](https://github.com/reearth/reearth-web/commit/48bbfe)
-- Layer select state not update properly ([#268](https://github.com/reearth/reearth-web/pull/268)) [`5f7c69`](https://github.com/reearth/reearth-web/commit/5f7c69)
-- Unselect layer not work properly ([#266](https://github.com/reearth/reearth-web/pull/266)) [`eb41da`](https://github.com/reearth/reearth-web/commit/eb41da)
-- Layer drag and drop does not work with indicators ([#265](https://github.com/reearth/reearth-web/pull/265)) [`12ae04`](https://github.com/reearth/reearth-web/commit/12ae04)
-- Testing-library react 18 warnings ([#263](https://github.com/reearth/reearth-web/pull/263)) [`4c9076`](https://github.com/reearth/reearth-web/commit/4c9076)
-- Auto fetch more items in dashboard page , project list , dataset page for big screens ([#255](https://github.com/reearth/reearth-web/pull/255)) [`fb8bf9`](https://github.com/reearth/reearth-web/commit/fb8bf9)
-- Asset modal flushes when camera limiter is enabled ([#261](https://github.com/reearth/reearth-web/pull/261)) [`204629`](https://github.com/reearth/reearth-web/commit/204629)
-- Not being able to override an image from the asset modal ([#260](https://github.com/reearth/reearth-web/pull/260)) [`1d3c3f`](https://github.com/reearth/reearth-web/commit/1d3c3f)
-- Layers pane does not update after move layer or create folder  ([#259](https://github.com/reearth/reearth-web/pull/259)) [`336d98`](https://github.com/reearth/reearth-web/commit/336d98)
-- Cesium flashes on camera change ([#257](https://github.com/reearth/reearth-web/pull/257)) [`ad2c0e`](https://github.com/reearth/reearth-web/commit/ad2c0e)
-- Router typos ([#252](https://github.com/reearth/reearth-web/pull/252)) [`19fcb6`](https://github.com/reearth/reearth-web/commit/19fcb6)
-- Dataset page showing errors on page refreshing  ([#253](https://github.com/reearth/reearth-web/pull/253)) [`3f48e9`](https://github.com/reearth/reearth-web/commit/3f48e9)
+- Some menu not displayed at sidebar in proejct setting page [`7c0705`](https://github.com/reearth/reearth-visualizer-web/commit/7c0705)
+- Nothing displayed at project setting page when there are many projects [`0a6744`](https://github.com/reearth/reearth-visualizer-web/commit/0a6744)
+- Plugins do not work as expected, update quickjs-emscripten ([#276](https://github.com/reearth/reearth-visualizer-web/pull/276)) [`9336e6`](https://github.com/reearth/reearth-visualizer-web/commit/9336e6)
+- Plugin editor changes do not take effect until run button is clicked ([#274](https://github.com/reearth/reearth-visualizer-web/pull/274)) [`39fdb2`](https://github.com/reearth/reearth-visualizer-web/commit/39fdb2)
+- Storytelling widget does not get layers&[#39](https://github.com/reearth/reearth-visualizer-web/pull/39); title ([#273](https://github.com/reearth/reearth-visualizer-web/pull/273)) [`5ff72b`](https://github.com/reearth/reearth-visualizer-web/commit/5ff72b)
+- Dataset icon not showing in layer list ([#275](https://github.com/reearth/reearth-visualizer-web/pull/275)) [`8dbc88`](https://github.com/reearth/reearth-visualizer-web/commit/8dbc88)
+- Show full camera values in camera property field popup ([#270](https://github.com/reearth/reearth-visualizer-web/pull/270)) [`7d3eac`](https://github.com/reearth/reearth-visualizer-web/commit/7d3eac)
+- Plugin dimensions and iframe issues ([#271](https://github.com/reearth/reearth-visualizer-web/pull/271)) [`f3a52a`](https://github.com/reearth/reearth-visualizer-web/commit/f3a52a)
+- Camera jump not working ([#269](https://github.com/reearth/reearth-visualizer-web/pull/269)) [`48bbfe`](https://github.com/reearth/reearth-visualizer-web/commit/48bbfe)
+- Layer select state not update properly ([#268](https://github.com/reearth/reearth-visualizer-web/pull/268)) [`5f7c69`](https://github.com/reearth/reearth-visualizer-web/commit/5f7c69)
+- Unselect layer not work properly ([#266](https://github.com/reearth/reearth-visualizer-web/pull/266)) [`eb41da`](https://github.com/reearth/reearth-visualizer-web/commit/eb41da)
+- Layer drag and drop does not work with indicators ([#265](https://github.com/reearth/reearth-visualizer-web/pull/265)) [`12ae04`](https://github.com/reearth/reearth-visualizer-web/commit/12ae04)
+- Testing-library react 18 warnings ([#263](https://github.com/reearth/reearth-visualizer-web/pull/263)) [`4c9076`](https://github.com/reearth/reearth-visualizer-web/commit/4c9076)
+- Auto fetch more items in dashboard page , project list , dataset page for big screens ([#255](https://github.com/reearth/reearth-visualizer-web/pull/255)) [`fb8bf9`](https://github.com/reearth/reearth-visualizer-web/commit/fb8bf9)
+- Asset modal flushes when camera limiter is enabled ([#261](https://github.com/reearth/reearth-visualizer-web/pull/261)) [`204629`](https://github.com/reearth/reearth-visualizer-web/commit/204629)
+- Not being able to override an image from the asset modal ([#260](https://github.com/reearth/reearth-visualizer-web/pull/260)) [`1d3c3f`](https://github.com/reearth/reearth-visualizer-web/commit/1d3c3f)
+- Layers pane does not update after move layer or create folder  ([#259](https://github.com/reearth/reearth-visualizer-web/pull/259)) [`336d98`](https://github.com/reearth/reearth-visualizer-web/commit/336d98)
+- Cesium flashes on camera change ([#257](https://github.com/reearth/reearth-visualizer-web/pull/257)) [`ad2c0e`](https://github.com/reearth/reearth-visualizer-web/commit/ad2c0e)
+- Router typos ([#252](https://github.com/reearth/reearth-visualizer-web/pull/252)) [`19fcb6`](https://github.com/reearth/reearth-visualizer-web/commit/19fcb6)
+- Dataset page showing errors on page refreshing  ([#253](https://github.com/reearth/reearth-visualizer-web/pull/253)) [`3f48e9`](https://github.com/reearth/reearth-visualizer-web/commit/3f48e9)
 
 #### 🧪 Testing
 
-- Fix test coverage target ([#272](https://github.com/reearth/reearth-web/pull/272)) [`b9db10`](https://github.com/reearth/reearth-web/commit/b9db10)
+- Fix test coverage target ([#272](https://github.com/reearth/reearth-visualizer-web/pull/272)) [`b9db10`](https://github.com/reearth/reearth-visualizer-web/commit/b9db10)
 
 #### Miscellaneous Tasks
 
-- Update dependency cesium to ^1.95.0 ([#262](https://github.com/reearth/reearth-web/pull/262)) [`845e2a`](https://github.com/reearth/reearth-web/commit/845e2a)
-- Upgrade cesium [`363071`](https://github.com/reearth/reearth-web/commit/363071)
-- Upgrade to React 18 and switch to React Router ([#234](https://github.com/reearth/reearth-web/pull/234)) [`b0e8e6`](https://github.com/reearth/reearth-web/commit/b0e8e6)
+- Update dependency cesium to ^1.95.0 ([#262](https://github.com/reearth/reearth-visualizer-web/pull/262)) [`845e2a`](https://github.com/reearth/reearth-visualizer-web/commit/845e2a)
+- Upgrade cesium [`363071`](https://github.com/reearth/reearth-visualizer-web/commit/363071)
+- Upgrade to React 18 and switch to React Router ([#234](https://github.com/reearth/reearth-visualizer-web/pull/234)) [`b0e8e6`](https://github.com/reearth/reearth-visualizer-web/commit/b0e8e6)
 
 ### reearth-backend
 
 #### 🚀 Features
 
-- Change layer indicators from preset list from backend side ([#158](https://github.com/reearth/reearth-backend/pull/158)) [`0267f1`](https://github.com/reearth/reearth-backend/commit/0267f1)
+- Change layer indicators from preset list from backend side ([#158](https://github.com/reearth/reearth-visualizer-backend/pull/158)) [`0267f1`](https://github.com/reearth/reearth-visualizer-backend/commit/0267f1)
 
 #### 🔧 Bug Fixes
 
-- Property fields in a property list cannot be removed ([#160](https://github.com/reearth/reearth-backend/pull/160)) [`358237`](https://github.com/reearth/reearth-backend/commit/358237)
+- Property fields in a property list cannot be removed ([#160](https://github.com/reearth/reearth-visualizer-backend/pull/160)) [`358237`](https://github.com/reearth/reearth-visualizer-backend/commit/358237)
 
 #### 🧪 Testing
 
-- Unit test for mongo auth request repo ([#159](https://github.com/reearth/reearth-backend/pull/159)) [`5afc81`](https://github.com/reearth/reearth-backend/commit/5afc81)
+- Unit test for mongo auth request repo ([#159](https://github.com/reearth/reearth-visualizer-backend/pull/159)) [`5afc81`](https://github.com/reearth/reearth-visualizer-backend/commit/5afc81)
 
 #### Miscellaneous Tasks
 
-- Update Makefile to remove unused targets [`67780b`](https://github.com/reearth/reearth-backend/commit/67780b)
+- Update Makefile to remove unused targets [`67780b`](https://github.com/reearth/reearth-visualizer-backend/commit/67780b)
 
 
 ## 0.8.0 - 2022-06-17
@@ -1817,57 +1817,57 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Add a basic timeline UI ([#232](https://github.com/reearth/reearth-web/pull/232)) [`fc9732`](https://github.com/reearth/reearth-web/commit/fc9732)
-- Add infinite scroll for project lists and datasets in dashboard and setting pages ([#225](https://github.com/reearth/reearth-web/pull/225)) [`28d377`](https://github.com/reearth/reearth-web/commit/28d377)
-- Adapt camera field to support 2d mode ([#233](https://github.com/reearth/reearth-web/pull/233)) [`172de5`](https://github.com/reearth/reearth-web/commit/172de5)
-- Add scene property overriding to Re:Earth API ([#224](https://github.com/reearth/reearth-web/pull/224)) [`b07603`](https://github.com/reearth/reearth-web/commit/b07603)
+- Add a basic timeline UI ([#232](https://github.com/reearth/reearth-visualizer-web/pull/232)) [`fc9732`](https://github.com/reearth/reearth-visualizer-web/commit/fc9732)
+- Add infinite scroll for project lists and datasets in dashboard and setting pages ([#225](https://github.com/reearth/reearth-visualizer-web/pull/225)) [`28d377`](https://github.com/reearth/reearth-visualizer-web/commit/28d377)
+- Adapt camera field to support 2d mode ([#233](https://github.com/reearth/reearth-visualizer-web/pull/233)) [`172de5`](https://github.com/reearth/reearth-visualizer-web/commit/172de5)
+- Add scene property overriding to Re:Earth API ([#224](https://github.com/reearth/reearth-visualizer-web/pull/224)) [`b07603`](https://github.com/reearth/reearth-visualizer-web/commit/b07603)
 
 #### 🔧 Bug Fixes
 
-- Some plugin APIs were missing ([#248](https://github.com/reearth/reearth-web/pull/248)) [`c83262`](https://github.com/reearth/reearth-web/commit/c83262)
-- Slight shift when capture a new position ([#246](https://github.com/reearth/reearth-web/pull/246)) [`182406`](https://github.com/reearth/reearth-web/commit/182406)
-- Dataset counts are displayed incorrectly in dataset pane ([#235](https://github.com/reearth/reearth-web/pull/235)) [`45a0c8`](https://github.com/reearth/reearth-web/commit/45a0c8)
-- Labeling hidden by marker symbol ([#238](https://github.com/reearth/reearth-web/pull/238)) [`99c378`](https://github.com/reearth/reearth-web/commit/99c378)
-- Vertical position style in infobox image block ([#236](https://github.com/reearth/reearth-web/pull/236)) [`647cf8`](https://github.com/reearth/reearth-web/commit/647cf8)
-- Unexpected values for theme and lang props of extension components [`723486`](https://github.com/reearth/reearth-web/commit/723486)
-- Wait until all extensions are loaded [`dfe2aa`](https://github.com/reearth/reearth-web/commit/dfe2aa)
-- Iframe not correctly sizing to plugin ([#230](https://github.com/reearth/reearth-web/pull/230)) [`500ce8`](https://github.com/reearth/reearth-web/commit/500ce8)
-- Plugin API cameramove event is not emitted in published pages ([#227](https://github.com/reearth/reearth-web/pull/227)) [`7a11b3`](https://github.com/reearth/reearth-web/commit/7a11b3)
+- Some plugin APIs were missing ([#248](https://github.com/reearth/reearth-visualizer-web/pull/248)) [`c83262`](https://github.com/reearth/reearth-visualizer-web/commit/c83262)
+- Slight shift when capture a new position ([#246](https://github.com/reearth/reearth-visualizer-web/pull/246)) [`182406`](https://github.com/reearth/reearth-visualizer-web/commit/182406)
+- Dataset counts are displayed incorrectly in dataset pane ([#235](https://github.com/reearth/reearth-visualizer-web/pull/235)) [`45a0c8`](https://github.com/reearth/reearth-visualizer-web/commit/45a0c8)
+- Labeling hidden by marker symbol ([#238](https://github.com/reearth/reearth-visualizer-web/pull/238)) [`99c378`](https://github.com/reearth/reearth-visualizer-web/commit/99c378)
+- Vertical position style in infobox image block ([#236](https://github.com/reearth/reearth-visualizer-web/pull/236)) [`647cf8`](https://github.com/reearth/reearth-visualizer-web/commit/647cf8)
+- Unexpected values for theme and lang props of extension components [`723486`](https://github.com/reearth/reearth-visualizer-web/commit/723486)
+- Wait until all extensions are loaded [`dfe2aa`](https://github.com/reearth/reearth-visualizer-web/commit/dfe2aa)
+- Iframe not correctly sizing to plugin ([#230](https://github.com/reearth/reearth-visualizer-web/pull/230)) [`500ce8`](https://github.com/reearth/reearth-visualizer-web/commit/500ce8)
+- Plugin API cameramove event is not emitted in published pages ([#227](https://github.com/reearth/reearth-visualizer-web/pull/227)) [`7a11b3`](https://github.com/reearth/reearth-visualizer-web/commit/7a11b3)
 
 #### ✨ Refactor
 
-- Migrate to react-intl from react-i18next ([#240](https://github.com/reearth/reearth-web/pull/240)) [`404743`](https://github.com/reearth/reearth-web/commit/404743)
+- Migrate to react-intl from react-i18next ([#240](https://github.com/reearth/reearth-visualizer-web/pull/240)) [`404743`](https://github.com/reearth/reearth-visualizer-web/commit/404743)
 
 #### 🧪 Testing
 
-- Disable util/raf tests that do not always succeed [`45a450`](https://github.com/reearth/reearth-web/commit/45a450)
-- Fix unit test for utils/raf [`a060d9`](https://github.com/reearth/reearth-web/commit/a060d9)
-- Fix Cypress login test fails ([#241](https://github.com/reearth/reearth-web/pull/241)) [`a5dbfb`](https://github.com/reearth/reearth-web/commit/a5dbfb)
+- Disable util/raf tests that do not always succeed [`45a450`](https://github.com/reearth/reearth-visualizer-web/commit/45a450)
+- Fix unit test for utils/raf [`a060d9`](https://github.com/reearth/reearth-visualizer-web/commit/a060d9)
+- Fix Cypress login test fails ([#241](https://github.com/reearth/reearth-visualizer-web/pull/241)) [`a5dbfb`](https://github.com/reearth/reearth-visualizer-web/commit/a5dbfb)
 
 #### Miscellaneous Tasks
 
-- Upgrade dependency cesium-dnd to 1.1.0 ([#244](https://github.com/reearth/reearth-web/pull/244)) [`ba6b51`](https://github.com/reearth/reearth-web/commit/ba6b51)
-- Fix typos [`f98005`](https://github.com/reearth/reearth-web/commit/f98005)
-- Update config so extensionUrls can be declared in .env file for local development ([#237](https://github.com/reearth/reearth-web/pull/237)) [`545b9e`](https://github.com/reearth/reearth-web/commit/545b9e)
+- Upgrade dependency cesium-dnd to 1.1.0 ([#244](https://github.com/reearth/reearth-visualizer-web/pull/244)) [`ba6b51`](https://github.com/reearth/reearth-visualizer-web/commit/ba6b51)
+- Fix typos [`f98005`](https://github.com/reearth/reearth-visualizer-web/commit/f98005)
+- Update config so extensionUrls can be declared in .env file for local development ([#237](https://github.com/reearth/reearth-visualizer-web/pull/237)) [`545b9e`](https://github.com/reearth/reearth-visualizer-web/commit/545b9e)
 
 ### reearth-backend
 
 #### 🚀 Features
 
-- Add totalCount field to DatasetSchema type of GraphQL schema ([#154](https://github.com/reearth/reearth-backend/pull/154)) [`ab6334`](https://github.com/reearth/reearth-backend/commit/ab6334)
-- Add timeline settings to scene property ([#153](https://github.com/reearth/reearth-backend/pull/153)) [`602ec0`](https://github.com/reearth/reearth-backend/commit/602ec0)
+- Add totalCount field to DatasetSchema type of GraphQL schema ([#154](https://github.com/reearth/reearth-visualizer-backend/pull/154)) [`ab6334`](https://github.com/reearth/reearth-visualizer-backend/commit/ab6334)
+- Add timeline settings to scene property ([#153](https://github.com/reearth/reearth-visualizer-backend/pull/153)) [`602ec0`](https://github.com/reearth/reearth-visualizer-backend/commit/602ec0)
 
 #### 🔧 Bug Fixes
 
-- Assets are not saved when files are uploaded ([#155](https://github.com/reearth/reearth-backend/pull/155)) [`e444e4`](https://github.com/reearth/reearth-backend/commit/e444e4)
+- Assets are not saved when files are uploaded ([#155](https://github.com/reearth/reearth-visualizer-backend/pull/155)) [`e444e4`](https://github.com/reearth/reearth-visualizer-backend/commit/e444e4)
 
 #### ✨ Refactor
 
-- Declarative description of use case structure (asset only) ([#151](https://github.com/reearth/reearth-backend/pull/151)) [`c6e98c`](https://github.com/reearth/reearth-backend/commit/c6e98c)
+- Declarative description of use case structure (asset only) ([#151](https://github.com/reearth/reearth-visualizer-backend/pull/151)) [`c6e98c`](https://github.com/reearth/reearth-visualizer-backend/commit/c6e98c)
 
 #### Miscellaneous Tasks
 
-- Update go modules ([#150](https://github.com/reearth/reearth-backend/pull/150)) [`6372bc`](https://github.com/reearth/reearth-backend/commit/6372bc)
+- Update go modules ([#150](https://github.com/reearth/reearth-visualizer-backend/pull/150)) [`6372bc`](https://github.com/reearth/reearth-visualizer-backend/commit/6372bc)
 
 ## 0.7.0 - 2022-05-17
 
@@ -1875,61 +1875,61 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Implementation of the avatar feature in workspaces screens ([#206](https://github.com/reearth/reearth-web/pull/206)) [`42d7aa`](https://github.com/reearth/reearth-web/commit/42d7aa)
-- Update placehoder for color field ([#215](https://github.com/reearth/reearth-web/pull/215)) [`c6c6e3`](https://github.com/reearth/reearth-web/commit/c6c6e3)
-- Add opacity field to map tiles ([#220](https://github.com/reearth/reearth-web/pull/220)) [`006a8d`](https://github.com/reearth/reearth-web/commit/006a8d)
+- Implementation of the avatar feature in workspaces screens ([#206](https://github.com/reearth/reearth-visualizer-web/pull/206)) [`42d7aa`](https://github.com/reearth/reearth-visualizer-web/commit/42d7aa)
+- Update placehoder for color field ([#215](https://github.com/reearth/reearth-visualizer-web/pull/215)) [`c6c6e3`](https://github.com/reearth/reearth-visualizer-web/commit/c6c6e3)
+- Add opacity field to map tiles ([#220](https://github.com/reearth/reearth-visualizer-web/pull/220)) [`006a8d`](https://github.com/reearth/reearth-visualizer-web/commit/006a8d)
 
 #### 🔧 Bug Fixes
 
-- Dropdown styles in right panel break when selected item's name is too long [`9a5993`](https://github.com/reearth/reearth-web/commit/9a5993)
-- Dashboard not updating on project creation [`4b5478`](https://github.com/reearth/reearth-web/commit/4b5478)
-- Query names in refetchQueries not updated ([#222](https://github.com/reearth/reearth-web/pull/222)) [`711712`](https://github.com/reearth/reearth-web/commit/711712)
-- Published page uses GraphQL and reports errors [`3e3e45`](https://github.com/reearth/reearth-web/commit/3e3e45)
+- Dropdown styles in right panel break when selected item's name is too long [`9a5993`](https://github.com/reearth/reearth-visualizer-web/commit/9a5993)
+- Dashboard not updating on project creation [`4b5478`](https://github.com/reearth/reearth-visualizer-web/commit/4b5478)
+- Query names in refetchQueries not updated ([#222](https://github.com/reearth/reearth-visualizer-web/pull/222)) [`711712`](https://github.com/reearth/reearth-visualizer-web/commit/711712)
+- Published page uses GraphQL and reports errors [`3e3e45`](https://github.com/reearth/reearth-visualizer-web/commit/3e3e45)
 
 #### ✨ Refactor
 
-- Queries/mutation code into a single directory ([#208](https://github.com/reearth/reearth-web/pull/208)) [`2afc16`](https://github.com/reearth/reearth-web/commit/2afc16)
-- Property, scene, tag, user, widget and workspace gql query files ([#221](https://github.com/reearth/reearth-web/pull/221)) [`3bf421`](https://github.com/reearth/reearth-web/commit/3bf421)
+- Queries/mutation code into a single directory ([#208](https://github.com/reearth/reearth-visualizer-web/pull/208)) [`2afc16`](https://github.com/reearth/reearth-visualizer-web/commit/2afc16)
+- Property, scene, tag, user, widget and workspace gql query files ([#221](https://github.com/reearth/reearth-visualizer-web/pull/221)) [`3bf421`](https://github.com/reearth/reearth-visualizer-web/commit/3bf421)
 
 #### Miscellaneous Tasks
 
-- Introduce i18next ([#212](https://github.com/reearth/reearth-web/pull/212)) [`0ac0c2`](https://github.com/reearth/reearth-web/commit/0ac0c2)
-- Add reference to style guide in README [`e29024`](https://github.com/reearth/reearth-web/commit/e29024)
-- Add useT hook to i18n ([#223](https://github.com/reearth/reearth-web/pull/223)) [`b96177`](https://github.com/reearth/reearth-web/commit/b96177)
-- Update dependency cesium to ^1.93.0 ([#216](https://github.com/reearth/reearth-web/pull/216)) [`06b563`](https://github.com/reearth/reearth-web/commit/06b563)
-- Update all dependencies ([#226](https://github.com/reearth/reearth-web/pull/226)) [`36fb79`](https://github.com/reearth/reearth-web/commit/36fb79)
+- Introduce i18next ([#212](https://github.com/reearth/reearth-visualizer-web/pull/212)) [`0ac0c2`](https://github.com/reearth/reearth-visualizer-web/commit/0ac0c2)
+- Add reference to style guide in README [`e29024`](https://github.com/reearth/reearth-visualizer-web/commit/e29024)
+- Add useT hook to i18n ([#223](https://github.com/reearth/reearth-visualizer-web/pull/223)) [`b96177`](https://github.com/reearth/reearth-visualizer-web/commit/b96177)
+- Update dependency cesium to ^1.93.0 ([#216](https://github.com/reearth/reearth-visualizer-web/pull/216)) [`06b563`](https://github.com/reearth/reearth-visualizer-web/commit/06b563)
+- Update all dependencies ([#226](https://github.com/reearth/reearth-visualizer-web/pull/226)) [`36fb79`](https://github.com/reearth/reearth-visualizer-web/commit/36fb79)
 
 #### Refactor
 
-- Clean gql pt1 asset ([#217](https://github.com/reearth/reearth-web/pull/217)) [`b88a8c`](https://github.com/reearth/reearth-web/commit/b88a8c)
-- Cluster, dataset, infobox, layer, plugin and project gql query files ([#219](https://github.com/reearth/reearth-web/pull/219)) [`e4dae9`](https://github.com/reearth/reearth-web/commit/e4dae9)
+- Clean gql pt1 asset ([#217](https://github.com/reearth/reearth-visualizer-web/pull/217)) [`b88a8c`](https://github.com/reearth/reearth-visualizer-web/commit/b88a8c)
+- Cluster, dataset, infobox, layer, plugin and project gql query files ([#219](https://github.com/reearth/reearth-visualizer-web/pull/219)) [`e4dae9`](https://github.com/reearth/reearth-visualizer-web/commit/e4dae9)
 
 ### reearth-backend
 
 #### 🚀 Features
 
-- Add an opacity slider to map tiles ([#138](https://github.com/reearth/reearth-backend/pull/138)) [`4f72b8`](https://github.com/reearth/reearth-backend/commit/4f72b8)
+- Add an opacity slider to map tiles ([#138](https://github.com/reearth/reearth-visualizer-backend/pull/138)) [`4f72b8`](https://github.com/reearth/reearth-visualizer-backend/commit/4f72b8)
 
 #### 🔧 Bug Fixes
 
-- Signup api requires password field [`a79376`](https://github.com/reearth/reearth-backend/commit/a79376)
-- "$in needs an array" error from mongo FindByIDs ([#142](https://github.com/reearth/reearth-backend/pull/142)) [`58e1b0`](https://github.com/reearth/reearth-backend/commit/58e1b0)
-- Name field is available again in signup api ([#144](https://github.com/reearth/reearth-backend/pull/144)) [`651852`](https://github.com/reearth/reearth-backend/commit/651852)
+- Signup api requires password field [`a79376`](https://github.com/reearth/reearth-visualizer-backend/commit/a79376)
+- "$in needs an array" error from mongo FindByIDs ([#142](https://github.com/reearth/reearth-visualizer-backend/pull/142)) [`58e1b0`](https://github.com/reearth/reearth-visualizer-backend/commit/58e1b0)
+- Name field is available again in signup api ([#144](https://github.com/reearth/reearth-visualizer-backend/pull/144)) [`651852`](https://github.com/reearth/reearth-visualizer-backend/commit/651852)
 
 #### ✨ Refactor
 
-- Retry mongo lock ([#145](https://github.com/reearth/reearth-backend/pull/145)) [`ddaeaa`](https://github.com/reearth/reearth-backend/commit/ddaeaa)
+- Retry mongo lock ([#145](https://github.com/reearth/reearth-visualizer-backend/pull/145)) [`ddaeaa`](https://github.com/reearth/reearth-visualizer-backend/commit/ddaeaa)
 
 #### 🧪 Testing
 
-- Add Mongo Asset's [`FindByID`](https://github.com/reearth/reearth-backend/commit/FindByID) unit testing ([#139](https://github.com/reearth/reearth-backend/pull/139)) [`35f9db`](https://github.com/reearth/reearth-backend/commit/35f9db)
-- Refactor mongo connect helper function [`751e66`](https://github.com/reearth/reearth-backend/commit/751e66)
-- Util.SyncMap.Range test sometimes fails ([#143](https://github.com/reearth/reearth-backend/pull/143)) [`c2b969`](https://github.com/reearth/reearth-backend/commit/c2b969)
+- Add Mongo Asset's [`FindByID`](https://github.com/reearth/reearth-visualizer-backend/commit/FindByID) unit testing ([#139](https://github.com/reearth/reearth-visualizer-backend/pull/139)) [`35f9db`](https://github.com/reearth/reearth-visualizer-backend/commit/35f9db)
+- Refactor mongo connect helper function [`751e66`](https://github.com/reearth/reearth-visualizer-backend/commit/751e66)
+- Util.SyncMap.Range test sometimes fails ([#143](https://github.com/reearth/reearth-visualizer-backend/pull/143)) [`c2b969`](https://github.com/reearth/reearth-visualizer-backend/commit/c2b969)
 
 #### Miscellaneous Tasks
 
-- Typo [`secrit`](https://github.com/reearth/reearth-backend/commit/secrit) on env example ([#137](https://github.com/reearth/reearth-backend/pull/137)) [`2c0220`](https://github.com/reearth/reearth-backend/commit/2c0220)
-- Update the go modules ([#146](https://github.com/reearth/reearth-backend/pull/146)) [`89009b`](https://github.com/reearth/reearth-backend/commit/89009b)
+- Typo [`secrit`](https://github.com/reearth/reearth-visualizer-backend/commit/secrit) on env example ([#137](https://github.com/reearth/reearth-visualizer-backend/pull/137)) [`2c0220`](https://github.com/reearth/reearth-visualizer-backend/commit/2c0220)
+- Update the go modules ([#146](https://github.com/reearth/reearth-visualizer-backend/pull/146)) [`89009b`](https://github.com/reearth/reearth-visualizer-backend/commit/89009b)
 
 ## 0.6.1 - 2022-04-20
 
@@ -1937,32 +1937,32 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Extend project publish settings and dataset import modal functionality through extension API ([#200](https://github.com/reearth/reearth-web/pull/200)) [`96aa56`](https://github.com/reearth/reearth-web/commit/96aa56)
+- Extend project publish settings and dataset import modal functionality through extension API ([#200](https://github.com/reearth/reearth-visualizer-web/pull/200)) [`96aa56`](https://github.com/reearth/reearth-visualizer-web/commit/96aa56)
 
 #### 🔧 Bug Fixes
 
-- Redirect after esc button in any setting page ([#193](https://github.com/reearth/reearth-web/pull/193)) [`c8ec35`](https://github.com/reearth/reearth-web/commit/c8ec35)
+- Redirect after esc button in any setting page ([#193](https://github.com/reearth/reearth-visualizer-web/pull/193)) [`c8ec35`](https://github.com/reearth/reearth-visualizer-web/commit/c8ec35)
 
 #### Miscellaneous Tasks
 
-- Follow GraphQL schema updates ([#209](https://github.com/reearth/reearth-web/pull/209)) [`8d9e75`](https://github.com/reearth/reearth-web/commit/8d9e75)
-- Update all dependencies ([#210](https://github.com/reearth/reearth-web/pull/210)) [`c22b7a`](https://github.com/reearth/reearth-web/commit/c22b7a)
+- Follow GraphQL schema updates ([#209](https://github.com/reearth/reearth-visualizer-web/pull/209)) [`8d9e75`](https://github.com/reearth/reearth-visualizer-web/commit/8d9e75)
+- Update all dependencies ([#210](https://github.com/reearth/reearth-visualizer-web/pull/210)) [`c22b7a`](https://github.com/reearth/reearth-visualizer-web/commit/c22b7a)
 
 ### reearth-backend
 
 #### 🔧 Bug Fixes
 
-- Renovate bot not running on schedule ([#136](https://github.com/reearth/reearth-backend/pull/136)) [`82843f`](https://github.com/reearth/reearth-backend/commit/82843f)
-- Aud was changed and jwt could not be validated correctly [`985100`](https://github.com/reearth/reearth-backend/commit/985100)
-- Auth audiences were unintentionally required [`7ec76a`](https://github.com/reearth/reearth-backend/commit/7ec76a)
+- Renovate bot not running on schedule ([#136](https://github.com/reearth/reearth-visualizer-backend/pull/136)) [`82843f`](https://github.com/reearth/reearth-visualizer-backend/commit/82843f)
+- Aud was changed and jwt could not be validated correctly [`985100`](https://github.com/reearth/reearth-visualizer-backend/commit/985100)
+- Auth audiences were unintentionally required [`7ec76a`](https://github.com/reearth/reearth-visualizer-backend/commit/7ec76a)
 
 #### ✨ Refactor
 
-- Introduce generics, reorganize GraphQL schema ([#135](https://github.com/reearth/reearth-backend/pull/135)) [`04a098`](https://github.com/reearth/reearth-backend/commit/04a098)
+- Introduce generics, reorganize GraphQL schema ([#135](https://github.com/reearth/reearth-visualizer-backend/pull/135)) [`04a098`](https://github.com/reearth/reearth-visualizer-backend/commit/04a098)
 
 #### Miscellaneous Tasks
 
-- Update dependencies ([#134](https://github.com/reearth/reearth-backend/pull/134)) [`1b9b6b`](https://github.com/reearth/reearth-backend/commit/1b9b6b)
+- Update dependencies ([#134](https://github.com/reearth/reearth-visualizer-backend/pull/134)) [`1b9b6b`](https://github.com/reearth/reearth-visualizer-backend/commit/1b9b6b)
 
 ## 0.6.0 - 2022-04-08
 
@@ -1970,78 +1970,78 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Add a plugin API to resize iframe by plugins ([#181](https://github.com/reearth/reearth-web/pull/181)) [`7c1019`](https://github.com/reearth/reearth-web/commit/7c1019)
-- Authentication ([#121](https://github.com/reearth/reearth-web/pull/121)) [`b63018`](https://github.com/reearth/reearth-web/commit/b63018)
-- Infinite scroll on assets ([#130](https://github.com/reearth/reearth-web/pull/130)) [`11f2f2`](https://github.com/reearth/reearth-web/commit/11f2f2)
-- Basic plugin editor ([#184](https://github.com/reearth/reearth-web/pull/184)) [`1c4e09`](https://github.com/reearth/reearth-web/commit/1c4e09)
+- Add a plugin API to resize iframe by plugins ([#181](https://github.com/reearth/reearth-visualizer-web/pull/181)) [`7c1019`](https://github.com/reearth/reearth-visualizer-web/commit/7c1019)
+- Authentication ([#121](https://github.com/reearth/reearth-visualizer-web/pull/121)) [`b63018`](https://github.com/reearth/reearth-visualizer-web/commit/b63018)
+- Infinite scroll on assets ([#130](https://github.com/reearth/reearth-visualizer-web/pull/130)) [`11f2f2`](https://github.com/reearth/reearth-visualizer-web/commit/11f2f2)
+- Basic plugin editor ([#184](https://github.com/reearth/reearth-visualizer-web/pull/184)) [`1c4e09`](https://github.com/reearth/reearth-visualizer-web/commit/1c4e09)
 
 #### 🔧 Bug Fixes
 
-- Unable to type RGBA values ([#180](https://github.com/reearth/reearth-web/pull/180)) [`f7345c`](https://github.com/reearth/reearth-web/commit/f7345c)
-- Small height of block plugins [`8070a3`](https://github.com/reearth/reearth-web/commit/8070a3)
-- Button widget squishing its text & infobox mask click away ([#185](https://github.com/reearth/reearth-web/pull/185)) [`ac7ef0`](https://github.com/reearth/reearth-web/commit/ac7ef0)
-- Cannot select layers that activate infobox mask ([#186](https://github.com/reearth/reearth-web/pull/186)) [`d824b6`](https://github.com/reearth/reearth-web/commit/d824b6)
-- Display error messages from auth server ([#187](https://github.com/reearth/reearth-web/pull/187)) [`e19fab`](https://github.com/reearth/reearth-web/commit/e19fab)
-- Duplicate asset results ([#188](https://github.com/reearth/reearth-web/pull/188)) [`b3eb7f`](https://github.com/reearth/reearth-web/commit/b3eb7f)
-- Workspace name cannot be changed, error displayed when deleting assets ([#189](https://github.com/reearth/reearth-web/pull/189)) [`a99cf3`](https://github.com/reearth/reearth-web/commit/a99cf3)
-- Multiple assets in infinite scroll and datasets not showing in DatasetPane  ([#192](https://github.com/reearth/reearth-web/pull/192)) [`6f5c93`](https://github.com/reearth/reearth-web/commit/6f5c93)
-- Asset modal showing only image-based assets ([#196](https://github.com/reearth/reearth-web/pull/196)) [`83a6bf`](https://github.com/reearth/reearth-web/commit/83a6bf)
-- Screen becomes inoperable when errors occur in sign up [`820a04`](https://github.com/reearth/reearth-web/commit/820a04)
-- Add missing translations [`a4c237`](https://github.com/reearth/reearth-web/commit/a4c237)
+- Unable to type RGBA values ([#180](https://github.com/reearth/reearth-visualizer-web/pull/180)) [`f7345c`](https://github.com/reearth/reearth-visualizer-web/commit/f7345c)
+- Small height of block plugins [`8070a3`](https://github.com/reearth/reearth-visualizer-web/commit/8070a3)
+- Button widget squishing its text & infobox mask click away ([#185](https://github.com/reearth/reearth-visualizer-web/pull/185)) [`ac7ef0`](https://github.com/reearth/reearth-visualizer-web/commit/ac7ef0)
+- Cannot select layers that activate infobox mask ([#186](https://github.com/reearth/reearth-visualizer-web/pull/186)) [`d824b6`](https://github.com/reearth/reearth-visualizer-web/commit/d824b6)
+- Display error messages from auth server ([#187](https://github.com/reearth/reearth-visualizer-web/pull/187)) [`e19fab`](https://github.com/reearth/reearth-visualizer-web/commit/e19fab)
+- Duplicate asset results ([#188](https://github.com/reearth/reearth-visualizer-web/pull/188)) [`b3eb7f`](https://github.com/reearth/reearth-visualizer-web/commit/b3eb7f)
+- Workspace name cannot be changed, error displayed when deleting assets ([#189](https://github.com/reearth/reearth-visualizer-web/pull/189)) [`a99cf3`](https://github.com/reearth/reearth-visualizer-web/commit/a99cf3)
+- Multiple assets in infinite scroll and datasets not showing in DatasetPane  ([#192](https://github.com/reearth/reearth-visualizer-web/pull/192)) [`6f5c93`](https://github.com/reearth/reearth-visualizer-web/commit/6f5c93)
+- Asset modal showing only image-based assets ([#196](https://github.com/reearth/reearth-visualizer-web/pull/196)) [`83a6bf`](https://github.com/reearth/reearth-visualizer-web/commit/83a6bf)
+- Screen becomes inoperable when errors occur in sign up [`820a04`](https://github.com/reearth/reearth-visualizer-web/commit/820a04)
+- Add missing translations [`a4c237`](https://github.com/reearth/reearth-visualizer-web/commit/a4c237)
 
 #### Miscellaneous Tasks
 
-- Update dependency cesium to ^1.91.0 ([#182](https://github.com/reearth/reearth-web/pull/182)) [`603a5c`](https://github.com/reearth/reearth-web/commit/603a5c)
-- Set default auth config to start app with zero configuration ([#191](https://github.com/reearth/reearth-web/pull/191)) [`d5a2aa`](https://github.com/reearth/reearth-web/commit/d5a2aa)
+- Update dependency cesium to ^1.91.0 ([#182](https://github.com/reearth/reearth-visualizer-web/pull/182)) [`603a5c`](https://github.com/reearth/reearth-visualizer-web/commit/603a5c)
+- Set default auth config to start app with zero configuration ([#191](https://github.com/reearth/reearth-visualizer-web/pull/191)) [`d5a2aa`](https://github.com/reearth/reearth-visualizer-web/commit/d5a2aa)
 
 ### reearth-backend
 
 #### 🚀 Features
 
-- Authentication system ([#108](https://github.com/reearth/reearth-backend/pull/108)) [`b89c32`](https://github.com/reearth/reearth-backend/commit/b89c32)
-- Default mailer that outputs mails into stdout [`aab26c`](https://github.com/reearth/reearth-backend/commit/aab26c)
-- Assets filtering & pagination ([#81](https://github.com/reearth/reearth-backend/pull/81)) [`739943`](https://github.com/reearth/reearth-backend/commit/739943)
-- Support sign up with information provided by OIDC providers ([#130](https://github.com/reearth/reearth-backend/pull/130)) [`fef60e`](https://github.com/reearth/reearth-backend/commit/fef60e)
+- Authentication system ([#108](https://github.com/reearth/reearth-visualizer-backend/pull/108)) [`b89c32`](https://github.com/reearth/reearth-visualizer-backend/commit/b89c32)
+- Default mailer that outputs mails into stdout [`aab26c`](https://github.com/reearth/reearth-visualizer-backend/commit/aab26c)
+- Assets filtering & pagination ([#81](https://github.com/reearth/reearth-visualizer-backend/pull/81)) [`739943`](https://github.com/reearth/reearth-visualizer-backend/commit/739943)
+- Support sign up with information provided by OIDC providers ([#130](https://github.com/reearth/reearth-visualizer-backend/pull/130)) [`fef60e`](https://github.com/reearth/reearth-visualizer-backend/commit/fef60e)
 
 #### 🔧 Bug Fixes
 
-- Load auth client domain from config ([#124](https://github.com/reearth/reearth-backend/pull/124)) [`9bde8a`](https://github.com/reearth/reearth-backend/commit/9bde8a)
-- Signup fails when password is not set [`27c2f0`](https://github.com/reearth/reearth-backend/commit/27c2f0)
-- Logger panics [`d1e3a8`](https://github.com/reearth/reearth-backend/commit/d1e3a8)
-- Set auth server dev mode automatically [`83a66a`](https://github.com/reearth/reearth-backend/commit/83a66a)
-- Auth server bugs and auth client bugs ([#125](https://github.com/reearth/reearth-backend/pull/125)) [`ce2309`](https://github.com/reearth/reearth-backend/commit/ce2309)
-- Auth0 setting is not used by JWT verification middleware [`232e75`](https://github.com/reearth/reearth-backend/commit/232e75)
-- Invalid mongo queries of pagination [`7caf68`](https://github.com/reearth/reearth-backend/commit/7caf68)
-- Auth config not loaded expectedly [`570fe7`](https://github.com/reearth/reearth-backend/commit/570fe7)
-- Users cannot creates a new team and scene [`5df25f`](https://github.com/reearth/reearth-backend/commit/5df25f)
-- Auth server certificate is not saved as pem format [`982a71`](https://github.com/reearth/reearth-backend/commit/982a71)
-- Repo filters are not merged expectedly [`f4cc3f`](https://github.com/reearth/reearth-backend/commit/f4cc3f)
-- Auth is no longer required for GraphQL endpoint [`58a6d1`](https://github.com/reearth/reearth-backend/commit/58a6d1)
-- Rename auth srv default client ID ([#128](https://github.com/reearth/reearth-backend/pull/128)) [`89adc3`](https://github.com/reearth/reearth-backend/commit/89adc3)
-- Signup API is disabled when auth server is disabled, users and auth requests in mongo cannot be deleted ([#132](https://github.com/reearth/reearth-backend/pull/132)) [`47be6a`](https://github.com/reearth/reearth-backend/commit/47be6a)
-- Auth to work with zero config ([#131](https://github.com/reearth/reearth-backend/pull/131)) [`3cbb45`](https://github.com/reearth/reearth-backend/commit/3cbb45)
-- Property.SchemaListMap.List test fails [`3e6dff`](https://github.com/reearth/reearth-backend/commit/3e6dff)
-- Errors when auth srv domain is not specified [`10691a`](https://github.com/reearth/reearth-backend/commit/10691a)
-- Errors when auth srv domain is not specified [`648073`](https://github.com/reearth/reearth-backend/commit/648073)
-- Login redirect does not work [`cb6ca4`](https://github.com/reearth/reearth-backend/commit/cb6ca4)
-- Enable auth srv dev mode when no domain is specified [`0c0e28`](https://github.com/reearth/reearth-backend/commit/0c0e28)
-- Add a trailing slash to jwt audiences [`e96f78`](https://github.com/reearth/reearth-backend/commit/e96f78)
-- Allow separate auth server ui domain [`0ce79f`](https://github.com/reearth/reearth-backend/commit/0ce79f)
+- Load auth client domain from config ([#124](https://github.com/reearth/reearth-visualizer-backend/pull/124)) [`9bde8a`](https://github.com/reearth/reearth-visualizer-backend/commit/9bde8a)
+- Signup fails when password is not set [`27c2f0`](https://github.com/reearth/reearth-visualizer-backend/commit/27c2f0)
+- Logger panics [`d1e3a8`](https://github.com/reearth/reearth-visualizer-backend/commit/d1e3a8)
+- Set auth server dev mode automatically [`83a66a`](https://github.com/reearth/reearth-visualizer-backend/commit/83a66a)
+- Auth server bugs and auth client bugs ([#125](https://github.com/reearth/reearth-visualizer-backend/pull/125)) [`ce2309`](https://github.com/reearth/reearth-visualizer-backend/commit/ce2309)
+- Auth0 setting is not used by JWT verification middleware [`232e75`](https://github.com/reearth/reearth-visualizer-backend/commit/232e75)
+- Invalid mongo queries of pagination [`7caf68`](https://github.com/reearth/reearth-visualizer-backend/commit/7caf68)
+- Auth config not loaded expectedly [`570fe7`](https://github.com/reearth/reearth-visualizer-backend/commit/570fe7)
+- Users cannot creates a new team and scene [`5df25f`](https://github.com/reearth/reearth-visualizer-backend/commit/5df25f)
+- Auth server certificate is not saved as pem format [`982a71`](https://github.com/reearth/reearth-visualizer-backend/commit/982a71)
+- Repo filters are not merged expectedly [`f4cc3f`](https://github.com/reearth/reearth-visualizer-backend/commit/f4cc3f)
+- Auth is no longer required for GraphQL endpoint [`58a6d1`](https://github.com/reearth/reearth-visualizer-backend/commit/58a6d1)
+- Rename auth srv default client ID ([#128](https://github.com/reearth/reearth-visualizer-backend/pull/128)) [`89adc3`](https://github.com/reearth/reearth-visualizer-backend/commit/89adc3)
+- Signup API is disabled when auth server is disabled, users and auth requests in mongo cannot be deleted ([#132](https://github.com/reearth/reearth-visualizer-backend/pull/132)) [`47be6a`](https://github.com/reearth/reearth-visualizer-backend/commit/47be6a)
+- Auth to work with zero config ([#131](https://github.com/reearth/reearth-visualizer-backend/pull/131)) [`3cbb45`](https://github.com/reearth/reearth-visualizer-backend/commit/3cbb45)
+- Property.SchemaListMap.List test fails [`3e6dff`](https://github.com/reearth/reearth-visualizer-backend/commit/3e6dff)
+- Errors when auth srv domain is not specified [`10691a`](https://github.com/reearth/reearth-visualizer-backend/commit/10691a)
+- Errors when auth srv domain is not specified [`648073`](https://github.com/reearth/reearth-visualizer-backend/commit/648073)
+- Login redirect does not work [`cb6ca4`](https://github.com/reearth/reearth-visualizer-backend/commit/cb6ca4)
+- Enable auth srv dev mode when no domain is specified [`0c0e28`](https://github.com/reearth/reearth-visualizer-backend/commit/0c0e28)
+- Add a trailing slash to jwt audiences [`e96f78`](https://github.com/reearth/reearth-visualizer-backend/commit/e96f78)
+- Allow separate auth server ui domain [`0ce79f`](https://github.com/reearth/reearth-visualizer-backend/commit/0ce79f)
 
 #### ⚡️ Performance
 
-- Reduce database queries to obtain scene IDs ([#119](https://github.com/reearth/reearth-backend/pull/119)) [`784332`](https://github.com/reearth/reearth-backend/commit/784332)
+- Reduce database queries to obtain scene IDs ([#119](https://github.com/reearth/reearth-visualizer-backend/pull/119)) [`784332`](https://github.com/reearth/reearth-visualizer-backend/commit/784332)
 
 #### ✨ Refactor
 
-- Remove filter args from repos to prevent implementation errors in the use case layer ([#122](https://github.com/reearth/reearth-backend/pull/122)) [`82cf28`](https://github.com/reearth/reearth-backend/commit/82cf28)
-- Http api to export layers [`3f2582`](https://github.com/reearth/reearth-backend/commit/3f2582)
+- Remove filter args from repos to prevent implementation errors in the use case layer ([#122](https://github.com/reearth/reearth-visualizer-backend/pull/122)) [`82cf28`](https://github.com/reearth/reearth-visualizer-backend/commit/82cf28)
+- Http api to export layers [`3f2582`](https://github.com/reearth/reearth-visualizer-backend/commit/3f2582)
 
 #### Miscellaneous Tasks
 
-- Update dependencies ([#117](https://github.com/reearth/reearth-backend/pull/117)) [`d1a38e`](https://github.com/reearth/reearth-backend/commit/d1a38e)
-- Update docker-compose config [`83f9b1`](https://github.com/reearth/reearth-backend/commit/83f9b1)
-- Add log for GraphQL Playground endpoint ([#133](https://github.com/reearth/reearth-backend/pull/133)) [`adeda4`](https://github.com/reearth/reearth-backend/commit/adeda4)
+- Update dependencies ([#117](https://github.com/reearth/reearth-visualizer-backend/pull/117)) [`d1a38e`](https://github.com/reearth/reearth-visualizer-backend/commit/d1a38e)
+- Update docker-compose config [`83f9b1`](https://github.com/reearth/reearth-visualizer-backend/commit/83f9b1)
+- Add log for GraphQL Playground endpoint ([#133](https://github.com/reearth/reearth-visualizer-backend/pull/133)) [`adeda4`](https://github.com/reearth/reearth-visualizer-backend/commit/adeda4)
 
 ## 0.5.0 - 2022-02-24
 
@@ -2049,51 +2049,51 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Allowing widget and block plugins to resize when they are expandable ([#170](https://github.com/reearth/reearth-web/pull/170)) [`4fdf5f`](https://github.com/reearth/reearth-web/commit/4fdf5f)
-- Plugin APIs to get camera viewport and layers in the viewport ([#165](https://github.com/reearth/reearth-web/pull/165)) [`f1f95a`](https://github.com/reearth/reearth-web/commit/f1f95a)
-- Improving the Infobox style  ([#176](https://github.com/reearth/reearth-web/pull/176)) [`f1ddda`](https://github.com/reearth/reearth-web/commit/f1ddda)
+- Allowing widget and block plugins to resize when they are expandable ([#170](https://github.com/reearth/reearth-visualizer-web/pull/170)) [`4fdf5f`](https://github.com/reearth/reearth-visualizer-web/commit/4fdf5f)
+- Plugin APIs to get camera viewport and layers in the viewport ([#165](https://github.com/reearth/reearth-visualizer-web/pull/165)) [`f1f95a`](https://github.com/reearth/reearth-visualizer-web/commit/f1f95a)
+- Improving the Infobox style  ([#176](https://github.com/reearth/reearth-visualizer-web/pull/176)) [`f1ddda`](https://github.com/reearth/reearth-visualizer-web/commit/f1ddda)
 
 #### 🔧 Bug Fixes
 
-- Plugin blocks cannot be deleted ([#164](https://github.com/reearth/reearth-web/pull/164)) [`a4f17f`](https://github.com/reearth/reearth-web/commit/a4f17f)
-- Support tree-structured layers and tags in published pages ([#168](https://github.com/reearth/reearth-web/pull/168)) [`17d968`](https://github.com/reearth/reearth-web/commit/17d968)
-- Workspace settings does not refresh ([#167](https://github.com/reearth/reearth-web/pull/167)) [`0f3654`](https://github.com/reearth/reearth-web/commit/0f3654)
-- Plugin layersInViewport API returns errors for layers that have no location fields [`e52b44`](https://github.com/reearth/reearth-web/commit/e52b44)
+- Plugin blocks cannot be deleted ([#164](https://github.com/reearth/reearth-visualizer-web/pull/164)) [`a4f17f`](https://github.com/reearth/reearth-visualizer-web/commit/a4f17f)
+- Support tree-structured layers and tags in published pages ([#168](https://github.com/reearth/reearth-visualizer-web/pull/168)) [`17d968`](https://github.com/reearth/reearth-visualizer-web/commit/17d968)
+- Workspace settings does not refresh ([#167](https://github.com/reearth/reearth-visualizer-web/pull/167)) [`0f3654`](https://github.com/reearth/reearth-visualizer-web/commit/0f3654)
+- Plugin layersInViewport API returns errors for layers that have no location fields [`e52b44`](https://github.com/reearth/reearth-visualizer-web/commit/e52b44)
 
 #### ✨ Refactor
 
-- Format codes [`219ac6`](https://github.com/reearth/reearth-web/commit/219ac6)
-- Format codes [`4e5b61`](https://github.com/reearth/reearth-web/commit/4e5b61)
+- Format codes [`219ac6`](https://github.com/reearth/reearth-visualizer-web/commit/219ac6)
+- Format codes [`4e5b61`](https://github.com/reearth/reearth-visualizer-web/commit/4e5b61)
 
 #### Miscellaneous Tasks
 
-- Upgrade dependencies ([#175](https://github.com/reearth/reearth-web/pull/175)) [`dba959`](https://github.com/reearth/reearth-web/commit/dba959)
+- Upgrade dependencies ([#175](https://github.com/reearth/reearth-visualizer-web/pull/175)) [`dba959`](https://github.com/reearth/reearth-visualizer-web/commit/dba959)
 
 ### reearth-backend
 
 #### 🚀 Features
 
-- Implement property.Diff and plugin/manifest.Diff ([#107](https://github.com/reearth/reearth-backend/pull/107)) [`700269`](https://github.com/reearth/reearth-backend/commit/700269)
-- Support 3rd party plugin translation ([#109](https://github.com/reearth/reearth-backend/pull/109)) [`67a618`](https://github.com/reearth/reearth-backend/commit/67a618)
-- Improve the Infobox style (manifest) ([#110](https://github.com/reearth/reearth-backend/pull/110)) [`7aebcd`](https://github.com/reearth/reearth-backend/commit/7aebcd)
-- Overwrite installation of new plug-ins without removing (automatic property migration) ([#113](https://github.com/reearth/reearth-backend/pull/113)) [`2dc192`](https://github.com/reearth/reearth-backend/commit/2dc192)
-- Update infobox style fields ([#115](https://github.com/reearth/reearth-backend/pull/115)) [`608436`](https://github.com/reearth/reearth-backend/commit/608436)
+- Implement property.Diff and plugin/manifest.Diff ([#107](https://github.com/reearth/reearth-visualizer-backend/pull/107)) [`700269`](https://github.com/reearth/reearth-visualizer-backend/commit/700269)
+- Support 3rd party plugin translation ([#109](https://github.com/reearth/reearth-visualizer-backend/pull/109)) [`67a618`](https://github.com/reearth/reearth-visualizer-backend/commit/67a618)
+- Improve the Infobox style (manifest) ([#110](https://github.com/reearth/reearth-visualizer-backend/pull/110)) [`7aebcd`](https://github.com/reearth/reearth-visualizer-backend/commit/7aebcd)
+- Overwrite installation of new plug-ins without removing (automatic property migration) ([#113](https://github.com/reearth/reearth-visualizer-backend/pull/113)) [`2dc192`](https://github.com/reearth/reearth-visualizer-backend/commit/2dc192)
+- Update infobox style fields ([#115](https://github.com/reearth/reearth-visualizer-backend/pull/115)) [`608436`](https://github.com/reearth/reearth-visualizer-backend/commit/608436)
 
 #### 🔧 Bug Fixes
 
-- Scene exporter should export layers and tags while maintaining the tree structure ([#104](https://github.com/reearth/reearth-backend/pull/104)) [`805d78`](https://github.com/reearth/reearth-backend/commit/805d78)
-- Property field in groups in list cannot be updated correctly [`5009c5`](https://github.com/reearth/reearth-backend/commit/5009c5)
-- Scenes and properties are not updated properly when plugin is updated [`861c4b`](https://github.com/reearth/reearth-backend/commit/861c4b)
-- Scene widgets and blocks are not update properly when plugin is updated [`f66f9a`](https://github.com/reearth/reearth-backend/commit/f66f9a)
+- Scene exporter should export layers and tags while maintaining the tree structure ([#104](https://github.com/reearth/reearth-visualizer-backend/pull/104)) [`805d78`](https://github.com/reearth/reearth-visualizer-backend/commit/805d78)
+- Property field in groups in list cannot be updated correctly [`5009c5`](https://github.com/reearth/reearth-visualizer-backend/commit/5009c5)
+- Scenes and properties are not updated properly when plugin is updated [`861c4b`](https://github.com/reearth/reearth-visualizer-backend/commit/861c4b)
+- Scene widgets and blocks are not update properly when plugin is updated [`f66f9a`](https://github.com/reearth/reearth-visualizer-backend/commit/f66f9a)
 
 #### ✨ Refactor
 
-- Graphql resolvers ([#105](https://github.com/reearth/reearth-backend/pull/105)) [`01a4e6`](https://github.com/reearth/reearth-backend/commit/01a4e6)
+- Graphql resolvers ([#105](https://github.com/reearth/reearth-visualizer-backend/pull/105)) [`01a4e6`](https://github.com/reearth/reearth-visualizer-backend/commit/01a4e6)
 
 #### Miscellaneous Tasks
 
-- Update all dependencies ([#111](https://github.com/reearth/reearth-backend/pull/111)) [`173881`](https://github.com/reearth/reearth-backend/commit/173881)
-- Increase batch size of db migration [ci skip] [`fbbca4`](https://github.com/reearth/reearth-backend/commit/fbbca4)
+- Update all dependencies ([#111](https://github.com/reearth/reearth-visualizer-backend/pull/111)) [`173881`](https://github.com/reearth/reearth-visualizer-backend/commit/173881)
+- Increase batch size of db migration [ci skip] [`fbbca4`](https://github.com/reearth/reearth-visualizer-backend/commit/fbbca4)
 
 ## 0.4.0 - 2022-01-27
 
@@ -2101,42 +2101,42 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Add "clamp to filed" option to file primitive ([#155](https://github.com/reearth/reearth-web/pull/155)) [`2e83ba`](https://github.com/reearth/reearth-web/commit/2e83ba)
-- Infobox padding ([#158](https://github.com/reearth/reearth-web/pull/158)) [`90084f`](https://github.com/reearth/reearth-web/commit/90084f)
-- Support tags in plugin API ([#153](https://github.com/reearth/reearth-web/pull/153)) [`1031c5`](https://github.com/reearth/reearth-web/commit/1031c5)
+- Add "clamp to filed" option to file primitive ([#155](https://github.com/reearth/reearth-visualizer-web/pull/155)) [`2e83ba`](https://github.com/reearth/reearth-visualizer-web/commit/2e83ba)
+- Infobox padding ([#158](https://github.com/reearth/reearth-visualizer-web/pull/158)) [`90084f`](https://github.com/reearth/reearth-visualizer-web/commit/90084f)
+- Support tags in plugin API ([#153](https://github.com/reearth/reearth-visualizer-web/pull/153)) [`1031c5`](https://github.com/reearth/reearth-visualizer-web/commit/1031c5)
 
 #### 🔧 Bug Fixes
 
-- Enable to select blocks of plugins ([#162](https://github.com/reearth/reearth-web/pull/162)) [`458402`](https://github.com/reearth/reearth-web/commit/458402)
-- Cesium Ion acces token is not set expectedly ([#160](https://github.com/reearth/reearth-web/pull/160)) [`e8e183`](https://github.com/reearth/reearth-web/commit/e8e183)
-- Cluster styling issue ([#161](https://github.com/reearth/reearth-web/pull/161)) [`c78872`](https://github.com/reearth/reearth-web/commit/c78872)
-- Clusters and layers are not displayed correctly [`4fc124`](https://github.com/reearth/reearth-web/commit/4fc124)
-- Type error [`b01bc7`](https://github.com/reearth/reearth-web/commit/b01bc7)
-- The style of infobox block dropdown list is broken ([#163](https://github.com/reearth/reearth-web/pull/163)) [`6e02a9`](https://github.com/reearth/reearth-web/commit/6e02a9)
-- Plugin blocks protrude from the infobox [`6cf0d3`](https://github.com/reearth/reearth-web/commit/6cf0d3)
+- Enable to select blocks of plugins ([#162](https://github.com/reearth/reearth-visualizer-web/pull/162)) [`458402`](https://github.com/reearth/reearth-visualizer-web/commit/458402)
+- Cesium Ion acces token is not set expectedly ([#160](https://github.com/reearth/reearth-visualizer-web/pull/160)) [`e8e183`](https://github.com/reearth/reearth-visualizer-web/commit/e8e183)
+- Cluster styling issue ([#161](https://github.com/reearth/reearth-visualizer-web/pull/161)) [`c78872`](https://github.com/reearth/reearth-visualizer-web/commit/c78872)
+- Clusters and layers are not displayed correctly [`4fc124`](https://github.com/reearth/reearth-visualizer-web/commit/4fc124)
+- Type error [`b01bc7`](https://github.com/reearth/reearth-visualizer-web/commit/b01bc7)
+- The style of infobox block dropdown list is broken ([#163](https://github.com/reearth/reearth-visualizer-web/pull/163)) [`6e02a9`](https://github.com/reearth/reearth-visualizer-web/commit/6e02a9)
+- Plugin blocks protrude from the infobox [`6cf0d3`](https://github.com/reearth/reearth-visualizer-web/commit/6cf0d3)
 
 #### ✨ Refactor
 
-- Layer clustering feature ([#157](https://github.com/reearth/reearth-web/pull/157)) [`db6e6c`](https://github.com/reearth/reearth-web/commit/db6e6c)
-- Camera limiter ([#149](https://github.com/reearth/reearth-web/pull/149)) [`105428`](https://github.com/reearth/reearth-web/commit/105428)
-- Layer clustering feature (GraphQL) ([#159](https://github.com/reearth/reearth-web/pull/159)) [`4365b8`](https://github.com/reearth/reearth-web/commit/4365b8)
+- Layer clustering feature ([#157](https://github.com/reearth/reearth-visualizer-web/pull/157)) [`db6e6c`](https://github.com/reearth/reearth-visualizer-web/commit/db6e6c)
+- Camera limiter ([#149](https://github.com/reearth/reearth-visualizer-web/pull/149)) [`105428`](https://github.com/reearth/reearth-visualizer-web/commit/105428)
+- Layer clustering feature (GraphQL) ([#159](https://github.com/reearth/reearth-visualizer-web/pull/159)) [`4365b8`](https://github.com/reearth/reearth-visualizer-web/commit/4365b8)
 
 ### reearth-backend
 
 #### 🚀 Features
 
-- Add "clamp to ground" option to file primitive ([#95](https://github.com/reearth/reearth-backend/pull/95)) [`559194`](https://github.com/reearth/reearth-backend/commit/559194)
-- Infobox and text block padding ([#100](https://github.com/reearth/reearth-backend/pull/100)) [`ddd0db`](https://github.com/reearth/reearth-backend/commit/ddd0db)
+- Add "clamp to ground" option to file primitive ([#95](https://github.com/reearth/reearth-visualizer-backend/pull/95)) [`559194`](https://github.com/reearth/reearth-visualizer-backend/commit/559194)
+- Infobox and text block padding ([#100](https://github.com/reearth/reearth-visualizer-backend/pull/100)) [`ddd0db`](https://github.com/reearth/reearth-visualizer-backend/commit/ddd0db)
 
 #### ⚡️ Performance
 
-- Add indexes of mongo collections ([#98](https://github.com/reearth/reearth-backend/pull/98)) [`691cb7`](https://github.com/reearth/reearth-backend/commit/691cb7)
+- Add indexes of mongo collections ([#98](https://github.com/reearth/reearth-visualizer-backend/pull/98)) [`691cb7`](https://github.com/reearth/reearth-visualizer-backend/commit/691cb7)
 
 #### ✨ Refactor
 
-- Pkg/id, use ID aliases, move JSON schemas ([#97](https://github.com/reearth/reearth-backend/pull/97)) [`1265ac`](https://github.com/reearth/reearth-backend/commit/1265ac)
-- Unit tests ([#99](https://github.com/reearth/reearth-backend/pull/99)) [`0d112c`](https://github.com/reearth/reearth-backend/commit/0d112c)
-- Pkg/property, pkg/layer, pkg/plugin ([#101](https://github.com/reearth/reearth-backend/pull/101)) [`17a463`](https://github.com/reearth/reearth-backend/commit/17a463)
+- Pkg/id, use ID aliases, move JSON schemas ([#97](https://github.com/reearth/reearth-visualizer-backend/pull/97)) [`1265ac`](https://github.com/reearth/reearth-visualizer-backend/commit/1265ac)
+- Unit tests ([#99](https://github.com/reearth/reearth-visualizer-backend/pull/99)) [`0d112c`](https://github.com/reearth/reearth-visualizer-backend/commit/0d112c)
+- Pkg/property, pkg/layer, pkg/plugin ([#101](https://github.com/reearth/reearth-visualizer-backend/pull/101)) [`17a463`](https://github.com/reearth/reearth-visualizer-backend/commit/17a463)
 
 ## 0.3.0 - 2022-01-11
 
@@ -2144,59 +2144,59 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Enhance terrain feature (type selection, exaggeration) ([#138](https://github.com/reearth/reearth-web/pull/138)) [`dae137`](https://github.com/reearth/reearth-web/commit/dae137)
-- Clustering layers ([#143](https://github.com/reearth/reearth-web/pull/143)) [`3439cc`](https://github.com/reearth/reearth-web/commit/3439cc)
-- Camera limiter ([#142](https://github.com/reearth/reearth-web/pull/142)) [`dec1dd`](https://github.com/reearth/reearth-web/commit/dec1dd)
-- Tagging of layers ([#144](https://github.com/reearth/reearth-web/pull/144)) [`4d0a40`](https://github.com/reearth/reearth-web/commit/4d0a40)
+- Enhance terrain feature (type selection, exaggeration) ([#138](https://github.com/reearth/reearth-visualizer-web/pull/138)) [`dae137`](https://github.com/reearth/reearth-visualizer-web/commit/dae137)
+- Clustering layers ([#143](https://github.com/reearth/reearth-visualizer-web/pull/143)) [`3439cc`](https://github.com/reearth/reearth-visualizer-web/commit/3439cc)
+- Camera limiter ([#142](https://github.com/reearth/reearth-visualizer-web/pull/142)) [`dec1dd`](https://github.com/reearth/reearth-visualizer-web/commit/dec1dd)
+- Tagging of layers ([#144](https://github.com/reearth/reearth-visualizer-web/pull/144)) [`4d0a40`](https://github.com/reearth/reearth-visualizer-web/commit/4d0a40)
 
 #### 🔧 Bug Fixes
 
-- Indicator is not displayed on selecting of clustered layer ([#146](https://github.com/reearth/reearth-web/pull/146)) [`e41f67`](https://github.com/reearth/reearth-web/commit/e41f67)
-- Use data URL for marker images [`576ea4`](https://github.com/reearth/reearth-web/commit/576ea4)
-- Layer clusters do not updated correctly [`ec74f6`](https://github.com/reearth/reearth-web/commit/ec74f6)
-- Position label in front of billboard ([#147](https://github.com/reearth/reearth-web/pull/147)) [`81c533`](https://github.com/reearth/reearth-web/commit/81c533)
-- Public pages do not work due to clustering feature [`48d8b3`](https://github.com/reearth/reearth-web/commit/48d8b3)
-- Photooverlay transition does not work in Android ([#154](https://github.com/reearth/reearth-web/pull/154)) [`decbfe`](https://github.com/reearth/reearth-web/commit/decbfe)
+- Indicator is not displayed on selecting of clustered layer ([#146](https://github.com/reearth/reearth-visualizer-web/pull/146)) [`e41f67`](https://github.com/reearth/reearth-visualizer-web/commit/e41f67)
+- Use data URL for marker images [`576ea4`](https://github.com/reearth/reearth-visualizer-web/commit/576ea4)
+- Layer clusters do not updated correctly [`ec74f6`](https://github.com/reearth/reearth-visualizer-web/commit/ec74f6)
+- Position label in front of billboard ([#147](https://github.com/reearth/reearth-visualizer-web/pull/147)) [`81c533`](https://github.com/reearth/reearth-visualizer-web/commit/81c533)
+- Public pages do not work due to clustering feature [`48d8b3`](https://github.com/reearth/reearth-visualizer-web/commit/48d8b3)
+- Photooverlay transition does not work in Android ([#154](https://github.com/reearth/reearth-visualizer-web/pull/154)) [`decbfe`](https://github.com/reearth/reearth-visualizer-web/commit/decbfe)
 
 #### 🎨 Styling
 
-- Fix the height of the header [`9d6acc`](https://github.com/reearth/reearth-web/commit/9d6acc)
+- Fix the height of the header [`9d6acc`](https://github.com/reearth/reearth-visualizer-web/commit/9d6acc)
 
 #### Miscellaneous Tasks
 
-- Upgrade dependencies ([#134](https://github.com/reearth/reearth-web/pull/134)) [`740821`](https://github.com/reearth/reearth-web/commit/740821)
-- Update dependency cesium to ^1.88.0 ([#139](https://github.com/reearth/reearth-web/pull/139)) [`7afdfb`](https://github.com/reearth/reearth-web/commit/7afdfb)
-- Fix webpack dev server config [`8d06fa`](https://github.com/reearth/reearth-web/commit/8d06fa)
-- Update dependency cesium to ^1.89.0 ([#156](https://github.com/reearth/reearth-web/pull/156)) [`d436ce`](https://github.com/reearth/reearth-web/commit/d436ce)
+- Upgrade dependencies ([#134](https://github.com/reearth/reearth-visualizer-web/pull/134)) [`740821`](https://github.com/reearth/reearth-visualizer-web/commit/740821)
+- Update dependency cesium to ^1.88.0 ([#139](https://github.com/reearth/reearth-visualizer-web/pull/139)) [`7afdfb`](https://github.com/reearth/reearth-visualizer-web/commit/7afdfb)
+- Fix webpack dev server config [`8d06fa`](https://github.com/reearth/reearth-visualizer-web/commit/8d06fa)
+- Update dependency cesium to ^1.89.0 ([#156](https://github.com/reearth/reearth-visualizer-web/pull/156)) [`d436ce`](https://github.com/reearth/reearth-visualizer-web/commit/d436ce)
 
 ### reearth-backend
 
 #### 🚀 Features
 
-- Clusters for scenes ([#75](https://github.com/reearth/reearth-backend/pull/75)) [`3512c0`](https://github.com/reearth/reearth-backend/commit/3512c0)
-- Add fields of scene property for terrain [`8693b4`](https://github.com/reearth/reearth-backend/commit/8693b4)
-- Camera limiter  ([#87](https://github.com/reearth/reearth-backend/pull/87)) [`63c582`](https://github.com/reearth/reearth-backend/commit/63c582)
+- Clusters for scenes ([#75](https://github.com/reearth/reearth-visualizer-backend/pull/75)) [`3512c0`](https://github.com/reearth/reearth-visualizer-backend/commit/3512c0)
+- Add fields of scene property for terrain [`8693b4`](https://github.com/reearth/reearth-visualizer-backend/commit/8693b4)
+- Camera limiter  ([#87](https://github.com/reearth/reearth-visualizer-backend/pull/87)) [`63c582`](https://github.com/reearth/reearth-visualizer-backend/commit/63c582)
 
 #### 🔧 Bug Fixes
 
-- Terrain fields of scene property [`5e3d25`](https://github.com/reearth/reearth-backend/commit/5e3d25)
-- Numbers are not decoded from gql to value [`2ddbc8`](https://github.com/reearth/reearth-backend/commit/2ddbc8)
-- Layers have their own tags separate from the scene ([#90](https://github.com/reearth/reearth-backend/pull/90)) [`c4fb9a`](https://github.com/reearth/reearth-backend/commit/c4fb9a)
-- Return property with clusters data ([#89](https://github.com/reearth/reearth-backend/pull/89)) [`1b99c6`](https://github.com/reearth/reearth-backend/commit/1b99c6)
-- Cast values, rename value.OptionalValue ([#93](https://github.com/reearth/reearth-backend/pull/93)) [`ba4b18`](https://github.com/reearth/reearth-backend/commit/ba4b18)
-- Synchronize mongo migration ([#94](https://github.com/reearth/reearth-backend/pull/94)) [`db4cea`](https://github.com/reearth/reearth-backend/commit/db4cea)
+- Terrain fields of scene property [`5e3d25`](https://github.com/reearth/reearth-visualizer-backend/commit/5e3d25)
+- Numbers are not decoded from gql to value [`2ddbc8`](https://github.com/reearth/reearth-visualizer-backend/commit/2ddbc8)
+- Layers have their own tags separate from the scene ([#90](https://github.com/reearth/reearth-visualizer-backend/pull/90)) [`c4fb9a`](https://github.com/reearth/reearth-visualizer-backend/commit/c4fb9a)
+- Return property with clusters data ([#89](https://github.com/reearth/reearth-visualizer-backend/pull/89)) [`1b99c6`](https://github.com/reearth/reearth-visualizer-backend/commit/1b99c6)
+- Cast values, rename value.OptionalValue ([#93](https://github.com/reearth/reearth-visualizer-backend/pull/93)) [`ba4b18`](https://github.com/reearth/reearth-visualizer-backend/commit/ba4b18)
+- Synchronize mongo migration ([#94](https://github.com/reearth/reearth-visualizer-backend/pull/94)) [`db4cea`](https://github.com/reearth/reearth-visualizer-backend/commit/db4cea)
 
 #### 📖 Documentation
 
-- Add pkg.go.dev badge to readme [`91f9b3`](https://github.com/reearth/reearth-backend/commit/91f9b3)
+- Add pkg.go.dev badge to readme [`91f9b3`](https://github.com/reearth/reearth-visualizer-backend/commit/91f9b3)
 
 #### ✨ Refactor
 
-- Make property.Value and dataset.Value independent in pkg/value ([#77](https://github.com/reearth/reearth-backend/pull/77)) [`73143b`](https://github.com/reearth/reearth-backend/commit/73143b)
+- Make property.Value and dataset.Value independent in pkg/value ([#77](https://github.com/reearth/reearth-visualizer-backend/pull/77)) [`73143b`](https://github.com/reearth/reearth-visualizer-backend/commit/73143b)
 
 #### Miscellaneous Tasks
 
-- Fix plugin manifest JSON schema [`2b57b1`](https://github.com/reearth/reearth-backend/commit/2b57b1)
+- Fix plugin manifest JSON schema [`2b57b1`](https://github.com/reearth/reearth-visualizer-backend/commit/2b57b1)
 
 
 ## 0.2.0 - 2021-11-18
@@ -2205,50 +2205,50 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Widget align system for mobile ([#115](https://github.com/reearth/reearth-web/pull/115)) [`afa4ba`](https://github.com/reearth/reearth-web/commit/afa4ba)
-- Support dataset schema preview and create layer group from selected primitive type ([#74](https://github.com/reearth/reearth-web/pull/74)) [`769b86`](https://github.com/reearth/reearth-web/commit/769b86)
+- Widget align system for mobile ([#115](https://github.com/reearth/reearth-visualizer-web/pull/115)) [`afa4ba`](https://github.com/reearth/reearth-visualizer-web/commit/afa4ba)
+- Support dataset schema preview and create layer group from selected primitive type ([#74](https://github.com/reearth/reearth-visualizer-web/pull/74)) [`769b86`](https://github.com/reearth/reearth-visualizer-web/commit/769b86)
 
 #### 🔧 Bug Fixes
 
-- Markdown background color is not transparent ([#123](https://github.com/reearth/reearth-web/pull/123)) [`f16706`](https://github.com/reearth/reearth-web/commit/f16706)
-- Layers would not be marshalled correctly ([#126](https://github.com/reearth/reearth-web/pull/126)) [`886302`](https://github.com/reearth/reearth-web/commit/886302)
-- Widget align system issues ([#124](https://github.com/reearth/reearth-web/pull/124)) [`3bc9fa`](https://github.com/reearth/reearth-web/commit/3bc9fa)
-- Project setting page does not display correctly after creating a new project ([#127](https://github.com/reearth/reearth-web/pull/127)) [`c120dc`](https://github.com/reearth/reearth-web/commit/c120dc)
-- Dataset info pane shows its property though after selected dataset schema is deleted ([#131](https://github.com/reearth/reearth-web/pull/131)) [`2307d8`](https://github.com/reearth/reearth-web/commit/2307d8)
+- Markdown background color is not transparent ([#123](https://github.com/reearth/reearth-visualizer-web/pull/123)) [`f16706`](https://github.com/reearth/reearth-visualizer-web/commit/f16706)
+- Layers would not be marshalled correctly ([#126](https://github.com/reearth/reearth-visualizer-web/pull/126)) [`886302`](https://github.com/reearth/reearth-visualizer-web/commit/886302)
+- Widget align system issues ([#124](https://github.com/reearth/reearth-visualizer-web/pull/124)) [`3bc9fa`](https://github.com/reearth/reearth-visualizer-web/commit/3bc9fa)
+- Project setting page does not display correctly after creating a new project ([#127](https://github.com/reearth/reearth-visualizer-web/pull/127)) [`c120dc`](https://github.com/reearth/reearth-visualizer-web/commit/c120dc)
+- Dataset info pane shows its property though after selected dataset schema is deleted ([#131](https://github.com/reearth/reearth-visualizer-web/pull/131)) [`2307d8`](https://github.com/reearth/reearth-visualizer-web/commit/2307d8)
 
 #### Miscellaneous Tasks
 
-- Disable storybook workflow for release commit [`80f4d2`](https://github.com/reearth/reearth-web/commit/80f4d2)
-- Change semantic commit type of renovate PRs, omit ci skip in changelog [`4a3e9e`](https://github.com/reearth/reearth-web/commit/4a3e9e)
-- Follow backend GraphQL schema update ([#120](https://github.com/reearth/reearth-web/pull/120)) [`aeee1f`](https://github.com/reearth/reearth-web/commit/aeee1f)
-- Load local reearth-config.json for debugging ([#119](https://github.com/reearth/reearth-web/pull/119)) [`6115ee`](https://github.com/reearth/reearth-web/commit/6115ee)
-- Update dependency cesium to ^1.87.0 ([#118](https://github.com/reearth/reearth-web/pull/118)) [`7c65d0`](https://github.com/reearth/reearth-web/commit/7c65d0)
-- Update dependency cesium to ^1.87.1 ([#128](https://github.com/reearth/reearth-web/pull/128)) [`a63aa7`](https://github.com/reearth/reearth-web/commit/a63aa7)
-- Update codecov.yml to add ignored files [`b72f17`](https://github.com/reearth/reearth-web/commit/b72f17)
+- Disable storybook workflow for release commit [`80f4d2`](https://github.com/reearth/reearth-visualizer-web/commit/80f4d2)
+- Change semantic commit type of renovate PRs, omit ci skip in changelog [`4a3e9e`](https://github.com/reearth/reearth-visualizer-web/commit/4a3e9e)
+- Follow backend GraphQL schema update ([#120](https://github.com/reearth/reearth-visualizer-web/pull/120)) [`aeee1f`](https://github.com/reearth/reearth-visualizer-web/commit/aeee1f)
+- Load local reearth-config.json for debugging ([#119](https://github.com/reearth/reearth-visualizer-web/pull/119)) [`6115ee`](https://github.com/reearth/reearth-visualizer-web/commit/6115ee)
+- Update dependency cesium to ^1.87.0 ([#118](https://github.com/reearth/reearth-visualizer-web/pull/118)) [`7c65d0`](https://github.com/reearth/reearth-visualizer-web/commit/7c65d0)
+- Update dependency cesium to ^1.87.1 ([#128](https://github.com/reearth/reearth-visualizer-web/pull/128)) [`a63aa7`](https://github.com/reearth/reearth-visualizer-web/commit/a63aa7)
+- Update codecov.yml to add ignored files [`b72f17`](https://github.com/reearth/reearth-visualizer-web/commit/b72f17)
 
 
 ### reearth-backend
 
 #### 🚀 Features
 
-- Support opentelemetry ([#68](https://github.com/reearth/reearth-backend/pull/68)) [`25c581`](https://github.com/reearth/reearth-backend/commit/25c581)
+- Support opentelemetry ([#68](https://github.com/reearth/reearth-visualizer-backend/pull/68)) [`25c581`](https://github.com/reearth/reearth-visualizer-backend/commit/25c581)
 
 #### 🔧 Bug Fixes
 
-- Add an index to mongo project collection to prevent creating projects whose alias is duplicated [`10f745`](https://github.com/reearth/reearth-backend/commit/10f745)
-- Check project alias duplication on project update [`443f2c`](https://github.com/reearth/reearth-backend/commit/443f2c)
+- Add an index to mongo project collection to prevent creating projects whose alias is duplicated [`10f745`](https://github.com/reearth/reearth-visualizer-backend/commit/10f745)
+- Check project alias duplication on project update [`443f2c`](https://github.com/reearth/reearth-visualizer-backend/commit/443f2c)
 
 #### ✨ Refactor
 
-- Add PropertySchemaGroupID to pkg/id ([#70](https://github.com/reearth/reearth-backend/pull/70)) [`9ece9e`](https://github.com/reearth/reearth-backend/commit/9ece9e)
+- Add PropertySchemaGroupID to pkg/id ([#70](https://github.com/reearth/reearth-visualizer-backend/pull/70)) [`9ece9e`](https://github.com/reearth/reearth-visualizer-backend/commit/9ece9e)
 
 #### Miscellaneous Tasks
 
-- Fix typo in github actions [`4a9dc5`](https://github.com/reearth/reearth-backend/commit/4a9dc5)
-- Clean up unused code [`b5b01b`](https://github.com/reearth/reearth-backend/commit/b5b01b)
-- Update codecov.yml to add ignored files [`d54309`](https://github.com/reearth/reearth-backend/commit/d54309)
-- Ignore generated files in codecov [`9d3822`](https://github.com/reearth/reearth-backend/commit/9d3822)
-- Upgrade dependencies [`215947`](https://github.com/reearth/reearth-backend/commit/215947)
+- Fix typo in github actions [`4a9dc5`](https://github.com/reearth/reearth-visualizer-backend/commit/4a9dc5)
+- Clean up unused code [`b5b01b`](https://github.com/reearth/reearth-visualizer-backend/commit/b5b01b)
+- Update codecov.yml to add ignored files [`d54309`](https://github.com/reearth/reearth-visualizer-backend/commit/d54309)
+- Ignore generated files in codecov [`9d3822`](https://github.com/reearth/reearth-visualizer-backend/commit/9d3822)
+- Upgrade dependencies [`215947`](https://github.com/reearth/reearth-visualizer-backend/commit/215947)
 
 
 ## 0.1.0 - 2021-11-02
@@ -2257,241 +2257,241 @@ All notable changes to this project will be documented in this file.
 
 #### 🚀 Features
 
-- Support Auth0 audience ([#2](https://github.com/reearth/reearth-web/pull/2)) [`0ad0f6`](https://github.com/reearth/reearth-web/commit/0ad0f6)
-- Asset modal redesign ([#1](https://github.com/reearth/reearth-web/pull/1)) [`f71117`](https://github.com/reearth/reearth-web/commit/f71117)
-- Basic auth for projects ([#3](https://github.com/reearth/reearth-web/pull/3)) [`372c4e`](https://github.com/reearth/reearth-web/commit/372c4e)
-- Google analytics ([#6](https://github.com/reearth/reearth-web/pull/6)) [`01aadf`](https://github.com/reearth/reearth-web/commit/01aadf)
-- Refine setting page ([#19](https://github.com/reearth/reearth-web/pull/19)) [`d06ee7`](https://github.com/reearth/reearth-web/commit/d06ee7)
-- Add  delete assets confirm modal and fix bugs ([#25](https://github.com/reearth/reearth-web/pull/25)) [`0310f5`](https://github.com/reearth/reearth-web/commit/0310f5)
-- Update link system and UI ([#12](https://github.com/reearth/reearth-web/pull/12)) [`51de77`](https://github.com/reearth/reearth-web/commit/51de77)
-- Import google sheet dataset ([#14](https://github.com/reearth/reearth-web/pull/14)) [`21b167`](https://github.com/reearth/reearth-web/commit/21b167)
-- Support multi-line infobox titles ([#40](https://github.com/reearth/reearth-web/pull/40)) [`4cddcc`](https://github.com/reearth/reearth-web/commit/4cddcc)
-- Public settings page ([#32](https://github.com/reearth/reearth-web/pull/32)) [`ebfd41`](https://github.com/reearth/reearth-web/commit/ebfd41)
-- Refine readme ([#51](https://github.com/reearth/reearth-web/pull/51)) [`41ddb3`](https://github.com/reearth/reearth-web/commit/41ddb3)
-- Add light theme ([#52](https://github.com/reearth/reearth-web/pull/52)) [`26159b`](https://github.com/reearth/reearth-web/commit/26159b)
-- Add a short discription for light theme ([#56](https://github.com/reearth/reearth-web/pull/56)) [`8b092d`](https://github.com/reearth/reearth-web/commit/8b092d)
-- Plugins settings page, install/uninstall plugins ([#22](https://github.com/reearth/reearth-web/pull/22)) [`018674`](https://github.com/reearth/reearth-web/commit/018674)
-- Plugin system, refactoring visualizer ([#50](https://github.com/reearth/reearth-web/pull/50)) [`172939`](https://github.com/reearth/reearth-web/commit/172939)
-- 3D tileset, model, rectangle primitive, more properties for marker and scene ([#63](https://github.com/reearth/reearth-web/pull/63)) [`a88600`](https://github.com/reearth/reearth-web/commit/a88600)
-- Graphiql page ([#70](https://github.com/reearth/reearth-web/pull/70)) [`aa5d10`](https://github.com/reearth/reearth-web/commit/aa5d10)
-- Enable to set theme for the scene ([#67](https://github.com/reearth/reearth-web/pull/67)) [`58e670`](https://github.com/reearth/reearth-web/commit/58e670)
-- Notification system update ([#73](https://github.com/reearth/reearth-web/pull/73)) [`92cdbb`](https://github.com/reearth/reearth-web/commit/92cdbb)
-- Widget align system ([#61](https://github.com/reearth/reearth-web/pull/61)) [`ed2940`](https://github.com/reearth/reearth-web/commit/ed2940)
-- Plugin system beta ([#87](https://github.com/reearth/reearth-web/pull/87)) [`d76f1c`](https://github.com/reearth/reearth-web/commit/d76f1c)
-- Enhance extended field of widget in plugin API ([#90](https://github.com/reearth/reearth-web/pull/90)) [`06cb14`](https://github.com/reearth/reearth-web/commit/06cb14)
-- Add overrideProperty to plugin layers API ([#92](https://github.com/reearth/reearth-web/pull/92)) [`563f88`](https://github.com/reearth/reearth-web/commit/563f88)
-- Add a fallback icon for extensions that do not have an icon ([#98](https://github.com/reearth/reearth-web/pull/98)) [`50de1f`](https://github.com/reearth/reearth-web/commit/50de1f)
-- Add password validation ([#86](https://github.com/reearth/reearth-web/pull/86)) [`2017aa`](https://github.com/reearth/reearth-web/commit/2017aa)
-- Draggable layer ([#58](https://github.com/reearth/reearth-web/pull/58)) [`25a217`](https://github.com/reearth/reearth-web/commit/25a217)
-- Multi widgets ([#99](https://github.com/reearth/reearth-web/pull/99)) [`bea1a3`](https://github.com/reearth/reearth-web/commit/bea1a3)
-- Front-end for new authentication system ([#102](https://github.com/reearth/reearth-web/pull/102)) [`964d92`](https://github.com/reearth/reearth-web/commit/964d92)
-- Add layers.overriddenProperties, find, findAll, walk ([#110](https://github.com/reearth/reearth-web/pull/110)) [`ebe131`](https://github.com/reearth/reearth-web/commit/ebe131)
+- Support Auth0 audience ([#2](https://github.com/reearth/reearth-visualizer-web/pull/2)) [`0ad0f6`](https://github.com/reearth/reearth-visualizer-web/commit/0ad0f6)
+- Asset modal redesign ([#1](https://github.com/reearth/reearth-visualizer-web/pull/1)) [`f71117`](https://github.com/reearth/reearth-visualizer-web/commit/f71117)
+- Basic auth for projects ([#3](https://github.com/reearth/reearth-visualizer-web/pull/3)) [`372c4e`](https://github.com/reearth/reearth-visualizer-web/commit/372c4e)
+- Google analytics ([#6](https://github.com/reearth/reearth-visualizer-web/pull/6)) [`01aadf`](https://github.com/reearth/reearth-visualizer-web/commit/01aadf)
+- Refine setting page ([#19](https://github.com/reearth/reearth-visualizer-web/pull/19)) [`d06ee7`](https://github.com/reearth/reearth-visualizer-web/commit/d06ee7)
+- Add  delete assets confirm modal and fix bugs ([#25](https://github.com/reearth/reearth-visualizer-web/pull/25)) [`0310f5`](https://github.com/reearth/reearth-visualizer-web/commit/0310f5)
+- Update link system and UI ([#12](https://github.com/reearth/reearth-visualizer-web/pull/12)) [`51de77`](https://github.com/reearth/reearth-visualizer-web/commit/51de77)
+- Import google sheet dataset ([#14](https://github.com/reearth/reearth-visualizer-web/pull/14)) [`21b167`](https://github.com/reearth/reearth-visualizer-web/commit/21b167)
+- Support multi-line infobox titles ([#40](https://github.com/reearth/reearth-visualizer-web/pull/40)) [`4cddcc`](https://github.com/reearth/reearth-visualizer-web/commit/4cddcc)
+- Public settings page ([#32](https://github.com/reearth/reearth-visualizer-web/pull/32)) [`ebfd41`](https://github.com/reearth/reearth-visualizer-web/commit/ebfd41)
+- Refine readme ([#51](https://github.com/reearth/reearth-visualizer-web/pull/51)) [`41ddb3`](https://github.com/reearth/reearth-visualizer-web/commit/41ddb3)
+- Add light theme ([#52](https://github.com/reearth/reearth-visualizer-web/pull/52)) [`26159b`](https://github.com/reearth/reearth-visualizer-web/commit/26159b)
+- Add a short discription for light theme ([#56](https://github.com/reearth/reearth-visualizer-web/pull/56)) [`8b092d`](https://github.com/reearth/reearth-visualizer-web/commit/8b092d)
+- Plugins settings page, install/uninstall plugins ([#22](https://github.com/reearth/reearth-visualizer-web/pull/22)) [`018674`](https://github.com/reearth/reearth-visualizer-web/commit/018674)
+- Plugin system, refactoring visualizer ([#50](https://github.com/reearth/reearth-visualizer-web/pull/50)) [`172939`](https://github.com/reearth/reearth-visualizer-web/commit/172939)
+- 3D tileset, model, rectangle primitive, more properties for marker and scene ([#63](https://github.com/reearth/reearth-visualizer-web/pull/63)) [`a88600`](https://github.com/reearth/reearth-visualizer-web/commit/a88600)
+- Graphiql page ([#70](https://github.com/reearth/reearth-visualizer-web/pull/70)) [`aa5d10`](https://github.com/reearth/reearth-visualizer-web/commit/aa5d10)
+- Enable to set theme for the scene ([#67](https://github.com/reearth/reearth-visualizer-web/pull/67)) [`58e670`](https://github.com/reearth/reearth-visualizer-web/commit/58e670)
+- Notification system update ([#73](https://github.com/reearth/reearth-visualizer-web/pull/73)) [`92cdbb`](https://github.com/reearth/reearth-visualizer-web/commit/92cdbb)
+- Widget align system ([#61](https://github.com/reearth/reearth-visualizer-web/pull/61)) [`ed2940`](https://github.com/reearth/reearth-visualizer-web/commit/ed2940)
+- Plugin system beta ([#87](https://github.com/reearth/reearth-visualizer-web/pull/87)) [`d76f1c`](https://github.com/reearth/reearth-visualizer-web/commit/d76f1c)
+- Enhance extended field of widget in plugin API ([#90](https://github.com/reearth/reearth-visualizer-web/pull/90)) [`06cb14`](https://github.com/reearth/reearth-visualizer-web/commit/06cb14)
+- Add overrideProperty to plugin layers API ([#92](https://github.com/reearth/reearth-visualizer-web/pull/92)) [`563f88`](https://github.com/reearth/reearth-visualizer-web/commit/563f88)
+- Add a fallback icon for extensions that do not have an icon ([#98](https://github.com/reearth/reearth-visualizer-web/pull/98)) [`50de1f`](https://github.com/reearth/reearth-visualizer-web/commit/50de1f)
+- Add password validation ([#86](https://github.com/reearth/reearth-visualizer-web/pull/86)) [`2017aa`](https://github.com/reearth/reearth-visualizer-web/commit/2017aa)
+- Draggable layer ([#58](https://github.com/reearth/reearth-visualizer-web/pull/58)) [`25a217`](https://github.com/reearth/reearth-visualizer-web/commit/25a217)
+- Multi widgets ([#99](https://github.com/reearth/reearth-visualizer-web/pull/99)) [`bea1a3`](https://github.com/reearth/reearth-visualizer-web/commit/bea1a3)
+- Front-end for new authentication system ([#102](https://github.com/reearth/reearth-visualizer-web/pull/102)) [`964d92`](https://github.com/reearth/reearth-visualizer-web/commit/964d92)
+- Add layers.overriddenProperties, find, findAll, walk ([#110](https://github.com/reearth/reearth-visualizer-web/pull/110)) [`ebe131`](https://github.com/reearth/reearth-visualizer-web/commit/ebe131)
 
 #### 🔧 Bug Fixes
 
-- Reorganize config [`f2e947`](https://github.com/reearth/reearth-web/commit/f2e947)
-- Update gql schema [`0905b6`](https://github.com/reearth/reearth-web/commit/0905b6)
-- Update dependency cesium to ^1.82.1 ([#4](https://github.com/reearth/reearth-web/pull/4)) [`0627bf`](https://github.com/reearth/reearth-web/commit/0627bf)
-- Google analytics ([#7](https://github.com/reearth/reearth-web/pull/7)) [`7505ca`](https://github.com/reearth/reearth-web/commit/7505ca)
-- Sprint15 bugs ([#8](https://github.com/reearth/reearth-web/pull/8)) [`e2fe0a`](https://github.com/reearth/reearth-web/commit/e2fe0a)
-- Google analytics typo ([#9](https://github.com/reearth/reearth-web/pull/9)) [`943b5e`](https://github.com/reearth/reearth-web/commit/943b5e)
-- Ga-typo2 ([#10](https://github.com/reearth/reearth-web/pull/10)) [`b498de`](https://github.com/reearth/reearth-web/commit/b498de)
-- Force logout when me query returns null ([#15](https://github.com/reearth/reearth-web/pull/15)) [`339d61`](https://github.com/reearth/reearth-web/commit/339d61)
-- Infinit logout loop ([#17](https://github.com/reearth/reearth-web/pull/17)) [`0d510f`](https://github.com/reearth/reearth-web/commit/0d510f)
-- Change data.json path [`38a69a`](https://github.com/reearth/reearth-web/commit/38a69a)
-- Menu button width ([#21](https://github.com/reearth/reearth-web/pull/21)) [`d08eba`](https://github.com/reearth/reearth-web/commit/d08eba)
-- Menu widget bugs ([#37](https://github.com/reearth/reearth-web/pull/37)) [`5d5483`](https://github.com/reearth/reearth-web/commit/5d5483)
-- Marker label position is oposite to actual display ([#39](https://github.com/reearth/reearth-web/pull/39)) [`38de46`](https://github.com/reearth/reearth-web/commit/38de46)
-- Disable default cesium mouse event ([#42](https://github.com/reearth/reearth-web/pull/42)) [`129ae3`](https://github.com/reearth/reearth-web/commit/129ae3)
-- Show layers in storytelling without names ([#45](https://github.com/reearth/reearth-web/pull/45)) [`00ae3c`](https://github.com/reearth/reearth-web/commit/00ae3c)
-- Infobox colors ([#47](https://github.com/reearth/reearth-web/pull/47)) [`2a6a36`](https://github.com/reearth/reearth-web/commit/2a6a36)
-- Project public image ([#48](https://github.com/reearth/reearth-web/pull/48)) [`91b5ee`](https://github.com/reearth/reearth-web/commit/91b5ee)
-- Auth0 redirect uri [`8336a3`](https://github.com/reearth/reearth-web/commit/8336a3)
-- Storybook ([#54](https://github.com/reearth/reearth-web/pull/54)) [`fde0c0`](https://github.com/reearth/reearth-web/commit/fde0c0)
-- Published data url [`e3d5b0`](https://github.com/reearth/reearth-web/commit/e3d5b0)
-- Icon background ([#64](https://github.com/reearth/reearth-web/pull/64)) [`9c69a4`](https://github.com/reearth/reearth-web/commit/9c69a4)
-- Prevent extra render, cannot rename layers, cannot display infobox on dataset layers ([#65](https://github.com/reearth/reearth-web/pull/65)) [`e3d618`](https://github.com/reearth/reearth-web/commit/e3d618)
-- Remove visibility icon from layer actions [`0ad8aa`](https://github.com/reearth/reearth-web/commit/0ad8aa)
-- Default published url, rename layer when focus is removed from text box [`f9accc`](https://github.com/reearth/reearth-web/commit/f9accc)
-- Storybook error ([#75](https://github.com/reearth/reearth-web/pull/75)) [`f27f9b`](https://github.com/reearth/reearth-web/commit/f27f9b)
-- Showing members section for personal workspace ([#85](https://github.com/reearth/reearth-web/pull/85)) [`8e78f9`](https://github.com/reearth/reearth-web/commit/8e78f9)
-- Widget bugs, language ([#89](https://github.com/reearth/reearth-web/pull/89)) [`9de9df`](https://github.com/reearth/reearth-web/commit/9de9df)
-- Update dependency cesium to ^1.86.0 ([#93](https://github.com/reearth/reearth-web/pull/93)) [`7ca298`](https://github.com/reearth/reearth-web/commit/7ca298)
-- Show properties of 3D tile features on infobox ([#95](https://github.com/reearth/reearth-web/pull/95)) [`a9cc23`](https://github.com/reearth/reearth-web/commit/a9cc23)
-- Navigator.language should be used as fallback lang ([#91](https://github.com/reearth/reearth-web/pull/91)) [`15df16`](https://github.com/reearth/reearth-web/commit/15df16)
-- Camera property panel bugs ([#96](https://github.com/reearth/reearth-web/pull/96)) [`2c3eaa`](https://github.com/reearth/reearth-web/commit/2c3eaa)
-- Camera flight bugs ([#97](https://github.com/reearth/reearth-web/pull/97)) [`b4f1ae`](https://github.com/reearth/reearth-web/commit/b4f1ae)
-- Storytelling image crop does not work [`9c23b3`](https://github.com/reearth/reearth-web/commit/9c23b3)
-- Export pane is not displayed [`58ceda`](https://github.com/reearth/reearth-web/commit/58ceda)
-- 1st bug hunt of october ([#100](https://github.com/reearth/reearth-web/pull/100)) [`1b9032`](https://github.com/reearth/reearth-web/commit/1b9032)
-- Layers disappearing when in nested folders ([#101](https://github.com/reearth/reearth-web/pull/101)) [`778395`](https://github.com/reearth/reearth-web/commit/778395)
-- Update dependency cesium to ^1.86.1 ([#103](https://github.com/reearth/reearth-web/pull/103)) [`385582`](https://github.com/reearth/reearth-web/commit/385582)
-- Bug bounty #2 ([#105](https://github.com/reearth/reearth-web/pull/105)) [`da4815`](https://github.com/reearth/reearth-web/commit/da4815)
-- Button widget ([#111](https://github.com/reearth/reearth-web/pull/111)) [`b93485`](https://github.com/reearth/reearth-web/commit/b93485)
-- Create team redirect + translations update ([#112](https://github.com/reearth/reearth-web/pull/112)) [`bafcfd`](https://github.com/reearth/reearth-web/commit/bafcfd)
-- 3d tile styles not updating sometimes ([#109](https://github.com/reearth/reearth-web/pull/109)) [`1e92b8`](https://github.com/reearth/reearth-web/commit/1e92b8)
-- Layers.overrideProperty property merging and rerendering ([#108](https://github.com/reearth/reearth-web/pull/108)) [`e5c255`](https://github.com/reearth/reearth-web/commit/e5c255)
-- Password policy conversion in config ([#113](https://github.com/reearth/reearth-web/pull/113)) [`5d57c4`](https://github.com/reearth/reearth-web/commit/5d57c4)
-- Password validation, add autofocus ([#117](https://github.com/reearth/reearth-web/pull/117)) [`348454`](https://github.com/reearth/reearth-web/commit/348454)
-- Password verification, add better feedback [`bd1725`](https://github.com/reearth/reearth-web/commit/bd1725)
+- Reorganize config [`f2e947`](https://github.com/reearth/reearth-visualizer-web/commit/f2e947)
+- Update gql schema [`0905b6`](https://github.com/reearth/reearth-visualizer-web/commit/0905b6)
+- Update dependency cesium to ^1.82.1 ([#4](https://github.com/reearth/reearth-visualizer-web/pull/4)) [`0627bf`](https://github.com/reearth/reearth-visualizer-web/commit/0627bf)
+- Google analytics ([#7](https://github.com/reearth/reearth-visualizer-web/pull/7)) [`7505ca`](https://github.com/reearth/reearth-visualizer-web/commit/7505ca)
+- Sprint15 bugs ([#8](https://github.com/reearth/reearth-visualizer-web/pull/8)) [`e2fe0a`](https://github.com/reearth/reearth-visualizer-web/commit/e2fe0a)
+- Google analytics typo ([#9](https://github.com/reearth/reearth-visualizer-web/pull/9)) [`943b5e`](https://github.com/reearth/reearth-visualizer-web/commit/943b5e)
+- Ga-typo2 ([#10](https://github.com/reearth/reearth-visualizer-web/pull/10)) [`b498de`](https://github.com/reearth/reearth-visualizer-web/commit/b498de)
+- Force logout when me query returns null ([#15](https://github.com/reearth/reearth-visualizer-web/pull/15)) [`339d61`](https://github.com/reearth/reearth-visualizer-web/commit/339d61)
+- Infinit logout loop ([#17](https://github.com/reearth/reearth-visualizer-web/pull/17)) [`0d510f`](https://github.com/reearth/reearth-visualizer-web/commit/0d510f)
+- Change data.json path [`38a69a`](https://github.com/reearth/reearth-visualizer-web/commit/38a69a)
+- Menu button width ([#21](https://github.com/reearth/reearth-visualizer-web/pull/21)) [`d08eba`](https://github.com/reearth/reearth-visualizer-web/commit/d08eba)
+- Menu widget bugs ([#37](https://github.com/reearth/reearth-visualizer-web/pull/37)) [`5d5483`](https://github.com/reearth/reearth-visualizer-web/commit/5d5483)
+- Marker label position is oposite to actual display ([#39](https://github.com/reearth/reearth-visualizer-web/pull/39)) [`38de46`](https://github.com/reearth/reearth-visualizer-web/commit/38de46)
+- Disable default cesium mouse event ([#42](https://github.com/reearth/reearth-visualizer-web/pull/42)) [`129ae3`](https://github.com/reearth/reearth-visualizer-web/commit/129ae3)
+- Show layers in storytelling without names ([#45](https://github.com/reearth/reearth-visualizer-web/pull/45)) [`00ae3c`](https://github.com/reearth/reearth-visualizer-web/commit/00ae3c)
+- Infobox colors ([#47](https://github.com/reearth/reearth-visualizer-web/pull/47)) [`2a6a36`](https://github.com/reearth/reearth-visualizer-web/commit/2a6a36)
+- Project public image ([#48](https://github.com/reearth/reearth-visualizer-web/pull/48)) [`91b5ee`](https://github.com/reearth/reearth-visualizer-web/commit/91b5ee)
+- Auth0 redirect uri [`8336a3`](https://github.com/reearth/reearth-visualizer-web/commit/8336a3)
+- Storybook ([#54](https://github.com/reearth/reearth-visualizer-web/pull/54)) [`fde0c0`](https://github.com/reearth/reearth-visualizer-web/commit/fde0c0)
+- Published data url [`e3d5b0`](https://github.com/reearth/reearth-visualizer-web/commit/e3d5b0)
+- Icon background ([#64](https://github.com/reearth/reearth-visualizer-web/pull/64)) [`9c69a4`](https://github.com/reearth/reearth-visualizer-web/commit/9c69a4)
+- Prevent extra render, cannot rename layers, cannot display infobox on dataset layers ([#65](https://github.com/reearth/reearth-visualizer-web/pull/65)) [`e3d618`](https://github.com/reearth/reearth-visualizer-web/commit/e3d618)
+- Remove visibility icon from layer actions [`0ad8aa`](https://github.com/reearth/reearth-visualizer-web/commit/0ad8aa)
+- Default published url, rename layer when focus is removed from text box [`f9accc`](https://github.com/reearth/reearth-visualizer-web/commit/f9accc)
+- Storybook error ([#75](https://github.com/reearth/reearth-visualizer-web/pull/75)) [`f27f9b`](https://github.com/reearth/reearth-visualizer-web/commit/f27f9b)
+- Showing members section for personal workspace ([#85](https://github.com/reearth/reearth-visualizer-web/pull/85)) [`8e78f9`](https://github.com/reearth/reearth-visualizer-web/commit/8e78f9)
+- Widget bugs, language ([#89](https://github.com/reearth/reearth-visualizer-web/pull/89)) [`9de9df`](https://github.com/reearth/reearth-visualizer-web/commit/9de9df)
+- Update dependency cesium to ^1.86.0 ([#93](https://github.com/reearth/reearth-visualizer-web/pull/93)) [`7ca298`](https://github.com/reearth/reearth-visualizer-web/commit/7ca298)
+- Show properties of 3D tile features on infobox ([#95](https://github.com/reearth/reearth-visualizer-web/pull/95)) [`a9cc23`](https://github.com/reearth/reearth-visualizer-web/commit/a9cc23)
+- Navigator.language should be used as fallback lang ([#91](https://github.com/reearth/reearth-visualizer-web/pull/91)) [`15df16`](https://github.com/reearth/reearth-visualizer-web/commit/15df16)
+- Camera property panel bugs ([#96](https://github.com/reearth/reearth-visualizer-web/pull/96)) [`2c3eaa`](https://github.com/reearth/reearth-visualizer-web/commit/2c3eaa)
+- Camera flight bugs ([#97](https://github.com/reearth/reearth-visualizer-web/pull/97)) [`b4f1ae`](https://github.com/reearth/reearth-visualizer-web/commit/b4f1ae)
+- Storytelling image crop does not work [`9c23b3`](https://github.com/reearth/reearth-visualizer-web/commit/9c23b3)
+- Export pane is not displayed [`58ceda`](https://github.com/reearth/reearth-visualizer-web/commit/58ceda)
+- 1st bug hunt of october ([#100](https://github.com/reearth/reearth-visualizer-web/pull/100)) [`1b9032`](https://github.com/reearth/reearth-visualizer-web/commit/1b9032)
+- Layers disappearing when in nested folders ([#101](https://github.com/reearth/reearth-visualizer-web/pull/101)) [`778395`](https://github.com/reearth/reearth-visualizer-web/commit/778395)
+- Update dependency cesium to ^1.86.1 ([#103](https://github.com/reearth/reearth-visualizer-web/pull/103)) [`385582`](https://github.com/reearth/reearth-visualizer-web/commit/385582)
+- Bug bounty #2 ([#105](https://github.com/reearth/reearth-visualizer-web/pull/105)) [`da4815`](https://github.com/reearth/reearth-visualizer-web/commit/da4815)
+- Button widget ([#111](https://github.com/reearth/reearth-visualizer-web/pull/111)) [`b93485`](https://github.com/reearth/reearth-visualizer-web/commit/b93485)
+- Create team redirect + translations update ([#112](https://github.com/reearth/reearth-visualizer-web/pull/112)) [`bafcfd`](https://github.com/reearth/reearth-visualizer-web/commit/bafcfd)
+- 3d tile styles not updating sometimes ([#109](https://github.com/reearth/reearth-visualizer-web/pull/109)) [`1e92b8`](https://github.com/reearth/reearth-visualizer-web/commit/1e92b8)
+- Layers.overrideProperty property merging and rerendering ([#108](https://github.com/reearth/reearth-visualizer-web/pull/108)) [`e5c255`](https://github.com/reearth/reearth-visualizer-web/commit/e5c255)
+- Password policy conversion in config ([#113](https://github.com/reearth/reearth-visualizer-web/pull/113)) [`5d57c4`](https://github.com/reearth/reearth-visualizer-web/commit/5d57c4)
+- Password validation, add autofocus ([#117](https://github.com/reearth/reearth-visualizer-web/pull/117)) [`348454`](https://github.com/reearth/reearth-visualizer-web/commit/348454)
+- Password verification, add better feedback [`bd1725`](https://github.com/reearth/reearth-visualizer-web/commit/bd1725)
 
 #### ✨ Refactor
 
-- Use jotai instead of redux ([#68](https://github.com/reearth/reearth-web/pull/68)) [`ea980c`](https://github.com/reearth/reearth-web/commit/ea980c)
-- Replace deprecated gql fields, pass widgetId to widget mutations ([#72](https://github.com/reearth/reearth-web/pull/72)) [`f36c86`](https://github.com/reearth/reearth-web/commit/f36c86)
+- Use jotai instead of redux ([#68](https://github.com/reearth/reearth-visualizer-web/pull/68)) [`ea980c`](https://github.com/reearth/reearth-visualizer-web/commit/ea980c)
+- Replace deprecated gql fields, pass widgetId to widget mutations ([#72](https://github.com/reearth/reearth-visualizer-web/pull/72)) [`f36c86`](https://github.com/reearth/reearth-visualizer-web/commit/f36c86)
 
 #### 🎨 Styling
 
-- Refine font ([#49](https://github.com/reearth/reearth-web/pull/49)) [`8b3755`](https://github.com/reearth/reearth-web/commit/8b3755)
-- Refine color vo.1 ([#59](https://github.com/reearth/reearth-web/pull/59)) [`ab7bce`](https://github.com/reearth/reearth-web/commit/ab7bce)
+- Refine font ([#49](https://github.com/reearth/reearth-visualizer-web/pull/49)) [`8b3755`](https://github.com/reearth/reearth-visualizer-web/commit/8b3755)
+- Refine color vo.1 ([#59](https://github.com/reearth/reearth-visualizer-web/pull/59)) [`ab7bce`](https://github.com/reearth/reearth-visualizer-web/commit/ab7bce)
 
 #### 🧪 Testing
 
-- Fix e2e test [`3bcd2d`](https://github.com/reearth/reearth-web/commit/3bcd2d)
-- Fix e2e test [`b3e512`](https://github.com/reearth/reearth-web/commit/b3e512)
-- Fix e2e test [`277f4e`](https://github.com/reearth/reearth-web/commit/277f4e)
-- Fix e2e test [`396f71`](https://github.com/reearth/reearth-web/commit/396f71)
-- Fix e2e test [`a8bd0c`](https://github.com/reearth/reearth-web/commit/a8bd0c)
-- Fix e2e test [`fd7cf5`](https://github.com/reearth/reearth-web/commit/fd7cf5)
-- Fix e2e test [`8c300b`](https://github.com/reearth/reearth-web/commit/8c300b)
-- Fix e2e test [`ea5050`](https://github.com/reearth/reearth-web/commit/ea5050)
-- Fix e2e test [`866c8c`](https://github.com/reearth/reearth-web/commit/866c8c)
-- Support display name in e2e test [`0edf58`](https://github.com/reearth/reearth-web/commit/0edf58)
+- Fix e2e test [`3bcd2d`](https://github.com/reearth/reearth-visualizer-web/commit/3bcd2d)
+- Fix e2e test [`b3e512`](https://github.com/reearth/reearth-visualizer-web/commit/b3e512)
+- Fix e2e test [`277f4e`](https://github.com/reearth/reearth-visualizer-web/commit/277f4e)
+- Fix e2e test [`396f71`](https://github.com/reearth/reearth-visualizer-web/commit/396f71)
+- Fix e2e test [`a8bd0c`](https://github.com/reearth/reearth-visualizer-web/commit/a8bd0c)
+- Fix e2e test [`fd7cf5`](https://github.com/reearth/reearth-visualizer-web/commit/fd7cf5)
+- Fix e2e test [`8c300b`](https://github.com/reearth/reearth-visualizer-web/commit/8c300b)
+- Fix e2e test [`ea5050`](https://github.com/reearth/reearth-visualizer-web/commit/ea5050)
+- Fix e2e test [`866c8c`](https://github.com/reearth/reearth-visualizer-web/commit/866c8c)
+- Support display name in e2e test [`0edf58`](https://github.com/reearth/reearth-visualizer-web/commit/0edf58)
 
 #### Miscellaneous Tasks
 
-- Update workflows, set up nightly release [`0ea0ff`](https://github.com/reearth/reearth-web/commit/0ea0ff)
-- Fix nightly release workflow [`d7d1d3`](https://github.com/reearth/reearth-web/commit/d7d1d3)
-- Fix config [`7a6ed3`](https://github.com/reearth/reearth-web/commit/7a6ed3)
-- Set up cd workflows [`a6f0f5`](https://github.com/reearth/reearth-web/commit/a6f0f5)
-- Fix workflows [`97ecf8`](https://github.com/reearth/reearth-web/commit/97ecf8)
-- Fix workflows [`a4d451`](https://github.com/reearth/reearth-web/commit/a4d451)
-- Fix workflows [`d77b53`](https://github.com/reearth/reearth-web/commit/d77b53)
-- Remove unused deps [`81d0eb`](https://github.com/reearth/reearth-web/commit/81d0eb)
-- Update cesium [`414b37`](https://github.com/reearth/reearth-web/commit/414b37)
-- Update renovate config [`b36740`](https://github.com/reearth/reearth-web/commit/b36740)
-- Use .env instead of .env.local [`0b8720`](https://github.com/reearth/reearth-web/commit/0b8720)
-- Add storybook workflow [`c624bd`](https://github.com/reearth/reearth-web/commit/c624bd)
-- Set up sentry ([#18](https://github.com/reearth/reearth-web/pull/18)) [`8a2d38`](https://github.com/reearth/reearth-web/commit/8a2d38)
-- Testable published page ([#43](https://github.com/reearth/reearth-web/pull/43)) [`90c37d`](https://github.com/reearth/reearth-web/commit/90c37d)
-- Update netlify.toml [`230e12`](https://github.com/reearth/reearth-web/commit/230e12)
-- Add gql sclar types [`09fb76`](https://github.com/reearth/reearth-web/commit/09fb76)
-- Update cesium and resium ([#79](https://github.com/reearth/reearth-web/pull/79)) [`c41601`](https://github.com/reearth/reearth-web/commit/c41601)
-- Update eslint, enable eslint-plugin-import, perform formatting ([#82](https://github.com/reearth/reearth-web/pull/82)) [`117bab`](https://github.com/reearth/reearth-web/commit/117bab)
-- Upgrade dependencies [`4924f9`](https://github.com/reearth/reearth-web/commit/4924f9)
-- Fix cypress and unit test [`97f74e`](https://github.com/reearth/reearth-web/commit/97f74e)
-- Support for dotenv switching ([#106](https://github.com/reearth/reearth-web/pull/106)) [`cd1974`](https://github.com/reearth/reearth-web/commit/cd1974)
-- Upgrade modules oct ([#107](https://github.com/reearth/reearth-web/pull/107)) [`24c145`](https://github.com/reearth/reearth-web/commit/24c145)
-- Upgrade react-align ([#116](https://github.com/reearth/reearth-web/pull/116)) [`7f4b98`](https://github.com/reearth/reearth-web/commit/7f4b98)
-- Add github workflows to release [`331afb`](https://github.com/reearth/reearth-web/commit/331afb)
-- Update translations + format ([#114](https://github.com/reearth/reearth-web/pull/114)) [`7f191e`](https://github.com/reearth/reearth-web/commit/7f191e)
-- Lock file maintenance ([#66](https://github.com/reearth/reearth-web/pull/66)) [`6d2a2d`](https://github.com/reearth/reearth-web/commit/6d2a2d)
-- Fix slack notifications in workflow [skip ci] [`b4fa35`](https://github.com/reearth/reearth-web/commit/b4fa35)
-- Fix sed in release workflow [skip ci] [`f3cd74`](https://github.com/reearth/reearth-web/commit/f3cd74)
+- Update workflows, set up nightly release [`0ea0ff`](https://github.com/reearth/reearth-visualizer-web/commit/0ea0ff)
+- Fix nightly release workflow [`d7d1d3`](https://github.com/reearth/reearth-visualizer-web/commit/d7d1d3)
+- Fix config [`7a6ed3`](https://github.com/reearth/reearth-visualizer-web/commit/7a6ed3)
+- Set up cd workflows [`a6f0f5`](https://github.com/reearth/reearth-visualizer-web/commit/a6f0f5)
+- Fix workflows [`97ecf8`](https://github.com/reearth/reearth-visualizer-web/commit/97ecf8)
+- Fix workflows [`a4d451`](https://github.com/reearth/reearth-visualizer-web/commit/a4d451)
+- Fix workflows [`d77b53`](https://github.com/reearth/reearth-visualizer-web/commit/d77b53)
+- Remove unused deps [`81d0eb`](https://github.com/reearth/reearth-visualizer-web/commit/81d0eb)
+- Update cesium [`414b37`](https://github.com/reearth/reearth-visualizer-web/commit/414b37)
+- Update renovate config [`b36740`](https://github.com/reearth/reearth-visualizer-web/commit/b36740)
+- Use .env instead of .env.local [`0b8720`](https://github.com/reearth/reearth-visualizer-web/commit/0b8720)
+- Add storybook workflow [`c624bd`](https://github.com/reearth/reearth-visualizer-web/commit/c624bd)
+- Set up sentry ([#18](https://github.com/reearth/reearth-visualizer-web/pull/18)) [`8a2d38`](https://github.com/reearth/reearth-visualizer-web/commit/8a2d38)
+- Testable published page ([#43](https://github.com/reearth/reearth-visualizer-web/pull/43)) [`90c37d`](https://github.com/reearth/reearth-visualizer-web/commit/90c37d)
+- Update netlify.toml [`230e12`](https://github.com/reearth/reearth-visualizer-web/commit/230e12)
+- Add gql sclar types [`09fb76`](https://github.com/reearth/reearth-visualizer-web/commit/09fb76)
+- Update cesium and resium ([#79](https://github.com/reearth/reearth-visualizer-web/pull/79)) [`c41601`](https://github.com/reearth/reearth-visualizer-web/commit/c41601)
+- Update eslint, enable eslint-plugin-import, perform formatting ([#82](https://github.com/reearth/reearth-visualizer-web/pull/82)) [`117bab`](https://github.com/reearth/reearth-visualizer-web/commit/117bab)
+- Upgrade dependencies [`4924f9`](https://github.com/reearth/reearth-visualizer-web/commit/4924f9)
+- Fix cypress and unit test [`97f74e`](https://github.com/reearth/reearth-visualizer-web/commit/97f74e)
+- Support for dotenv switching ([#106](https://github.com/reearth/reearth-visualizer-web/pull/106)) [`cd1974`](https://github.com/reearth/reearth-visualizer-web/commit/cd1974)
+- Upgrade modules oct ([#107](https://github.com/reearth/reearth-visualizer-web/pull/107)) [`24c145`](https://github.com/reearth/reearth-visualizer-web/commit/24c145)
+- Upgrade react-align ([#116](https://github.com/reearth/reearth-visualizer-web/pull/116)) [`7f4b98`](https://github.com/reearth/reearth-visualizer-web/commit/7f4b98)
+- Add github workflows to release [`331afb`](https://github.com/reearth/reearth-visualizer-web/commit/331afb)
+- Update translations + format ([#114](https://github.com/reearth/reearth-visualizer-web/pull/114)) [`7f191e`](https://github.com/reearth/reearth-visualizer-web/commit/7f191e)
+- Lock file maintenance ([#66](https://github.com/reearth/reearth-visualizer-web/pull/66)) [`6d2a2d`](https://github.com/reearth/reearth-visualizer-web/commit/6d2a2d)
+- Fix slack notifications in workflow [skip ci] [`b4fa35`](https://github.com/reearth/reearth-visualizer-web/commit/b4fa35)
+- Fix sed in release workflow [skip ci] [`f3cd74`](https://github.com/reearth/reearth-visualizer-web/commit/f3cd74)
 
 
 ### reearth-backend
 
 #### 🚀 Features
 
-- Support Auth0 audience ([#3](https://github.com/reearth/reearth-backend/pull/3)) [`c3758e`](https://github.com/reearth/reearth-backend/commit/c3758e)
-- Basic auth for projects ([#6](https://github.com/reearth/reearth-backend/pull/6)) [`5db065`](https://github.com/reearth/reearth-backend/commit/5db065)
-- Google analytics for scene ([#10](https://github.com/reearth/reearth-backend/pull/10)) [`b44249`](https://github.com/reearth/reearth-backend/commit/b44249)
-- Create installable plugins ([#1](https://github.com/reearth/reearth-backend/pull/1)) [`5b7a5f`](https://github.com/reearth/reearth-backend/commit/5b7a5f)
-- Add thumbnail, author fields on plugin metadata query ([#15](https://github.com/reearth/reearth-backend/pull/15)) [`888fe0`](https://github.com/reearth/reearth-backend/commit/888fe0)
-- Published page api ([#11](https://github.com/reearth/reearth-backend/pull/11)) [`aebac3`](https://github.com/reearth/reearth-backend/commit/aebac3)
-- Import dataset from google sheets ([#16](https://github.com/reearth/reearth-backend/pull/16)) [`2ef7ef`](https://github.com/reearth/reearth-backend/commit/2ef7ef)
-- Add scenePlugin resolver to layers ([#20](https://github.com/reearth/reearth-backend/pull/20)) [`5213f3`](https://github.com/reearth/reearth-backend/commit/5213f3)
-- Marker label position [`bb9e4c`](https://github.com/reearth/reearth-backend/commit/bb9e4c)
-- Refine dataset import ([#26](https://github.com/reearth/reearth-backend/pull/26)) [`5dd3db`](https://github.com/reearth/reearth-backend/commit/5dd3db)
-- Plugin upload and deletion ([#33](https://github.com/reearth/reearth-backend/pull/33)) [`8742db`](https://github.com/reearth/reearth-backend/commit/8742db)
-- New primitives, new properties on primitives [`108711`](https://github.com/reearth/reearth-backend/commit/108711)
-- Set scene theme ([#35](https://github.com/reearth/reearth-backend/pull/35)) [`2e4f52`](https://github.com/reearth/reearth-backend/commit/2e4f52)
-- Widget align system ([#19](https://github.com/reearth/reearth-backend/pull/19)) [`94611f`](https://github.com/reearth/reearth-backend/commit/94611f)
-- Tag system ([#67](https://github.com/reearth/reearth-backend/pull/67)) [`163fcf`](https://github.com/reearth/reearth-backend/commit/163fcf)
+- Support Auth0 audience ([#3](https://github.com/reearth/reearth-visualizer-backend/pull/3)) [`c3758e`](https://github.com/reearth/reearth-visualizer-backend/commit/c3758e)
+- Basic auth for projects ([#6](https://github.com/reearth/reearth-visualizer-backend/pull/6)) [`5db065`](https://github.com/reearth/reearth-visualizer-backend/commit/5db065)
+- Google analytics for scene ([#10](https://github.com/reearth/reearth-visualizer-backend/pull/10)) [`b44249`](https://github.com/reearth/reearth-visualizer-backend/commit/b44249)
+- Create installable plugins ([#1](https://github.com/reearth/reearth-visualizer-backend/pull/1)) [`5b7a5f`](https://github.com/reearth/reearth-visualizer-backend/commit/5b7a5f)
+- Add thumbnail, author fields on plugin metadata query ([#15](https://github.com/reearth/reearth-visualizer-backend/pull/15)) [`888fe0`](https://github.com/reearth/reearth-visualizer-backend/commit/888fe0)
+- Published page api ([#11](https://github.com/reearth/reearth-visualizer-backend/pull/11)) [`aebac3`](https://github.com/reearth/reearth-visualizer-backend/commit/aebac3)
+- Import dataset from google sheets ([#16](https://github.com/reearth/reearth-visualizer-backend/pull/16)) [`2ef7ef`](https://github.com/reearth/reearth-visualizer-backend/commit/2ef7ef)
+- Add scenePlugin resolver to layers ([#20](https://github.com/reearth/reearth-visualizer-backend/pull/20)) [`5213f3`](https://github.com/reearth/reearth-visualizer-backend/commit/5213f3)
+- Marker label position [`bb9e4c`](https://github.com/reearth/reearth-visualizer-backend/commit/bb9e4c)
+- Refine dataset import ([#26](https://github.com/reearth/reearth-visualizer-backend/pull/26)) [`5dd3db`](https://github.com/reearth/reearth-visualizer-backend/commit/5dd3db)
+- Plugin upload and deletion ([#33](https://github.com/reearth/reearth-visualizer-backend/pull/33)) [`8742db`](https://github.com/reearth/reearth-visualizer-backend/commit/8742db)
+- New primitives, new properties on primitives [`108711`](https://github.com/reearth/reearth-visualizer-backend/commit/108711)
+- Set scene theme ([#35](https://github.com/reearth/reearth-visualizer-backend/pull/35)) [`2e4f52`](https://github.com/reearth/reearth-visualizer-backend/commit/2e4f52)
+- Widget align system ([#19](https://github.com/reearth/reearth-visualizer-backend/pull/19)) [`94611f`](https://github.com/reearth/reearth-visualizer-backend/commit/94611f)
+- Tag system ([#67](https://github.com/reearth/reearth-visualizer-backend/pull/67)) [`163fcf`](https://github.com/reearth/reearth-visualizer-backend/commit/163fcf)
 
 #### 🔧 Bug Fixes
 
-- Add mutex for each memory repo ([#2](https://github.com/reearth/reearth-backend/pull/2)) [`f4c3b0`](https://github.com/reearth/reearth-backend/commit/f4c3b0)
-- Auth0 audience in reearth_config.json [`72e3ed`](https://github.com/reearth/reearth-backend/commit/72e3ed)
-- Auth0 domain and multiple auds [`835a02`](https://github.com/reearth/reearth-backend/commit/835a02)
-- Signing up and deleting user [`f17b9d`](https://github.com/reearth/reearth-backend/commit/f17b9d)
-- Deleting user [`e9b8c9`](https://github.com/reearth/reearth-backend/commit/e9b8c9)
-- Sign up and update user [`e5ab87`](https://github.com/reearth/reearth-backend/commit/e5ab87)
-- Make gql mutation payloads optional [`9b1c4a`](https://github.com/reearth/reearth-backend/commit/9b1c4a)
-- Auth0 [`6a27c6`](https://github.com/reearth/reearth-backend/commit/6a27c6)
-- Errors are be overwriten by tx [`2d08c5`](https://github.com/reearth/reearth-backend/commit/2d08c5)
-- Deleting user [`f531bd`](https://github.com/reearth/reearth-backend/commit/f531bd)
-- Always enable dev mode in debug [`0815d3`](https://github.com/reearth/reearth-backend/commit/0815d3)
-- User deletion [`a5eeae`](https://github.com/reearth/reearth-backend/commit/a5eeae)
-- Invisible layer issue in published project ([#7](https://github.com/reearth/reearth-backend/pull/7)) [`06cd44`](https://github.com/reearth/reearth-backend/commit/06cd44)
-- Dataset link merge bug #378 ([#18](https://github.com/reearth/reearth-backend/pull/18)) [`25da0d`](https://github.com/reearth/reearth-backend/commit/25da0d)
-- Ogp image for published page ([#17](https://github.com/reearth/reearth-backend/pull/17)) [`dcb4b0`](https://github.com/reearth/reearth-backend/commit/dcb4b0)
-- Change default value of marker label position [`a2059e`](https://github.com/reearth/reearth-backend/commit/a2059e)
-- Import dataset from google sheet bug ([#23](https://github.com/reearth/reearth-backend/pull/23)) [`077558`](https://github.com/reearth/reearth-backend/commit/077558)
-- Public api param [`846957`](https://github.com/reearth/reearth-backend/commit/846957)
-- Replace strings.Split() with strings.field() ([#25](https://github.com/reearth/reearth-backend/pull/25)) [`ba7d16`](https://github.com/reearth/reearth-backend/commit/ba7d16)
-- Project public image type [`e82b54`](https://github.com/reearth/reearth-backend/commit/e82b54)
-- Published API ([#27](https://github.com/reearth/reearth-backend/pull/27)) [`8ad1f8`](https://github.com/reearth/reearth-backend/commit/8ad1f8)
-- Plugin manifest parser bugs ([#32](https://github.com/reearth/reearth-backend/pull/32)) [`78ac13`](https://github.com/reearth/reearth-backend/commit/78ac13)
-- Dataset layers are not exported correctly ([#36](https://github.com/reearth/reearth-backend/pull/36)) [`0b8c00`](https://github.com/reearth/reearth-backend/commit/0b8c00)
-- Hide parent infobox fields when child infobox is not nil ([#37](https://github.com/reearth/reearth-backend/pull/37)) [`d8c8cd`](https://github.com/reearth/reearth-backend/commit/d8c8cd)
-- Mongo.PropertySchema.FindByIDs, propertySchemaID.Equal [`be00da`](https://github.com/reearth/reearth-backend/commit/be00da)
-- Gql propertySchemaGroup.translatedTitle resolver [`a4770e`](https://github.com/reearth/reearth-backend/commit/a4770e)
-- Use PropertySchemaID.Equal [`8a6459`](https://github.com/reearth/reearth-backend/commit/8a6459)
-- Use PropertySchemaID.Equal [`1c3cf1`](https://github.com/reearth/reearth-backend/commit/1c3cf1)
-- Tweak field names of model primitive [`080ab9`](https://github.com/reearth/reearth-backend/commit/080ab9)
-- Layer importing bug ([#41](https://github.com/reearth/reearth-backend/pull/41)) [`02b17f`](https://github.com/reearth/reearth-backend/commit/02b17f)
-- Skip nil geometries ([#42](https://github.com/reearth/reearth-backend/pull/42)) [`90c327`](https://github.com/reearth/reearth-backend/commit/90c327)
-- Validate widget extended when moved [`a7daf7`](https://github.com/reearth/reearth-backend/commit/a7daf7)
-- Widget extended validation [`98db7e`](https://github.com/reearth/reearth-backend/commit/98db7e)
-- Nil error in mongodoc plugin [`d236be`](https://github.com/reearth/reearth-backend/commit/d236be)
-- Add widget to default location [`eb1db4`](https://github.com/reearth/reearth-backend/commit/eb1db4)
-- Invalid extension data from GraphQL, plugin manifest schema improvement, more friendly error from manifest parser ([#56](https://github.com/reearth/reearth-backend/pull/56)) [`92d137`](https://github.com/reearth/reearth-backend/commit/92d137)
-- Translated fields in plugin gql [`0a658a`](https://github.com/reearth/reearth-backend/commit/0a658a)
-- Fallback widgetLocation [`579b7a`](https://github.com/reearth/reearth-backend/commit/579b7a)
+- Add mutex for each memory repo ([#2](https://github.com/reearth/reearth-visualizer-backend/pull/2)) [`f4c3b0`](https://github.com/reearth/reearth-visualizer-backend/commit/f4c3b0)
+- Auth0 audience in reearth_config.json [`72e3ed`](https://github.com/reearth/reearth-visualizer-backend/commit/72e3ed)
+- Auth0 domain and multiple auds [`835a02`](https://github.com/reearth/reearth-visualizer-backend/commit/835a02)
+- Signing up and deleting user [`f17b9d`](https://github.com/reearth/reearth-visualizer-backend/commit/f17b9d)
+- Deleting user [`e9b8c9`](https://github.com/reearth/reearth-visualizer-backend/commit/e9b8c9)
+- Sign up and update user [`e5ab87`](https://github.com/reearth/reearth-visualizer-backend/commit/e5ab87)
+- Make gql mutation payloads optional [`9b1c4a`](https://github.com/reearth/reearth-visualizer-backend/commit/9b1c4a)
+- Auth0 [`6a27c6`](https://github.com/reearth/reearth-visualizer-backend/commit/6a27c6)
+- Errors are be overwriten by tx [`2d08c5`](https://github.com/reearth/reearth-visualizer-backend/commit/2d08c5)
+- Deleting user [`f531bd`](https://github.com/reearth/reearth-visualizer-backend/commit/f531bd)
+- Always enable dev mode in debug [`0815d3`](https://github.com/reearth/reearth-visualizer-backend/commit/0815d3)
+- User deletion [`a5eeae`](https://github.com/reearth/reearth-visualizer-backend/commit/a5eeae)
+- Invisible layer issue in published project ([#7](https://github.com/reearth/reearth-visualizer-backend/pull/7)) [`06cd44`](https://github.com/reearth/reearth-visualizer-backend/commit/06cd44)
+- Dataset link merge bug #378 ([#18](https://github.com/reearth/reearth-visualizer-backend/pull/18)) [`25da0d`](https://github.com/reearth/reearth-visualizer-backend/commit/25da0d)
+- Ogp image for published page ([#17](https://github.com/reearth/reearth-visualizer-backend/pull/17)) [`dcb4b0`](https://github.com/reearth/reearth-visualizer-backend/commit/dcb4b0)
+- Change default value of marker label position [`a2059e`](https://github.com/reearth/reearth-visualizer-backend/commit/a2059e)
+- Import dataset from google sheet bug ([#23](https://github.com/reearth/reearth-visualizer-backend/pull/23)) [`077558`](https://github.com/reearth/reearth-visualizer-backend/commit/077558)
+- Public api param [`846957`](https://github.com/reearth/reearth-visualizer-backend/commit/846957)
+- Replace strings.Split() with strings.field() ([#25](https://github.com/reearth/reearth-visualizer-backend/pull/25)) [`ba7d16`](https://github.com/reearth/reearth-visualizer-backend/commit/ba7d16)
+- Project public image type [`e82b54`](https://github.com/reearth/reearth-visualizer-backend/commit/e82b54)
+- Published API ([#27](https://github.com/reearth/reearth-visualizer-backend/pull/27)) [`8ad1f8`](https://github.com/reearth/reearth-visualizer-backend/commit/8ad1f8)
+- Plugin manifest parser bugs ([#32](https://github.com/reearth/reearth-visualizer-backend/pull/32)) [`78ac13`](https://github.com/reearth/reearth-visualizer-backend/commit/78ac13)
+- Dataset layers are not exported correctly ([#36](https://github.com/reearth/reearth-visualizer-backend/pull/36)) [`0b8c00`](https://github.com/reearth/reearth-visualizer-backend/commit/0b8c00)
+- Hide parent infobox fields when child infobox is not nil ([#37](https://github.com/reearth/reearth-visualizer-backend/pull/37)) [`d8c8cd`](https://github.com/reearth/reearth-visualizer-backend/commit/d8c8cd)
+- Mongo.PropertySchema.FindByIDs, propertySchemaID.Equal [`be00da`](https://github.com/reearth/reearth-visualizer-backend/commit/be00da)
+- Gql propertySchemaGroup.translatedTitle resolver [`a4770e`](https://github.com/reearth/reearth-visualizer-backend/commit/a4770e)
+- Use PropertySchemaID.Equal [`8a6459`](https://github.com/reearth/reearth-visualizer-backend/commit/8a6459)
+- Use PropertySchemaID.Equal [`1c3cf1`](https://github.com/reearth/reearth-visualizer-backend/commit/1c3cf1)
+- Tweak field names of model primitive [`080ab9`](https://github.com/reearth/reearth-visualizer-backend/commit/080ab9)
+- Layer importing bug ([#41](https://github.com/reearth/reearth-visualizer-backend/pull/41)) [`02b17f`](https://github.com/reearth/reearth-visualizer-backend/commit/02b17f)
+- Skip nil geometries ([#42](https://github.com/reearth/reearth-visualizer-backend/pull/42)) [`90c327`](https://github.com/reearth/reearth-visualizer-backend/commit/90c327)
+- Validate widget extended when moved [`a7daf7`](https://github.com/reearth/reearth-visualizer-backend/commit/a7daf7)
+- Widget extended validation [`98db7e`](https://github.com/reearth/reearth-visualizer-backend/commit/98db7e)
+- Nil error in mongodoc plugin [`d236be`](https://github.com/reearth/reearth-visualizer-backend/commit/d236be)
+- Add widget to default location [`eb1db4`](https://github.com/reearth/reearth-visualizer-backend/commit/eb1db4)
+- Invalid extension data from GraphQL, plugin manifest schema improvement, more friendly error from manifest parser ([#56](https://github.com/reearth/reearth-visualizer-backend/pull/56)) [`92d137`](https://github.com/reearth/reearth-visualizer-backend/commit/92d137)
+- Translated fields in plugin gql [`0a658a`](https://github.com/reearth/reearth-visualizer-backend/commit/0a658a)
+- Fallback widgetLocation [`579b7a`](https://github.com/reearth/reearth-visualizer-backend/commit/579b7a)
 
 #### 📖 Documentation
 
-- Refine readme ([#28](https://github.com/reearth/reearth-backend/pull/28)) [`a9d209`](https://github.com/reearth/reearth-backend/commit/a9d209)
-- Add badges to readme [skip ci] [`cc63cd`](https://github.com/reearth/reearth-backend/commit/cc63cd)
+- Refine readme ([#28](https://github.com/reearth/reearth-visualizer-backend/pull/28)) [`a9d209`](https://github.com/reearth/reearth-visualizer-backend/commit/a9d209)
+- Add badges to readme [skip ci] [`cc63cd`](https://github.com/reearth/reearth-visualizer-backend/commit/cc63cd)
 
 #### ✨ Refactor
 
-- Remove unused code [`37b2c2`](https://github.com/reearth/reearth-backend/commit/37b2c2)
-- Pkg/error ([#31](https://github.com/reearth/reearth-backend/pull/31)) [`a3f8b6`](https://github.com/reearth/reearth-backend/commit/a3f8b6)
-- Graphql adapter ([#40](https://github.com/reearth/reearth-backend/pull/40)) [`2a1d4f`](https://github.com/reearth/reearth-backend/commit/2a1d4f)
-- Reorganize graphql schema ([#43](https://github.com/reearth/reearth-backend/pull/43)) [`d3360b`](https://github.com/reearth/reearth-backend/commit/d3360b)
+- Remove unused code [`37b2c2`](https://github.com/reearth/reearth-visualizer-backend/commit/37b2c2)
+- Pkg/error ([#31](https://github.com/reearth/reearth-visualizer-backend/pull/31)) [`a3f8b6`](https://github.com/reearth/reearth-visualizer-backend/commit/a3f8b6)
+- Graphql adapter ([#40](https://github.com/reearth/reearth-visualizer-backend/pull/40)) [`2a1d4f`](https://github.com/reearth/reearth-visualizer-backend/commit/2a1d4f)
+- Reorganize graphql schema ([#43](https://github.com/reearth/reearth-visualizer-backend/pull/43)) [`d3360b`](https://github.com/reearth/reearth-visualizer-backend/commit/d3360b)
 
 #### 🧪 Testing
 
-- Pkg/shp ([#5](https://github.com/reearth/reearth-backend/pull/5)) [`72ed8e`](https://github.com/reearth/reearth-backend/commit/72ed8e)
-- Pkg/id ([#4](https://github.com/reearth/reearth-backend/pull/4)) [`c31bdb`](https://github.com/reearth/reearth-backend/commit/c31bdb)
+- Pkg/shp ([#5](https://github.com/reearth/reearth-visualizer-backend/pull/5)) [`72ed8e`](https://github.com/reearth/reearth-visualizer-backend/commit/72ed8e)
+- Pkg/id ([#4](https://github.com/reearth/reearth-visualizer-backend/pull/4)) [`c31bdb`](https://github.com/reearth/reearth-visualizer-backend/commit/c31bdb)
 
 #### Miscellaneous Tasks
 
-- Enable nightly release workflow [`16c037`](https://github.com/reearth/reearth-backend/commit/16c037)
-- Set up workflows [`819639`](https://github.com/reearth/reearth-backend/commit/819639)
-- Fix workflows [`c022a4`](https://github.com/reearth/reearth-backend/commit/c022a4)
-- Print config [`0125aa`](https://github.com/reearth/reearth-backend/commit/0125aa)
-- Load .env instead of .env.local [`487a73`](https://github.com/reearth/reearth-backend/commit/487a73)
-- Add godoc workflow [`9629dd`](https://github.com/reearth/reearth-backend/commit/9629dd)
-- Fix godoc workflow [`cc45b5`](https://github.com/reearth/reearth-backend/commit/cc45b5)
-- Fix godoc workflow [`0db163`](https://github.com/reearth/reearth-backend/commit/0db163)
-- Fix godoc workflow [`9b78fc`](https://github.com/reearth/reearth-backend/commit/9b78fc)
-- Fix godoc workflow [`f1e5a7`](https://github.com/reearth/reearth-backend/commit/f1e5a7)
-- Fix godoc workflow [`f7866c`](https://github.com/reearth/reearth-backend/commit/f7866c)
-- Fix godoc workflow [`5bc089`](https://github.com/reearth/reearth-backend/commit/5bc089)
-- Fix godoc workflow [`5f808b`](https://github.com/reearth/reearth-backend/commit/5f808b)
-- Fix godoc workflow [`9f8e11`](https://github.com/reearth/reearth-backend/commit/9f8e11)
-- Fix godoc workflow [`150550`](https://github.com/reearth/reearth-backend/commit/150550)
-- Use go:embed ([#24](https://github.com/reearth/reearth-backend/pull/24)) [`f7866e`](https://github.com/reearth/reearth-backend/commit/f7866e)
-- Add internal error log [`41c377`](https://github.com/reearth/reearth-backend/commit/41c377)
-- Support multiple platform docker image [`3651e2`](https://github.com/reearth/reearth-backend/commit/3651e2)
-- Stop using upx as it doesn't work on arm64 [`3b5f93`](https://github.com/reearth/reearth-backend/commit/3b5f93)
-- Update golang version and modules ([#51](https://github.com/reearth/reearth-backend/pull/51)) [`33f4c7`](https://github.com/reearth/reearth-backend/commit/33f4c7)
-- Updating modules ([#62](https://github.com/reearth/reearth-backend/pull/62)) [`65ae32`](https://github.com/reearth/reearth-backend/commit/65ae32)
-- Add github workflows to release [`fbcdef`](https://github.com/reearth/reearth-backend/commit/fbcdef)
-- Fix release workflow, fix build comment [skip ci] [`cfc79a`](https://github.com/reearth/reearth-backend/commit/cfc79a)
-- Fix renaming file names in release workflow [`96f0b3`](https://github.com/reearth/reearth-backend/commit/96f0b3)
-- Fix and refactor release workflow [skip ci] [`d5466b`](https://github.com/reearth/reearth-backend/commit/d5466b)
+- Enable nightly release workflow [`16c037`](https://github.com/reearth/reearth-visualizer-backend/commit/16c037)
+- Set up workflows [`819639`](https://github.com/reearth/reearth-visualizer-backend/commit/819639)
+- Fix workflows [`c022a4`](https://github.com/reearth/reearth-visualizer-backend/commit/c022a4)
+- Print config [`0125aa`](https://github.com/reearth/reearth-visualizer-backend/commit/0125aa)
+- Load .env instead of .env.local [`487a73`](https://github.com/reearth/reearth-visualizer-backend/commit/487a73)
+- Add godoc workflow [`9629dd`](https://github.com/reearth/reearth-visualizer-backend/commit/9629dd)
+- Fix godoc workflow [`cc45b5`](https://github.com/reearth/reearth-visualizer-backend/commit/cc45b5)
+- Fix godoc workflow [`0db163`](https://github.com/reearth/reearth-visualizer-backend/commit/0db163)
+- Fix godoc workflow [`9b78fc`](https://github.com/reearth/reearth-visualizer-backend/commit/9b78fc)
+- Fix godoc workflow [`f1e5a7`](https://github.com/reearth/reearth-visualizer-backend/commit/f1e5a7)
+- Fix godoc workflow [`f7866c`](https://github.com/reearth/reearth-visualizer-backend/commit/f7866c)
+- Fix godoc workflow [`5bc089`](https://github.com/reearth/reearth-visualizer-backend/commit/5bc089)
+- Fix godoc workflow [`5f808b`](https://github.com/reearth/reearth-visualizer-backend/commit/5f808b)
+- Fix godoc workflow [`9f8e11`](https://github.com/reearth/reearth-visualizer-backend/commit/9f8e11)
+- Fix godoc workflow [`150550`](https://github.com/reearth/reearth-visualizer-backend/commit/150550)
+- Use go:embed ([#24](https://github.com/reearth/reearth-visualizer-backend/pull/24)) [`f7866e`](https://github.com/reearth/reearth-visualizer-backend/commit/f7866e)
+- Add internal error log [`41c377`](https://github.com/reearth/reearth-visualizer-backend/commit/41c377)
+- Support multiple platform docker image [`3651e2`](https://github.com/reearth/reearth-visualizer-backend/commit/3651e2)
+- Stop using upx as it doesn't work on arm64 [`3b5f93`](https://github.com/reearth/reearth-visualizer-backend/commit/3b5f93)
+- Update golang version and modules ([#51](https://github.com/reearth/reearth-visualizer-backend/pull/51)) [`33f4c7`](https://github.com/reearth/reearth-visualizer-backend/commit/33f4c7)
+- Updating modules ([#62](https://github.com/reearth/reearth-visualizer-backend/pull/62)) [`65ae32`](https://github.com/reearth/reearth-visualizer-backend/commit/65ae32)
+- Add github workflows to release [`fbcdef`](https://github.com/reearth/reearth-visualizer-backend/commit/fbcdef)
+- Fix release workflow, fix build comment [skip ci] [`cfc79a`](https://github.com/reearth/reearth-visualizer-backend/commit/cfc79a)
+- Fix renaming file names in release workflow [`96f0b3`](https://github.com/reearth/reearth-visualizer-backend/commit/96f0b3)
+- Fix and refactor release workflow [skip ci] [`d5466b`](https://github.com/reearth/reearth-visualizer-backend/commit/d5466b)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Re:Earth has adopted a Code of Conduct that we expect project participants to fo
 
 ## Good for First Issues
 
-To help you get your feet wet and get you familiar with our contribution process, we have [a list of good](https://github.com/reearth/reearth/projects/1#column-14917909) first issues that contain bugs which have a relatively limited scope. This is a great place to get started.
+To help you get your feet wet and get you familiar with our contribution process, we have [a list of good](https://github.com/reearth/reearth-visualizer/projects/1#column-14917909) first issues that contain bugs which have a relatively limited scope. This is a great place to get started.
 
 ## Bonus for Contributors
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <p align="center">
-  <a href="https://github.com/reearth/reearth">
+  <a href="https://github.com/reearth/reearth-visualizer">
     <img src="./public/reearth-logo.svg" alt="Logo" width="300" height="300">
   </a>
 </p>
 
-[![GitHub stars](https://img.shields.io/github/stars/reearth/reearth.svg?style=social&label=Star&maxAge=2592000)](https://github.com/reearth/reearth/stargazers/)
+[![GitHub stars](https://img.shields.io/github/stars/reearth/reearth.svg?style=social&label=Star&maxAge=2592000)](https://github.com/reearth/reearth-visualizer/stargazers/)
 [![issues](https://img.shields.io/github/issues/reearth/reearth)](https://img.shields.io/github/issues/reearth/reearth)
-[![license](https://img.shields.io/github/license/reearth/reearth)](https://github.com/reearth/reearth/blob/main/LICENSE)
-[![release](https://img.shields.io/github/release/reearth/reearth.svg)](https://GitHub.com/reearth/reearth/releases/)
-[![discussions](https://img.shields.io/badge/discussion-welcome-green.svg)](https://github.com/reearth/reearth/discussions)
+[![license](https://img.shields.io/github/license/reearth/reearth)](https://github.com/reearth/reearth-visualizer/blob/main/LICENSE)
+[![release](https://img.shields.io/github/release/reearth/reearth.svg)](https://github.com/reearth/reearth-visualizer/releases/)
+[![discussions](https://img.shields.io/badge/discussion-welcome-green.svg)](https://github.com/reearth/reearth-visualizer/discussions)
 [![chat](https://img.shields.io/discord/870497079166910514?color=%237289DA&logo=discord)](https://discord.gg/Q6kmXnywfw)
 
 <p align="center">
@@ -18,9 +18,9 @@
   ·
   <a href="https://www.figma.com/community/file/1027048965458642686">Figma</a>
   ·
-  <a href="https://github.com/reearth/reearth/issues">Issues</a>
+  <a href="https://github.com/reearth/reearth-visualizer/issues">Issues</a>
   ·
-  <a href="https://github.com/reearth/reearth/discussions">Discussions</a>
+  <a href="https://github.com/reearth/reearth-visualizer/discussions">Discussions</a>
   ·
   <a href="https://discord.gg/XJhYkQQDAu">Discord</a>
 </p>
@@ -75,12 +75,12 @@ We also maintain a cloud service [here](https://reearth.io/), which can help you
 
 ## Roadmap
 
-See the [Roadmap](https://github.com/reearth/reearth/projects/1) for a list of proposed features (and known issues).
-If your have any requests for features, they are more than welcome! Just create an issue [here](https://github.com/reearth/reearth/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) with the `feature request` tag.
+See the [Roadmap](https://github.com/reearth/reearth-visualizer/projects/1) for a list of proposed features (and known issues).
+If your have any requests for features, they are more than welcome! Just create an issue [here](https://github.com/reearth/reearth-visualizer/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) with the `feature request` tag.
 
 ## Community
 
-- [Discussions](https://github.com/reearth/reearth/discussions)
+- [Discussions](https://github.com/reearth/reearth-visualizer/discussions)
 - [Discord](https://discord.gg/Q6kmXnywfw): Feel free to come in!
 
 ## Contributing
@@ -89,7 +89,7 @@ See [the contributing guide](contributing.md).
 
 ## Contributers
 
-[![Contributers](https://contrib.rocks/image?repo=reearth/reearth)](https://github.com/reearth/reearth/graphs/contributors)
+[![Contributers](https://contrib.rocks/image?repo=reearth/reearth)](https://github.com/reearth/reearth-visualizer/graphs/contributors)
 
 Made with [contrib.rocks](https://contrib.rocks).
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,4 +1,4 @@
-[![ci-server](https://github.com/reearth/reearth-visualizer-visualizer/actions/workflows/ci_server.yml/badge.svg)](https://github.com/reearth/reearth-visualizer/actions/workflows/ci_server.yml) [![codecov](https://codecov.io/gh/reearth/reearth/branch/main/graph/badge.svg?flag=server)](https://codecov.io/gh/reearth/reearth)
+[![ci-server](https://github.com/reearth/reearth-visualizer/actions/workflows/ci_server.yml/badge.svg)](https://github.com/reearth/reearth-visualizer/actions/workflows/ci_server.yml) [![codecov](https://codecov.io/gh/reearth/reearth/branch/main/graph/badge.svg?flag=server)](https://codecov.io/gh/reearth/reearth)
 
 # reearth/server
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,4 +1,4 @@
-[![ci-server](https://github.com/reearth/reearth/actions/workflows/ci_server.yml/badge.svg)](https://github.com/reearth/reearth/actions/workflows/ci_server.yml) [![codecov](https://codecov.io/gh/reearth/reearth/branch/main/graph/badge.svg?flag=server)](https://codecov.io/gh/reearth/reearth)
+[![ci-server](https://github.com/reearth/reearth-visualizer-visualizer-visualizer/actions/workflows/ci_server.yml/badge.svg)](https://github.com/reearth/reearth-visualizer/actions/workflows/ci_server.yml) [![codecov](https://codecov.io/gh/reearth/reearth/branch/main/graph/badge.svg?flag=server)](https://codecov.io/gh/reearth/reearth)
 
 # reearth/server
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,4 +1,4 @@
-[![ci-server](https://github.com/reearth/reearth-visualizer-visualizer-visualizer/actions/workflows/ci_server.yml/badge.svg)](https://github.com/reearth/reearth-visualizer/actions/workflows/ci_server.yml) [![codecov](https://codecov.io/gh/reearth/reearth/branch/main/graph/badge.svg?flag=server)](https://codecov.io/gh/reearth/reearth)
+[![ci-server](https://github.com/reearth/reearth-visualizer-visualizer/actions/workflows/ci_server.yml/badge.svg)](https://github.com/reearth/reearth-visualizer/actions/workflows/ci_server.yml) [![codecov](https://codecov.io/gh/reearth/reearth/branch/main/graph/badge.svg?flag=server)](https://codecov.io/gh/reearth/reearth)
 
 # reearth/server
 

--- a/web/.storybook/theme.ts
+++ b/web/.storybook/theme.ts
@@ -5,7 +5,7 @@ export default create({
   fontBase: '"Open Sans", sans-serif',
   fontCode: "monospace",
   brandTitle: "Re:Earth",
-  brandUrl: "https://github.com/reearth/reearth",
+  brandUrl: "https://github.com/reearth/reearth-visualizer",
   brandImage: "/logo.svg",
   brandTarget: "_self",
   colorPrimary: "#E95518",

--- a/web/README.md
+++ b/web/README.md
@@ -1,4 +1,4 @@
-[![ci-web](https://github.com/reearth/reearth/actions/workflows/ci_web.yml/badge.svg)](https://github.com/reearth/reearth/actions/workflows/ci_web.yml) [![codecov](https://codecov.io/gh/reearth/reearth/branch/main/graph/badge.svg?flag=web-beta,web-utils,web-classic)](https://codecov.io/gh/reearth/reearth)
+[![ci-web](https://github.com/reearth/reearth-visualizer/actions/workflows/ci_web.yml/badge.svg)](https://github.com/reearth/reearth-visualizer/actions/workflows/ci_web.yml) [![codecov](https://codecov.io/gh/reearth/reearth/branch/main/graph/badge.svg?flag=web-beta,web-utils,web-classic)](https://codecov.io/gh/reearth/reearth)
 
 # reearth/web
 Documentation (coming soon)

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "@reearth/web",
+    "name": "@reearth/visualizer",
     "version": "0.20.0",
-    "repository": "https://github.com/reearth/reearth.git",
+    "repository": "https://github.com/reearth/reearth-visualizer.git",
     "author": "Re:Earth contributors <community@reearth.io>",
     "license": "Apache-2.0",
     "type": "module",

--- a/web/src/beta/features/ProjectSettings/innerPages/PluginSettings/PluginInstall/PublicRepo/hooks.test.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PluginSettings/PluginInstall/PublicRepo/hooks.test.tsx
@@ -6,8 +6,8 @@ test("should validate url", () => {
   const wrongUrl1 = "https://google.com";
   const wrongUrl2 = "";
   const wrongUrl3 = "https://github.com";
-  const correctUrl1 = "https://github.com/reearth/reearth";
-  const correctUrl2 = "https://github.com/reearth/reearth-web";
+  const correctUrl1 = "https://github.com/reearth/reearth-visualizer";
+  const correctUrl2 = "https://github.com/reearth/reearth-visualizer-web";
   expect(validateUrl(wrongUrl1).result).toBe(false);
   expect(validateUrl(wrongUrl2).result).toBe(false);
   expect(validateUrl(wrongUrl3).result).toBe(false);

--- a/web/src/classic/components/molecules/Settings/Project/Plugin/PluginSection/PluginInstall/PublicRepo/hooks.test.tsx
+++ b/web/src/classic/components/molecules/Settings/Project/Plugin/PluginSection/PluginInstall/PublicRepo/hooks.test.tsx
@@ -6,8 +6,8 @@ test("should validate url", () => {
   const wrongUrl1 = "https://google.com";
   const wrongUrl2 = "";
   const wrongUrl3 = "https://github.com";
-  const correctUrl1 = "https://github.com/reearth/reearth";
-  const correctUrl2 = "https://github.com/reearth/reearth-web";
+  const correctUrl1 = "https://github.com/reearth/reearth-visualizer";
+  const correctUrl2 = "https://github.com/reearth/reearth-visualizer-web";
   expect(validateUrl(wrongUrl1).result).toBe(false);
   expect(validateUrl(wrongUrl2).result).toBe(false);
   expect(validateUrl(wrongUrl3).result).toBe(false);


### PR DESCRIPTION
# Overview
This PR renames `reearth/reearth` repo to `reearth/reearth-visualizer` in this repo.
