### PR TITLE
feat(web): support asset field in layer style editor

### DIFF
--- a/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/StyleNode/Field/index.tsx
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/StyleNode/Field/index.tsx
@@ -50,7 +50,7 @@ const fieldComponents = {
       onChange={props.onUpdate}
     />
   ),
-  asset: (props: FieldProps) => (
+  image: (props: FieldProps) => (
     <AssetField
       inputMethod="asset"
       value={props.value as string}

--- a/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/StyleNode/Field/index.tsx
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/StyleNode/Field/index.tsx
@@ -1,9 +1,11 @@
+import { IMAGE_TYPES } from "@reearth/beta/features/AssetsManager/constants";
 import {
   ColorInput,
   NumberInput,
   Selector,
   TextInput
 } from "@reearth/beta/lib/reearth-ui";
+import { AssetField } from "@reearth/beta/ui/fields";
 import { FC } from "react";
 
 import { AppearanceField, StyleSimpleValue, Typography } from "../../types";
@@ -45,6 +47,14 @@ const fieldComponents = {
   typography: (props: FieldProps) => (
     <TypographyInput
       value={props.value as Typography}
+      onChange={props.onUpdate}
+    />
+  ),
+  asset: (props: FieldProps) => (
+    <AssetField
+      inputMethod="asset"
+      value={props.value as string}
+      assetsTypes={IMAGE_TYPES}
       onChange={props.onUpdate}
     />
   )

--- a/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/StyleNode/ValueTab.tsx
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/StyleNode/ValueTab.tsx
@@ -29,7 +29,7 @@ export default ValueTab;
 
 const Wrapper = styled("div")(({ theme }) => ({
   display: "flex",
+  flexDirection: "column",
   gap: theme.spacing.smallest,
-  alignItems: "center",
   minHeight: 28
 }));

--- a/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/appearanceNodes/marker.ts
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/appearanceNodes/marker.ts
@@ -56,7 +56,7 @@ export const markerNodes: AppearanceNode[] = [
   {
     id: "image",
     title: "Image",
-    field: "asset",
+    field: "image",
     defaultValue: ""
   },
   {

--- a/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/appearanceNodes/marker.ts
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/appearanceNodes/marker.ts
@@ -56,7 +56,7 @@ export const markerNodes: AppearanceNode[] = [
   {
     id: "image",
     title: "Image",
-    field: "text",
+    field: "asset",
     defaultValue: ""
   },
   {

--- a/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/types.ts
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/types.ts
@@ -12,7 +12,7 @@ export type AppearanceField =
   | "select"
   | "text"
   | "typography"
-  | "asset";
+  | "image";
 
 export type AppearanceNodes = Record<AppearanceType, AppearanceNode[]>;
 

--- a/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/types.ts
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/types.ts
@@ -11,7 +11,8 @@ export type AppearanceField =
   | "number"
   | "select"
   | "text"
-  | "typography";
+  | "typography"
+  | "asset";
 
 export type AppearanceNodes = Record<AppearanceType, AppearanceNode[]>;
 


### PR DESCRIPTION
# Overview
- supported asset field in layer field node
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new component for handling image fields in the StyleNode's Field component.
	- Expanded the options for appearance fields to include an "image" type.

- **Bug Fixes**
	- Adjusted the handling of image assets within the marker nodes to reflect the new "image" type.

- **Style**
	- Modified the layout direction of the ValueTab component for improved visual organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->