### PR TITLE
feat(web): support custom domain function

### DIFF
--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
@@ -38,21 +38,23 @@ export type PublicGASettingsType = {
   trackingId?: string;
 };
 
+export type SettingsProject = {
+  id: string;
+  publicTitle: string;
+  publicDescription: string;
+  publicImage: string;
+  isBasicAuthActive: boolean;
+  basicAuthUsername: string;
+  basicAuthPassword: string;
+  alias: string;
+  publishmentStatus: string;
+  isArchived: boolean;
+  enableGa: boolean;
+  trackingId: string;
+};
+
 type Props = {
-  project: {
-    id: string;
-    publicTitle: string;
-    publicDescription: string;
-    publicImage: string;
-    isBasicAuthActive: boolean;
-    basicAuthUsername: string;
-    basicAuthPassword: string;
-    alias: string;
-    publishmentStatus: string;
-    isArchived: boolean;
-    enableGa: boolean;
-    trackingId: string;
-  };
+  project: SettingsProject;
   stories: Story[];
   currentStory?: Story;
   subId?: string;

--- a/web/src/services/api/storytellingApi/utils.ts
+++ b/web/src/services/api/storytellingApi/utils.ts
@@ -41,6 +41,8 @@ export type Story = {
   panelPosition?: Position;
   alias: string;
   pages?: Page[];
+  trackingId?: string; // Not supported yet
+  enableGa?: boolean; // Not supported yet
 };
 
 export const getStories = (rawScene?: GetSceneQuery) => {

--- a/web/src/services/i18n/translations/en.yml
+++ b/web/src/services/i18n/translations/en.yml
@@ -202,6 +202,7 @@ You are about to change the site name for your project. Only alphanumeric charac
 Google Analytics: ''
 Enable Google Analytics: ''
 Tracking ID: ''
+Custom Domain: ''
 Left: ''
 Right: ''
 Story Panel: ''

--- a/web/src/services/i18n/translations/ja.yml
+++ b/web/src/services/i18n/translations/ja.yml
@@ -202,6 +202,7 @@ You are about to change the site name for your project. Only alphanumeric charac
 Google Analytics: ''
 Enable Google Analytics: 有効
 Tracking ID: ''
+Custom Domain: ''
 Left: 左
 Right: 右
 Story Panel: ストーリーパネル


### PR DESCRIPTION
# Overview

This PR adds back using publication extension. But the extension itself is not updated yet. It need to be done on reearth-cloud.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced project settings component with improved authentication and notification handling.
	- Dynamic rendering of custom domains based on access token availability.
	- Introduced a new type definition for project settings to improve maintainability.
	- Added support for custom domain localization in English and Japanese.

- **Bug Fixes**
	- Corrected props structure to streamline data handling in project settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->