### PR TITLE
refactor(web): submit button for sketch feature custom property update

### DIFF
--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -19,7 +19,6 @@ const config: StorybookConfig = {
       define: {
         "process.env.QTS_DEBUG": "false", // quickjs-emscripten
       },
-
       build:
         configType === "PRODUCTION"
           ? {
@@ -50,6 +49,9 @@ const config: StorybookConfig = {
           // https://github.com/storybookjs/storybook/issues/22253#issuecomment-1673229400
           ignored: ["**/.env"],
         },
+      },
+      optimizeDeps: {
+        exclude: ["storybook"],
       },
     });
   },

--- a/web/src/beta/features/Editor/Map/InspectorPanel/LayerInspector/FeatureInspector/CustomPropertField.tsx
+++ b/web/src/beta/features/Editor/Map/InspectorPanel/LayerInspector/FeatureInspector/CustomPropertField.tsx
@@ -1,34 +1,25 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback } from "react";
 
 import { AssetField, InputField, NumberField, SwitchField } from "@reearth/beta/ui/fields";
 import TextAreaField from "@reearth/beta/ui/fields/TextareaField";
-import { SketchFeature } from "@reearth/services/api/layersApi/utils";
 import { useT } from "@reearth/services/i18n";
 
 import { FieldProp, ValueProp } from ".";
 
 type Props = {
-  field: any;
-  selectedFeature?: SketchFeature;
-  setField?: (v: FieldProp[] | ((prevFields: FieldProp[]) => FieldProp[])) => void;
-  onSubmit?: (inp: any) => void;
+  field: FieldProp;
+  setFields?: (v: FieldProp[] | ((prevFields: FieldProp[]) => FieldProp[])) => void;
 };
 
 const fileTypes = ["file" as const];
 const imageTypes = ["image" as const];
 
