### PR TITLE
chore(web): missing prop currentCamera for story built-in blocks

### DIFF
--- a/web/src/beta/features/Visualizer/StoryPanel/Page/index.tsx
+++ b/web/src/beta/features/Visualizer/StoryPanel/Page/index.tsx
@@ -1,7 +1,7 @@
 import { Fragment, MutableRefObject, ReactNode, useEffect } from "react";
 
 import DragAndDropList from "@reearth/beta/components/DragAndDropList";
-import type { ValueType, ValueTypes } from "@reearth/beta/utils/value";
+import type { Camera, ValueType, ValueTypes } from "@reearth/beta/utils/value";
 import type { InstallableStoryBlock } from "@reearth/services/api/storytellingApi/blocks";
 import { useT } from "@reearth/services/i18n";
 import { styled } from "@reearth/services/theme";
@@ -29,6 +29,7 @@ type Props = {
   isEditable?: boolean;
   isAutoScrolling?: MutableRefObject<boolean>;
   scrollTimeoutRef: MutableRefObject<NodeJS.Timeout | undefined>;
+  currentCamera?: Camera;
   children?: ReactNode;
   onCurrentPageChange?: (pageId: string, disableScrollIntoView?: boolean) => void;
   onPageSettingsToggle?: () => void;
@@ -73,6 +74,7 @@ const StoryPanel: React.FC<Props> = ({
   isEditable,
   scrollTimeoutRef,
   isAutoScrolling,
+  currentCamera,
   children,
   onCurrentPageChange,
   onPageSettingsToggle,
@@ -175,6 +177,7 @@ const StoryPanel: React.FC<Props> = ({
               }}
               isEditable={isEditable}
               isSelected={selectedStoryBlockId === titleId}
+              currentCamera={currentCamera}
               onClick={() => onBlockSelect?.(titleId)}
               onBlockDoubleClick={() => onBlockDoubleClick?.(titleId)}
               onClickAway={onBlockSelect}
@@ -224,6 +227,7 @@ const StoryPanel: React.FC<Props> = ({
                     pageId={page?.id}
                     isSelected={selectedStoryBlockId === b.id}
                     isEditable={isEditable}
+                    currentCamera={currentCamera}
                     onClick={() => onBlockSelect?.(b.id)}
                     onBlockDoubleClick={() => onBlockDoubleClick?.(b.id)}
                     onClickAway={onBlockSelect}

--- a/web/src/beta/features/Visualizer/StoryPanel/PanelContent/index.tsx
+++ b/web/src/beta/features/Visualizer/StoryPanel/PanelContent/index.tsx
@@ -1,6 +1,6 @@
 import { MutableRefObject } from "react";
 
-import { ValueType, ValueTypes } from "@reearth/beta/utils/value";
+import { Camera, ValueType, ValueTypes } from "@reearth/beta/utils/value";
 import type { InstallableStoryBlock } from "@reearth/services/api/storytellingApi/blocks";
 import { styled } from "@reearth/services/theme";
 
@@ -17,6 +17,7 @@ export type Props = {
   showingIndicator?: boolean;
   isAutoScrolling?: MutableRefObject<boolean>;
   isEditable?: boolean;
+  currentCamera?: Camera;
   onPageSettingsToggle?: () => void;
   onPageSelect?: (pageId?: string | undefined) => void;
   onCurrentPageChange?: (pageId: string, disableScrollIntoView?: boolean) => void;
@@ -61,6 +62,7 @@ const StoryContent: React.FC<Props> = ({
   showingIndicator,
   isAutoScrolling,
   isEditable,
+  currentCamera,
   onPageSettingsToggle,
   onPageSelect,
   onCurrentPageChange,
@@ -94,6 +96,7 @@ const StoryContent: React.FC<Props> = ({
           selectedStoryBlockId={selectedStoryBlockId}
           showPageSettings={showPageSettings}
           isEditable={isEditable}
+          currentCamera={currentCamera}
           scrollTimeoutRef={scrollTimeoutRef}
           isAutoScrolling={isAutoScrolling}
           onCurrentPageChange={onCurrentPageChange}

--- a/web/src/beta/features/Visualizer/StoryPanel/index.tsx
+++ b/web/src/beta/features/Visualizer/StoryPanel/index.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, memo, Ref, RefObject, useMemo } from "react";
 import { createPortal } from "react-dom";
 
-import { ValueType, ValueTypes } from "@reearth/beta/utils/value";
+import { Camera, ValueType, ValueTypes } from "@reearth/beta/utils/value";
 import { styled } from "@reearth/services/theme";
 
 import { BlockProvider } from "../shared/contexts/blockContext";
@@ -25,6 +25,7 @@ export type StoryPanelProps = {
   selectedStory?: Story;
   isEditable?: boolean;
   installableStoryBlocks?: InstallableStoryBlock[];
+  currentCamera?: Camera;
   onStoryPageChange?: (id?: string, disableScrollIntoView?: boolean) => void;
   onStoryBlockCreate?: (
     pageId?: string | undefined,
@@ -64,6 +65,7 @@ export const StoryPanel = memo(
         selectedStory,
         isEditable,
         installableStoryBlocks,
+        currentCamera,
         onStoryPageChange,
         onStoryBlockCreate,
         onStoryBlockMove,
@@ -157,6 +159,7 @@ export const StoryPanel = memo(
                       showingIndicator={!!pageInfo}
                       isAutoScrolling={isAutoScrolling}
                       isEditable={isEditable}
+                      currentCamera={currentCamera}
                       onPageSettingsToggle={handlePageSettingsToggle}
                       onPageSelect={handlePageSelect}
                       onCurrentPageChange={handleCurrentPageChange}

--- a/web/src/beta/features/Visualizer/index.tsx
+++ b/web/src/beta/features/Visualizer/index.tsx
@@ -211,6 +211,7 @@ const Visualizer: FC<VisualizerProps> = ({
             selectedStory={story}
             installableStoryBlocks={installableStoryBlocks}
             isEditable={!!inEditor}
+            currentCamera={currentCamera}
             onStoryPageChange={handleStoryPageChange}
             onStoryBlockCreate={handleStoryBlockCreate}
             onStoryBlockDelete={handleStoryBlockDelete}


### PR DESCRIPTION
# Overview

It was missing when refactor the global jotai state.

## What I've done

## What I haven't done

## How I tested

Test the camera block on story page

## Which point I want you to review particularly

## Memo
