### PR TITLE
fix(server): extension cahnge

### DIFF
--- a/server/internal/adapter/gql/resolver_mutation_project.go
+++ b/server/internal/adapter/gql/resolver_mutation_project.go
@@ -125,7 +125,7 @@ func (r *mutationResolver) ExportProject(ctx context.Context, input gqlmodel.Exp
 	t := time.Now().UTC()
 	entropy := ulid.Monotonic(rand.New(rand.NewSource(uint64(t.UnixNano()))), 0)
 	name := ulid.MustNew(ulid.Timestamp(t), entropy)
-	zipFile, err := fs.Create(fmt.Sprintf("%s.reearth", name.String()))
+	zipFile, err := fs.Create(fmt.Sprintf("%s.zip", name.String()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Overview
Cannot download with .reearth extension in CloudStrage

## What I've done
Revert the zip file extension

## What I haven't done

## How I tested
This is a speculative fix and cannot be confirmed until it is released.

## Which point I want you to review particularly

## Memo
https://www.notion.so/eukarya/BUG-Export-project-404-on-test-env-11316e0fb16580a3b042df5d12a679bc