### PR TITLE
ci: migrate to secret manager for Cesium ion token updater

### DIFF
--- a/.github/workflows/_upload_cesium_token_txt.yml
+++ b/.github/workflows/_upload_cesium_token_txt.yml
@@ -1,13 +1,14 @@
 name: Upload Cesium Ion token
 on:
   workflow_call:
-    inputs:
-      gcs_dst:
-        type: string
-        required: true
     secrets:
       credentials_json:
         required: true
+      secret_name:
+        required: true
+env:
+  APP_NAME: reearth-visualizer-web
+  REGION: us-central1
 jobs:
   upload:
     runs-on: ubuntu-latest
@@ -21,7 +22,7 @@ jobs:
           credentials_json: ${{ secrets.credentials_json }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
-      - name: Upload Ion token
+      - name: Get Cesium Ion token
         id: ion_token
         run: |
           cesium_ion_token_txt_path="/tmp/cesium_ion_token.txt"
@@ -32,4 +33,18 @@ jobs:
             echo "Token length is invalid. TokenLength: ${token_length}"
             exit 1
           fi
-          gsutil cp ${cesium_ion_token_txt_path} ${{ inputs.gcs_dst }}/cesium_ion_token.txt
+          echo "token=$(<${cesium_ion_token_txt_path})" >> $GITHUB_OUTPUT
+      - name: Update Secret Manager secret
+        run: |
+          echo -n "${{ steps.ion_token.outputs.token }}" | gcloud secrets versions add ${{ secrets.secret_name }} \
+            --data-file=-
+      - name: Update Cloud Run
+        run: |
+          gcloud run services update $APP_NAME \
+            --update-secrets REEARTH_WEB_CESIUM_ION_ACCESS_TOKEN=${{ secrets.CESIUM_ION_TOKEN_SECRET_NAME }}:latest \
+            --region $REGION
+      - name: Update Cloud Run traffic
+        run: |
+          gcloud run services update-traffic $APP_NAME \
+            --to-latest \
+            --region $REGION

--- a/.github/workflows/update_cesium_ion_token_nightly.yml
+++ b/.github/workflows/update_cesium_ion_token_nightly.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   upload:
     uses: ./.github/workflows/_upload_cesium_token_txt.yml
-    with:
-      gcs_dst: gs://reearth-visualizer-oss-static-bucket
     secrets:
       credentials_json: ${{ secrets.GCP_SA_KEY }}
+      secret_name: ${{ secrets.CESIUM_ION_TOKEN_SECRET_NAME }}


### PR DESCRIPTION
# Overview

As the title says.

## What I've done

Instead of updating the GCS file, I made the GitHub Actions update the secret manager secret and route the traffic to the new Cloud Run service revision.

## What I haven't done

## How I tested

* https://github.com/reearth/reearth-visualizer/actions/runs/12108972401/job/33757575875
    * This workflow failed but I've added the permissions already.

## Which point I want you to review particularly

## Memo

* CMS version: https://github.com/reearth/reearth-cms/pull/1301


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new required input for secret management in the Cesium Ion token workflows.
	- Added environment variables for application name and region.

- **Bug Fixes**
	- Updated the process for handling the Cesium Ion token to improve security and efficiency.

- **Documentation**
	- Enhanced workflow configurations for clarity on token management and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->