### PR TITLE
fix(web): style code condition values need to be wrapped

### DIFF
--- a/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/convert.test.tsx
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/convert.test.tsx
@@ -180,7 +180,7 @@ describe("convertToLayerStyleValue", () => {
 
 describe("parseStyleValue", () => {
   it("should  parse style value  and return value as value type", () => {
-    const value = parseStyleValue("clamp");
+    const value = parseStyleValue("select", "clamp");
 
     expect(value).toEqual({
       valueType: "value",
@@ -190,7 +190,9 @@ describe("parseStyleValue", () => {
     });
   });
   it("should  parse style value and return expression as value type", () => {
-    const value = parseStyleValue({ expression: "color('#ffffff', 0.8)" });
+    const value = parseStyleValue("color", {
+      expression: "color('#ffffff', 0.8)"
+    });
 
     expect(value).toEqual({
       valueType: "expression",
@@ -203,7 +205,9 @@ describe("parseStyleValue", () => {
 
 describe("parseConditions", () => {
   it("should parse conditions correctly", () => {
-    const conditions = parseConditions([["${marker-size}==='medium'", "12"]]);
+    const conditions = parseConditions("number", [
+      ["${marker-size}==='medium'", "12"]
+    ]);
 
     expect(conditions).toEqual([
       {
@@ -225,7 +229,10 @@ describe("generateStyleValue", () => {
 });
 
 describe("generateConditions", () => {
-  const conditions = generateConditions(mockStyleNodes?.marker[0].conditions);
+  const conditions = generateConditions(
+    "number",
+    mockStyleNodes?.marker[0].conditions
+  );
 
   it("should generate conditions'", () => {
     expect(conditions).toEqual([

--- a/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/convert.test.tsx
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/convert.test.tsx
@@ -220,6 +220,21 @@ describe("parseConditions", () => {
   });
 });
 
+it("should parse conditions with URL values correctly", () => {
+  const conditions = parseConditions("model", [
+    ["${type}==='1'", "'https://example.com/model.glb'"]
+  ]);
+
+  expect(conditions).toEqual([
+    {
+      variable: "${type}",
+      operator: "===",
+      value: "'1'",
+      applyValue: "https://example.com/model.glb"
+    }
+  ]);
+});
+
 describe("generateStyleValue", () => {
   it("should generate style value'", () => {
     expect(generateStyleValue(mockStyleNodes?.model[0])).toEqual(

--- a/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/convert.ts
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/convert.ts
@@ -235,7 +235,6 @@ export const unwrapConditionAppliedValue = (
 };
 
 export const wrapExpression = (field: AppearanceField, expression: string) => {
-  // check if expression is in format of ${}
   if (/^\${.+}$/.test(expression)) {
     return expression;
   }
@@ -255,7 +254,6 @@ export const unwrapExpression = (
   field: AppearanceField | undefined,
   expression: string
 ) => {
-  // check if expression is wrapped with color()
   if (/^\${.+}$/.test(expression)) {
     return expression;
   }


### PR DESCRIPTION
# Overview

As a special requirement from style code conditions, some values need to be wrapped with `''` or `""`, espcially for urls since there's `:` within the url string.

## What I've done

- Update the wrap / unwrap function for condition & expression values.
- Update reg exp for color value.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of style values and conditions with improved type specificity.
	- Introduced new functions for wrapping and unwrapping expressions and conditions, allowing for more nuanced value processing.

- **Bug Fixes**
	- Adjusted function signatures for better clarity and type safety in style value parsing and condition generation.

- **Documentation**
	- Updated documentation to reflect changes in function parameters and new functionalities for style value handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->