### PR TITLE
fix(web): popup menu has an unexpected horizontal scroll bar

### DIFF
--- a/web/src/beta/features/Dashboard/ContentsContainer/Projects/Project/ProjectGridViewItem.tsx
+++ b/web/src/beta/features/Dashboard/ContentsContainer/Projects/Project/ProjectGridViewItem.tsx
@@ -125,7 +125,7 @@ const CardImage = styled("div")<{
   borderRadius: theme.radius.normal,
   boxSizing: "border-box",
   cursor: "pointer",
-  border: `1px solid ${isHovered ? theme.outline.weak : "transparent"}`
+  boxShadow: `inset 0 0 0 1px ${isHovered ? theme.outline.weak : "transparent"}`
 }));
 
 const StarButtonWrapper = styled("div")<{

--- a/web/src/beta/features/Editor/Widgets/WidgetManagerPanel/Action.tsx
+++ b/web/src/beta/features/Editor/Widgets/WidgetManagerPanel/Action.tsx
@@ -55,6 +55,7 @@ const ActionArea: FC<ActionAreaProps> = ({
       }
       menu={items}
       extendTriggerWidth
+      extendContentWidth
     />
   );
 };

--- a/web/src/beta/lib/reearth-ui/components/PopupMenu/index.tsx
+++ b/web/src/beta/lib/reearth-ui/components/PopupMenu/index.tsx
@@ -127,13 +127,13 @@ export const PopupMenu: FC<PopupMenuProps> = ({
             <PopupMenu label={title} menu={subItem} width={width} nested />
           ) : path ? (
             <StyledLink to={disabled ? "" : path}>
-              <TitleWrapper disabled={disabled}>
+              <TitleWrapper disabled={disabled} flex={!!tileComponent}>
                 {title}
                 {tileComponent}
               </TitleWrapper>
             </StyledLink>
           ) : (
-            <TitleWrapper disabled={disabled}>
+            <TitleWrapper disabled={disabled} flex={!!tileComponent}>
               {title}
               {tileComponent}
             </TitleWrapper>
@@ -302,7 +302,8 @@ const Item = styled("div")<{
 
 const StyledLink = styled(Link)(() => ({
   textDecoration: "none",
-  width: "100%"
+  flex: 1,
+  display: "flex"
 }));
 
 const IconWrapper = styled("div")(() => ({
@@ -323,7 +324,9 @@ const SubItem = styled("div")(() => ({
   justifyContent: "space-between",
   justifyItems: "center",
   flexGrow: 1,
-  alignItems: "center"
+  alignItems: "center",
+  width: "100%",
+  overflow: "hidden"
 }));
 
 const Label = styled("p")<{ nested: boolean }>(({ nested, theme }) => ({
@@ -361,15 +364,15 @@ const Group = styled("div")(({ theme }) => ({
   gap: `${theme.spacing.micro}px`
 }));
 
-const TitleWrapper = styled("div")<{ disabled?: boolean }>(
-  ({ theme, disabled }) => ({
+const TitleWrapper = styled("div")<{ disabled?: boolean; flex?: boolean }>(
+  ({ theme, disabled, flex }) => ({
     fontSize: theme.fonts.sizes.body,
     color: disabled ? theme.content.weak : theme.content.main,
     whiteSpace: "nowrap",
     overflow: "hidden",
     textOverflow: "ellipsis",
-    display: "flex",
-    alignItems: "center",
-    gap: theme.spacing.small
+    gap: theme.spacing.small,
+    flex: 1,
+    ...(flex ? { display: "flex", alignItems: "center" } : {})
   })
 );

--- a/web/src/services/api/widgetsApi/utils.ts
+++ b/web/src/services/api/widgetsApi/utils.ts
@@ -1,3 +1,5 @@
+import { IconName } from "@reearth/beta/lib/reearth-ui";
+
 import { GetSceneQuery, PluginExtensionType } from "../../gql";
 import { Item, convert } from "../propertyApi/utils";
 
@@ -57,7 +59,9 @@ export const getInstallableWidgets = (rawScene?: GetSceneQuery) => {
             title: e.translatedName,
             description: e.description,
             icon:
-              e.icon || (plugin.id === "reearth" && e.extensionId) || "plugin",
+              e.icon ||
+              getBuiltinExtensionIcon(plugin.id, e.extensionId) ||
+              "plugin",
             disabled:
               (e.singleOnly &&
                 !!scene?.widgets?.find(
@@ -72,6 +76,23 @@ export const getInstallableWidgets = (rawScene?: GetSceneQuery) => {
     })
     .reduce<InstallableWidget[]>((a, b) => (b ? [...a, ...b] : a), []);
 };
+
+function getBuiltinExtensionIcon(
+  pluginId: string,
+  extensionId: string
+): IconName | undefined {
+  switch (`${pluginId}/${extensionId}`) {
+    // TODO: get the correct icon from design
+    case BUTTON_BUILTIN_WIDGET_ID:
+      return "return";
+    case NAVIGATOR_BUILTIN_WIDGET_ID:
+      return "crosshair";
+    case DATA_ATTRIBUTION_WIDGET_ID:
+      return "listDashes";
+    default:
+      return undefined;
+  }
+}
 
 export const getInstalledWidgets = (
   rawScene?: GetSceneQuery


### PR DESCRIPTION
# Overview

Popup menu is designed without any horizontal scroll bar, this PR fix this style issue, also updated the icons for builtin widgets.

## What I've done

- Update the style on popup menu so that the overflow could be hidden.
- Add the icon for builtin widgets
- Update the add widget selector to full width

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Screenshot

BEFORE:
![image](https://github.com/user-attachments/assets/cd5d4f4b-c7f2-4e6b-ae76-6a788797ef50)

AFTER:
![image](https://github.com/user-attachments/assets/2e618b57-e421-4648-9c73-a8272ea2911c)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced visual representation of project items with a new inset shadow effect on hover.
	- Improved layout of the popup menu with a new property to extend content width.

- **Improvements**
	- Updated styling capabilities for the `PopupMenu` component, allowing for more flexible rendering based on content.
	- Modularized icon assignment logic for installable widgets, enhancing clarity and maintainability. 

These changes aim to improve user experience and interface consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->