### PR TITLE
ci(web): add missing `GCP_REGION` environment variables

### DIFF
--- a/.github/workflows/deploy_web_nightly.yml
+++ b/.github/workflows/deploy_web_nightly.yml
@@ -3,6 +3,7 @@ on:
   workflow_dispatch:
 env:
   REEARTH_URL: visualizer.test.reearth.dev
+  GCP_REGION: us-central1
   GCS_DEST: gs://reearth-visualizer-oss-static-bucket/
 
   IMAGE: reearth/reearth-visualizer-web:nightly


### PR DESCRIPTION
# Overview

It's required for the `gcloud` command's `--region` flag.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
