### PR TITLE
fix(server): fix filter bug

### DIFF
--- a/server/e2e/gql_asset_test.go
+++ b/server/e2e/gql_asset_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"testing"
@@ -52,18 +51,30 @@ func TestGetAssets(t *testing.T) {
 		ValueEqual("name", "test.csv").
 		ValueEqual("coreSupport", false)
 
+	// Write directly to the DB
 	ctx := context.Background()
-
-	a, err := asset.New().
-		NewID().
-		Workspace(wID).
-		Name("name").
-		Size(100).
-		URL("url").
-		CoreSupport(true).
+	a1, err := asset.New().
+		NewID().Workspace(wID).Name("test.png").Size(30438).URL("https://example.com/xxxxxxxxxxxxxxxxxxxxxxxxxx.png").
+		// CoreSupport(true). // not set CoreSupport
 		Build()
 	assert.Nil(t, err)
-	err = r.Asset.Save(ctx, a)
+	err = r.Asset.Save(ctx, a1)
+	assert.Nil(t, err)
+
+	a2, err := asset.New().
+		NewID().Workspace(wID).Name("test.png").Size(30438).URL("https://example.com/xxxxxxxxxxxxxxxxxxxxxxxxxx.png").
+		CoreSupport(true). // CoreSupport true
+		Build()
+	assert.Nil(t, err)
+	err = r.Asset.Save(ctx, a2)
+	assert.Nil(t, err)
+
+	a3, err := asset.New().
+		NewID().Workspace(wID).Name("test.png").Size(30438).URL("https://example.com/xxxxxxxxxxxxxxxxxxxxxxxxxx.png").
+		CoreSupport(false). // CoreSupport false
+		Build()
+	assert.Nil(t, err)
+	err = r.Asset.Save(ctx, a3)
 	assert.Nil(t, err)
 
 	f := int64(20)
@@ -73,9 +84,7 @@ func TestGetAssets(t *testing.T) {
 		}.Wrap(),
 	})
 	assert.Nil(t, err)
-	for _, a := range as {
-		fmt.Printf("===== %v\n", a)
-	}
+	assert.Equal(t, len(as), 3)
 
 	res = getAssets(e, teamId)
 	assets := res.Object().Value("data").Object().Value("assets").Object().Value("nodes").Array().Iter()

--- a/server/internal/infrastructure/mongo/asset.go
+++ b/server/internal/infrastructure/mongo/asset.go
@@ -70,11 +70,8 @@ func (r *Asset) FindByWorkspace(ctx context.Context, id accountdomain.WorkspaceI
 	}
 
 	var filter any = bson.M{
-		"team": id.String(),
-		"$or": []bson.M{
-			{"coresupport": true},
-			{"coresupport": bson.M{"$exists": false}},
-		},
+		"team":        id.String(),
+		"coresupport": true,
 	}
 
 	if uFilter.Keyword != nil {


### PR DESCRIPTION
# Overview
The query for cases where coresupport does not exist in the database is incorrect.

## What I've done

## What I haven't done

## How I tested
It worked correctly after processing the data locally.

<img width="657" alt="スクリーンショット 2024-11-25 13 49 58" src="https://github.com/user-attachments/assets/19a492f5-e5eb-4e55-8c21-5d8b106a9a7f">

![スクリーンショット 2024-11-25 13 50 13](https://github.com/user-attachments/assets/964404bf-b003-4952-b7de-a62d81102274)

## Which point I want you to review particularly

The test case was skipped because data without coresupport could not be created.

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced asset retrieval logic to ensure only assets with core support are fetched.
	- Improved asset creation process in tests using a builder pattern for better structure and readability.

- **Bug Fixes**
	- Streamlined filtering logic for asset queries, reducing complexity and improving performance.

- **Tests**
	- Updated test functions to incorporate context management and repository interactions for better error handling and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->