### PR TITLE
fix(web): assets upload & sort & size unit

### DIFF
--- a/web/src/beta/features/AssetsManager/hooks.ts
+++ b/web/src/beta/features/AssetsManager/hooks.ts
@@ -38,7 +38,7 @@ export default ({
   // sort
   const [sort, setSort] = useState<{ type?: SortType; reverse?: boolean }>({
     type: "date",
-    reverse: false,
+    reverse: true,
   });
   const t = useT();
 
@@ -46,7 +46,7 @@ export default ({
     if (!sort) return undefined;
     switch (sort.type) {
       case "date":
-        return sort.reverse ? "date-reverse" : "date";
+        return sort.reverse ? "date" : "date-reverse";
       case "name":
         return sort.reverse ? "name-reverse" : "name";
       case "size":
@@ -71,10 +71,10 @@ export default ({
   const handleSortChange = useCallback((value: string) => {
     switch (value) {
       case "date":
-        setSort({ type: "date", reverse: false });
+        setSort({ type: "date", reverse: true });
         break;
       case "date-reverse":
-        setSort({ type: "date", reverse: true });
+        setSort({ type: "date", reverse: false });
         break;
       case "name":
         setSort({ type: "name", reverse: false });

--- a/web/src/beta/features/AssetsManager/item/AssetListItem.tsx
+++ b/web/src/beta/features/AssetsManager/item/AssetListItem.tsx
@@ -34,6 +34,8 @@ const AssetListItem: FC<AssetItemProps> = ({ asset, selectedAssetIds, onSelect }
     [asset.createdAt],
   );
 
+  const formattedSize = useMemo(() => formatBytes(asset.size), [asset.size]);
+
   return (
     <Wrapper selected={selected} title={asset.name} onClick={handleAssetClick}>
       <Thumbnail>
@@ -50,7 +52,7 @@ const AssetListItem: FC<AssetItemProps> = ({ asset, selectedAssetIds, onSelect }
         <Typography size="body">{formattedDate}</Typography>
       </Col>
       <Col width={30}>
-        <Typography size="body">{asset.size}</Typography>
+        <Typography size="body">{formattedSize}</Typography>
       </Col>
     </Wrapper>
   );
@@ -98,3 +100,21 @@ const Col = styled("div")<{ width: number }>(({ width }) => ({
   flexGrow: 0,
   flexShrink: 0,
 }));
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 Bytes";
+
+  const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const value = bytes / Math.pow(1024, i);
+
+  let formattedValue;
+
+  if (i === 0) {
+    formattedValue = Math.floor(value).toLocaleString();
+  } else {
+    formattedValue = value.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  }
+
+  return `${formattedValue} ${sizes[i]}`;
+}

--- a/web/src/beta/lib/reearth-ui/components/Selector/index.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Selector/index.tsx
@@ -79,9 +79,9 @@ export const Selector: FC<SelectorProps> = ({
         onChange?.(newSelectedArr);
       }
     } else {
-      if (value === selectedValue) setSelectedValue(undefined);
-      else setSelectedValue(value);
       setIsOpen(!isOpen);
+      if (value === selectedValue) return;
+      setSelectedValue(value);
       onChange?.(value);
     }
   };

--- a/web/src/beta/ui/fields/AssetField/index.tsx
+++ b/web/src/beta/ui/fields/AssetField/index.tsx
@@ -104,15 +104,6 @@ const AssetField: FC<AssetFieldProps> = ({
           onAssetSelect={handleChange}
           assetsTypes={assetsTypes}
         />
-        // <AssetModal
-        //   open={open}
-        //   onModalClose={handleModalClose}
-        //   assetType={entityType}
-        //   currentWorkspace={currentWorkspace}
-        //   currentValue={currentValue}
-        //   fileFormat={fileFormat}
-        //   onSelect={handleChange}
-        // />
       )}
     </CommonField>
   );

--- a/web/src/services/api/assetsApi.ts
+++ b/web/src/services/api/assetsApi.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@apollo/client";
+import { useApolloClient, useMutation, useQuery } from "@apollo/client";
 import { useCallback, useMemo } from "react";
 
 import { CreateAssetInput, GetAssetsQueryVariables, GetAssetsQuery } from "@reearth/services/gql";
@@ -11,6 +11,7 @@ export type AssetNodes = NonNullable<GetAssetsQuery["assets"]["nodes"][number]>[
 export default () => {
   const t = useT();
   const [, setNotification] = useNotification();
+  const apolloCache = useApolloClient().cache;
 
   const useAssetsQuery = useCallback((input: GetAssetsQueryVariables) => {
     const { data, loading, networkStatus, fetchMore, ...rest } = useQuery(GET_ASSETS, {
@@ -56,9 +57,12 @@ export default () => {
           text: t("Successfully added one or more assets."),
         });
       }
+
+      apolloCache.evict({ fieldName: "assets" });
+
       return { data: results, result: "success" };
     },
-    [createAssetMutation, t, setNotification],
+    [apolloCache, createAssetMutation, t, setNotification],
   );
 
   const [removeAssetMutation] = useMutation(REMOVE_ASSET, {


### PR DESCRIPTION
# Overview

This PR fixes:
- New uploaded file through assets field not shown in assets manager or assets selector.
- Asset sort of first created & last created has opposite order.
- Selector will unselect the item when click on current item.
- Formatted the file size.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced sorting logic for asset listings, now defaulting to descending order by date.
	- Introduced a new utility function for formatting asset sizes into human-readable strings.
  
- **Improvements**
	- Streamlined event handling in the Selector component to prevent unnecessary state updates.
	- Improved cache management for asset data, ensuring UI reflects the most current state after data changes.

- **Chores**
	- Removed commented-out code in the AssetField component for clarity and simplicity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->