### PR TITLE
fix(web): pagination with duplicate data fetch

### DIFF
--- a/web/src/services/gql/provider/pagination.ts
+++ b/web/src/services/gql/provider/pagination.ts
@@ -10,7 +10,7 @@ export function paginationMerge(
 
   const merged = existing ? existing.edges.slice(0) : [];
 
-  let offset = offsetFromCursor(merged, existing?.pageInfo.endCursor, readField);
+  let offset = offsetFromCursor(merged, incoming?.pageInfo.startCursor, readField);
   if (offset < 0) offset = merged.length;
 
   for (let i = 0; i < incoming?.edges?.length; ++i) {
@@ -25,10 +25,9 @@ export function paginationMerge(
 
 function offsetFromCursor(items: any, cursor: string, readField: ReadFieldFunction) {
   if (items.length < 1) return -1;
-  for (let i = 0; i <= items.length; ++i) {
-    const item = items[i];
-    if (readField("cursor", item) === cursor) {
-      return i + 1;
+  for (let i = 0; i < items.length; ++i) {
+    if (readField("cursor", items[i]) === cursor) {
+      return i;
     }
   }
   return -1;


### PR DESCRIPTION
# Overview

Current implement is only doing connect results, finding `existing?.pageInfo.endCursor` in `merged` (which is a shadow copy of existing) doesn't make much secse.
When response from duplicated request coming, it will result in connect all which leads to duplicate item exists.
I changed it to find `incoming?.pageInfo.startCursor` in exist, and replace from the found item so that we can avoid duplicate item shows up.


## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