-export const FieldComponent = ({ field, selectedFeature, setField, onSubmit }: Props) => {
+export const FieldComponent = ({ field, setFields }: Props) => {
   const t = useT();
-
-  const currentSelectedFeature = useRef(selectedFeature);
-
-  useEffect(() => {
-    currentSelectedFeature.current = selectedFeature;
-  }, [selectedFeature]);
 
   const handleChange = useCallback(
     (value: ValueProp) => {
-      setField?.(prevFields => {
+      setFields?.(prevFields => {
         if (!prevFields) return [];
         return prevFields.map(prevField => {
           if (prevField.id === field.id) {
@@ -37,38 +28,22 @@ export const FieldComponent = ({ field, selectedFeature, setField, onSubmit }: P
           return prevField;
         });
       });
-
-      const updatedProperties = {
-        ...currentSelectedFeature.current?.properties,
-        [field.title]: value,
-      };
-      if (Object.keys(updatedProperties).length) {
-        onSubmit?.(updatedProperties);
-      }
     },
-    [field.id, field.title, setField, onSubmit],
+    [field.id, setFields],
   );
 
-  const getDynamicValue = useCallback(
-    (selectedFeature: SketchFeature | undefined, fieldTitle: string, fieldValue: any) => {
-      return selectedFeature?.properties && fieldTitle in selectedFeature.properties
-        ? selectedFeature.properties[fieldTitle]
-        : fieldValue;
-    },
-    [],
-  );
   return field?.type === "Text" ? (
     <InputField
       key={field?.id}
       commonTitle={field?.title}
-      value={getDynamicValue(selectedFeature, field.title, field.value)}
+      value={field.value as string}
       onBlur={handleChange}
     />
   ) : field?.type === "TextArea" ? (
     <TextAreaField
       key={field?.id}
       commonTitle={field?.title}
-      value={getDynamicValue(selectedFeature, field.title, field.value)}
+      value={field.value as string}
       onBlur={handleChange}
     />
   ) : field?.type === "Asset" ? (
@@ -77,7 +52,7 @@ export const FieldComponent = ({ field, selectedFeature, setField, onSubmit }: P
       commonTitle={field?.title}
       assetsTypes={imageTypes}
       inputMethod={"asset"}
-      value={getDynamicValue(selectedFeature, field.title, field.value)}
+      value={field.value as string}
       onChange={handleChange}
     />
   ) : field?.type === "URL" ? (
@@ -86,21 +61,21 @@ export const FieldComponent = ({ field, selectedFeature, setField, onSubmit }: P
       commonTitle={field?.title}
       assetsTypes={fileTypes}
       inputMethod={"URL"}
-      value={getDynamicValue(selectedFeature, field.title, field.value)}
+      value={field.value as string}
       onChange={handleChange}
     />
   ) : field?.type === "Float" || field.type === "Int" ? (
     <NumberField
       key={field?.id}
       commonTitle={field?.title}
-      value={getDynamicValue(selectedFeature, field.title, field.value)}
+      value={field.value as number}
       onBlur={handleChange}
     />
   ) : field?.type === "Boolean" ? (
     <SwitchField
       key={field?.id}
       commonTitle={field?.title}
-      value={getDynamicValue(selectedFeature, field.title, field.value)}
+      value={field.value as boolean}
       onChange={handleChange}
     />
   ) : (

--- a/web/src/beta/features/Editor/Map/InspectorPanel/LayerInspector/FeatureInspector/index.tsx
+++ b/web/src/beta/features/Editor/Map/InspectorPanel/LayerInspector/FeatureInspector/index.tsx
@@ -67,14 +67,13 @@ const FeatureData: FC<Props> = ({
 
   const handleSubmit = useCallback(() => {
     if (!selectedFeature || !sketchFeature?.id || !layer?.id) return;
+    const newProperties = { ...selectedFeature.properties };
+    Object.assign(newProperties, ...fields.map(f => ({ [f.title]: f.value })));
     onGeoJsonFeatureUpdate?.({
       layerId: layer.id,
       featureId: sketchFeature.id,
       geometry: selectedFeature.geometry,
-      properties: {
-        ...selectedFeature.properties,
-        ...fields.reduce((acc, f) => ({ ...acc, [f.title]: f.value }), {}),
-      },
+      properties: newProperties,
     });
   }, [layer?.id, fields, onGeoJsonFeatureUpdate, selectedFeature, sketchFeature?.id]);
 

--- a/web/src/beta/features/Editor/Map/InspectorPanel/LayerInspector/index.tsx
+++ b/web/src/beta/features/Editor/Map/InspectorPanel/LayerInspector/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from "react";
+import { FC, useCallback, useMemo, useState } from "react";
 
 import { SelectedLayer } from "@reearth/beta/features/Editor/hooks/useLayers";
 import { GeoJsonFeatureUpdateProps } from "@reearth/beta/features/Editor/hooks/useSketch";
@@ -12,6 +12,8 @@ import DataSource from "./DataSource";
 import FeatureInspector from "./FeatureInspector";
 import InfoboxSettings from "./InfoboxSettings";
 import LayerStyle from "./LayerStyle";
+
+const LAYER_INSPECTOR_TAB_STORAGE_KEY = "reearth-visualizer-map-layer-inspector-tab";
 
 type Props = {
   layerStyles?: LayerStyleType[];
@@ -74,9 +76,7 @@ const InspectorTabs: FC<Props> = ({
         children: selectedFeature && (
           <FeatureInspector
             selectedFeature={selectedFeature}
-            isSketchLayer={selectedLayer?.layer?.isSketch}
-            customProperties={selectedLayer?.layer?.sketch?.customPropertySchema}
-            layerId={selectedLayer?.layer?.id}
+            layer={selectedLayer?.layer}
             sketchFeature={selectedSketchFeature}
             onGeoJsonFeatureUpdate={onGeoJsonFeatureUpdate}
           />
@@ -118,7 +118,18 @@ const InspectorTabs: FC<Props> = ({
     ],
   );
 
-  return <Tabs tabs={tabItems} position="left" />;
+  const [currentTab, setCurrentTab] = useState(
+    localStorage.getItem(LAYER_INSPECTOR_TAB_STORAGE_KEY) ?? "dataSource",
+  );
+
+  const handleTabChange = useCallback((newTab: string) => {
+    setCurrentTab(newTab);
+    localStorage.setItem(LAYER_INSPECTOR_TAB_STORAGE_KEY, newTab);
+  }, []);
+
+  return (
+    <Tabs tabs={tabItems} currentTab={currentTab} position="left" onChange={handleTabChange} />
+  );
 };
 
 export default InspectorTabs;

--- a/web/src/beta/lib/reearth-ui/components/TextArea/index.tsx
+++ b/web/src/beta/lib/reearth-ui/components/TextArea/index.tsx
@@ -105,7 +105,7 @@ const StyledTextArea = styled.textarea<{
 }>(({ theme, resizable, disabled, appearance }) => ({
   outline: "none",
   border: "none",
-  background: "none",
+  background: theme.bg[1],
   resize: resizable === "height" ? "vertical" : "none",
   overflow: resizable === "height" ? "scroll" : "auto",
   flex: 1,

--- a/web/src/services/i18n/translations/en.yml
+++ b/web/src/services/i18n/translations/en.yml
@@ -109,6 +109,8 @@ Layer Name: Layer Name
 Format: Format
 Unsupported custom field: Unsupported custom field
 Custom Properties: Custom Properties
+Save & Apply: ''
+No custom properties: ''
 Geometry: Geometry
 Properties: Properties
 Enable Infobox: Enable Infobox

--- a/web/src/services/i18n/translations/ja.yml
+++ b/web/src/services/i18n/translations/ja.yml
@@ -107,6 +107,8 @@ Layer Name: ''
 Format: フォーマット
 Unsupported custom field: ''
 Custom Properties: ''
+Save & Apply: ''
+No custom properties: ''
 Geometry: ジオメトリ
 Properties: プロパティ
 Enable Infobox: インフォボックスを有効化

--- a/web/src/services/theme/reearthTheme/darkTheme/index.ts
+++ b/web/src/services/theme/reearthTheme/darkTheme/index.ts
@@ -56,6 +56,7 @@ const darkTheme: Theme = {
     lightest: rgba("#ffffff", 0.2),
     lighter: rgba("#ffffff", 0.15),
     light: rgba("#ffffff", 0.1),
+    dim: rgba("#ffffff", 0.05),
     dark: rgba("#000000", 0.1),
     darker: rgba("#000000", 0.15),
     darkest: rgba("#000000", 0.2),

--- a/web/src/services/theme/reearthTheme/lightTheme/index.ts
+++ b/web/src/services/theme/reearthTheme/lightTheme/index.ts
@@ -56,6 +56,7 @@ const lightTheme: Theme = {
     lightest: rgba("#ffffff", 0.2),
     lighter: rgba("#ffffff", 0.15),
     light: rgba("#ffffff", 0.1),
+    dim: rgba("#ffffff", 0.05),
     dark: rgba("#000000", 0.1),
     darker: rgba("#000000", 0.15),
     darkest: rgba("#000000", 0.2),

--- a/web/src/services/theme/reearthTheme/types.ts
+++ b/web/src/services/theme/reearthTheme/types.ts
@@ -56,6 +56,7 @@ export type Theme = Common & {
     lightest: string;
     lighter: string;
     light: string;
+    dim: string;
     dark: string;
     darker: string;
     darkest: string;


### PR DESCRIPTION
# Overview

This PR:
- Added a submit button for update sketch feature custom property to avoid it triggers too often on each field blur.
- Simplify the logic around field status.
- Correct the color of collapse used here.
- Update a config on storybook to avoid dynamic import error.
- Add localstorage to remember the selected tab in Inspector panel.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Layer Inspector with improved state management for selected tabs, now persisted in local storage.
	- Added new `dim` property to both light and dark theme configurations for enhanced styling options.
	- Introduced new entries in English and Japanese translation files for better localization support.

- **Bug Fixes**
	- Streamlined the `FeatureData` component by improving custom property handling to prevent potential runtime errors.

- **Style**
	- Updated the `StyledTextArea` background to align with the application theme, enhancing visual consistency.

- **Chores**
	- Improved formatting and configuration in Storybook setup for better dependency management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->