### PR TITLE
feat(web): add ability to share plugin in plugin-playground

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -156,6 +156,7 @@
     "localforage": "1.10.0",
     "lodash-es": "4.17.21",
     "lucide-react": "0.462.0",
+    "lz-string": "^1.5.0",
     "quickjs-emscripten": "0.24.0",
     "quickjs-emscripten-sync": "1.5.2",
     "rc-slider": "9.7.5",

--- a/web/src/beta/features/PluginPlayground/Plugins/index.tsx
+++ b/web/src/beta/features/PluginPlayground/Plugins/index.tsx
@@ -18,6 +18,7 @@ type UsePluginsReturn = Pick<
   | "updateFileTitle"
   | "deleteFile"
   | "handleFileUpload"
+  | "sharedPlugins"
 >;
 
 type Props = UsePluginsReturn;
@@ -32,9 +33,14 @@ const Plugins: FC<Props> = ({
   addFile,
   updateFileTitle,
   deleteFile,
-  handleFileUpload
+  handleFileUpload,
+  sharedPlugins
 }) => {
   const [isAddingNewFile, setIsAddingNewFile] = useState(false);
+
+  const handleShareIconClicked = (pluginId: string): void => {
+    encodeAndSharePlugin(pluginId);
+  };
 
   return (
     <Wrapper>
@@ -53,7 +59,7 @@ const Plugins: FC<Props> = ({
                     id: "0",
                     title: "share",
                     icon: "paperPlaneTilt",
-                    onClick: () => encodeAndSharePlugin()
+                    onClick: () => handleShareIconClicked(plugin.id)
                   }
                 ]}
                 optionsMenuWidth={100}
@@ -61,6 +67,26 @@ const Plugins: FC<Props> = ({
             ))}
           </div>
         ))}
+        <div>
+          <CategoryTitle>Shared</CategoryTitle>
+          {sharedPlugins.map((plugin) => (
+            <EntryItem
+              key={plugin.id}
+              highlighted={selectedPlugin.id === plugin.id}
+              onClick={() => selectPlugin(plugin.id)}
+              title={plugin.title}
+              optionsMenu={[
+                {
+                  id: "0",
+                  title: "share",
+                  icon: "paperPlaneTilt",
+                  onClick: () => handleShareIconClicked(plugin.id)
+                }
+              ]}
+              optionsMenuWidth={100}
+            />
+          ))}
+        </div>
       </PluginList>
       <FileListWrapper>
         <ButtonsWrapper>

--- a/web/src/beta/features/PluginPlayground/Plugins/index.tsx
+++ b/web/src/beta/features/PluginPlayground/Plugins/index.tsx
@@ -8,6 +8,7 @@ import usePlugins from "./usePlugins";
 
 type UsePluginsReturn = Pick<
   ReturnType<typeof usePlugins>,
+  | "encodeAndSharePlugin"
   | "presetPlugins"
   | "selectPlugin"
   | "selectedPlugin"
