### PR TITLE
chore(web): fix typo in layer style notifications

### DIFF
--- a/web/src/services/api/layerStyleApi/index.ts
+++ b/web/src/services/api/layerStyleApi/index.ts
@@ -90,11 +90,11 @@ export default () => {
       if (!input.styleId) return { status: "error" };
       const { data, errors } = await removeLayerStyleMutation({ variables: { input } });
       if (errors || !data?.removeStyle) {
-        setNotification({ type: "error", text: t("Failed to remove the layer style.") });
+        setNotification({ type: "error", text: t("Failed to delete the layer style.") });
 
         return { status: "error", errors };
       }
-      setNotification({ type: "success", text: t("Successfully removed the layer style!") });
+      setNotification({ type: "success", text: t("Successfully deleted the layer style!") });
 
       return { data, status: "success" };
     },

--- a/web/src/services/api/layerStyleApi/index.ts
+++ b/web/src/services/api/layerStyleApi/index.ts
@@ -52,11 +52,11 @@ export default () => {
     async (input: AddStyleInput): Promise<MutationReturn<AddStyleMutation>> => {
       const { data, errors } = await addLayerStyleMutation({ variables: { input } });
       if (errors || !data?.addStyle?.style?.id) {
-        setNotification({ type: "error", text: t("Failed to add layerStyle.") });
+        setNotification({ type: "error", text: t("Failed to add layer style.") });
 
         return { status: "error", errors };
       }
-      setNotification({ type: "success", text: t("Successfully added a new layerStyle!") });
+      setNotification({ type: "success", text: t("Successfully added a new layer style!") });
 
       return { data, status: "success" };
     },
@@ -90,11 +90,11 @@ export default () => {
       if (!input.styleId) return { status: "error" };
       const { data, errors } = await removeLayerStyleMutation({ variables: { input } });
       if (errors || !data?.removeStyle) {
-        setNotification({ type: "error", text: t("Failed to remove the layerStyle.") });
+        setNotification({ type: "error", text: t("Failed to remove the layer style.") });
 
         return { status: "error", errors };
       }
-      setNotification({ type: "success", text: t("Successfully removed a the layerStyle!") });
+      setNotification({ type: "success", text: t("Successfully removed the layer style!") });
 
       return { data, status: "success" };
     },

--- a/web/src/services/api/layersApi/index.ts
+++ b/web/src/services/api/layersApi/index.ts
@@ -89,7 +89,7 @@ export default () => {
 
         return { status: "error", errors };
       }
-      setNotification({ type: "success", text: t("Successfully removed a the layer!") });
+      setNotification({ type: "success", text: t("Successfully removed the layer!") });
 
       return { data, status: "success" };
     },

--- a/web/src/services/i18n/translations/en.yml
+++ b/web/src/services/i18n/translations/en.yml
@@ -353,8 +353,8 @@ Failed to add layer style.: ''
 Successfully added a new layer style!: ''
 Failed to update the layerStyle.: ''
 Successfully updated a the layerStyle!: ''
-Failed to remove the layer style.: ''
-Successfully removed the layer style!: ''
+Failed to delete the layer style.: ''
+Successfully deleted the layer style!: ''
 Failed to install plugin.: Failed to install plugin.
 Successfully installed plugin!: Successfully installed plugin!
 Failed to upgrade plugin.: ''

--- a/web/src/services/i18n/translations/en.yml
+++ b/web/src/services/i18n/translations/en.yml
@@ -348,13 +348,13 @@ Failed to move block.: Failed to move block.
 Block was successfully moved.: Block was successfully moved.
 Successfully updated the layer!: ''
 Failed to remove the layer.: ''
-Successfully removed a the layer!: ''
-Failed to add layerStyle.: ''
-Successfully added a new layerStyle!: ''
+Successfully removed the layer!: ''
+Failed to add layer style.: ''
+Successfully added a new layer style!: ''
 Failed to update the layerStyle.: ''
 Successfully updated a the layerStyle!: ''
-Failed to remove the layerStyle.: ''
-Successfully removed a the layerStyle!: ''
+Failed to remove the layer style.: ''
+Successfully removed the layer style!: ''
 Failed to install plugin.: Failed to install plugin.
 Successfully installed plugin!: Successfully installed plugin!
 Failed to upgrade plugin.: ''

--- a/web/src/services/i18n/translations/ja.yml
+++ b/web/src/services/i18n/translations/ja.yml
@@ -327,13 +327,13 @@ Failed to move block.: ブロックの移動に失敗しました。
 Block was successfully moved.: ブロックの移動に成功しました。
 Successfully updated the layer!: ''
 Failed to remove the layer.: レイヤーの削除に失敗しました。
-Successfully removed a the layer!: レイヤーの削除に成功しました！
-Failed to add layerStyle.: レイヤースタイルの追加に失敗しました。
-Successfully added a new layerStyle!: 新しいレイヤースタイルの追加に成功しました！
+Successfully removed the layer!: ''
+Failed to add layer style.: ''
+Successfully added a new layer style!: ''
 Failed to update the layerStyle.: レイヤースタイルのアップデートに失敗しました。
 Successfully updated a the layerStyle!: レイヤースタイルのアップデートに成功しました！
-Failed to remove the layerStyle.: レイヤースタイルの削除に失敗しました。
-Successfully removed a the layerStyle!: レイヤースタイルの削除に成功しました！
+Failed to remove the layer style.: ''
+Successfully removed the layer style!: ''
 Failed to install plugin.: プラグインのインストールに失敗しました。
 Successfully installed plugin!: プラグインがインストールされました。
 Failed to upgrade plugin.: プラグインのアップグレードに失敗しました。

--- a/web/src/services/i18n/translations/ja.yml
+++ b/web/src/services/i18n/translations/ja.yml
@@ -332,8 +332,8 @@ Failed to add layer style.: ''
 Successfully added a new layer style!: ''
 Failed to update the layerStyle.: レイヤースタイルのアップデートに失敗しました。
 Successfully updated a the layerStyle!: レイヤースタイルのアップデートに成功しました！
-Failed to remove the layer style.: ''
-Successfully removed the layer style!: ''
+Failed to delete the layer style.: ''
+Successfully deleted the layer style!: ''
 Failed to install plugin.: プラグインのインストールに失敗しました。
 Successfully installed plugin!: プラグインがインストールされました。
 Failed to upgrade plugin.: プラグインのアップグレードに失敗しました。


### PR DESCRIPTION
# Overview
PR amends a small typo to notifications when added and removing a layer style. I am wondering if we should use the word `remove` or `delete` as from the UI we display the word `delete` to the user. 
<img width="317" alt="Screenshot 2024-07-22 at 5 32 24 PM" src="https://github.com/user-attachments/assets/acd35121-0585-429b-8907-2326d8a53fae">

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
