### PR TITLE
chore(web): missing visualizerRef on published page

### DIFF
--- a/web/src/beta/features/PublishedVisualizer/hooks.ts
+++ b/web/src/beta/features/PublishedVisualizer/hooks.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 
 import {
   InternalWidget,
@@ -8,6 +8,7 @@ import {
   isBuiltinWidget,
 } from "@reearth/beta/features/Visualizer/Crust";
 import { Story } from "@reearth/beta/features/Visualizer/StoryPanel";
+import { MapRef } from "@reearth/core";
 import { config } from "@reearth/services/config";
 
 import { processProperty } from "./convert";
@@ -22,6 +23,7 @@ import type {
 } from "./types";
 
 export default (alias?: string) => {
+  const visualizerRef = useRef<MapRef | null>(null);
   const [data, setData] = useState<PublishedData>();
   const [ready, setReady] = useState(false);
   const [error, setError] = useState(false);
@@ -248,6 +250,7 @@ export default (alias?: string) => {
     ready,
     error,
     engineMeta,
+    visualizerRef,
   };
 };
 

--- a/web/src/beta/features/PublishedVisualizer/index.tsx
+++ b/web/src/beta/features/PublishedVisualizer/index.tsx
@@ -10,8 +10,17 @@ export type Props = {
 
 export default function Published({ alias }: Props) {
   const t = useT();
-  const { sceneProperty, pluginProperty, layers, widgets, story, ready, error, engineMeta } =
-    useHooks(alias);
+  const {
+    sceneProperty,
+    pluginProperty,
+    layers,
+    widgets,
+    story,
+    ready,
+    error,
+    engineMeta,
+    visualizerRef,
+  } = useHooks(alias);
 
   return error ? (
     <NotFound
@@ -20,6 +29,7 @@ export default function Published({ alias }: Props) {
     />
   ) : (
     <Visualizer
+      visualizerRef={visualizerRef}
       engine="cesium"
       engineMeta={engineMeta}
       isBuilt


### PR DESCRIPTION
# Overview

visualizerRef is required for plugins, it was missing in previous refactor around split core.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
