### PR TITLE
chore(web): add prettier package to organize imports

### DIFF
--- a/web/.prettierrc
+++ b/web/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "plugins": ["prettier-plugin-organize-imports"]
 }

--- a/web/package.json
+++ b/web/package.json
@@ -85,6 +85,7 @@
     "lint-staged": "15.2.10",
     "npm-run-all": "4.1.5",
     "prettier": "3.3.3",
+    "prettier-plugin-organize-imports": "^4.1.0",
     "read-env": "2.0.0",
     "rollup": "4.21.2",
     "rollup-plugin-visualizer": "5.12.0",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -8302,6 +8302,7 @@ __metadata:
     lodash-es: "npm:4.17.21"
     npm-run-all: "npm:4.1.5"
     prettier: "npm:3.3.3"
+    prettier-plugin-organize-imports: "npm:^4.1.0"
     quickjs-emscripten: "npm:0.24.0"
     quickjs-emscripten-sync: "npm:1.5.2"
     rc-slider: "npm:9.7.5"
@@ -21790,6 +21791,20 @@ __metadata:
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
   checksum: 10c0/b00d617431e7886c520a6f498a2e14c75ec58f6d93ba48c3b639cf241b54232d90daa05d83a9e9b9fef6baa63cb7e1e4602c2372fea5bc169668401eb127d0cd
+  languageName: node
+  linkType: hard
+
+"prettier-plugin-organize-imports@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "prettier-plugin-organize-imports@npm:4.1.0"
+  peerDependencies:
+    prettier: ">=2.0"
+    typescript: ">=2.9"
+    vue-tsc: ^2.1.0
+  peerDependenciesMeta:
+    vue-tsc:
+      optional: true
+  checksum: 10c0/fb2d6d415bac96b65a77ea7de9f708e8613436aeb9d82bbe63edeb312fd1362c0d3c57319bd4cc4adfc8b9964fb6c205cbbf8efd9546931b0f9874c0ae624a6a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Overview
Small package that will help organize imports when a file is saved in the editor. It does not scan through all the files but only checks when a single file is open. Might not be needed but helps keep imports in order and one less thing for the developer to think of how to sort. 
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Prettier plugin to automatically organize imports in the codebase.
- **Chores**
	- Updated the project version to `1.0.0-alpha.8`.
	- Added `prettier-plugin-organize-imports` as a new development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->