### PR TITLE
fix(web): Update button on publish modal is always disabled on first time

### DIFF
--- a/web/src/beta/features/Editor/Publish/PublishToolsPanel/hooks.ts
+++ b/web/src/beta/features/Editor/Publish/PublishToolsPanel/hooks.ts
@@ -72,10 +72,7 @@ export default ({
   const generateAlias = useCallback(() => generateRandomString(10), []);
 
   const [validAlias, setValidAlias] = useState(false);
-  const alias = useMemo(
-    () => project?.alias ?? generateAlias(),
-    [project?.alias, generateAlias]
-  );
+  const [alias, setAlias] = useState<string>(project?.alias ?? generateAlias());
 
   const [
     checkProjectAlias,
@@ -109,6 +106,17 @@ export default ({
     },
     [project?.alias, checkProjectAlias]
   );
+
+  useEffect(() => {
+    if (modalOpen) {
+      if (!alias) {
+        const generatedAlias = generateAlias();
+        setAlias(generatedAlias);
+      }
+
+      handleProjectAliasCheck(alias);
+    }
+  }, [modalOpen, alias, generateAlias, handleProjectAliasCheck]);
 
   useEffect(() => {
     setValidAlias(


### PR DESCRIPTION
# Overview
https://www.notion.so/eukarya/BUG-Update-button-on-publish-modal-is-always-disabled-on-first-time-10616e0fb16580b7878dcf1dc3321d25
## What I've done
<img width="502" alt="スクリーンショット 2024-09-19 17 17 55" src="https://github.com/user-attachments/assets/27a59793-555c-449b-92d4-0ad4c6ece648">

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved alias management in the Publish Tools Panel, ensuring that aliases are generated and validated when the modal is opened.

- **Bug Fixes**
	- Enhanced responsiveness of alias updates to modal state changes, ensuring valid aliases are always presented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->