### PR TITLE
fix(web): timezone selector unexpected closes the popup

### DIFF
--- a/web/src/beta/ui/fields/TimePointField/EditPanel/index.tsx
+++ b/web/src/beta/ui/fields/TimePointField/EditPanel/index.tsx
@@ -65,7 +65,11 @@ const EditPanel: FC<Props> = ({ onChange, onClose, value }) => {
         </Wrapper>
         <Wrapper>
           <Label>{t("Time Zone")}</Label>
-          <InputWrapper>
+          <InputWrapper
+            onMouseDown={(e) => {
+              e.stopPropagation();
+            }}
+          >
             <Selector
               value={timezone}
               options={TIMEZONE_OFFSETS.map((offset) => ({


### PR DESCRIPTION
# Overview

Need to stopPropagation on select timezone.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
