### PR TITLE
fix(web): embed git commit hash from vite in correct way

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -11,6 +11,7 @@ import wdyr from "./wdyr";
 
 window.React = React;
 window.ReactDOM = ReactDOM;
+window.REEARTH_COMMIT_HASH = __REEARTH_COMMIT_HASH__;
 
 loadConfig().finally(async () => {
   const element = document.getElementById("root");

--- a/web/src/services/config/index.ts
+++ b/web/src/services/config/index.ts
@@ -51,10 +51,12 @@ export type Config = {
 
 declare global {
   let __APP_VERSION__: string;
+  let __REEARTH_COMMIT_HASH__: string;
   interface Window {
     REEARTH_CONFIG?: Config;
     REEARTH_E2E_ACCESS_TOKEN?: string;
     REEARTH_E2E_CESIUM_VIEWER?: any;
+    REEARTH_COMMIT_HASH?: string;
   }
 }
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
   define: {
     "process.env.QTS_DEBUG": "false", // quickjs-emscripten
     __APP_VERSION__: JSON.stringify(pkg.version),
-    "window.REEARTH_COMMIT_HASH": JSON.stringify(commitHash),
+    __REEARTH_COMMIT_HASH__: JSON.stringify(commitHash),
   },
   mode: NO_MINIFY ? "development" : undefined,
   server: {


### PR DESCRIPTION
# Overview

I added a functionality to embed git commit hash from vite define API in [this commit](https://github.com/reearth/reearth-visualizer/pull/1047), but the variable is removed in production build, so I fixed to assign the variable into `window` in runtime.


## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
