### PR TITLE
feat(server): enable original key filter

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/paulmach/go.geojson v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/ravilushqa/otelgqlgen v0.15.0
-	github.com/reearth/reearthx v0.0.0-20241120060035-e4cc7e5e2643
+	github.com/reearth/reearthx v0.0.0-20241127093551-4fcdd23fa824
 	github.com/samber/lo v1.39.0
 	github.com/spf13/afero v1.11.0
 	github.com/square/mongo-lock v0.0.0-20201208161834-4db518ed7fb2

--- a/server/go.sum
+++ b/server/go.sum
@@ -509,8 +509,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/ravilushqa/otelgqlgen v0.15.0 h1:U85nrlweMXTGaMChUViYM39/MXBZVeVVlpuHq+6eECQ=
 github.com/ravilushqa/otelgqlgen v0.15.0/go.mod h1:o+1Eju0VySmgq2BP8Vupz2YrN21Bj7D7imBqu3m2uB8=
-github.com/reearth/reearthx v0.0.0-20241120060035-e4cc7e5e2643 h1:wv28cqjc49af4+EU7IdkrxoVuqn9r5WHq5jJYdtjC3A=
-github.com/reearth/reearthx v0.0.0-20241120060035-e4cc7e5e2643/go.mod h1:/ByvE9o0WANHL2nhOyZjOXWwY8cCgze0OmwyNzxcYoA=
+github.com/reearth/reearthx v0.0.0-20241127093551-4fcdd23fa824 h1:Zy0dk/fXMIhJBKh5xBbFRyxDbw4PWU4ek0eEnH00GJg=
+github.com/reearth/reearthx v0.0.0-20241127093551-4fcdd23fa824/go.mod h1:/ByvE9o0WANHL2nhOyZjOXWwY8cCgze0OmwyNzxcYoA=
 github.com/robertkrimen/godocdown v0.0.0-20130622164427-0bfa04905481/go.mod h1:C9WhFzY47SzYBIvzFqSvHIR6ROgDo4TtdTuRaOMjF/s=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -251,7 +251,7 @@ func (r *Project) paginate(ctx context.Context, filter any, sort *project.SortTy
 	findOptions := options.Find().SetCollation(&collation)
 
 	c := mongodoc.NewProjectConsumer(r.f.Readable)
-	pageInfo, err := r.client.Paginate(ctx, filter, usort, pagination, c, findOptions)
+	pageInfo, err := r.client.PaginateProject(ctx, filter, usort, pagination, c, findOptions)
 	if err != nil {
 		return nil, nil, rerror.ErrInternalByWithContext(ctx, err)
 	}


### PR DESCRIPTION
# Overview

Projects from a different workspace are shown when fetching projects

## What I've done

This bug will be resolved by incorporating this fix.
https://github.com/reearth/reearthx/pull/57

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated dependency for improved functionality or bug fixes in the `reearthx` package.
  
- **Bug Fixes**
	- Enhanced pagination handling for project entities, improving data retrieval efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->