### PR TITLE
fix(web): exclude czml & kml for the default layer style

### DIFF
--- a/web/src/beta/features/Editor/Visualizer/convert.ts
+++ b/web/src/beta/features/Editor/Visualizer/convert.ts
@@ -392,7 +392,7 @@ export function processLayers(
     const layerStyle = getLayerStyleValue(
       layerStyles,
       nlsLayer.config?.layerStyleId,
-      (nlsLayer.config?.data?.type ?? "").toLowerCase()
+      nlsLayer.config?.data?.type
     );
 
     const sketchLayerData = nlsLayer.isSketch && {

--- a/web/src/beta/features/Editor/Visualizer/convert.ts
+++ b/web/src/beta/features/Editor/Visualizer/convert.ts
@@ -1,4 +1,3 @@
-import { defaultStyle } from "@reearth/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/presetLayerStyles";
 import {
   type WidgetZone,
   type WidgetSection,
@@ -13,8 +12,8 @@ import {
   isBuiltinWidget
 } from "@reearth/beta/features/Visualizer/Crust/Widgets";
 import { WidgetAreaPadding } from "@reearth/beta/features/Visualizer/Crust/Widgets/WidgetAlignSystem/types";
+import { getLayerStyleValue } from "@reearth/beta/utils/layer-style";
 import { valueTypeFromGQL } from "@reearth/beta/utils/value";
-import { LayerAppearanceTypes } from "@reearth/core";
 import type { Layer } from "@reearth/core";
 import { NLSLayer } from "@reearth/services/api/layersApi/utils";
 import { LayerStyle } from "@reearth/services/api/layerStyleApi/utils";
@@ -389,22 +388,12 @@ export function processLayers(
   parent?: RawNLSLayer | null | undefined,
   infoboxBlockNames?: Record<string, string>
 ): Layer[] | undefined {
-  const getLayerStyleValue = (id?: string) => {
-    const layerStyleValue: Partial<LayerAppearanceTypes> | undefined =
-      layerStyles?.find((a) => a.id === id)?.value;
-    if (typeof layerStyleValue === "object") {
-      try {
-        return layerStyleValue;
-      } catch (e) {
-        console.error("Error parsing layerStyle JSON:", e);
-      }
-    }
-
-    return defaultStyle;
-  };
-
   return newLayers?.map((nlsLayer) => {
-    const layerStyle = getLayerStyleValue(nlsLayer.config?.layerStyleId);
+    const layerStyle = getLayerStyleValue(
+      layerStyles,
+      nlsLayer.config?.layerStyleId,
+      (nlsLayer.config?.data?.type ?? "").toLowerCase()
+    );
 
     const sketchLayerData = nlsLayer.isSketch && {
       ...nlsLayer.config.data,

--- a/web/src/beta/features/Published/convert-new-property.ts
+++ b/web/src/beta/features/Published/convert-new-property.ts
@@ -63,7 +63,7 @@ export function processLayers(
     const layerStyle = getLayerStyleValue(
       layerStyles,
       nlsLayer.config?.layerStyleId,
-      (nlsLayer.config?.data?.type ?? "").toLowerCase()
+      nlsLayer.config?.data?.type
     );
     const sketchLayerData = nlsLayer.isSketch && {
       ...nlsLayer.config.data,

--- a/web/src/beta/features/Published/convert-new-property.ts
+++ b/web/src/beta/features/Published/convert-new-property.ts
@@ -1,6 +1,6 @@
-import { defaultStyle } from "@reearth/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/presetLayerStyles";
 import { InfoboxBlock } from "@reearth/beta/features/Visualizer/Crust/Infobox/types";
-import { Layer, LayerAppearanceTypes } from "@reearth/core";
+import { getLayerStyleValue } from "@reearth/beta/utils/layer-style";
+import { Layer } from "@reearth/core";
 import {
   NLSInfobox,
   NLSLayer,
@@ -59,22 +59,12 @@ export function processLayers(
   newLayers?: NLSLayer[],
   layerStyles?: LayerStyle[]
 ): Layer[] | undefined {
-  const getLayerStyleValue = (id?: string) => {
-    const layerStyleValue: Partial<LayerAppearanceTypes> | undefined =
-      layerStyles?.find((a) => a.id === id)?.value;
-    if (typeof layerStyleValue === "object") {
-      try {
-        return layerStyleValue;
-      } catch (e) {
-        console.error("Error parsing layerStyle JSON:", e);
-      }
-    }
-
-    return defaultStyle;
-  };
-
   return newLayers?.map((nlsLayer) => {
-    const layerStyle = getLayerStyleValue(nlsLayer.config?.layerStyleId);
+    const layerStyle = getLayerStyleValue(
+      layerStyles,
+      nlsLayer.config?.layerStyleId,
+      (nlsLayer.config?.data?.type ?? "").toLowerCase()
+    );
     const sketchLayerData = nlsLayer.isSketch && {
       ...nlsLayer.config.data,
       value: {

--- a/web/src/beta/utils/layer-style.ts
+++ b/web/src/beta/utils/layer-style.ts
@@ -1,0 +1,18 @@
+import { defaultStyle } from "@reearth/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/presetLayerStyles";
+import { LayerAppearanceTypes } from "@reearth/core";
+import { LayerStyle } from "@reearth/services/api/layerStyleApi/utils";
+
+export const getLayerStyleValue = (
+  layerStyles: LayerStyle[] | undefined,
+  id?: string,
+  type?: string
+) => {
+  const layerStyleValue: Partial<LayerAppearanceTypes> | undefined =
+    layerStyles?.find((a) => a.id === id)?.value;
+  if (typeof layerStyleValue === "object") {
+    return layerStyleValue;
+  }
+
+  if (type === "czml" || type === "kml") return {};
+  return defaultStyle;
+};

--- a/web/src/beta/utils/layer-style.ts
+++ b/web/src/beta/utils/layer-style.ts
@@ -9,10 +9,14 @@ export const getLayerStyleValue = (
 ) => {
   const layerStyleValue: Partial<LayerAppearanceTypes> | undefined =
     layerStyles?.find((a) => a.id === id)?.value;
-  if (typeof layerStyleValue === "object") {
+
+  const typeInLowercase = type?.toLowerCase() ?? "";
+
+  if (layerStyleValue !== null && typeof layerStyleValue === "object") {
     return layerStyleValue;
   }
 
-  if (type === "czml" || type === "kml") return {};
+  if (["czml", "kml"].includes(typeInLowercase)) return {};
+
   return defaultStyle;
 };


### PR DESCRIPTION
# Overview

CZML & KML supports define styles by themselves, we should exclude them when try applying default layer style.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a utility function for enhanced layer style retrieval, improving flexibility in handling different layer configurations.
- **Improvements**
	- Updated the processing logic for layers to utilize the new utility function, streamlining the handling of layer styles.
- **Bug Fixes**
	- Removed outdated inline functions to simplify code and reduce potential errors in layer style processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->