### PR TITLE
feat(web): support infobox for plugin layer

### DIFF
--- a/web/src/beta/features/Visualizer/Crust/Plugins/hooks/useLayers.ts
+++ b/web/src/beta/features/Visualizer/Crust/Plugins/hooks/useLayers.ts
@@ -43,7 +43,9 @@ export default ({
 
   const addLayer = useCallback(
     (layer: NaiveLayer) => {
-      return layersRef?.add(layer)?.id;
+      const layerId = layersRef?.add(layer)?.id;
+      // TODO: handle infobox
+      return layerId;
     },
     [layersRef]
   );

--- a/web/src/beta/features/Visualizer/Crust/index.tsx
+++ b/web/src/beta/features/Visualizer/Crust/index.tsx
@@ -244,15 +244,18 @@ export default function Crust({
   });
 
   const featuredInfobox = useMemo(() => {
-    const selected = layers?.find((l) => l.id === selectedLayer?.layerId);
+    const selected = mapRef?.current?.layers?.find(
+      (l) => l.id === selectedLayer?.layerId
+    );
     return selectedLayerId?.featureId && selected?.infobox
       ? {
           property: selected?.infobox?.property,
           blocks: [...(selected?.infobox?.blocks ?? [])],
-          featureId: selectedLayerId.featureId
+          featureId: selectedLayerId.featureId,
+          readOnly: !layers?.find((l) => l.id === selectedLayer?.layerId)
         }
       : undefined;
-  }, [layers, selectedLayer, selectedLayerId?.featureId]);
+  }, [mapRef, layers, selectedLayer, selectedLayerId?.featureId]);
 
   return (
     <Plugins
@@ -312,7 +315,7 @@ export default function Crust({
       <Infobox
         infobox={featuredInfobox}
         installableInfoboxBlocks={installableInfoboxBlocks}
-        isEditable={!!inEditor}
+        isEditable={!!inEditor && !featuredInfobox?.readOnly}
         renderBlock={renderBlock}
         onBlockCreate={onInfoboxBlockCreate}
         onBlockDelete={onInfoboxBlockDelete}

--- a/web/src/beta/features/Visualizer/Crust/index.tsx
+++ b/web/src/beta/features/Visualizer/Crust/index.tsx
@@ -244,17 +244,29 @@ export default function Crust({
   });
 
   const featuredInfobox = useMemo(() => {
+    if (!selectedLayerId?.featureId) return undefined;
+    const selectedDataLayer = layers?.find(
+      (l) => l.id === selectedLayer?.layerId
+    );
+    if (selectedDataLayer?.infobox) {
+      return {
+        property: selectedDataLayer?.infobox?.property,
+        blocks: [...(selectedDataLayer?.infobox?.blocks ?? [])],
+        featureId: selectedLayerId.featureId
+      };
+    }
     const selected = mapRef?.current?.layers?.find(
       (l) => l.id === selectedLayer?.layerId
     );
-    return selectedLayerId?.featureId && selected?.infobox
-      ? {
-          property: selected?.infobox?.property,
-          blocks: [...(selected?.infobox?.blocks ?? [])],
-          featureId: selectedLayerId.featureId,
-          readOnly: !layers?.find((l) => l.id === selectedLayer?.layerId)
-        }
-      : undefined;
+    if (selected?.infobox) {
+      return {
+        property: selected?.infobox?.property,
+        blocks: [...(selected?.infobox?.blocks ?? [])],
+        featureId: selectedLayerId.featureId,
+        readOnly: true
+      };
+    }
+    return undefined;
   }, [mapRef, layers, selectedLayer, selectedLayerId?.featureId]);
 
   return (


### PR DESCRIPTION
# Overview

This PR make it functional to render infobox for plugin layer.

## What I've done

Visualizer's infobox should be handled by Visualizer only, currently it has a lot of relationship with core, which is coming from classic design. In the near future we need to refactor this part and interface.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved layer selection logic for enhanced accuracy in the visualizer.
	- Introduced a new `readOnly` property for the infobox, affecting its editability based on the selected layer.

- **Bug Fixes**
	- Enhanced robustness of the infobox rendering by refining conditions for editability.

- **Refactor**
	- Improved code readability and clarity in the layer addition process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->