### PR TITLE
fix(web): add functionality to reset 3d tile styles to default styles

### DIFF
--- a/web/src/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/presetLayerStyles.ts
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/presetLayerStyles.ts
@@ -19,7 +19,10 @@ export const defaultStyle: Partial<LayerAppearanceTypes> = {
     strokeColor: "#FFFFFF",
     strokeWidth: 2
   },
-  "3dtiles": {}
+  "3dtiles": {
+    color: "#FFFFFF",
+    colorBlendMode: "highlight"
+  }
 };
 
 export const professionalStyle = {


### PR DESCRIPTION
# Overview
This is a bug-fix where the color of the 3d tiles turned to black when we tried to set the styles to default styles ( no styles ). Made a change to the preset layer styles for this fix. Thanks to Shaun for the help!
## What I've done
Made a screen-recording shared on Slack.
## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
