### PR TITLE
feat(server) New Policy Enforcement for Visualizer

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -1,3 +1,16 @@
+help:
+	@echo "Usage:"
+	@echo "  make <target>"
+	@echo ""
+	@echo "Targets:"
+	@echo "  lint       Run golangci-lint with auto-fix"
+	@echo "  test       Run unit tests with race detector in short mode"
+	@echo "  e2e        Run end-to-end tests"
+	@echo "  build      Build the project"
+	@echo "  run-app    Run the application"
+	@echo "  run-db     Run the MongoDB database using Docker Compose"
+	@echo "  gql        Generate GraphQL code"
+
 lint:
 	golangci-lint run --fix
 

--- a/server/gql/workspace.graphql
+++ b/server/gql/workspace.graphql
@@ -25,6 +25,10 @@ type Policy {
   assetStorageSize: FileSize
   datasetSchemaCount: Int
   datasetCount: Int
+  nlsLayersCount: Int
+  pageCount: Int
+  storyCount: Int
+  blocksCount: Int
 }
 
 enum Role {

--- a/server/internal/adapter/gql/generated.go
+++ b/server/internal/adapter/gql/generated.go
@@ -803,14 +803,18 @@ type ComplexityRoot struct {
 
 	Policy struct {
 		AssetStorageSize      func(childComplexity int) int
+		BlocksCount           func(childComplexity int) int
 		DatasetCount          func(childComplexity int) int
 		DatasetSchemaCount    func(childComplexity int) int
 		ID                    func(childComplexity int) int
 		LayerCount            func(childComplexity int) int
 		MemberCount           func(childComplexity int) int
 		Name                  func(childComplexity int) int
+		NlsLayersCount        func(childComplexity int) int
+		PageCount             func(childComplexity int) int
 		ProjectCount          func(childComplexity int) int
 		PublishedProjectCount func(childComplexity int) int
+		StoryCount            func(childComplexity int) int
 	}
 
 	Polygon struct {
@@ -5526,6 +5530,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Policy.AssetStorageSize(childComplexity), true
 
+	case "Policy.blocksCount":
+		if e.complexity.Policy.BlocksCount == nil {
+			break
+		}
+
+		return e.complexity.Policy.BlocksCount(childComplexity), true
+
 	case "Policy.datasetCount":
 		if e.complexity.Policy.DatasetCount == nil {
 			break
@@ -5568,6 +5579,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Policy.Name(childComplexity), true
 
+	case "Policy.nlsLayersCount":
+		if e.complexity.Policy.NlsLayersCount == nil {
+			break
+		}
+
+		return e.complexity.Policy.NlsLayersCount(childComplexity), true
+
+	case "Policy.pageCount":
+		if e.complexity.Policy.PageCount == nil {
+			break
+		}
+
+		return e.complexity.Policy.PageCount(childComplexity), true
+
 	case "Policy.projectCount":
 		if e.complexity.Policy.ProjectCount == nil {
 			break
@@ -5581,6 +5606,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Policy.PublishedProjectCount(childComplexity), true
+
+	case "Policy.storyCount":
+		if e.complexity.Policy.StoryCount == nil {
+			break
+		}
+
+		return e.complexity.Policy.StoryCount(childComplexity), true
 
 	case "Polygon.polygonCoordinates":
 		if e.complexity.Polygon.PolygonCoordinates == nil {
@@ -10569,6 +10601,10 @@ type Policy {
   assetStorageSize: FileSize
   datasetSchemaCount: Int
   datasetCount: Int
+  nlsLayersCount: Int
+  pageCount: Int
+  storyCount: Int
+  blocksCount: Int
 }
 
 enum Role {
@@ -38130,6 +38166,170 @@ func (ec *executionContext) fieldContext_Policy_datasetCount(ctx context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _Policy_nlsLayersCount(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.Policy) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Policy_nlsLayersCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NlsLayersCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Policy_nlsLayersCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Policy",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Policy_pageCount(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.Policy) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Policy_pageCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Policy_pageCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Policy",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Policy_storyCount(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.Policy) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Policy_storyCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.StoryCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Policy_storyCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Policy",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Policy_blocksCount(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.Policy) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Policy_blocksCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BlocksCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Policy_blocksCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Policy",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Polygon_type(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.Polygon) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Polygon_type(ctx, field)
 	if err != nil {
@@ -52860,6 +53060,14 @@ func (ec *executionContext) fieldContext_Team_policy(ctx context.Context, field 
 				return ec.fieldContext_Policy_datasetSchemaCount(ctx, field)
 			case "datasetCount":
 				return ec.fieldContext_Policy_datasetCount(ctx, field)
+			case "nlsLayersCount":
+				return ec.fieldContext_Policy_nlsLayersCount(ctx, field)
+			case "pageCount":
+				return ec.fieldContext_Policy_pageCount(ctx, field)
+			case "storyCount":
+				return ec.fieldContext_Policy_storyCount(ctx, field)
+			case "blocksCount":
+				return ec.fieldContext_Policy_blocksCount(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Policy", field.Name)
 		},
@@ -70015,6 +70223,14 @@ func (ec *executionContext) _Policy(ctx context.Context, sel ast.SelectionSet, o
 			out.Values[i] = ec._Policy_datasetSchemaCount(ctx, field, obj)
 		case "datasetCount":
 			out.Values[i] = ec._Policy_datasetCount(ctx, field, obj)
+		case "nlsLayersCount":
+			out.Values[i] = ec._Policy_nlsLayersCount(ctx, field, obj)
+		case "pageCount":
+			out.Values[i] = ec._Policy_pageCount(ctx, field, obj)
+		case "storyCount":
+			out.Values[i] = ec._Policy_storyCount(ctx, field, obj)
+		case "blocksCount":
+			out.Values[i] = ec._Policy_blocksCount(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/server/internal/adapter/gql/gqlmodel/convert_workspace.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_workspace.go
@@ -72,5 +72,9 @@ func ToPolicy(p *policy.Policy) *Policy {
 		AssetStorageSize:      o.AssetStorageSize,
 		DatasetSchemaCount:    o.DatasetSchemaCount,
 		DatasetCount:          o.DatasetCount,
+		NlsLayersCount:        o.NLSLayersCount,
+		PageCount:             o.PageCount,
+		StoryCount:            o.StoryCount,
+		BlocksCount:           o.BlocksCount,
 	}
 }

--- a/server/internal/adapter/gql/gqlmodel/convert_workspace_test.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_workspace_test.go
@@ -36,6 +36,10 @@ func TestToPolicy(t *testing.T) {
 		AssetStorageSize:      lo.ToPtr(int64(5)),
 		DatasetCount:          lo.ToPtr(6),
 		DatasetSchemaCount:    lo.ToPtr(7),
+		NlsLayersCount:        lo.ToPtr(8),
+		PageCount:             lo.ToPtr(9),
+		StoryCount:            lo.ToPtr(10),
+		BlocksCount:           lo.ToPtr(6),
 	}, ToPolicy(policy.New(policy.Option{
 		ID:                    policy.ID("x"),
 		Name:                  "aaa",
@@ -46,6 +50,10 @@ func TestToPolicy(t *testing.T) {
 		AssetStorageSize:      lo.ToPtr(int64(5)),
 		DatasetCount:          lo.ToPtr(6),
 		DatasetSchemaCount:    lo.ToPtr(7),
+		NLSLayersCount:        lo.ToPtr(8),
+		PageCount:             lo.ToPtr(9),
+		StoryCount:            lo.ToPtr(10),
+		BlocksCount:           lo.ToPtr(6),
 	})))
 	assert.Nil(t, ToPolicy(nil))
 }

--- a/server/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/server/internal/adapter/gql/gqlmodel/models_gen.go
@@ -1115,6 +1115,10 @@ type Policy struct {
 	AssetStorageSize      *int64 `json:"assetStorageSize,omitempty"`
 	DatasetSchemaCount    *int   `json:"datasetSchemaCount,omitempty"`
 	DatasetCount          *int   `json:"datasetCount,omitempty"`
+	NlsLayersCount        *int   `json:"nlsLayersCount,omitempty"`
+	PageCount             *int   `json:"pageCount,omitempty"`
+	StoryCount            *int   `json:"storyCount,omitempty"`
+	BlocksCount           *int   `json:"blocksCount,omitempty"`
 }
 
 type Polygon struct {

--- a/server/internal/infrastructure/mongo/mongodoc/policy.go
+++ b/server/internal/infrastructure/mongo/mongodoc/policy.go
@@ -15,6 +15,10 @@ type PolicyDocument struct {
 	DatasetCount          *int
 	DatasetSchemaCount    *int
 	AssetStorageSize      *int64
+	NLSLayersCount        *int
+	PageCount             *int
+	StoryCount            *int
+	BlocksCount           *int
 }
 
 func (d PolicyDocument) Model() *policy.Policy {
@@ -28,6 +32,10 @@ func (d PolicyDocument) Model() *policy.Policy {
 		DatasetCount:          d.DatasetCount,
 		DatasetSchemaCount:    d.DatasetSchemaCount,
 		AssetStorageSize:      d.AssetStorageSize,
+		NLSLayersCount:        d.NLSLayersCount,
+		PageCount:             d.PageCount,
+		StoryCount:            d.StoryCount,
+		BlocksCount:           d.BlocksCount,
 	})
 }
 

--- a/server/internal/usecase/interactor/nlslayer.go
+++ b/server/internal/usecase/interactor/nlslayer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/reearth/reearth/server/pkg/nlslayer/nlslayerops"
 	"github.com/reearth/reearth/server/pkg/plugin"
 	"github.com/reearth/reearth/server/pkg/property"
+	"github.com/reearth/reearthx/account/accountusecase/accountrepo"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/reearth/reearthx/usecasex"
 )
@@ -26,6 +27,8 @@ type NLSLayer struct {
 	sceneRepo     repo.Scene
 	propertyRepo  repo.Property
 	pluginRepo    repo.Plugin
+	policyRepo    repo.Policy
+	workspaceRepo accountrepo.Workspace
 	transaction   usecasex.Transaction
 }
 
@@ -85,6 +88,30 @@ func (i *NLSLayer) AddLayerSimple(ctx context.Context, inp interfaces.AddNLSLaye
 	}.Initialize()
 	if err != nil {
 		return nil, err
+	}
+
+	s, err := i.sceneRepo.FindByID(ctx, inp.SceneID)
+	if err != nil {
+		return nil, err
+	}
+
+	ws, err := i.workspaceRepo.FindByID(ctx, s.Workspace())
+	if err != nil {
+		return nil, err
+	}
+
+	if policyID := operator.Policy(ws.Policy()); policyID != nil {
+		p, err := i.policyRepo.FindByID(ctx, *policyID)
+		if err != nil {
+			return nil, err
+		}
+		s, err := i.nlslayerRepo.CountByScene(ctx, s.ID())
+		if err != nil {
+			return nil, err
+		}
+		if err := p.EnforceNLSLayersCount(s + 1); err != nil {
+			return nil, err
+		}
 	}
 
 	if inp.Schema != nil {

--- a/server/internal/usecase/repo/nlslayer.go
+++ b/server/internal/usecase/repo/nlslayer.go
@@ -18,6 +18,7 @@ type NLSLayer interface {
 	FindParentByID(context.Context, id.NLSLayerID) (*nlslayer.NLSLayerGroup, error)
 	FindParentsByIDs(context.Context, id.NLSLayerIDList) (nlslayer.NLSLayerGroupList, error)
 	FindByScene(context.Context, id.SceneID) (nlslayer.NLSLayerList, error)
+	CountByScene(context.Context, id.SceneID) (int, error)
 	Save(context.Context, nlslayer.NLSLayer) error
 	SaveAll(context.Context, nlslayer.NLSLayerList) error
 	Remove(context.Context, id.NLSLayerID) error

--- a/server/pkg/policy/policy.go
+++ b/server/pkg/policy/policy.go
@@ -25,6 +25,10 @@ type Option struct {
 	AssetStorageSize      *int64
 	DatasetSchemaCount    *int
 	DatasetCount          *int
+	NLSLayersCount        *int
+	PageCount             *int
+	StoryCount            *int
+	BlocksCount           *int
 }
 
 func New(opts Option) *Policy {
@@ -71,6 +75,22 @@ func (p *Policy) EnforceDatasetCount(count int) error {
 	return p.error(p == nil || p.opts.DatasetCount == nil || *p.opts.DatasetCount >= count)
 }
 
+func (p *Policy) EnforceNLSLayersCount(count int) error {
+	return p.error(p == nil || p.opts.NLSLayersCount == nil || *p.opts.NLSLayersCount >= count)
+}
+
+func (p *Policy) EnforcePageCount(count int) error {
+	return p.error(p == nil || p.opts.PageCount == nil || *p.opts.PageCount >= count)
+}
+
+func (p *Policy) EnforceStoryCount(count int) error {
+	return p.error(p == nil || p.opts.StoryCount == nil || *p.opts.StoryCount >= count)
+}
+
+func (p *Policy) EnforceBlocksCount(count int) error {
+	return p.error(p == nil || p.opts.BlocksCount == nil || *p.opts.BlocksCount >= count)
+}
+
 func (*Policy) error(ok bool) error {
 	if !ok {
 		return ErrPolicyViolation
@@ -96,5 +116,9 @@ func (p Option) Clone() Option {
 		AssetStorageSize:      util.CloneRef(p.AssetStorageSize),
 		DatasetSchemaCount:    util.CloneRef(p.DatasetSchemaCount),
 		DatasetCount:          util.CloneRef(p.DatasetCount),
+		NLSLayersCount:        util.CloneRef(p.NLSLayersCount),
+		PageCount:             util.CloneRef(p.PageCount),
+		StoryCount:            util.CloneRef(p.StoryCount),
+		BlocksCount:           util.CloneRef(p.DatasetCount),
 	}
 }

--- a/server/pkg/policy/policy_test.go
+++ b/server/pkg/policy/policy_test.go
@@ -150,6 +150,74 @@ func TestPolicy_EnforceDatasetCount(t *testing.T) {
 	})
 }
 
+func TestPolicy_EnforceNLSLayersCount(t *testing.T) {
+	tests := []policyTest[int]{
+		{limit: 0, arg: 0, fail: false},
+		{limit: 1, arg: 0, fail: false},
+		{limit: 1, arg: 1, fail: false},
+		{limit: 1, arg: 2, fail: true},
+		{limitNil: true, arg: 100, fail: false},
+		{policyNil: true, arg: 100, fail: false},
+	}
+
+	testPolicy(t, tests, func(d int) Option {
+		return Option{NLSLayersCount: lo.ToPtr(d)}
+	}, func(p *Policy, a int) error {
+		return p.EnforceNLSLayersCount(a)
+	})
+}
+
+func TestPolicy_EnforcePageCount(t *testing.T) {
+	tests := []policyTest[int]{
+		{limit: 0, arg: 0, fail: false},
+		{limit: 1, arg: 0, fail: false},
+		{limit: 1, arg: 1, fail: false},
+		{limit: 1, arg: 2, fail: true},
+		{limitNil: true, arg: 100, fail: false},
+		{policyNil: true, arg: 100, fail: false},
+	}
+
+	testPolicy(t, tests, func(d int) Option {
+		return Option{PageCount: lo.ToPtr(d)}
+	}, func(p *Policy, a int) error {
+		return p.EnforcePageCount(a)
+	})
+}
+
+func TestPolicy_EnforceStoryCount(t *testing.T) {
+	tests := []policyTest[int]{
+		{limit: 0, arg: 0, fail: false},
+		{limit: 1, arg: 0, fail: false},
+		{limit: 1, arg: 1, fail: false},
+		{limit: 1, arg: 2, fail: true},
+		{limitNil: true, arg: 100, fail: false},
+		{policyNil: true, arg: 100, fail: false},
+	}
+
+	testPolicy(t, tests, func(d int) Option {
+		return Option{StoryCount: lo.ToPtr(d)}
+	}, func(p *Policy, a int) error {
+		return p.EnforceStoryCount(a)
+	})
+}
+
+func TestPolicy_EnforceBlocksCount(t *testing.T) {
+	tests := []policyTest[int]{
+		{limit: 0, arg: 0, fail: false},
+		{limit: 1, arg: 0, fail: false},
+		{limit: 1, arg: 1, fail: false},
+		{limit: 1, arg: 2, fail: true},
+		{limitNil: true, arg: 100, fail: false},
+		{policyNil: true, arg: 100, fail: false},
+	}
+
+	testPolicy(t, tests, func(d int) Option {
+		return Option{BlocksCount: lo.ToPtr(d)}
+	}, func(p *Policy, a int) error {
+		return p.EnforceBlocksCount(a)
+	})
+}
+
 func testPolicy[T any](t *testing.T, tests []policyTest[T], f func(d T) Option, tf func(p *Policy, a T) error) {
 	t.Helper()
 	for _, tt := range tests {
@@ -191,7 +259,11 @@ func TestPolicy_Clone(t *testing.T) {
 			LayerCount:            lo.ToPtr(1),
 			AssetStorageSize:      lo.ToPtr(int64(1)),
 			DatasetSchemaCount:    lo.ToPtr(1),
-			DatasetCount:          lo.ToPtr(2),
+			DatasetCount:          lo.ToPtr(1),
+			NLSLayersCount:        lo.ToPtr(1),
+			PageCount:             lo.ToPtr(1),
+			StoryCount:            lo.ToPtr(1),
+			BlocksCount:           lo.ToPtr(1),
 		},
 	}
 	got := p.Clone()


### PR DESCRIPTION
# Overview
New Policy Enforcement for Visualizer

## What I've done
1. Added the following parameter to Policy's Option
* NLSLayersCount *int
* PageCount *int
* StoryCount *int
* BlocksCount *int
2. Add Enforce function for added parameters
3. Add parameters and generate code in Graphql
4. Add the following test code
* policy.go
* convert_workspace.go

## What I haven't done
There is no process to invoke, only to add.

## How I tested
Only that the test code worked

## Which point I want you to review particularly
Are there any points that affect other codes?

## Memo
* Notion
https://www.notion.so/eukarya/New-Policy-Enforcement-for-Visualizer-e2d18247ff914ac5afb0e872fae3c8d6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added a `help` target in the Makefile, providing a comprehensive usage guide for available commands.
  - Introduced new fields to the `Policy` type in GraphQL, enabling more detailed data representation: `nlsLayersCount`, `pageCount`, `storyCount`, and `blocksCount`.
  - Enhanced the `Policy` class with new methods for enforcing additional metrics: `EnforceNLSLayersCount`, `EnforcePageCount`, `EnforceStoryCount`, and `EnforceBlocksCount`.
  - Added a `CountByScene` method to the `NLSLayer` interface, improving layer data management.

- **Bug Fixes**
  - Enhanced test coverage for new enforcement methods to ensure correct functionality of the policy management system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->