### PR TITLE
feat(web): basic structure of plugin playground

### DIFF
--- a/web/src/beta/features/Editor/Map/index.tsx
+++ b/web/src/beta/features/Editor/Map/index.tsx
@@ -24,7 +24,7 @@ const Map: FC = () => {
           <LayersPanel />
         </Area>
         <Area direction="column" extend asWrapper>
-          <Area height={34}>
+          <Area initialHeight={34}>
             <ToolsPanel />
           </Area>
           <Area extend onResize={handleVisualizerResize} windowRef={windowRef} passive />

--- a/web/src/beta/features/Editor/Publish/index.tsx
+++ b/web/src/beta/features/Editor/Publish/index.tsx
@@ -13,7 +13,7 @@ const Publish: FC = () => {
     <Window ref={windowRef}>
       <Area extend asWrapper>
         <Area direction="column" extend asWrapper>
-          <Area height={34}>
+          <Area initialHeight={34}>
             <PublishToolsPanel />
           </Area>
           <Area extend onResize={handleVisualizerResize} windowRef={windowRef} passive />

--- a/web/src/beta/features/Editor/Widgets/index.tsx
+++ b/web/src/beta/features/Editor/Widgets/index.tsx
@@ -18,7 +18,7 @@ const Widgets: FC = () => {
     <Window ref={windowRef}>
       <Area extend asWrapper>
         <Area direction="column" extend asWrapper>
-          <Area height={34}>
+          <Area initialHeight={34}>
             <WASToolsPanel />
           </Area>
           <Area extend onResize={handleVisualizerResize} windowRef={windowRef} passive />

--- a/web/src/beta/features/PluginPlayground/Console/index.tsx
+++ b/web/src/beta/features/PluginPlayground/Console/index.tsx
@@ -1,0 +1,7 @@
+import { FC } from "react";
+
+const Console: FC = () => {
+  return <div>Console content</div>;
+};
+
+export default Console;

--- a/web/src/beta/features/PluginPlayground/PluginInspector/index.tsx
+++ b/web/src/beta/features/PluginPlayground/PluginInspector/index.tsx
@@ -1,0 +1,7 @@
+import { FC } from "react";
+
+const PluginInspector: FC = () => {
+  return <div>Plugin inspector content</div>;
+};
+
+export default PluginInspector;

--- a/web/src/beta/features/PluginPlayground/Plugins/index.tsx
+++ b/web/src/beta/features/PluginPlayground/Plugins/index.tsx
@@ -1,0 +1,7 @@
+import { FC } from "react";
+
+const Plugins: FC = () => {
+  return <div>Plugins content</div>;
+};
+
+export default Plugins;

--- a/web/src/beta/features/PluginPlayground/Viewer/hooks.ts
+++ b/web/src/beta/features/PluginPlayground/Viewer/hooks.ts
@@ -1,0 +1,44 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { Camera } from "@reearth/beta/utils/value";
+import { MapRef } from "@reearth/core";
+import { config } from "@reearth/services/config";
+
+export default () => {
+  // Refrence: hooks of Editor/Visualizer/hooks.ts and Publish/hooks.ts
+  const visualizerRef = useRef<MapRef | null>(null);
+  const [ready, setReady] = useState(false);
+  const [currentCamera, setCurrentCamera] = useState<Camera | undefined>(undefined);
+
+  const engineMeta = useMemo(
+    () => ({
+      cesiumIonAccessToken: config()?.cesiumIonAccessToken,
+    }),
+    [],
+  );
+
+  const sceneProperty = useMemo(
+    () => ({
+      tiles: [
+        {
+          id: "default",
+          type: "default",
+        },
+      ],
+    }),
+    [],
+  );
+
+  useEffect(() => {
+    setReady(true);
+  }, []);
+
+  return {
+    visualizerRef,
+    sceneProperty,
+    ready,
+    engineMeta,
+    currentCamera,
+    setCurrentCamera,
+  };
+};

--- a/web/src/beta/features/PluginPlayground/Viewer/index.tsx
+++ b/web/src/beta/features/PluginPlayground/Viewer/index.tsx
@@ -1,0 +1,24 @@
+import { FC } from "react";
+
+import Visualizer from "@reearth/beta/features/Visualizer";
+
+import useHooks from "./hooks";
+
+const Viewer: FC = () => {
+  const { visualizerRef, sceneProperty, ready, engineMeta, currentCamera, setCurrentCamera } =
+    useHooks();
+
+  return (
+    <Visualizer
+      engine="cesium"
+      visualizerRef={visualizerRef}
+      sceneProperty={sceneProperty}
+      ready={ready}
+      engineMeta={engineMeta}
+      currentCamera={currentCamera}
+      onCameraChange={setCurrentCamera}
+    />
+  );
+};
+
+export default Viewer;

--- a/web/src/beta/features/PluginPlayground/hooks.tsx
+++ b/web/src/beta/features/PluginPlayground/hooks.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+
+import { TabItem } from "@reearth/beta/lib/reearth-ui";
+
+import Console from "./Console";
+import PluginInspector from "./PluginInspector";
+import Plugins from "./Plugins";
+import Viewer from "./Viewer";
+
+export default () => {
+  // Note: currently we put visualizer in tab content, so better not have more tabs in this area,
+  // otherwise visualizer will got unmount and mount when switching tabs.
+  const MainAreaTabs: TabItem[] = useMemo(
+    () => [
+      {
+        id: "viewer",
+        name: "Viewer",
+        children: <Viewer />,
+      },
+    ],
+    [],
+  );
+
+  const BottomAreaTabs: TabItem[] = useMemo(
+    () => [
+      {
+        id: "console",
+        name: "Console",
+        children: <Console />,
+      },
+    ],
+    [],
+  );
+
+  const SubRightAreaTabs: TabItem[] = useMemo(
+    () => [
+      {
+        id: "plugins",
+        name: "Plugins",
+        children: <Plugins />,
+      },
+    ],
+    [],
+  );
+
+  const RightAreaTabs: TabItem[] = useMemo(
+    () => [
+      {
+        id: "plugin-inspector",
+        name: "Plugin Inspector",
+        children: <PluginInspector />,
+      },
+    ],
+    [],
+  );
+
+  return {
+    MainAreaTabs,
+    BottomAreaTabs,
+    SubRightAreaTabs,
+    RightAreaTabs,
+  };
+};

--- a/web/src/beta/features/PluginPlayground/index.tsx
+++ b/web/src/beta/features/PluginPlayground/index.tsx
@@ -1,0 +1,33 @@
+import { FC } from "react";
+
+import { Tabs } from "@reearth/beta/lib/reearth-ui";
+import { Area, Window } from "@reearth/beta/ui/layout";
+
+import useHooks from "./hooks";
+
+const PluginPlayground: FC = () => {
+  const { MainAreaTabs, BottomAreaTabs, SubRightAreaTabs, RightAreaTabs } = useHooks();
+
+  return (
+    <Window>
+      <Area extend asWrapper>
+        <Area direction="column" extend asWrapper>
+          <Area extend>
+            <Tabs position="top" tabs={MainAreaTabs} />
+          </Area>
+          <Area resizableEdge="top" height={100} storageId="plugin-playground-bottom-area">
+            <Tabs position="top" tabs={BottomAreaTabs} />
+          </Area>
+        </Area>
+        <Area direction="column" resizableEdge="left" storageId="plugin-playground-sub-right-area">
+          <Tabs position="top" tabs={SubRightAreaTabs} />
+        </Area>
+        <Area direction="column" resizableEdge="left" storageId="plugin-playground-right-area">
+          <Tabs position="top" tabs={RightAreaTabs} />
+        </Area>
+      </Area>
+    </Window>
+  );
+};
+
+export default PluginPlayground;

--- a/web/src/beta/features/PluginPlayground/index.tsx
+++ b/web/src/beta/features/PluginPlayground/index.tsx
@@ -15,7 +15,7 @@ const PluginPlayground: FC = () => {
           <Area extend>
             <Tabs position="top" tabs={MainAreaTabs} />
           </Area>
-          <Area resizableEdge="top" height={100} storageId="plugin-playground-bottom-area">
+          <Area resizableEdge="top" initialHeight={100} storageId="plugin-playground-bottom-area">
             <Tabs position="top" tabs={BottomAreaTabs} />
           </Area>
         </Area>

--- a/web/src/beta/lib/reearth-ui/components/Tabs/index.stories.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Tabs/index.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { FC, useCallback, useState } from "react";
+import { FC } from "react";
 
-import { TabItems, Tabs as TabsMenu, TabsProps } from ".";
+import { TabItem, Tabs as TabsMenu, TabsProps } from ".";
 
 const meta: Meta<TabsProps> = {
   component: TabsMenu,
@@ -12,23 +12,10 @@ export default meta;
 type Story = StoryObj<TabsProps>;
 
 const Tabs: FC<TabsProps> = ({ position, tabs, tabStyle }) => {
-  const [activeTab, setActiveTab] = useState("tab1");
-  const handleTabChange = useCallback((newTab: string) => {
-    setActiveTab(newTab);
-  }, []);
-
-  return (
-    <TabsMenu
-      position={position}
-      activeTab={activeTab}
-      tabStyle={tabStyle}
-      tabs={tabs}
-      onChange={handleTabChange}
-    />
-  );
+  return <TabsMenu position={position} tabStyle={tabStyle} tabs={tabs} />;
 };
 
-const tabsItem: TabItems[] = [
+const tabsItem: TabItem[] = [
   {
     id: "tab1",
     name: "Tab One",
@@ -52,7 +39,7 @@ const tabsItem: TabItems[] = [
   },
 ];
 
-const tabsIcons: TabItems[] = [
+const tabsIcons: TabItem[] = [
   {
     id: "tab1",
     icon: "data",

--- a/web/src/beta/lib/reearth-ui/components/Tabs/index.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Tabs/index.tsx
@@ -1,9 +1,9 @@
-import { FC, ReactNode, useMemo } from "react";
+import { FC, ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 
 import { Icon, IconName, Typography } from "@reearth/beta/lib/reearth-ui";
 import { styled, useTheme } from "@reearth/services/theme";
 
-export type TabItems = {
+export type TabItem = {
   id: string;
   name?: string;
   icon?: IconName;
@@ -11,10 +11,10 @@ export type TabItems = {
 };
 
 export type TabsProps = {
-  tabs: TabItems[];
+  tabs: TabItem[];
   position?: "top" | "left";
   tabStyle?: "normal" | "separated";
-  activeTab?: string;
+  currentTab?: string;
   onChange?: (tab: string) => void;
 };
 
@@ -22,10 +22,27 @@ export const Tabs: FC<TabsProps> = ({
   tabs,
   position = "top",
   tabStyle = "normal",
-  activeTab,
+  currentTab,
   onChange,
 }) => {
+  const [activeTab, setActiveTab] = useState(currentTab ?? tabs[0].id);
+
+  const handleTabChange = useCallback(
+    (newTab: string) => {
+      setActiveTab(newTab);
+      onChange?.(newTab);
+    },
+    [onChange],
+  );
+
+  useEffect(() => {
+    if (currentTab) {
+      setActiveTab(currentTab);
+    }
+  }, [currentTab]);
+
   const theme = useTheme();
+
   const selectedTabItem = useMemo(() => {
     return tabs.find(({ id }) => id === activeTab);
   }, [activeTab, tabs]);
@@ -36,7 +53,7 @@ export const Tabs: FC<TabsProps> = ({
         {tabs.map(({ id, icon, name }) => (
           <Tab
             key={id}
-            onClick={() => onChange?.(id)}
+            onClick={() => handleTabChange?.(id)}
             selected={id === activeTab}
             position={position}
             tabStyle={tabStyle}>
@@ -67,6 +84,7 @@ const Wrapper = styled("div")<{ position?: "top" | "left" }>(({ position, theme 
   flexFlow: position === "top" ? "column nowrap" : "row nowrap",
   background: theme.bg[1],
   height: "100%",
+  width: "100%",
 }));
 
 const TabsMenu = styled("div")<{ position?: "top" | "left"; tabStyle?: "normal" | "separated" }>(
@@ -98,5 +116,7 @@ const Tab = styled("div")<{
 
 const Content = styled("div")(({ theme }) => ({
   padding: theme.spacing.normal,
-  height: "auto",
+  height: "100%",
+  width: "100%",
+  minHeight: 0,
 }));

--- a/web/src/beta/lib/reearth-ui/components/index.ts
+++ b/web/src/beta/lib/reearth-ui/components/index.ts
@@ -20,3 +20,4 @@ export * from "./IconButton";
 export * from "./Selector";
 export * from "./PopupMenu";
 export * from "./DragAndDropList";
+export * from "./Tabs";

--- a/web/src/beta/pages/PluginPlaygroundPage/index.tsx
+++ b/web/src/beta/pages/PluginPlaygroundPage/index.tsx
@@ -1,0 +1,9 @@
+import PluginPlayground from "@reearth/beta/features/PluginPlayground";
+
+type Props = {};
+
+const PluginPlaygroundPage: React.FC<Props> = () => {
+  return <PluginPlayground />;
+};
+
+export default PluginPlaygroundPage;

--- a/web/src/beta/ui/layout/Area/index.stories.tsx
+++ b/web/src/beta/ui/layout/Area/index.stories.tsx
@@ -26,7 +26,7 @@ export const Default: StoryObj<typeof Area> = {
           Left
         </Area>
         <Area direction="column" extend asWrapper>
-          <Area height={50} backgroundColor={colors[1]}>
+          <Area initialHeight={50} backgroundColor={colors[1]}>
             Center-Top
           </Area>
           <Area extend backgroundColor={colors[2]}>
@@ -55,7 +55,7 @@ export const Complicated: StoryObj<typeof Area> = {
   render: () => (
     <div style={{ width: "100%", height: "800px" }}>
       <Area extend direction="column" asWrapper>
-        <Area height={40} backgroundColor={colors[0]}>
+        <Area initialHeight={40} backgroundColor={colors[0]}>
           Header
         </Area>
         <Area extend asWrapper>
@@ -63,14 +63,14 @@ export const Complicated: StoryObj<typeof Area> = {
             direction="column"
             resizableEdge="right"
             resizeHandleColor={resizeHandleColor}
-            width={200}
+            initialWidth={200}
             backgroundColor={colors[1]}>
             Left
           </Area>
           <Area direction="column" extend asWrapper>
-            <Area height={50} asWrapper>
+            <Area initialHeight={50} asWrapper>
               <Area
-                width={50}
+                initialWidth={50}
                 direction="column"
                 resizableEdge="right"
                 resizeHandleColor={resizeHandleColor}
@@ -84,7 +84,7 @@ export const Complicated: StoryObj<typeof Area> = {
             <Area
               resizableEdge="top"
               resizeHandleColor={resizeHandleColor}
-              height={50}
+              initialHeight={50}
               backgroundColor={colors[5]}>
               Center-Bottom
             </Area>
@@ -92,7 +92,7 @@ export const Complicated: StoryObj<typeof Area> = {
           <Area
             direction="column"
             resizableEdge="left"
-            width={200}
+            initialWidth={200}
             resizeHandleColor={resizeHandleColor}
             backgroundColor={colors[6]}>
             Right
@@ -100,12 +100,12 @@ export const Complicated: StoryObj<typeof Area> = {
           <Area
             direction="column"
             resizableEdge="left"
-            width={50}
+            initialWidth={50}
             resizeHandleColor={resizeHandleColor}
             backgroundColor={colors[7]}
           />
         </Area>
-        <Area height={40} backgroundColor={colors[8]}>
+        <Area initialHeight={40} backgroundColor={colors[8]}>
           Footer
         </Area>
       </Area>

--- a/web/src/beta/ui/layout/Area/index.tsx
+++ b/web/src/beta/ui/layout/Area/index.tsx
@@ -27,8 +27,8 @@ export type AreaSize = {
 
 export type AreaProps = {
   direction?: "row" | "column";
-  width?: number;
-  height?: number;
+  initialWidth?: number;
+  initialHeight?: number;
   extend?: boolean;
   backgroundColor?: string;
   resizableEdge?: ResizableEdge;
@@ -59,8 +59,8 @@ export const Area = forwardRef<AreaRef, AreaProps>(
   (
     {
       direction = "row",
-      width,
-      height,
+      initialWidth,
+      initialHeight,
       backgroundColor,
       resizableEdge,
       resizeHandleColor,
@@ -82,14 +82,14 @@ export const Area = forwardRef<AreaRef, AreaProps>(
         (sizeStorageKey && direction === "column"
           ? localStorage.getItem(sizeStorageKey)
           : undefined) ??
-          width ??
+          initialWidth ??
           DEFAULT_WIDTH,
       ),
       height: Number(
         (sizeStorageKey && direction === "row"
           ? localStorage.getItem(sizeStorageKey)
           : undefined) ??
-          height ??
+          initialHeight ??
           DEFAULT_HEIGHT,
       ),
     });
@@ -235,8 +235,8 @@ export const Area = forwardRef<AreaRef, AreaProps>(
         localStorage.setItem(collapsedStorageKey, "0");
       }
       setSize(prevSize => {
-        const w = direction === "column" ? width ?? DEFAULT_WIDTH : prevSize.width;
-        const h = direction === "row" ? height ?? DEFAULT_HEIGHT : prevSize.height;
+        const w = direction === "column" ? initialWidth ?? DEFAULT_WIDTH : prevSize.width;
+        const h = direction === "row" ? initialHeight ?? DEFAULT_HEIGHT : prevSize.height;
 
         if (sizeStorageKey) {
           localStorage.setItem(sizeStorageKey, direction === "row" ? h.toString() : w.toString());
@@ -247,7 +247,7 @@ export const Area = forwardRef<AreaRef, AreaProps>(
           height: h,
         };
       });
-    }, [direction, sizeStorageKey, collapsedStorageKey, height, width]);
+    }, [direction, sizeStorageKey, collapsedStorageKey, initialWidth, initialHeight]);
 
     const collapse = useCallback(() => {
       setCollapsed(true);

--- a/web/src/beta/ui/layout/Area/index.tsx
+++ b/web/src/beta/ui/layout/Area/index.tsx
@@ -235,22 +235,19 @@ export const Area = forwardRef<AreaRef, AreaProps>(
         localStorage.setItem(collapsedStorageKey, "0");
       }
       setSize(prevSize => {
-        const width = direction === "column" ? DEFAULT_WIDTH : prevSize.width;
-        const height = direction === "row" ? DEFAULT_HEIGHT : prevSize.height;
+        const w = direction === "column" ? width ?? DEFAULT_WIDTH : prevSize.width;
+        const h = direction === "row" ? height ?? DEFAULT_HEIGHT : prevSize.height;
 
         if (sizeStorageKey) {
-          localStorage.setItem(
-            sizeStorageKey,
-            direction === "row" ? height.toString() : width.toString(),
-          );
+          localStorage.setItem(sizeStorageKey, direction === "row" ? h.toString() : w.toString());
         }
 
         return {
-          width,
-          height,
+          width: w,
+          height: h,
         };
       });
-    }, [direction, sizeStorageKey, collapsedStorageKey]);
+    }, [direction, sizeStorageKey, collapsedStorageKey, height, width]);
 
     const collapse = useCallback(() => {
       setCollapsed(true);
@@ -305,6 +302,7 @@ export const Area = forwardRef<AreaRef, AreaProps>(
               icon="arrowsHorizontalOut"
               size="small"
               appearance="simple"
+              vertical={resizableEdge === "top" || resizableEdge === "bottom"}
               onClick={uncollapse}
             />
           </Panel>
@@ -362,8 +360,12 @@ const ResizeHandle = styled("div")<{ edge: ResizableEdge; color?: string }>(({ e
   background: color ?? "none",
 }));
 
-const StyledIconButton = styled(IconButton)(() => ({
+const StyledIconButton = styled(IconButton)<{ vertical?: boolean }>(({ vertical }) => ({
   height: "100%",
+  width: "100%",
+  ["svg"]: {
+    transform: vertical ? "rotate(90deg)" : "none",
+  },
 }));
 
 export const Window = styled("div")(({ theme }) => ({

--- a/web/src/services/routing/index.tsx
+++ b/web/src/services/routing/index.tsx
@@ -16,6 +16,7 @@ import { styled } from "@reearth/services/theme";
 
 const BetaEditor = lazy(() => import("@reearth/beta/pages/EditorPage"));
 const BetaProjectSettings = lazy(() => import("@reearth/beta/pages/ProjectSettingsPage"));
+const PluginPlaygroundPage = lazy(() => import("@reearth/beta/pages/PluginPlaygroundPage"));
 
 const NotFound = lazy(() => import("@reearth/beta/components/NotFound"));
 const LoginPage = lazy(() => import("@reearth/classic/components/pages/Authentication/LoginPage"));
@@ -94,6 +95,10 @@ export const AppRoutes = () => {
     {
       path: "plugin-editor",
       element: <PluginEditor />,
+    },
+    {
+      path: "plugin-playground",
+      element: <PluginPlaygroundPage />,
     },
     {
       path: "settings",


### PR DESCRIPTION
# Overview

This PR adds the basic structure of plugin playground to help further development.
Added new router as `/plugin-playground`.

Also refactors some on Tab and Area component.
- Tab
  - The switch tab logic should be handled internally and support controlled by props as well.
- Area
  - Updates some on vertical collapse.  

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Screenshot
![localhost_3000_plugin-playground(Desktop 1920)](https://github.com/reearth/reearth-visualizer/assets/21994748/5445975f-c7bc-4c6a-864f-ed87df3ede78)


