### PR TITLE
fix(web): number input been interrupted during the input on layer style editor

### DIFF
--- a/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/StyleNode/Field/index.tsx
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/StyleNode/Field/index.tsx
@@ -28,10 +28,10 @@ const fieldComponents = {
     />
   ),
   number: (props: FieldProps) => (
-    <NumberInput value={props.value as number} onChange={props.onUpdate} />
+    <NumberInput value={props.value as number} onBlur={props.onUpdate} />
   ),
   text: (props: FieldProps) => (
-    <TextInput value={props.value as string} onChange={props.onUpdate} />
+    <TextInput value={props.value as string} onBlur={props.onUpdate} />
   ),
   color: (props: FieldProps) => (
     <ColorInput value={props.value as string} onChange={props.onUpdate} />


### PR DESCRIPTION
# Overview

Style code will go though JSON encode/decode on update, this PR changed the trigger timing for text and number input to onBlur to avoid the update leading to interrupt user's input.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated input handling for `NumberInput` and `TextInput` components to trigger updates on blur instead of on change, enhancing user experience by reducing input lag.

- **Bug Fixes**
	- Improved event handling consistency across input components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->