### PR TITLE
fix(web): story page property

### DIFF
--- a/web/src/beta/features/Published/hooks.ts
+++ b/web/src/beta/features/Published/hooks.ts
@@ -186,7 +186,7 @@ export default (alias?: string) => {
               id: p.id,
               swipeable: p.swipeable,
               layerIds: p.layers,
-              property: processNewProperty(p.property),
+              property: processProperty(p.property),
               blocks: p.blocks.map(b => {
                 return {
                   id: b.id,

--- a/web/src/beta/features/Visualizer/Crust/StoryPanel/Page/hooks.ts
+++ b/web/src/beta/features/Visualizer/Crust/StoryPanel/Page/hooks.ts
@@ -53,16 +53,19 @@ export default ({
   const panelSettings = useMemo(
     () => ({
       padding: {
-        ...property?.panel?.padding,
         value: calculatePaddingValue(
           DEFAULT_STORY_PAGE_PADDING,
-          property?.panel?.padding?.value,
+          property?.panel?.padding,
           isEditable,
         ),
+        title: "Padding",
+        type: "spacing",
+        ui: "padding",
       },
       gap: {
-        ...property?.panel?.gap,
-        value: property?.panel?.gap?.value ?? DEFAULT_STORY_PAGE_GAP,
+        value: property?.panel?.gap ?? DEFAULT_STORY_PAGE_GAP,
+        type: "number",
+        title: "Gap",
       },
     }),
     [property?.panel, isEditable],

--- a/web/src/beta/features/Visualizer/Crust/StoryPanel/Page/hooks.ts
+++ b/web/src/beta/features/Visualizer/Crust/StoryPanel/Page/hooks.ts
@@ -71,10 +71,17 @@ export default ({
   const titleProperty = useMemo(
     () => ({
       title: {
-        title: property?.title?.title,
-        color: property?.title?.color,
+        title: { value: property?.title?.title, title: "Title", type: "string" },
+        color: { value: property?.title?.color, title: "Color", type: "string", ui: "color" },
       },
-      panel: { padding: property?.title?.padding },
+      panel: {
+        padding: {
+          value: property?.title?.padding,
+          title: "Padding",
+          type: "spacing",
+          ui: "padding",
+        },
+      },
     }),
     [property?.title],
   );


### PR DESCRIPTION
# Overview

Story page property was not processed with the same logic in Editor and in Published page.
The property item's structure was not suitable for a common field component.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced the `titleProperty` structure for the `StoryPanel`, allowing for richer metadata representation of `title`, `color`, and `padding`.
  
- **Improvements**
  - Improved clarity and extensibility of the data structure, facilitating better UI integration and overall functionality of the `StoryPanel`.
  
- **Bug Fixes**
  - Updated property processing function to ensure consistent handling of component properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->