### PR TITLE
fix(web): layer style editor condition item can't resize properly with a selector

### DIFF
--- a/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/StyleNode/ConditionsTab.tsx
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/StyleNode/ConditionsTab.tsx
@@ -269,7 +269,8 @@ const ConditionWrapper = styled("div")(({ theme }) => ({
   flexDirection: "column",
   gap: theme.spacing.smallest,
   alignItems: "flex-start",
-  flex: 1
+  flex: 1,
+  minWidth: 0
 }));
 
 const ConditionStatement = styled("div")(({ theme }) => ({


### PR DESCRIPTION
# Overview

On layer style editor conditions tab, when resize the panel width from small to large, it resizes correctly, but when resize the panel width from large to small, the condition item will keep its own width, which will be too wide for the panel.

This PR adds the style `minWidth: 0` to the ConditionWrapper to allow it shrink.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced layout behavior of the ConditionsTab component for improved flex item handling.

- **Bug Fixes**
	- No core logic or functionality changes; existing features like drag-and-drop, condition management, and error handling remain intact. 

- **Documentation**
	- Continued support for internationalization, ensuring adaptability for different languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->