### PR TITLE
chore(web): remember the open status of Feature Inspector Groups

### DIFF
--- a/web/src/beta/features/Editor/Map/InspectorPanel/LayerInspector/FeatureInspector/index.tsx
+++ b/web/src/beta/features/Editor/Map/InspectorPanel/LayerInspector/FeatureInspector/index.tsx
@@ -48,13 +48,11 @@ const FeatureData: FC<Props> = ({
 
   // Initialize collapsed state from localStorage
   const initialCollapsedStates = useMemo(() => {
-    const storedStates = ["customProperties", "geometry", "properties"].reduce(
-      (acc, id) => ({
-        ...acc,
-        [id]: localStorage.getItem(`reearth-visualizer-feature-${id}-collapsed`) === "true",
-      }),
-      {},
-    );
+    const storedStates: Record<string, boolean> = {};
+    ["customProperties", "geometry", "properties"].forEach(id => {
+      storedStates[id] =
+        localStorage.getItem(`reearth-visualizer-feature-${id}-collapsed`) === "true";
+    });
     return storedStates;
   }, []);
 
@@ -183,7 +181,7 @@ const FeatureData: FC<Props> = ({
         collapsed={collapsedStates.properties}
         onCollapse={state => handleCollapse("properties", state)}>
         <ValueWrapper>
-          <JsonView src={selectedFeature?.properties} theme="vscode" dark />
+          <JsonView src={selectedFeature?.properties} theme="vscode" dark style={jsonStyle} />
         </ValueWrapper>
       </Collapse>
       {!!layer?.isSketch && sketchFeature?.id && (

--- a/web/src/beta/features/Editor/Map/InspectorPanel/LayerInspector/FeatureInspector/index.tsx
+++ b/web/src/beta/features/Editor/Map/InspectorPanel/LayerInspector/FeatureInspector/index.tsx
@@ -46,16 +46,20 @@ const FeatureData: FC<Props> = ({
   const theme = useTheme();
   const [fields, setFields] = useState<FieldProp[]>([]);
 
-  const [collapsedStates, setCollapsedStates] = useState<Record<string, boolean>>({
-    customProperties: false,
-    geometry: false,
-    properties: false,
-  });
-
-  const getCollapseState = useCallback((storageId: string) => {
-    const storedState = localStorage.getItem(`reearth-visualizer-feature-${storageId}-collapsed`);
-    return storedState ? JSON.parse(storedState) : false;
+  // Initialize collapsed state from localStorage
+  const initialCollapsedStates = useMemo(() => {
+    const storedStates = ["customProperties", "geometry", "properties"].reduce(
+      (acc, id) => ({
+        ...acc,
+        [id]: localStorage.getItem(`reearth-visualizer-feature-${id}-collapsed`) === "true",
+      }),
+      {},
+    );
+    return storedStates;
   }, []);
+
+  const [collapsedStates, setCollapsedStates] =
+    useState<Record<string, boolean>>(initialCollapsedStates);
 
   const saveCollapseState = useCallback((storageId: string, state: boolean) => {
     localStorage.setItem(
@@ -63,15 +67,6 @@ const FeatureData: FC<Props> = ({
       JSON.stringify(state),
     );
   }, []);
-
-  useEffect(() => {
-    const FeatureGroups = ["customProperties", "geometry", "properties"];
-    const states = FeatureGroups.reduce((acc, id) => {
-      acc[id] = getCollapseState(id);
-      return acc;
-    }, {} as Record<string, boolean>);
-    setCollapsedStates(states);
-  }, [getCollapseState]);
 
   const handleCollapse = useCallback(
     (storageId: string, state: boolean) => {

--- a/web/src/beta/features/Editor/Map/InspectorPanel/SceneSettings/index.tsx
+++ b/web/src/beta/features/Editor/Map/InspectorPanel/SceneSettings/index.tsx
@@ -20,8 +20,8 @@ const Settings: FC<Props> = ({ propertyId, propertyItems, onFlyTo }) => {
 
   return (
     <Wrapper>
-      {visibleItems?.map((i, idx) => (
-        <Collapse key={idx} title={i.title ?? t("Settings")} size="small">
+      {visibleItems?.map(i => (
+        <Collapse key={i.schemaGroup} title={i.title ?? t("Settings")} size="small">
           <PropertyItem key={i.id} propertyId={propertyId} item={i} onFlyTo={onFlyTo} />
         </Collapse>
       ))}


### PR DESCRIPTION
# Overview
- Improved feature inspector to remember the opened status of groups by storing the status in local storage
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Implemented collapsible sections in the FeatureData component, enhancing user interaction with custom properties, geometry, and properties.
    - Added functionality to save and retrieve collapse states in local storage, preserving user preferences across sessions.

- **Improvements**
    - Enhanced component lifecycle management to initialize collapse states based on previously saved user preferences, ensuring a consistent user experience.
    - Improved key handling in the Settings component for better performance and stability during re-renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->