### PR TITLE
refactor(web): improve recycle bin default image

### DIFF
--- a/web/src/beta/features/Dashboard/ContentsContainer/RecycleBin/items/RecycleBinItem.tsx
+++ b/web/src/beta/features/Dashboard/ContentsContainer/RecycleBin/items/RecycleBinItem.tsx
@@ -2,6 +2,7 @@ import { Button, PopupMenu, PopupMenuItem } from "@reearth/beta/lib/reearth-ui";
 import { useT } from "@reearth/services/i18n";
 import { styled } from "@reearth/services/theme";
 import { FC, useCallback, useState } from "react";
+import defaultProjectBackgroundImage from "@reearth/beta/ui/assets/defaultProjectBackgroundImage.webp";
 
 import { DeletedProject } from "../../../type";
 import ProjectDeleteModal from "../ProjectDeleteModal";
@@ -48,7 +49,7 @@ const RecycleBinItem: FC<Prop> = ({
   return (
     <Card>
       <CardImage
-        backgroundImage={project?.imageUrl}
+        backgroundImage={project?.imageUrl ?? defaultProjectBackgroundImage}
         isHovered={isHovered ?? false}
         onMouseEnter={() => handleProjectHover(true)}
         onMouseLeave={() => handleProjectHover(false)}
@@ -94,9 +95,8 @@ const CardImage = styled("div")<{
 }>(({ theme, backgroundImage, isHovered }) => ({
   flex: 1,
   position: "relative",
-  background: backgroundImage
-    ? `url(${backgroundImage}) center/cover`
-    : theme.bg[1],
+  background: backgroundImage ? `url(${backgroundImage}) center/cover` : "",
+  backgroundColor: theme.bg[1],
   borderRadius: theme.radius.normal,
   boxSizing: "border-box",
   cursor: "pointer",


### PR DESCRIPTION
# Overview
- Added default Project background image in recycle bin card
## What I've done

before
<img width="1508" alt="recycle-bin1" src="https://github.com/user-attachments/assets/fb954085-0c95-4985-b491-590b9b907e47">

Cureent
<img width="1508" alt="updated-recycle-bin" src="https://github.com/user-attachments/assets/0415f686-8d19-44bc-b874-946d16c06daa">

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a default background image for the `CardImage` component when no project image URL is provided, ensuring a consistent visual appearance.
  
- **Bug Fixes**
	- Adjusted the background property to maintain a defined background color from the theme when no image URL is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->