### PR TITLE
chore: remove deprecated husky command

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
         "test": "vitest",
         "coverage": "vitest --coverage",
         "e2e": "playwright test",
-        "prepare": "cd .. && husky install web/.husky",
+        "prepare": "cd .. && husky web/.husky",
         "build": "vite build",
         "build:preview": "run-s build storybook:build",
         "clean": "del coverage dist node_modules/.cache",


### PR DESCRIPTION
# Overview
`husky install ...` command is deprecated. Also, this is a small PR to make sure I can push commits hence the PR.
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
