### PR TITLE
docs: fix getting started link URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ docker compose up -d
 # visit http://localhost:8080
 ```
 
-For more information, refer to the [Documentation](https://docs.reearth.io/developer-guide/intro/setup/set-up-reearth-in-your-environment).
+For more information, refer to the [Documentation](https://docs.reearth.io/developer-guide/intro/setup/).
 
 ## Cloud Service (SaaS)
 


### PR DESCRIPTION
# Overview

## What I've done
fixed the link in README.md

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
The link in Getting Started was incorrect.(go to 404 page)