### PR TITLE
feat(server): add data attribute as default plugin when project gets created

### DIFF
--- a/server/internal/usecase/interactor/scene.go
+++ b/server/internal/usecase/interactor/scene.go
@@ -246,7 +246,7 @@ func (i *Scene) addDefaultExtensionWidget(ctx context.Context, sceneID id.SceneI
 		res.Widgets().Alignment().Area(loc).Add(widget.ID(), -1)
 	}
 
-	if err := i.propertyRepo.Save(ctx, prop); err != nil {
+	if err := i.propertyRepo.Filtered(repo.SceneFilter{Writable: scene.IDList{sceneID}}).Save(ctx, prop); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method for adding default tiles to scenes, enhancing scene creation.
	- Added a method for managing default widget extensions within scenes.

- **Improvements**
	- Restructured the scene creation process for better clarity and modularity.
	- Enhanced error handling and feedback during scene export processes, providing clearer messages for failures.
	- Improved JSON validation in the test suite for GraphQL story management, ensuring more robust output verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->