### PR TITLE
fix(web): disable link when id undefined

### DIFF
--- a/web/src/beta/features/Navbar/LeftSection/index.tsx
+++ b/web/src/beta/features/Navbar/LeftSection/index.tsx
@@ -50,11 +50,11 @@ const LeftSection: React.FC<Props> = ({
 
   return (
     <Wrapper>
-      <StyledLink to={`/dashboard/${currentWorkspace?.id}`}>
+      <StyledLink to={`/dashboard/${currentWorkspace?.id}`} disabled={!currentWorkspace?.id}>
         <IconButton icon="grid" appearance="simple" size="large" />
       </StyledLink>
       {page !== "editor" && (
-        <StyledLink to={`/scene/${sceneId}/map`}>
+        <StyledLink to={`/scene/${sceneId}/map`} disabled={!sceneId}>
           <IconButton icon="editor" appearance="simple" size="large" />
         </StyledLink>
       )}
@@ -79,10 +79,11 @@ const Wrapper = styled("div")(({ theme }) => ({
   gap: theme.spacing.small,
 }));
 
-const StyledLink = styled(Link)(({ theme }) => ({
+const StyledLink = styled(Link)<{ disabled?: boolean }>(({ theme, disabled }) => ({
   display: "flex",
   color: theme.content.main,
   textDecoration: "none",
+  pointerEvents: disabled ? "none" : "all",
   "&:hover": {
     textDecoration: "none",
   },


### PR DESCRIPTION
# Overview

The link to dashboard was enabled even the id is undefined. This PR adds a disabled option to avoid that.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Introduced a `disabled` state for links in the Navbar's LeftSection, preventing navigation when certain conditions are not met. 
    - Enhanced user experience by dynamically enabling or disabling links based on workspace and scene identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->