### PR TITLE
refactor(server): delete useless server stamen definition

### DIFF
--- a/server/pkg/builtin/manifest.yml
+++ b/server/pkg/builtin/manifest.yml
@@ -54,10 +54,6 @@ extensions:
                   label: Labelled
                 - key: default_road
                   label: Road Map
-                - key: stamen_watercolor
-                  label: Stamen Watercolor
-                - key: stamen_toner
-                  label: Stamen Toner
                 - key: open_street_map
                   label: OpenStreetMap
                 - key: esri_world_topo

--- a/server/pkg/builtin/manifest_ja.yml
+++ b/server/pkg/builtin/manifest_ja.yml
@@ -27,8 +27,6 @@ extensions:
               default: デフォルト
               default_label: ラベル付き地図
               default_road: 道路地図
-              stamen_watercolor: Stamen Watercolor
-              stamen_toner: Stamen Toner
               open_street_map: OpenStreetMap
               esri_world_topo: ESRI Topography
               black_marble: Black Marble


### PR DESCRIPTION
# Overview

## What I've done
refactor: delete useless server stamen definition

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined map options by removing "Stamen Watercolor" and "Stamen Toner" from the available map styles.
- **Impact**
	- Users now have a more curated selection of map types, which may enhance usability but limits options for those who preferred the removed styles. Remaining options include "OpenStreetMap" and "ESRI Topography."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->