### PR TITLE
chore(web): support default built-in layer style

### DIFF
--- a/web/src/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/presetLayerStyles.ts
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/presetLayerStyles.ts
@@ -1,6 +1,7 @@
+import { LayerAppearanceTypes } from "@reearth/core";
 import { LayerStyle } from "@reearth/services/api/layerStyleApi/utils";
 
-export const defaultStyle = {
+export const defaultStyle: Partial <LayerAppearanceTypes>   = {
   marker: {
     heightReference: "clamp"
   },

--- a/web/src/beta/features/Editor/Visualizer/convert.ts
+++ b/web/src/beta/features/Editor/Visualizer/convert.ts
@@ -1,3 +1,4 @@
+import { defaultStyle } from "@reearth/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/presetLayerStyles";
 import {
   type WidgetZone,
   type WidgetSection,
@@ -12,10 +13,7 @@ import {
   isBuiltinWidget
 } from "@reearth/beta/features/Visualizer/Crust/Widgets";
 import { WidgetAreaPadding } from "@reearth/beta/features/Visualizer/Crust/Widgets/WidgetAlignSystem/types";
-import {
-  DEFAULT_LAYER_STYLE,
-  valueTypeFromGQL
-} from "@reearth/beta/utils/value";
+import { valueTypeFromGQL } from "@reearth/beta/utils/value";
 import { LayerAppearanceTypes } from "@reearth/core";
 import type { Layer } from "@reearth/core";
 import { NLSLayer } from "@reearth/services/api/layersApi/utils";
@@ -402,7 +400,7 @@ export function processLayers(
       }
     }
 
-    return DEFAULT_LAYER_STYLE;
+    return defaultStyle;
   };
 
   return newLayers?.map((nlsLayer) => {

--- a/web/src/beta/features/Editor/Visualizer/hooks.ts
+++ b/web/src/beta/features/Editor/Visualizer/hooks.ts
@@ -145,6 +145,7 @@ export default ({
     }));
   }, [nlsLayers, layerStyles, infoboxBlockNames, showStoryPanel]);
 
+  console.log("layers", layers);
   const handleCoreLayerSelect = useCallback(
     (
       layerId?: string,

--- a/web/src/beta/features/Editor/Visualizer/hooks.ts
+++ b/web/src/beta/features/Editor/Visualizer/hooks.ts
@@ -145,7 +145,6 @@ export default ({
     }));
   }, [nlsLayers, layerStyles, infoboxBlockNames, showStoryPanel]);
 
-  console.log("layers", layers);
   const handleCoreLayerSelect = useCallback(
     (
       layerId?: string,

--- a/web/src/beta/features/Published/convert-new-property.ts
+++ b/web/src/beta/features/Published/convert-new-property.ts
@@ -1,5 +1,5 @@
+import { defaultStyle } from "@reearth/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/presetLayerStyles";
 import { InfoboxBlock } from "@reearth/beta/features/Visualizer/Crust/Infobox/types";
-import { DEFAULT_LAYER_STYLE } from "@reearth/beta/utils/value";
 import { Layer, LayerAppearanceTypes } from "@reearth/core";
 import {
   NLSInfobox,
@@ -70,7 +70,7 @@ export function processLayers(
       }
     }
 
-    return DEFAULT_LAYER_STYLE;
+    return defaultStyle;
   };
 
   return newLayers?.map((nlsLayer) => {

--- a/web/src/beta/utils/value.ts
+++ b/web/src/beta/utils/value.ts
@@ -1,4 +1,3 @@
-import { LayerAppearanceTypes } from "@reearth/core";
 import { ValueType as GQLValueType } from "@reearth/services/gql";
 import { css } from "@reearth/services/theme";
 import { Color } from "cesium";
@@ -253,20 +252,3 @@ export const zeroValues: { [key in ValueType]?: ValueTypes[ValueType] } = {
   string: ""
 };
 
-export const DEFAULT_LAYER_STYLE: Partial<LayerAppearanceTypes> = {
-  "3dtiles": {
-    show: true
-  },
-  resource: {
-    clampToGround: true
-  },
-  marker: {
-    heightReference: "clamp"
-  },
-  polygon: {
-    heightReference: "clamp"
-  },
-  polyline: {
-    clampToGround: true
-  }
-};


### PR DESCRIPTION
# Overview
Use the Default style defined  inside preset as default style for the layers
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type safety for default layer styles.
	- Improved debugging capabilities in the Visualizer component.
  
- **Bug Fixes**
	- Adjusted the default layer style retrieval mechanism to ensure accurate application behavior.

- **Chores**
	- Removed deprecated `DEFAULT_LAYER_STYLE` constant to streamline layer style management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->