### PR TITLE
refactor(web): clean up console.log on data attribution widget

### DIFF
--- a/web/src/beta/features/Visualizer/Crust/Widgets/Widget/builtin/DataAttribution/UI/hooks.ts
+++ b/web/src/beta/features/Visualizer/Crust/Widgets/Widget/builtin/DataAttribution/UI/hooks.ts
@@ -53,8 +53,6 @@ export const useDataAttribution = ({
       ...widgetProcessedCredits
     ];
 
-    console.log(combinedCredits);
-
     setProcessedCredits(combinedCredits);
   }, [processedCoreCredits, widgetCredits]);
 

--- a/web/src/beta/features/Visualizer/Crust/Widgets/Widget/builtin/DataAttribution/index.tsx
+++ b/web/src/beta/features/Visualizer/Crust/Widgets/Widget/builtin/DataAttribution/index.tsx
@@ -34,7 +34,6 @@ const DataAttribution = ({
         const credits = getCredits?.();
         if (credits) {
           setVisualizerCredits(credits);
-          console.log("update", credits);
         }
       }, 3000);
     }


### PR DESCRIPTION
# Overview

There's console.log left on this widget, should be removed.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed unnecessary console log statements from the `DataAttribution` component and its associated hook, streamlining credit processing without affecting functionality.

- **Chores**
	- Cleaned up logging within the `setInterval` function to improve performance and reduce console clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->