### PR TITLE
chore(web): Migrate Jotai to v2

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -148,7 +148,7 @@
         "graphql": "16.6.0",
         "i18next": "22.4.15",
         "i18next-browser-languagedetector": "7.0.1",
-        "jotai": "^2.9.0",
+        "jotai": "2.9.0",
         "js-file-download": "0.4.12",
         "js-md5": "0.7.3",
         "jsep": "1.3.8",

--- a/web/package.json
+++ b/web/package.json
@@ -148,7 +148,7 @@
         "graphql": "16.6.0",
         "i18next": "22.4.15",
         "i18next-browser-languagedetector": "7.0.1",
-        "jotai": "1.12.1",
+        "jotai": "^2.9.0",
         "js-file-download": "0.4.12",
         "js-md5": "0.7.3",
         "jsep": "1.3.8",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -14360,7 +14360,7 @@ jotai@1.12.1:
   resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.12.1.tgz#18808724c96f8c038f6ee8b75f3ac37e1ac35608"
   integrity sha512-t6gsYM1WkQHMOazaZYLykCA+fh9KPDGrA+tDYzDeV0268QsCqmX6S4lO46uswgt1LGUeG0EDFGuMd9ac8cWNTA==
 
-jotai@^2.9.0:
+jotai@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.9.0.tgz#240f37fb1bb8a8d4c8d178b423575f2da677814f"
   integrity sha512-MioTpMvR78IGfJ+W8EwQj3kwTkb+u0reGnTyg3oJZMWK9rK9v8NBSC9Rhrg9jrrFYA6bGZtzJa96zsuAYF6W3w==

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -14360,6 +14360,11 @@ jotai@1.12.1:
   resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.12.1.tgz#18808724c96f8c038f6ee8b75f3ac37e1ac35608"
   integrity sha512-t6gsYM1WkQHMOazaZYLykCA+fh9KPDGrA+tDYzDeV0268QsCqmX6S4lO46uswgt1LGUeG0EDFGuMd9ac8cWNTA==
 
+jotai@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.9.0.tgz#240f37fb1bb8a8d4c8d178b423575f2da677814f"
+  integrity sha512-MioTpMvR78IGfJ+W8EwQj3kwTkb+u0reGnTyg3oJZMWK9rK9v8NBSC9Rhrg9jrrFYA6bGZtzJa96zsuAYF6W3w==
+
 js-cookie@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"


### PR DESCRIPTION
# Overview
Migration of Jotai to v2

## What I've done
I updated Jotai from v1.12.1 to v2.9.0
I checked through the docs (https://jotai.org/docs/guides/migrating-to-v2-api ) to check for any disparities in our code.

## What I haven't done

## How I tested
I tested Beta locally, both on my branch and on the main branch and nothing seemed to break on my end.

## Which point I want you to review particularly

## Memo
