### PR TITLE
feat(web): update preset layer style hideIndicator setting

### DIFF
--- a/web/src/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/presetLayerStyles.ts
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/presetLayerStyles.ts
@@ -83,7 +83,7 @@ export const pointWithLabelStyle = {
 export const polylineStyle = {
   polyline: {
     clampToGround: true,
-    hideIndicator: false,
+    hideIndicator: true,
     selectedFeatureColor: "#F1AF02",
     strokeColor: "#E9373D",
     strokeWidth: 2
@@ -94,7 +94,7 @@ export const polygonStyle = {
   polygon: {
     fillColor: "#E9373D",
     heightReference: "clamp",
-    hideIndicator: false,
+    hideIndicator: true,
     selectedFeatureColor: "#F1AF02"
   }
 };
@@ -106,7 +106,7 @@ export const extrudedPolygonStyle = {
     },
     fillColor: "#E9373D",
     heightReference: "clamp",
-    hideIndicator: false,
+    hideIndicator: true,
     selectedFeatureColor: "#F1AF02"
   }
 };

--- a/web/src/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/presetLayerStyles.ts
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/presetLayerStyles.ts
@@ -23,7 +23,7 @@ export const defaultStyle = {
 export const professionalStyle = {
   marker: {
     heightReference: "clamp",
-    hideIndicator: false,
+    hideIndicator: true,
     pointColor: "#E9373D",
     pointOutlineColor: "white",
     pointOutlineWidth: 1,
@@ -39,14 +39,14 @@ export const professionalStyle = {
       expression: "color('#E9373D',0.6)"
     },
     heightReference: "clamp",
-    hideIndicator: false,
+    hideIndicator: true,
     selectedFeatureColor: {
       expression: "color('#F1AF02',0.6)"
     }
   },
   polyline: {
     clampToGround: true,
-    hideIndicator: false,
+    hideIndicator: true,
     selectedFeatureColor: "#F1AF02",
     strokeColor: "#E9373D",
     strokeWidth: 2


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated styles for various map layers, enhancing visual customization options.

- **Bug Fixes**
	- The indicator for `professionalStyle`, `polylineStyle`, `polygonStyle`, and `extrudedPolygonStyle` is now hidden for a cleaner appearance.

- **Improvements**
	- Changed the fill color of the `professionalStyle` polygon for better visual distinction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->