### PR TITLE
chore: revert addition of `--force` to push to protected branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,4 +54,4 @@ jobs:
           git tag $TAG
           git push --atomic origin release $TAG
       - name: Commit & push to main
-        run: git switch main && git cherry-pick release && git push --force
+        run: git switch main && git cherry-pick release && git push

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Merge main branch to release branch
         run: git merge -X theirs main
       - name: Git push
-        run: git push origin release --force
+        run: git push origin release


### PR DESCRIPTION
Reverts reearth/reearth-visualizer#1003

Because updating the protection branch was enough 👉 https://github.com/reearth/reearth-visualizer/actions/runs/9359266662