### PR TITLE
refactor(server): refactor test code

### DIFF
--- a/server/e2e/dataset_export_test.go
+++ b/server/e2e/dataset_export_test.go
@@ -4,16 +4,11 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/reearth/reearth/server/internal/app/config"
 	"github.com/reearth/reearth/server/pkg/dataset"
 )
 
 func TestDatasetExport(t *testing.T) {
-	e := StartServer(t, &config.Config{
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeeder)
+	e := Server(t)
 
 	e.GET("/api/datasets/test").
 		Expect().

--- a/server/e2e/gql_featureCollection_test.go
+++ b/server/e2e/gql_featureCollection_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"net/http"
 	"testing"
 
 	"github.com/gavv/httpexpect/v2"
@@ -72,14 +71,7 @@ func addGeoJSONFeature(
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	featureId := res.Path("$.data.addGeoJSONFeature.id").Raw().(string)
 	return requestBody, res, featureId
@@ -150,14 +142,7 @@ func updateGeoJSONFeature(
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	fId := res.Path("$.data.updateGeoJSONFeature.id").Raw().(string)
 	return requestBody, res, fId
@@ -183,14 +168,7 @@ func deleteGeoJSONFeature(
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	fId := res.Path("$.data.deleteGeoJSONFeature.deletedFeatureId").Raw().(string)
 	return requestBody, res, fId

--- a/server/e2e/gql_layer_test.go
+++ b/server/e2e/gql_layer_test.go
@@ -1,8 +1,6 @@
 package e2e
 
 import (
-	"net/http"
-
 	"github.com/gavv/httpexpect/v2"
 )
 
@@ -31,14 +29,7 @@ func addLayerItemFromPrimitive(e *httpexpect.Expect, rootLayerId string) (GraphQ
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	return requestBody, res, res.Path("$.data.addLayerItem.layer.id").Raw().(string)
 }

--- a/server/e2e/gql_me_test.go
+++ b/server/e2e/gql_me_test.go
@@ -1,20 +1,11 @@
 package e2e
 
 import (
-	"net/http"
 	"testing"
-
-	"github.com/reearth/reearth/server/internal/app/config"
 )
 
 func TestMe(t *testing.T) {
-	e := StartServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	},
-		true, baseSeeder)
+	e := Server(t)
 
 	requestBody := GraphQLRequest{
 		OperationName: "GetMe",
@@ -22,15 +13,7 @@ func TestMe(t *testing.T) {
 		Variables:     map[string]any{},
 	}
 
-	e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		// WithHeader("authorization", "Bearer test").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON().
+	Request(e, uID.String(), requestBody).
 		Object().
 		Value("data").Object().
 		Value("me").Object().

--- a/server/e2e/gql_nlslayer_test.go
+++ b/server/e2e/gql_nlslayer_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/gavv/httpexpect/v2"
-	"github.com/reearth/reearth/server/internal/app/config"
 	"github.com/samber/lo"
 )
 
@@ -70,14 +69,7 @@ func addNLSLayerSimple(e *httpexpect.Expect, sId string) (GraphQLRequest, *httpe
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	layerId := res.Path("$.data.addNLSLayerSimple.layers.id").Raw().(string)
 	return requestBody, res, layerId
@@ -96,14 +88,7 @@ func removeNLSLayer(e *httpexpect.Expect, layerId string) (GraphQLRequest, *http
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	return requestBody, res
 }
@@ -153,14 +138,7 @@ func updateNLSLayer(e *httpexpect.Expect, layerId string) (GraphQLRequest, *http
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	return requestBody, res
 }
@@ -182,14 +160,7 @@ func duplicateNLSLayer(e *httpexpect.Expect, layerId string) (GraphQLRequest, *h
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	return requestBody, res
 }
@@ -239,14 +210,7 @@ func fetchProjectForNewLayers(e *httpexpect.Expect, pID string) (GraphQLRequest,
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(fetchProjectRequestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), fetchProjectRequestBody)
 
 	return fetchProjectRequestBody, res
 }
@@ -344,25 +308,13 @@ func fetchSceneForNewLayers(e *httpexpect.Expect, sID string) (GraphQLRequest, *
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(fetchSceneRequestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), fetchSceneRequestBody)
 
 	return fetchSceneRequestBody, res
 }
 
 func TestNLSLayerCRUD(t *testing.T) {
-	e := StartServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeeder)
+	e := Server(t)
 
 	pId := createProject(e, "test")
 
@@ -507,14 +459,7 @@ func createInfobox(e *httpexpect.Expect, layerId string) (GraphQLRequest, *httpe
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -544,14 +489,7 @@ func createInfobox(e *httpexpect.Expect, layerId string) (GraphQLRequest, *httpe
 // 		},
 // 	}
 
-// 	res := e.POST("/api/graphql").
-// 		WithHeader("Origin", "https://example.com").
-// 		WithHeader("X-Reearth-Debug-User", uID.String()).
-// 		WithHeader("Content-Type", "application/json").
-// 		WithJSON(requestBody).
-// 		Expect().
-// 		Status(http.StatusOK).
-// 		JSON()
+// 	res := Request(e, uID.String(), requestBody)
 
 // 	return requestBody, res
 // }
@@ -597,14 +535,7 @@ func addInfoboxBlock(e *httpexpect.Expect, layerId, pluginId, extensionId string
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -653,14 +584,7 @@ func removeInfoboxBlock(e *httpexpect.Expect, layerId, infoboxBlockId string) (G
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Path("$.data.removeNLSInfoboxBlock.layer.infobox.blocks[:].id").Array().NotContains(infoboxBlockId)
@@ -706,14 +630,7 @@ func moveInfoboxBlock(e *httpexpect.Expect, layerId, infoboxBlockId string, inde
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Path("$.data.moveNLSInfoboxBlock.layer.infobox.blocks[:].id").Array().Contains(infoboxBlockId)
@@ -723,12 +640,7 @@ func moveInfoboxBlock(e *httpexpect.Expect, layerId, infoboxBlockId string, inde
 
 func TestInfoboxBlocksCRUD(t *testing.T) {
 
-	e := StartServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeeder)
+	e := Server(t)
 
 	pId := createProject(e, "test")
 
@@ -824,25 +736,13 @@ func addCustomProperties(
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	return requestBody, res
 }
 
 func TestCustomProperties(t *testing.T) {
-	e := StartServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeeder)
+	e := Server(t)
 
 	pId := createProject(e, "test")
 

--- a/server/e2e/gql_project_export_test.go
+++ b/server/e2e/gql_project_export_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/gavv/httpexpect/v2"
-	"github.com/reearth/reearth/server/internal/app/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,12 +15,7 @@ import (
 
 func TestCallExportProject(t *testing.T) {
 
-	e := StartServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeeder)
+	e := Server(t)
 
 	pID := createProjectWithExternalImage(e, "test")
 
@@ -86,14 +80,7 @@ func createProjectWithExternalImage(e *httpexpect.Expect, name string) string {
 			"coreSupport": true,
 		},
 	}
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 	return res.Path("$.data.createProject.project.id").Raw().(string)
 }
 
@@ -105,15 +92,7 @@ func exporProject(t *testing.T, e *httpexpect.Expect, p string) string {
 			"projectId": p,
 		},
 	}
-	r := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON().
+	r := Request(e, uID.String(), requestBody).
 		Object()
 	downloadPath := r.
 		Value("data").Object().

--- a/server/e2e/gql_property_test.go
+++ b/server/e2e/gql_property_test.go
@@ -1,8 +1,6 @@
 package e2e
 
 import (
-	"net/http"
-
 	"github.com/gavv/httpexpect/v2"
 )
 
@@ -49,14 +47,7 @@ func updatePropertyValue(e *httpexpect.Expect, propertyID, schemaGroupID, itemID
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	return requestBody, res
 }

--- a/server/e2e/gql_scene_test.go
+++ b/server/e2e/gql_scene_test.go
@@ -1,33 +1,14 @@
 package e2e
 
 import (
-	"context"
 	"testing"
 
-	"github.com/reearth/reearth/server/internal/app/config"
-	"github.com/reearth/reearth/server/internal/usecase/repo"
 	"golang.org/x/text/language"
 )
 
-// export REEARTH_DB=mongodb://localhost
-
-// go test -v -run TestGetScenePlaceholderEnglish ./e2e/...
 func TestGetScenePlaceholderEnglish(t *testing.T) {
 
-	e := StartServer(
-		t,
-		&config.Config{
-			Origins: []string{"https://example.com"},
-			AuthSrv: config.AuthSrvConfig{
-				Disabled: true,
-			},
-		},
-		true,
-		// English user Seeder
-		func(ctx context.Context, r *repo.Container) error {
-			return baseSeederWithLang(ctx, r, language.English)
-		},
-	)
+	e := ServerEnglish(t)
 	pID := createProjectWithExternalImage(e, "test")
 	_, _, sID := createScene(e, pID)
 	r := getScene(e, sID, language.English.String())
@@ -53,24 +34,9 @@ func TestGetScenePlaceholderEnglish(t *testing.T) {
 
 }
 
-// go test -v -run TestGetScenePlaceholderJapanese ./e2e/...
-
 func TestGetScenePlaceholderJapanese(t *testing.T) {
 
-	e := StartServer(
-		t,
-		&config.Config{
-			Origins: []string{"https://example.com"},
-			AuthSrv: config.AuthSrvConfig{
-				Disabled: true,
-			},
-		},
-		true,
-		// Japanese user Seeder
-		func(ctx context.Context, r *repo.Container) error {
-			return baseSeederWithLang(ctx, r, language.Japanese)
-		},
-	)
+	e := ServerJapanese(t)
 	pID := createProjectWithExternalImage(e, "test")
 	_, _, sID := createScene(e, pID)
 	r := getScene(e, sID, language.Japanese.String())

--- a/server/e2e/gql_storytelling_test.go
+++ b/server/e2e/gql_storytelling_test.go
@@ -37,14 +37,7 @@ func createProject(e *httpexpect.Expect, name string) string {
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	return res.Path("$.data.createProject.project.id").Raw().(string)
 }
@@ -66,14 +59,7 @@ func createScene(e *httpexpect.Expect, pID string) (GraphQLRequest, *httpexpect.
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	sID := res.Path("$.data.createScene.scene.id").Raw().(string)
 	return requestBody, res, sID
@@ -128,14 +114,7 @@ func fetchSceneForStories(e *httpexpect.Expect, sID string) (GraphQLRequest, *ht
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(fetchSceneRequestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), fetchSceneRequestBody)
 
 	return fetchSceneRequestBody, res
 }
@@ -160,14 +139,7 @@ func createStory(e *httpexpect.Expect, sID, name string, index int) (GraphQLRequ
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -201,14 +173,7 @@ func updateStory(e *httpexpect.Expect, storyID, sID string) (GraphQLRequest, *ht
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -233,14 +198,7 @@ func deleteStory(e *httpexpect.Expect, storyID, sID string) (GraphQLRequest, *ht
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -268,14 +226,7 @@ func publishStory(e *httpexpect.Expect, storyID, alias string) (GraphQLRequest, 
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -312,14 +263,7 @@ func createPage(e *httpexpect.Expect, sID, storyID, name string, swipeable bool)
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -355,14 +299,7 @@ func updatePage(e *httpexpect.Expect, sID, storyID, pageID, name string, swipeab
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -396,14 +333,7 @@ func movePage(e *httpexpect.Expect, storyID, pageID string, idx int) (GraphQLReq
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -434,14 +364,7 @@ func deletePage(e *httpexpect.Expect, sID, storyID, pageID string) (GraphQLReque
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -477,14 +400,7 @@ func duplicatePage(e *httpexpect.Expect, sID, storyID, pageID string) (GraphQLRe
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	pID := res.Object().
 		Value("data").Object().
@@ -526,14 +442,7 @@ func addLayerToPage(e *httpexpect.Expect, sId, storyId, pageId, layerId string, 
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	pageRes := res.Object().
 		Value("data").Object().
@@ -582,14 +491,7 @@ func removeLayerToPage(e *httpexpect.Expect, sId, storyId, pageId, layerId strin
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	pageRes := res.Object().
 		Value("data").Object().
@@ -641,14 +543,7 @@ func createBlock(e *httpexpect.Expect, sID, storyID, pageID, pluginId, extension
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -688,14 +583,7 @@ func removeBlock(e *httpexpect.Expect, storyID, pageID, blockID string) (GraphQL
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Path("$.data.removeStoryBlock.page.blocks[:].id").Array().NotContains(blockID)
@@ -733,14 +621,7 @@ func moveBlock(e *httpexpect.Expect, storyID, pageID, blockID string, index int)
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Path("$.data.moveStoryBlock.page.blocks[:].id").Array().Contains(blockID)
@@ -836,14 +717,7 @@ func TestStoryPageCRUD(t *testing.T) {
 
 	// update page with invalid page id
 	requestBody.Variables["pageId"] = id.NewPageID().String()
-	res = e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res = Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("errors").Array().

--- a/server/e2e/gql_style_test.go
+++ b/server/e2e/gql_style_test.go
@@ -1,11 +1,9 @@
 package e2e
 
 import (
-	"net/http"
 	"testing"
 
 	"github.com/gavv/httpexpect/v2"
-	"github.com/reearth/reearth/server/internal/app/config"
 )
 
 func addStyle(e *httpexpect.Expect, sId, name string) (GraphQLRequest, *httpexpect.Value, string) {
@@ -51,12 +49,7 @@ func addStyle(e *httpexpect.Expect, sId, name string) (GraphQLRequest, *httpexpe
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	styleId := res.Path("$.data.addStyle.style.id").String().Raw()
 	return requestBody, res, styleId
@@ -80,12 +73,7 @@ func updateStyleName(e *httpexpect.Expect, styleId, newName string) (GraphQLRequ
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	return requestBody, res
 }
@@ -103,12 +91,7 @@ func removeStyle(e *httpexpect.Expect, styleId string) (GraphQLRequest, *httpexp
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	return requestBody, res
 }
@@ -130,12 +113,7 @@ func duplicateStyle(e *httpexpect.Expect, styleId string) (GraphQLRequest, *http
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	return requestBody, res
 }
@@ -162,25 +140,13 @@ func fetchSceneForStyles(e *httpexpect.Expect, sID string) (GraphQLRequest, *htt
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(fetchSceneRequestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), fetchSceneRequestBody)
 
 	return fetchSceneRequestBody, res
 }
 
 func TestStyleCRUD(t *testing.T) {
-	e := StartServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeeder)
+	e := Server(t)
 
 	pId := createProject(e, "test")
 	_, _, sId := createScene(e, pId)

--- a/server/e2e/gql_user_test.go
+++ b/server/e2e/gql_user_test.go
@@ -2,98 +2,13 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"testing"
 
-	"github.com/reearth/reearth/server/internal/app/config"
-	"github.com/reearth/reearth/server/internal/usecase/repo"
-	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/account/accountdomain/user"
-	"github.com/reearth/reearthx/account/accountdomain/workspace"
-	"github.com/reearth/reearthx/idx"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/text/language"
 )
-
-var (
-	uId1 = accountdomain.NewUserID()
-	uId2 = accountdomain.NewUserID()
-	uId3 = accountdomain.NewUserID()
-	wId1 = accountdomain.NewWorkspaceID()
-	wId2 = accountdomain.NewWorkspaceID()
-	iId1 = accountdomain.NewIntegrationID()
-)
-
-func baseSeederUser(ctx context.Context, r *repo.Container) error {
-	auth := user.ReearthSub(uId1.String())
-	u := user.New().ID(uId1).
-		Name("e2e").
-		Email("e2e@e2e.com").
-		Auths([]user.Auth{*auth}).
-		Theme(user.ThemeDark).
-		Lang(language.Japanese).
-		Workspace(wId1).
-		MustBuild()
-	if err := r.User.Save(ctx, u); err != nil {
-		return err
-	}
-	u2 := user.New().ID(uId2).
-		Name("e2e2").
-		Workspace(wId2).
-		Email("e2e2@e2e.com").
-		MustBuild()
-	if err := r.User.Save(ctx, u2); err != nil {
-		return err
-	}
-	u3 := user.New().ID(uId3).
-		Name("e2e3").
-		Workspace(wId2).
-		Email("e2e3@e2e.com").
-		MustBuild()
-	if err := r.User.Save(ctx, u3); err != nil {
-		return err
-	}
-	roleOwner := workspace.Member{
-		Role:      workspace.RoleOwner,
-		InvitedBy: uId1,
-	}
-	roleReader := workspace.Member{
-		Role:      workspace.RoleReader,
-		InvitedBy: uId2,
-	}
-
-	w := workspace.New().ID(wId1).
-		Name("e2e").
-		Members(map[idx.ID[accountdomain.User]]workspace.Member{
-			uId1: roleOwner,
-		}).
-		Integrations(map[idx.ID[accountdomain.Integration]]workspace.Member{
-			iId1: roleOwner,
-		}).
-		MustBuild()
-	if err := r.Workspace.Save(ctx, w); err != nil {
-		return err
-	}
-
-	w2 := workspace.New().ID(wId2).
-		Name("e2e2").
-		Members(map[idx.ID[accountdomain.User]]workspace.Member{
-			uId1: roleOwner,
-			uId3: roleReader,
-		}).
-		Integrations(map[idx.ID[accountdomain.Integration]]workspace.Member{
-			iId1: roleOwner,
-		}).
-		MustBuild()
-	if err := r.Workspace.Save(ctx, w2); err != nil {
-		return err
-	}
-
-	return nil
-}
 
 // func TestSignUp(t *testing.T) {
 // 	e, _ := StartGQLServer(t, &config.Config{
@@ -120,25 +35,9 @@ func baseSeederUser(ctx context.Context, r *repo.Container) error {
 // }
 
 func TestUpdateMe(t *testing.T) {
-	e, _ := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, _ := ServerUser(t)
 	query := `mutation { updateMe(input: {name: "updated",email:"hoge@test.com",lang: "ja",theme: DEFAULT,password: "Ajsownndww1",passwordConfirmation: "Ajsownndww1"}){ me{ id name email lang theme } }}`
-	request := GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object().Value("data").Object().Value("updateMe").Object().Value("me").Object()
+	o := RequestQuery(t, e, query, uId1.String()).Object().Value("data").Object().Value("updateMe").Object().Value("me").Object()
 	o.Value("name").String().Equal("updated")
 	o.Value("email").String().Equal("hoge@test.com")
 	o.Value("lang").String().Equal("ja")
@@ -146,29 +45,13 @@ func TestUpdateMe(t *testing.T) {
 }
 
 func TestRemoveMyAuth(t *testing.T) {
-	e, r := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, r := ServerUser(t)
 	u, err := r.User.FindByID(context.Background(), uId1)
 	assert.Nil(t, err)
 	assert.Equal(t, &user.Auth{Provider: "reearth", Sub: "reearth|" + uId1.String()}, u.Auths().GetByProvider("reearth"))
 
 	query := `mutation { removeMyAuth(input: {auth: "reearth"}){ me{ id name email lang theme } }}`
-	request := GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	RequestQuery(t, e, query, uId1.String()).Object()
 
 	u, err = r.User.FindByID(context.Background(), uId1)
 	assert.Nil(t, err)
@@ -176,116 +59,42 @@ func TestRemoveMyAuth(t *testing.T) {
 }
 
 func TestDeleteMe(t *testing.T) {
-	e, r := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, r := ServerUser(t)
 	u, err := r.User.FindByID(context.Background(), uId1)
 	assert.Nil(t, err)
 	assert.NotNil(t, u)
 
 	query := fmt.Sprintf(`mutation { deleteMe(input: {userId: "%s"}){ userId }}`, uId1)
-	request := GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	RequestQuery(t, e, query, uId1.String()).Object()
 
 	_, err = r.User.FindByID(context.Background(), uId1)
 	assert.Equal(t, rerror.ErrNotFound, err)
 }
 
 func TestSearchUser(t *testing.T) {
-	e, _ := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, _ := ServerUser(t)
+
 	query := fmt.Sprintf(` { searchUser(nameOrEmail: "%s"){ id name email } }`, "e2e")
-	request := GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object().Value("data").Object().Value("searchUser").Object()
+	o := RequestQuery(t, e, query, uId1.String()).Object().Value("data").Object().Value("searchUser").Object()
 	o.Value("id").String().Equal(uId1.String())
 	o.Value("name").String().Equal("e2e")
 	o.Value("email").String().Equal("e2e@e2e.com")
 
 	query = fmt.Sprintf(` { searchUser(nameOrEmail: "%s"){ id name email } }`, "notfound")
-	request = GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err = json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object().
+	RequestQuery(t, e, query, uId1.String()).Object().
 		Value("data").Object().Value("searchUser").Null()
 }
 
 func TestNode(t *testing.T) {
-	e, _ := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, _ := ServerUser(t)
 	query := fmt.Sprintf(` { node(id: "%s", type: USER){ id } }`, uId1.String())
-	request := GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object().Value("data").Object().Value("node").Object()
+	o := RequestQuery(t, e, query, uId1.String()).Object().Value("data").Object().Value("node").Object()
 	o.Value("id").String().Equal(uId1.String())
 }
 
 func TestNodes(t *testing.T) {
-	e, _ := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, _ := ServerUser(t)
 	query := fmt.Sprintf(` { nodes(id: "%s", type: USER){ id } }`, uId1.String())
-	request := GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object().Value("data").Object().Value("nodes")
+	o := RequestQuery(t, e, query, uId1.String()).Object().Value("data").Object().Value("nodes")
 	o.Array().Contains(map[string]string{"id": uId1.String()})
 }

--- a/server/e2e/gql_workspace_test.go
+++ b/server/e2e/gql_workspace_test.go
@@ -2,12 +2,9 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"testing"
 
-	"github.com/reearth/reearth/server/internal/app/config"
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
 	"github.com/reearth/reearthx/rerror"
@@ -15,95 +12,39 @@ import (
 )
 
 func TestCreateTeam(t *testing.T) {
-	e, _ := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, _ := ServerUser(t)
 	query := `mutation { createTeam(input: {name: "test"}){ team{ id name } }}`
-	request := GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	o := RequestQuery(t, e, query, uId1.String()).Object()
 	o.Value("data").Object().Value("createTeam").Object().Value("team").Object().Value("name").String().Equal("test")
 }
 
 func TestDeleteTeam(t *testing.T) {
-	e, r := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, r := ServerUser(t)
 	_, err := r.Workspace.FindByID(context.Background(), wId1)
 	assert.Nil(t, err)
-	query := fmt.Sprintf(`mutation { deleteTeam(input: {teamId: "%s"}){ teamId }}`, wId1)
-	request := GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err := json.Marshal(request)
-	assert.Nil(t, err)
 
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	query := fmt.Sprintf(`mutation { deleteTeam(input: {teamId: "%s"}){ teamId }}`, wId1)
+	o := RequestQuery(t, e, query, uId1.String()).Object()
 	o.Value("data").Object().Value("deleteTeam").Object().Value("teamId").String().Equal(wId1.String())
 
 	_, err = r.Workspace.FindByID(context.Background(), wId1)
 	assert.Equal(t, rerror.ErrNotFound, err)
 
 	query = fmt.Sprintf(`mutation { deleteTeam(input: {teamId: "%s"}){ teamId }}`, accountdomain.NewWorkspaceID())
-	request = GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err = json.Marshal(request)
-	assert.Nil(t, err)
-
-	o = e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	o = RequestQuery(t, e, query, uId1.String()).Object()
 
 	o.Value("errors").Array().First().Object().Value("message").Equal("input: deleteTeam operation denied")
 }
 
 func TestUpdateTeam(t *testing.T) {
-	e, r := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, r := ServerUser(t)
 
 	w, err := r.Workspace.FindByID(context.Background(), wId1)
 	assert.Nil(t, err)
 	assert.Equal(t, "e2e", w.Name())
 
 	query := fmt.Sprintf(`mutation { updateTeam(input: {teamId: "%s",name: "%s"}){ team{ id name } }}`, wId1, "updated")
-	request := GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.Nil(t, err)
-	}
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	o := RequestQuery(t, e, query, uId1.String()).Object()
 	o.Value("data").Object().Value("updateTeam").Object().Value("team").Object().Value("name").String().Equal("updated")
 
 	w, err = r.Workspace.FindByID(context.Background(), wId1)
@@ -111,46 +52,19 @@ func TestUpdateTeam(t *testing.T) {
 	assert.Equal(t, "updated", w.Name())
 
 	query = fmt.Sprintf(`mutation { updateTeam(input: {teamId: "%s",name: "%s"}){ team{ id name } }}`, accountdomain.NewWorkspaceID(), "updated")
-	request = GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err = json.Marshal(request)
-	if err != nil {
-		assert.Nil(t, err)
-	}
-	o = e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	o = RequestQuery(t, e, query, uId1.String()).Object()
 	o.Value("errors").Array().First().Object().Value("message").Equal("input: updateTeam not found")
 }
 
 func TestAddMemberToTeam(t *testing.T) {
-	e, r := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, r := ServerUser(t)
 
 	w, err := r.Workspace.FindByID(context.Background(), wId1)
 	assert.Nil(t, err)
 	assert.False(t, w.Members().HasUser(uId2))
 
 	query := fmt.Sprintf(`mutation { addMemberToTeam(input: {teamId: "%s", userId: "%s", role: READER}){ team{ id } }}`, wId1, uId2)
-	request := GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.Nil(t, err)
-	}
-	e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK)
+	RequestQuery(t, e, query, uId1.String())
 
 	w, err = r.Workspace.FindByID(context.Background(), wId1)
 	assert.Nil(t, err)
@@ -158,100 +72,43 @@ func TestAddMemberToTeam(t *testing.T) {
 	assert.Equal(t, w.Members().User(uId2).Role, workspace.RoleReader)
 
 	query = fmt.Sprintf(`mutation { addMemberToTeam(input: {teamId: "%s", userId: "%s", role: READER}){ team{ id } }}`, wId1, uId2)
-	request = GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err = json.Marshal(request)
-	if err != nil {
-		assert.Nil(t, err)
-	}
-	e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object().
+	RequestQuery(t, e, query, uId1.String()).Object().
 		Value("errors").Array().First().Object().Value("message").Equal("input: addMemberToTeam user already joined")
 }
 
 func TestRemoveMemberFromTeam(t *testing.T) {
-	e, r := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, r := ServerUser(t)
 
 	w, err := r.Workspace.FindByID(context.Background(), wId2)
 	assert.Nil(t, err)
 	assert.True(t, w.Members().HasUser(uId3))
 
 	query := fmt.Sprintf(`mutation { removeMemberFromTeam(input: {teamId: "%s", userId: "%s"}){ team{ id } }}`, wId2, uId3)
-	request := GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.Nil(t, err)
-	}
-	e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK)
+	RequestQuery(t, e, query, uId1.String())
 
 	w, err = r.Workspace.FindByID(context.Background(), wId1)
 	assert.Nil(t, err)
 	assert.False(t, w.Members().HasUser(uId3))
 
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	o := RequestQuery(t, e, query, uId1.String()).Object()
 	o.Value("errors").Array().First().Object().Value("message").Equal("input: removeMemberFromTeam target user does not exist in the workspace")
 }
 
 func TestUpdateMemberOfTeam(t *testing.T) {
-	e, r := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, r := ServerUser(t)
 
 	w, err := r.Workspace.FindByID(context.Background(), wId2)
 	assert.Nil(t, err)
 	assert.Equal(t, w.Members().User(uId3).Role, workspace.RoleReader)
+
 	query := fmt.Sprintf(`mutation { updateMemberOfTeam(input: {teamId: "%s", userId: "%s", role: WRITER}){ team{ id } }}`, wId2, uId3)
-	request := GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.Nil(t, err)
-	}
-	e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK)
+	RequestQuery(t, e, query, uId1.String())
 
 	w, err = r.Workspace.FindByID(context.Background(), wId2)
 	assert.Nil(t, err)
 	assert.Equal(t, w.Members().User(uId3).Role, workspace.RoleWriter)
 
 	query = fmt.Sprintf(`mutation { updateMemberOfTeam(input: {teamId: "%s", userId: "%s", role: WRITER}){ team{ id } }}`, accountdomain.NewWorkspaceID(), uId3)
-	request = GraphQLRequest{
-		Query: query,
-	}
-	jsonData, err = json.Marshal(request)
-	if err != nil {
-		assert.Nil(t, err)
-	}
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	o := RequestQuery(t, e, query, uId1.String()).Object()
 	o.Value("errors").Array().First().Object().Value("message").Equal("input: updateMemberOfTeam operation denied")
 }

--- a/server/e2e/mock_test.go
+++ b/server/e2e/mock_test.go
@@ -41,17 +41,10 @@ func TestMockAuth(t *testing.T) {
 		Query:         "query GetMe { \n me { \n id \n name \n email\n } \n}",
 		Variables:     map[string]any{},
 	}
-	response2 := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", userId).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody2).
-		Expect().
-		Status(http.StatusOK).
-		JSON().
-		Object()
+	response2 := Request(e, userId, requestBody2).
+		Object().Value("data").Object().Value("me").Object()
 
-	response2.Value("data").Object().Value("me").Object().ContainsKey("id")
-	response2.Value("data").Object().Value("me").Object().Value("name").String().Equal("Mock User")
-	response2.Value("data").Object().Value("me").Object().Value("email").String().Equal("mock@example.com")
+	response2.ContainsKey("id")
+	response2.Value("name").String().Equal("Mock User")
+	response2.Value("email").String().Equal("mock@example.com")
 }

--- a/server/e2e/seeder.go
+++ b/server/e2e/seeder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/account/accountdomain/user"
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
+	"github.com/reearth/reearthx/idx"
 	"github.com/reearth/reearthx/util"
 	"github.com/samber/lo"
 	"golang.org/x/text/language"
@@ -35,6 +36,13 @@ var (
 	dsfID4 = dataset.NewFieldID()
 
 	now = time.Date(2022, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	uId1 = accountdomain.NewUserID()
+	uId2 = accountdomain.NewUserID()
+	uId3 = accountdomain.NewUserID()
+	wId1 = accountdomain.NewWorkspaceID()
+	wId2 = accountdomain.NewWorkspaceID()
+	iId1 = accountdomain.NewIntegrationID()
 )
 
 func baseSeeder(ctx context.Context, r *repo.Container) error {
@@ -117,6 +125,74 @@ func baseSetup(ctx context.Context, r *repo.Container, u *user.User) error {
 		}).
 		MustBuild()
 	if err := r.Dataset.Save(ctx, ds); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func baseSeederUser(ctx context.Context, r *repo.Container) error {
+	auth := user.ReearthSub(uId1.String())
+	u := user.New().ID(uId1).
+		Name("e2e").
+		Email("e2e@e2e.com").
+		Auths([]user.Auth{*auth}).
+		Theme(user.ThemeDark).
+		Lang(language.Japanese).
+		Workspace(wId1).
+		MustBuild()
+	if err := r.User.Save(ctx, u); err != nil {
+		return err
+	}
+	u2 := user.New().ID(uId2).
+		Name("e2e2").
+		Workspace(wId2).
+		Email("e2e2@e2e.com").
+		MustBuild()
+	if err := r.User.Save(ctx, u2); err != nil {
+		return err
+	}
+	u3 := user.New().ID(uId3).
+		Name("e2e3").
+		Workspace(wId2).
+		Email("e2e3@e2e.com").
+		MustBuild()
+	if err := r.User.Save(ctx, u3); err != nil {
+		return err
+	}
+	roleOwner := workspace.Member{
+		Role:      workspace.RoleOwner,
+		InvitedBy: uId1,
+	}
+	roleReader := workspace.Member{
+		Role:      workspace.RoleReader,
+		InvitedBy: uId2,
+	}
+
+	w := workspace.New().ID(wId1).
+		Name("e2e").
+		Members(map[idx.ID[accountdomain.User]]workspace.Member{
+			uId1: roleOwner,
+		}).
+		Integrations(map[idx.ID[accountdomain.Integration]]workspace.Member{
+			iId1: roleOwner,
+		}).
+		MustBuild()
+	if err := r.Workspace.Save(ctx, w); err != nil {
+		return err
+	}
+
+	w2 := workspace.New().ID(wId2).
+		Name("e2e2").
+		Members(map[idx.ID[accountdomain.User]]workspace.Member{
+			uId1: roleOwner,
+			uId3: roleReader,
+		}).
+		Integrations(map[idx.ID[accountdomain.Integration]]workspace.Member{
+			iId1: roleOwner,
+		}).
+		MustBuild()
+	if err := r.Workspace.Save(ctx, w2); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Overview
In the e2e test code, I standardized the server startup and request calls.

## What I've done
Main changes:

### 1.Consolidated common processes into server/e2e/common.go.

#### Server
* Server(): Starts a server using the baseSeeder.
* ServerUser(): Starts a server using the baseSeederUser.
* ServerEnglish(): Starts a server using the baseSeeder, with the language set to language.English.
* ServerJapanese(): Starts a server using the baseSeeder, with the language set to language.Japanese.
  
#### Request
* Request(): Executes a GraphQL query/mutation.
* RequestQuery(): Executes a GraphQL query.
* RequestWithMultipart(): Executes a GraphQL query/mutation with file uploads or other multipart data.

### 2.Grouped individual seeders into server/e2e/seeder.go.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced simplified server initialization methods enhancing test setup efficiency.
  - Added new functions for handling GraphQL requests, improving request management and readability.

- **Refactor**
  - Replaced repetitive HTTP request handling with a centralized `Request` function across multiple test files.
  - Streamlined server setup by removing complex configuration requirements.

- **Bug Fixes**
  - Enhanced error handling for various GraphQL operations to ensure robust response validation.

- **Documentation**
  - Improved clarity and maintainability of test code through refactoring and removal of redundant elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->