### PR TITLE
fix(web): plugin iframe has an incorrect size

### DIFF
--- a/web/src/beta/features/Visualizer/Crust/Plugins/PluginFrame/SafeIFrame/hooks.ts
+++ b/web/src/beta/features/Visualizer/Crust/Plugins/PluginFrame/SafeIFrame/hooks.ts
@@ -153,10 +153,8 @@ export default function useHook({
           const st = win.getComputedStyle(html, "");
           horizontalMargin = parseInt(st.getPropertyValue("margin-left"), 10) + parseInt(st.getPropertyValue("margin-right"), 10);
           verticalMargin = parseInt(st.getPropertyValue("margin-top"), 10) + parseInt(st.getPropertyValue("margin-bottom"), 10);
-          const horizontalScrollbarHeight = window.innerHeight - document.documentElement.clientHeight;
-          const verticalScrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
-          const width = html.offsetWidth + horizontalMargin + verticalScrollbarWidth;
-          const height = html.offsetHeight + verticalMargin + horizontalScrollbarHeight;
+          const width = html.offsetWidth + horizontalMargin;
+          const height = html.offsetHeight + verticalMargin;
           if(parent){
             parent.postMessage({
               [${JSON.stringify(autoResizeMessageKey)}]: { width, height }


### PR DESCRIPTION
# Overview

When auto resize base on plugin html css we don't need to take scrollbar size in consider.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified the calculations for the dimensions of HTML elements, improving the resizing logic by removing the impact of scrollbars.
- **Refactor**
	- Enhanced the efficiency of the dimension calculations for a more straightforward implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->