### PR TITLE
fix(web): expose git commit hash on window

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 /// <reference types="vitest" />
 
+import { execSync } from "child_process";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 
@@ -18,6 +19,8 @@ import pkg from "./package.json";
 const NO_MINIFY = !!process.env.NO_MINIFY;
 const DEFAULT_CESIUM_ION_TOKEN_LENGTH = 177;
 
+const commitHash = execSync("git rev-parse HEAD").toString().trimEnd();
+
 export default defineConfig({
   envPrefix: "REEARTH_WEB_",
   plugins: [svgr(), react(), yaml(), cesium(), serverHeaders(), config(), tsconfigPaths()],
@@ -26,6 +29,7 @@ export default defineConfig({
   define: {
     "process.env.QTS_DEBUG": "false", // quickjs-emscripten
     __APP_VERSION__: JSON.stringify(pkg.version),
+    "window.REEARTH_COMMIT_HASH": JSON.stringify(commitHash),
   },
   mode: NO_MINIFY ? "development" : undefined,
   server: {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -19,7 +19,10 @@ import pkg from "./package.json";
 const NO_MINIFY = !!process.env.NO_MINIFY;
 const DEFAULT_CESIUM_ION_TOKEN_LENGTH = 177;
 
-const commitHash = execSync("git rev-parse HEAD").toString().trimEnd();
+let commitHash = "";
+try {
+  commitHash = execSync("git rev-parse HEAD").toString().trimEnd();
+} catch {}
 
 export default defineConfig({
   envPrefix: "REEARTH_WEB_",


### PR DESCRIPTION
# Overview

We have no way to check which commit is being released in production environment so far. Also we can't know if we are using same version between front-end and back-end.
So I've exposed git commit hash on `window.REEARTH_COMMIT_HASH`. The same functionality is going to be added in back-end as well.

## What I've done

- Exposed git commit hash on `window.REEARTH_COMMIT_HASH`.

## What I haven't done

- Didn't for back-end

## How I tested

- Run `window.REEARTH_COMMIT_HASH` on browser console.

## Which point I want you to review particularly

## Memo
