### PR TITLE
refactor(web): correct lang state in settings with meData

### DIFF
--- a/web/src/beta/features/AccountSetting/hooks.ts
+++ b/web/src/beta/features/AccountSetting/hooks.ts
@@ -7,7 +7,7 @@ type UpdatePasswordType = {
 };
 
 export default () => {
-  const { useMeQuery, useUpdatePassword, useDeleteUser, updateLanguage } =
+  const { useMeQuery, useUpdatePassword, useDeleteUser, useUpdateLanguage } =
     useMeFetcher();
   const { me: data } = useMeQuery();
 
@@ -36,12 +36,12 @@ export default () => {
   const handleUpdateUserLanguage = useCallback(
     async ({ lang }: { lang: string }) => {
       try {
-        await updateLanguage(lang);
+        await useUpdateLanguage(lang);
       } catch (error) {
         console.error("Failed to update language:", error);
       }
     },
-    [updateLanguage]
+    [useUpdateLanguage]
   );
 
   return {

--- a/web/src/beta/features/AccountSetting/index.tsx
+++ b/web/src/beta/features/AccountSetting/index.tsx
@@ -26,8 +26,6 @@ const AccountSetting: FC = () => {
     handleUpdateUserPassword,
     handleUpdateUserLanguage
   } = useHook();
-  const { name, email, lang } = meData;
-
   const [currentWorkspace] = useWorkspace();
 
   const { tabs } = useAccountSettingsTabs({
@@ -57,13 +55,13 @@ const AccountSetting: FC = () => {
             <SettingsFields>
               <InputField
                 title={t("Name")}
-                value={name ? t(name) : ""}
+                value={meData.name ? t(meData.name) : ""}
                 appearance="readonly"
                 disabled
               />
               <InputField
                 title={t("Email address")}
-                value={email ? t(email) : ""}
+                value={meData.email ? t(meData.email) : ""}
                 appearance="readonly"
                 disabled
               />
@@ -90,7 +88,7 @@ const AccountSetting: FC = () => {
               </PasswordWrapper>
               <SelectField
                 title={t("Language")}
-                value={lang ?? "und"}
+                value={meData.lang ?? "und"}
                 options={options}
                 onChange={(value) => {
                   handleUpdateUserLanguage({ lang: value as string });

--- a/web/src/beta/features/AccountSetting/index.tsx
+++ b/web/src/beta/features/AccountSetting/index.tsx
@@ -26,7 +26,7 @@ const AccountSetting: FC = () => {
     handleUpdateUserPassword,
     handleUpdateUserLanguage
   } = useHook();
-  const { name, email } = meData;
+  const { name, email, lang } = meData;
 
   const [currentWorkspace] = useWorkspace();
 
@@ -48,8 +48,6 @@ const AccountSetting: FC = () => {
       value: "ja"
     }
   ];
-  type LanguageOption = (typeof options)[number]["value"];
-  const [languageLabel, setLanguageLabel] = useState<LanguageOption>("und");
 
   return (
     <SettingBase tabs={tabs} tab={"account"}>
@@ -92,13 +90,10 @@ const AccountSetting: FC = () => {
               </PasswordWrapper>
               <SelectField
                 title={t("Language")}
-                value={languageLabel}
+                value={lang ?? "und"}
                 options={options}
                 onChange={(value) => {
-                  if (typeof value === "string") {
-                    setLanguageLabel(value);
-                    handleUpdateUserLanguage({ lang: value });
-                  }
+                  handleUpdateUserLanguage({ lang: value as string });
                 }}
               />
             </SettingsFields>

--- a/web/src/services/api/meApi.ts
+++ b/web/src/services/api/meApi.ts
@@ -77,11 +77,10 @@ export default () => {
     [deleteMeMutation, setNotification, t]
   );
 
-  const updateLanguage = useCallback(
+  const useUpdateLanguage = useCallback(
     async (lang: string) => {
       if (!lang) return;
       const { data, errors } = await updateMeMutation({ variables: { lang } });
-      console.log(data);
       if (errors || !data?.updateMe) {
         console.log("GraphQL: Failed to update language", errors);
         setNotification({
@@ -104,6 +103,6 @@ export default () => {
     useMeQuery,
     useUpdatePassword,
     useDeleteUser,
-    updateLanguage
+    useUpdateLanguage
   };
 };


### PR DESCRIPTION
# Overview

- The lang value should coming from me data.
- Rename api hooks to follow the common format.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The Account Settings component now directly utilizes the user's language preference from the `meData` object for improved language handling.
  
- **Improvements**
	- Streamlined the language selection process by removing unnecessary state management and simplifying the `SelectField` component.
	- Enhanced naming consistency by renaming functions to align with hook conventions, improving clarity and maintainability. 

These changes contribute to a more efficient and user-friendly experience when managing language preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->