### PR TITLE
fix(server): coresupport query missmatch

### DIFF
--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -89,16 +89,11 @@ func (r *Project) FindByWorkspace(ctx context.Context, id accountdomain.Workspac
 			{
 				"$or": []bson.M{
 					{"deleted": false},
-					{"deleted": bson.M{"$exists": false}}, // If it does not exist, it will be considered valid.
-				},
-			},
-			{
-				"$and": []bson.M{
-					{"coresupport": true},
-					{"coresupport": bson.M{"$exists": true}}, //If it does not exist, it will be excluded.
+					{"deleted": bson.M{"$exists": false}},
 				},
 			},
 		},
+		"coresupport": true,
 	}
 
 	if uFilter.Keyword != nil {
@@ -128,16 +123,11 @@ func (r *Project) FindStarredByWorkspace(ctx context.Context, id accountdomain.W
 			{
 				"$or": []bson.M{
 					{"deleted": false},
-					{"deleted": bson.M{"$exists": false}}, // If it does not exist, it will be considered valid.
-				},
-			},
-			{
-				"$and": []bson.M{
-					{"coresupport": true},
-					{"coresupport": bson.M{"$exists": true}}, //If it does not exist, it will be excluded.
+					{"deleted": bson.M{"$exists": false}},
 				},
 			},
 		},
+		"coresupport": true,
 	}
 
 	return r.find(ctx, filter)
@@ -149,12 +139,9 @@ func (r *Project) FindDeletedByWorkspace(ctx context.Context, id accountdomain.W
 	}
 
 	filter := bson.M{
-		"team":    id.String(),
-		"deleted": true,
-		"$and": []bson.M{
-			{"coresupport": true},
-			{"coresupport": bson.M{"$exists": true}}, //If it does not exist, it will be excluded.
-		},
+		"team":        id.String(),
+		"deleted":     true,
+		"coresupport": true,
 	}
 
 	return r.find(ctx, filter)

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -85,13 +85,9 @@ func (r *Project) FindByWorkspace(ctx context.Context, id accountdomain.Workspac
 
 	filter := bson.M{
 		"team": id.String(),
-		"$and": []bson.M{
-			{
-				"$or": []bson.M{
-					{"deleted": false},
-					{"deleted": bson.M{"$exists": false}},
-				},
-			},
+		"$or": []bson.M{
+			{"deleted": false},
+			{"deleted": bson.M{"$exists": false}},
 		},
 		"coresupport": true,
 	}
@@ -119,13 +115,9 @@ func (r *Project) FindStarredByWorkspace(ctx context.Context, id accountdomain.W
 	filter := bson.M{
 		"team":    id.String(),
 		"starred": true,
-		"$and": []bson.M{
-			{
-				"$or": []bson.M{
-					{"deleted": false},
-					{"deleted": bson.M{"$exists": false}},
-				},
-			},
+		"$or": []bson.M{
+			{"deleted": false},
+			{"deleted": bson.M{"$exists": false}},
 		},
 		"coresupport": true,
 	}

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -89,13 +89,13 @@ func (r *Project) FindByWorkspace(ctx context.Context, id accountdomain.Workspac
 			{
 				"$or": []bson.M{
 					{"deleted": false},
-					{"deleted": bson.M{"$exists": false}},
+					{"deleted": bson.M{"$exists": false}}, // If it does not exist, it will be considered valid.
 				},
 			},
 			{
-				"$or": []bson.M{
+				"$and": []bson.M{
 					{"coresupport": true},
-					{"coresupport": bson.M{"$exists": false}},
+					{"coresupport": bson.M{"$exists": true}}, //If it does not exist, it will be excluded.
 				},
 			},
 		},
@@ -128,13 +128,13 @@ func (r *Project) FindStarredByWorkspace(ctx context.Context, id accountdomain.W
 			{
 				"$or": []bson.M{
 					{"deleted": false},
-					{"deleted": bson.M{"$exists": false}},
+					{"deleted": bson.M{"$exists": false}}, // If it does not exist, it will be considered valid.
 				},
 			},
 			{
-				"$or": []bson.M{
+				"$and": []bson.M{
 					{"coresupport": true},
-					{"coresupport": bson.M{"$exists": false}},
+					{"coresupport": bson.M{"$exists": true}}, //If it does not exist, it will be excluded.
 				},
 			},
 		},
@@ -149,9 +149,12 @@ func (r *Project) FindDeletedByWorkspace(ctx context.Context, id accountdomain.W
 	}
 
 	filter := bson.M{
-		"team":        id.String(),
-		"deleted":     true,
-		"coresupport": true,
+		"team":    id.String(),
+		"deleted": true,
+		"$and": []bson.M{
+			{"coresupport": true},
+			{"coresupport": bson.M{"$exists": true}}, //If it does not exist, it will be excluded.
+		},
 	}
 
 	return r.find(ctx, filter)


### PR DESCRIPTION
# Overview

There was an error in the CoreSupport query.

## What I've done

The cases where the CoreSupport flag was missing were being retrieved, but I have fixed it so that they are no longer retrieved.
https://github.com/reearth/reearth-visualizer/pull/1293/files#diff-4eb50880165a0ccf452eacc035a8cbda52a86094b43d8156a3332524a8dfe41eL95

## What I haven't done

## How I tested

I have reflected this case in the test code.
https://github.com/reearth/reearth-visualizer/pull/1293/files#diff-f7d123401a1a82a94205ef95de13237e750f27d1cce05443924ce5e3fec0e541R691

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced project creation functionality with a new parameter for core support status.
	- Introduced a new function to maintain backward compatibility for project creation without core support.

- **Bug Fixes**
	- Streamlined filtering logic for project queries to enforce stricter criteria based on core support status.

- **Tests**
	- Modified test cases to incorporate the new core support parameter and validate expected project attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->