### PR TITLE
feat(server): add coresupport as story and project metadata field

### DIFF
--- a/server/internal/usecase/interfaces/published.go
+++ b/server/internal/usecase/interfaces/published.go
@@ -14,6 +14,7 @@ type HasPublicMeta interface {
 	IsBasicAuthActive() bool
 	BasicAuthUsername() string
 	BasicAuthPassword() string
+	CoreSupport() bool
 }
 
 type ProjectPublishedMetadata struct {
@@ -24,6 +25,7 @@ type ProjectPublishedMetadata struct {
 	IsBasicAuthActive bool   `json:"isBasicAuthActive,omitempty"`
 	BasicAuthUsername string `json:"basicAuthUsername,omitempty"`
 	BasicAuthPassword string `json:"basicAuthPassword,omitempty"`
+	CoreSupport       bool   `json:"coreSupport,omitempty"`
 }
 
 func PublishedMetadataFrom(i HasPublicMeta) ProjectPublishedMetadata {
@@ -35,6 +37,7 @@ func PublishedMetadataFrom(i HasPublicMeta) ProjectPublishedMetadata {
 		IsBasicAuthActive: i.IsBasicAuthActive(),
 		BasicAuthUsername: i.BasicAuthUsername(),
 		BasicAuthPassword: i.BasicAuthPassword(),
+		CoreSupport:       i.CoreSupport(),
 	}
 }
 

--- a/server/pkg/storytelling/story.go
+++ b/server/pkg/storytelling/story.go
@@ -26,6 +26,7 @@ type Story struct {
 	panelPosition Position
 	bgColor       string
 	updatedAt     time.Time
+	coreSupport   bool
 
 	alias             string
 	status            PublishmentStatus
@@ -99,6 +100,10 @@ func (s *Story) BasicAuthPassword() string {
 
 func (s *Story) PublicTitle() string {
 	return s.publicTitle
+}
+
+func (s *Story) CoreSupport() bool {
+	return s.coreSupport
 }
 
 func (s *Story) SetPublicDescription(publicDescription string) {

--- a/server/pkg/storytelling/story_bulider.go
+++ b/server/pkg/storytelling/story_bulider.go
@@ -22,6 +22,7 @@ func (b *StoryBuilder) Build() (*Story, error) {
 	if len(b.s.panelPosition) == 0 {
 		b.s.panelPosition = PositionLeft
 	}
+	b.s.coreSupport = true
 	return b.s, nil
 }
 

--- a/server/pkg/storytelling/story_bulider_test.go
+++ b/server/pkg/storytelling/story_bulider_test.go
@@ -60,6 +60,7 @@ func TestStoryBuilder(t *testing.T) {
 		isBasicAuthActive: true,
 		basicAuthUsername: "user",
 		basicAuthPassword: "pass",
+		coreSupport:       true,
 	}, s)
 
 	now := util.Now()


### PR DESCRIPTION
# Overview
This PR adds `coreSupport` as one of the Project and Story's Published Meta Data field.