### PR TITLE
fix: update sub-route for projects

### DIFF
--- a/web/src/beta/features/Dashboard/ContentsContainer/Projects/Project/hooks.ts
+++ b/web/src/beta/features/Dashboard/ContentsContainer/Projects/Project/hooks.ts
@@ -97,7 +97,7 @@ export default ({
     {
       id: "setting",
       title: t("Project Setting"),
-      path: `/settings/project/${project.id}`,
+      path: `/settings/projects/${project.id}`,
       icon: "setting"
     },
     {

--- a/web/src/beta/features/Navbar/LeftSection/index.tsx
+++ b/web/src/beta/features/Navbar/LeftSection/index.tsx
@@ -41,14 +41,16 @@ const LeftSection: React.FC<Props> = ({
         icon: "setting",
         id: "setting",
         title: t("Project settings"),
-        path: currentProject?.id ? `/settings/project/${currentProject.id}` : ""
+        path: currentProject?.id
+          ? `/settings/projects/${currentProject.id}`
+          : ""
       },
       {
         icon: "plugin",
         id: "plugin",
         title: t("Plugin"),
         path: currentProject?.id
-          ? `/settings/project/${currentProject.id}/plugins`
+          ? `/settings/projects/${currentProject.id}/plugins`
           : ""
       }
     ],

--- a/web/src/beta/features/ProjectSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/index.tsx
@@ -69,7 +69,7 @@ const ProjectSettings: React.FC<Props> = ({ projectId, tab, subId }) => {
         id: tab.id,
         icon: tab.icon,
         text: t(tab.text),
-        path: `/settings/project/${projectId}/${tab.id === "general" ? "" : tab.id}`
+        path: `/settings/projects/${projectId}/${tab.id === "general" ? "" : tab.id}`
       })),
     [projectId, t]
   );

--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
@@ -90,14 +90,14 @@ const PublicSettings: React.FC<Props> = ({
         id: "map",
         title: t("Map"),
         icon: "globeSimple" as const,
-        path: `/settings/project/${project.id}/public/`,
+        path: `/settings/projects/${project.id}/public/`,
         active: selectedTab === "map"
       },
       ...stories.map((s) => ({
         id: s.id,
         title: (!s.title || s.title) === "Default" ? t("Story") : s.title,
         icon: "sidebar" as const,
-        path: `/settings/project/${project.id}/public/${s.id}`,
+        path: `/settings/projects/${project.id}/public/${s.id}`,
         active: selectedTab === s.id
       }))
     ],

--- a/web/src/beta/hooks/navigationHooks.ts
+++ b/web/src/beta/hooks/navigationHooks.ts
@@ -27,7 +27,7 @@ export const useSettingsNavigation = ({
     (page?: "public" | "story" | "asset" | "plugin", subId?: string) => {
       if (!projectId || !page) return;
       navigate(
-        `/settings/project/${projectId}/${page}${subId ? `/${subId}` : ""}`
+        `/settings/projects/${projectId}/${page}${subId ? `/${subId}` : ""}`
       );
     },
     [projectId, navigate]

--- a/web/src/services/routing/index.tsx
+++ b/web/src/services/routing/index.tsx
@@ -38,7 +38,7 @@ export const AppRoutes = () => {
       element: <Editor />
     },
     {
-      path: "settings/project/:projectId/:tab?/:subId?",
+      path: "settings/projects/:projectId/:tab?/:subId?",
       element: <ProjectSettings />
     },
     {


### PR DESCRIPTION
# Overview
Updated the sub-route for projects to align with RESTful route naming convention
## What I've done

## What I haven't done

## How I tested
Tested by navigating to the pages leading to the `projects` page and `individual project` settings page.
## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated URL paths for project settings and related components to reflect a pluralized structure, enhancing navigation consistency.

- **Bug Fixes**
	- Corrected path inconsistencies across various components related to project settings and plugins.

- **Documentation**
	- Improved clarity in routing configurations to align with the new URL structure for accessing project settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->