### PR TITLE
fix(web): page time not updated when switch story page

### DIFF
--- a/web/src/beta/features/Visualizer/Crust/StoryPanel/hooks.ts
+++ b/web/src/beta/features/Visualizer/Crust/StoryPanel/hooks.ts
@@ -107,10 +107,9 @@ export default (
       return visualizer?.current?.timeline?.current?.commit({
         cmd: "SET_TIME",
         payload: {
-          start:
-            visualizer?.current?.timeline?.current?.computedTimeline?.start,
+          start: time,
           current: time,
-          stop: visualizer?.current?.timeline?.current?.computedTimeline?.stop
+          stop: time
         },
         committer: { source: "storyPage", id: currentPageId }
       });
@@ -120,11 +119,9 @@ export default (
 
   const handlePageTime = useCallback(
     (page: StoryPage) => {
-      const timePointField = page.property?.timePoint;
-      if (!timePointField?.timePoint?.value) return;
-      return onTimeChange?.(
-        new Date(formatISO8601(timePointField?.timePoint?.value) ?? "")
-      );
+      const time = page.property?.timePoint?.timePoint;
+      if (!time) return;
+      onTimeChange?.(new Date(formatISO8601(time)));
     },
     [onTimeChange]
   );


### PR DESCRIPTION
# Overview

This PR fixes the bug that page time doesn't got updated when switch story page

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved time handling logic in the StoryPanel component for better clarity and efficiency.
  
- **Bug Fixes**
	- Streamlined the time update process by simplifying the checks and ensuring consistent start and stop times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->