### PR TITLE
chore: remove no need force for git push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,4 +54,4 @@ jobs:
           git tag $TAG
           git push --atomic origin release $TAG
       - name: Commit & push to main
-        run: git switch main && git cherry-pick release && git push  --force
+        run: git switch main && git cherry-pick release && git push

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Merge main branch to release branch
         run: git merge -X theirs main
       - name: Git push
-        run: git push origin release --force
+        run: git push origin release


### PR DESCRIPTION
# Overview

Because it was just for testing and PoC-ing.

## What I've done

Remove the `--force` option.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
