### PR TITLE
fix(web): 3d tiles' style cannot be reset

### DIFF
--- a/web/src/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/presetLayerStyles.ts
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/presetLayerStyles.ts
@@ -18,7 +18,8 @@ export const defaultStyle: Partial<LayerAppearanceTypes> = {
     clampToGround: true,
     strokeColor: "#FFFFFF",
     strokeWidth: 2
-  }
+  },
+  "3dtiles": {}
 };
 
 export const professionalStyle = {


### PR DESCRIPTION
# Overview

After you assign a style to 3dtiles and reset, the style can't be reset properly on map. That's due to the '3dtiles' property is `undefined`. We should give a default empty object `{}` as the default 3dtiles style.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced styling capabilities for 3D tiles, including new properties for dynamic color assignment and rendering options.
	- Updated visibility settings for marker and polygon styles.
- **Improvements**
	- Added support for additional properties in style definitions, improving customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->