### PR TITLE
fix(web): widget ui style missing on built

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -8,7 +8,6 @@ import { AuthProvider } from "./services/auth";
 import { Provider as GqlProvider } from "./services/gql";
 import { AppRoutes } from "./services/routing";
 import { Provider as ThemeProvider } from "./services/theme";
-import "@reearth-widget-ui/styles/globals.css";
 
 export default function App() {
   return (

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,6 +8,7 @@ import App from "./app";
 import { initialize as initializeSentry } from "./sentry";
 import loadConfig from "./services/config";
 import wdyr from "./wdyr";
+import "@reearth-widget-ui/styles/globals.css";
 
 window.React = React;
 window.ReactDOM = ReactDOM;

--- a/web/src/published.tsx
+++ b/web/src/published.tsx
@@ -7,6 +7,7 @@ import { createRoot } from "react-dom/client";
 import App from "./publishedapp";
 import loadConfig from "./services/config";
 import "./wdyr";
+import "@reearth-widget-ui/styles/globals.css";
 
 window.React = React;
 window.ReactDOM = ReactDOM;

--- a/web/src/publishedapp.tsx
+++ b/web/src/publishedapp.tsx
@@ -2,7 +2,6 @@ import PublishedPage from "@reearth/beta/pages/PublishedPage";
 
 import { PublishedProvider as I18nProvider } from "./services/i18n";
 import { PublishedAppProvider as ThemeProvider } from "./services/theme";
-import "@reearth-widget-ui/styles/globals.css";
 
 export default function App() {
   return (


### PR DESCRIPTION
# Overview

Tailwind global style should be imported on main entrance.
Updated on both main and published.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced global CSS styles in the application.
  
- **Bug Fixes**
  - Removed conflicting global CSS styles from certain components, which may improve layout consistency.

- **Chores**
  - Updated import statements for global styles across multiple files to ensure proper application styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->