@@ -22,6 +23,7 @@ type UsePluginsReturn = Pick<
 type Props = UsePluginsReturn;
 
 const Plugins: FC<Props> = ({
+  encodeAndSharePlugin,
   presetPlugins,
   selectedPlugin,
   selectPlugin,
@@ -46,6 +48,15 @@ const Plugins: FC<Props> = ({
                 highlighted={selectedPlugin.id === plugin.id}
                 onClick={() => selectPlugin(plugin.id)}
                 title={plugin.title}
+                optionsMenu={[
+                  {
+                    id: "0",
+                    title: "share",
+                    icon: "paperPlaneTilt",
+                    onClick: () => encodeAndSharePlugin()
+                  }
+                ]}
+                optionsMenuWidth={100}
               />
             ))}
           </div>

--- a/web/src/beta/features/PluginPlayground/Plugins/usePlugins.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/usePlugins.ts
@@ -1,7 +1,7 @@
 import { useNotification } from "@reearth/services/state";
 import JSZip from "jszip";
 import LZString from "lz-string";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import useFileInput from "use-file-input";
 import { v4 as uuidv4 } from "uuid";
@@ -12,26 +12,52 @@ import { validateFileTitle } from "./utils";
 
 export default () => {
   const [searchParams] = useSearchParams();
+  const sharedPluginUrl = searchParams.get("plugin");
+
   const decodePluginURL = useCallback((encoded: string) => {
     const base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
-
     // Decompress and parse
     const decompressed = LZString.decompressFromBase64(base64);
 
     return JSON.parse(decompressed);
   }, []);
 
-  const sharedPluginUrl = searchParams.get("plugin");
-
   const sharedPlugin = sharedPluginUrl
     ? decodePluginURL(sharedPluginUrl)
     : null;
+
+  const locallyStoredSharedPlugins = localStorage.getItem("SHARED_PLUGINS");
+  const [sharedPlugins, setSharedPlugins] = useState<PluginType[]>(
+    JSON.parse(locallyStoredSharedPlugins ?? "[]")
+  );
+
+  useEffect(() => {
+    if (sharedPlugin) {
+      setSharedPlugins((prevSharedPlugins) => {
+        const doesSharedPluginExist = prevSharedPlugins.some(
+          (element) => element.id === sharedPlugin.id
+        );
+        const tempSharedPlugins = doesSharedPluginExist
+          ? prevSharedPlugins
+          : [...prevSharedPlugins, sharedPlugin];
+        localStorage.setItem(
+          "SHARED_PLUGINS",
+          JSON.stringify(tempSharedPlugins)
+        );
+        return tempSharedPlugins;
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const presetPluginsArray = presetPlugins
     .map((category) => category.plugins)
     .flat();
 
   const [plugins, setPlugins] = useState<PluginType[]>(
-    sharedPlugin ? [sharedPlugin, ...presetPluginsArray] : presetPluginsArray
+    locallyStoredSharedPlugins
+      ? [...JSON.parse(locallyStoredSharedPlugins), ...presetPluginsArray]
+      : presetPluginsArray
   );
 
   const [selectedPluginId, setSelectedPluginId] = useState(plugins[0].id);
@@ -220,32 +246,41 @@ export default () => {
     }
   }, [selectedPlugin, setNotification]);
 
-  const encodeAndSharePlugin = useCallback((): string | undefined => {
-    // First compress the code
+  const encodeAndSharePlugin = useCallback(
+    (pluginId: string): string | undefined => {
+      selectPlugin(pluginId);
+      // Need to do a find here as the selectedPlugin does not get updated immediately
+      const sharedPlugin = plugins.find((plugin) => plugin.id === pluginId);
 
-    try {
-      const compressed = LZString.compressToBase64(
-        JSON.stringify(selectedPlugin)
-      )
-        .replace(/\+/g, "-") // Convert + to -
-        .replace(/\//g, "_") // Convert / to _
-        .replace(/=/g, ""); // Remove padding =
+      // Note: We can't use the same id for a shared plugin
+      const selectedPluginCopy = { ...sharedPlugin, id: uuidv4() };
 
-      const shareUrl = `${window.location.origin}${window.location.pathname}?plugin=${compressed}`;
-      navigator.clipboard.writeText(shareUrl);
+      // First compress the code
+      try {
+        const compressed = LZString.compressToBase64(
+          JSON.stringify(selectedPluginCopy)
+        )
+          .replace(/\+/g, "-") // Convert + to -
+          .replace(/\//g, "_") // Convert / to _
+          .replace(/=/g, ""); // Remove padding =
 
-      setNotification({
-        type: "success",
-        text: "Plugin link copied to clipboard"
-      });
-      return compressed;
-    } catch (error) {
-      if (error instanceof Error) {
-        setNotification({ type: "error", text: error.message });
+        const shareUrl = `${window.location.origin}${window.location.pathname}?plugin=${compressed}`;
+        navigator.clipboard.writeText(shareUrl);
+
+        setNotification({
+          type: "success",
+          text: "Plugin link copied to clipboard"
+        });
+        return compressed;
+      } catch (error) {
+        if (error instanceof Error) {
+          setNotification({ type: "error", text: error.message });
+        }
+        return;
       }
-      return;
-    }
-  }, [selectedPlugin, setNotification]);
+    },
+    [plugins, selectPlugin, setNotification]
+  );
 
   return {
     encodeAndSharePlugin,
@@ -259,6 +294,7 @@ export default () => {
     updateFileSourceCode,
     deleteFile,
     handleFileUpload,
-    handlePluginDownload
+    handlePluginDownload,
+    sharedPlugins
   };
 };

--- a/web/src/beta/features/PluginPlayground/Plugins/usePlugins.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/usePlugins.ts
@@ -12,7 +12,7 @@ import { validateFileTitle } from "./utils";
 
 export default () => {
   const [searchParams] = useSearchParams();
-  const decodePlugin = useCallback((encoded: string) => {
+  const decodePluginURL = useCallback((encoded: string) => {
     const base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
 
     // Decompress and parse
@@ -23,7 +23,9 @@ export default () => {
 
   const sharedPluginUrl = searchParams.get("plugin");
 
-  const sharedPlugin = sharedPluginUrl ? decodePlugin(sharedPluginUrl) : null;
+  const sharedPlugin = sharedPluginUrl
+    ? decodePluginURL(sharedPluginUrl)
+    : null;
   const presetPluginsArray = presetPlugins
     .map((category) => category.plugins)
     .flat();
@@ -229,8 +231,7 @@ export default () => {
         .replace(/\//g, "_") // Convert / to _
         .replace(/=/g, ""); // Remove padding =
 
-      const shareUrl =
-        "http://localhost:3000/plugin-playground?plugin=" + compressed;
+      const shareUrl = `${window.location.origin}${window.location.pathname}?plugin=${compressed}`;
       navigator.clipboard.writeText(shareUrl);
 
       setNotification({
@@ -248,7 +249,6 @@ export default () => {
 
   return {
     encodeAndSharePlugin,
-    decodePlugin,
     presetPlugins,
     selectPlugin,
     selectedPlugin,

--- a/web/src/beta/features/PluginPlayground/hooks.tsx
+++ b/web/src/beta/features/PluginPlayground/hooks.tsx
@@ -21,7 +21,8 @@ export default () => {
     updateFileSourceCode,
     deleteFile,
     handleFileUpload,
-    handlePluginDownload
+    handlePluginDownload,
+    encodeAndSharePlugin
   } = usePlugins();
 
   const { widgets, executeCode, fileOutputs } = useCode({
@@ -59,6 +60,7 @@ export default () => {
         name: "Plugins",
         children: (
           <Plugins
+            encodeAndSharePlugin={encodeAndSharePlugin}
             presetPlugins={presetPlugins}
             selectedPlugin={selectedPlugin}
             selectPlugin={selectPlugin}
@@ -73,6 +75,7 @@ export default () => {
       }
     ],
     [
+      encodeAndSharePlugin,
       presetPlugins,
       selectedPlugin,
       selectPlugin,

--- a/web/src/beta/features/PluginPlayground/hooks.tsx
+++ b/web/src/beta/features/PluginPlayground/hooks.tsx
@@ -22,7 +22,8 @@ export default () => {
     deleteFile,
     handleFileUpload,
     handlePluginDownload,
-    encodeAndSharePlugin
+    encodeAndSharePlugin,
+    sharedPlugins
   } = usePlugins();
 
   const { widgets, executeCode, fileOutputs } = useCode({
@@ -70,6 +71,7 @@ export default () => {
             updateFileTitle={updateFileTitle}
             deleteFile={deleteFile}
             handleFileUpload={handleFileUpload}
+            sharedPlugins={sharedPlugins}
           />
         )
       }
@@ -84,7 +86,8 @@ export default () => {
       addFile,
       updateFileTitle,
       deleteFile,
-      handleFileUpload
+      handleFileUpload,
+      sharedPlugins
     ]
   );
 

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -8321,6 +8321,7 @@ __metadata:
     localforage: "npm:1.10.0"
     lodash-es: "npm:4.17.21"
     lucide-react: "npm:0.462.0"
+    lz-string: "npm:^1.5.0"
     npm-run-all: "npm:4.1.5"
     postcss: "npm:8.4.49"
     prettier: "npm:3.3.3"


### PR DESCRIPTION
# Overview
Added ability to share plugin and added a sub-category for shared plugins. Stored the shared plugins locally so that they are not overriden when more than one plugin is shared.
## What I've done

## What I haven't done
Need to consider when to clear the the local storage for the shared plugins.
## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to share plugins via a new "share" option in the menu.
  - Added a section for displaying shared plugins within the Plugins component.
  
- **Enhancements**
  - Improved plugin management by allowing users to encode plugins into shareable URLs.
  - Integrated shared plugin functionality with local storage management.

- **Dependencies**
  - Added support for string compression with the inclusion of the `lz-string` library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->