### PR TITLE
chore(server, web): filter out classic asset from visualizer

### DIFF
--- a/server/internal/infrastructure/mongo/asset.go
+++ b/server/internal/infrastructure/mongo/asset.go
@@ -77,6 +77,11 @@ func (r *Asset) FindByWorkspace(ctx context.Context, id accountdomain.WorkspaceI
 		})
 	}
 
+	// Classic's Assets shouldn't been shown @pyshx
+	filter = mongox.And(filter, "url", bson.M{
+		"$regex": primitive.Regex{Pattern: "visualizer", Options: "i"},
+	})
+
 	return r.paginate(ctx, filter, uFilter.Sort, uFilter.Pagination)
 }
 

--- a/web/src/services/api/assetsApi.ts
+++ b/web/src/services/api/assetsApi.ts
@@ -18,12 +18,10 @@ export default () => {
       skip: !input.teamId,
     });
 
-    const assets = useMemo(() => {
-      return (data?.assets.edges?.map(e => e.node) as AssetNodes)?.filter(asset =>
-        // Show assets which belongs to Visualizer only @pyshx
-        asset.url.includes("visualizer"),
-      );
-    }, [data?.assets]);
+    const assets = useMemo(
+      () => data?.assets.edges?.map(e => e.node) as AssetNodes,
+      [data?.assets],
+    );
 
     const hasMoreAssets = useMemo(
       () => data?.assets.pageInfo?.hasNextPage || data?.assets.pageInfo?.hasPreviousPage,


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced asset retrieval process by excluding specific assets associated with "visualizer" in their URLs, improving relevance.
	- Expanded the range of assets returned by removing previous URL filtering, allowing a broader selection of assets in the application.
  
- **Bug Fixes**
	- Adjusted logic in asset mapping to ensure completeness and correctness of data returned to components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->