### PR TITLE
ci: remove `--rm-dist` from Goreleaser arguments

### DIFF
--- a/.github/workflows/build_server.yml
+++ b/.github/workflows/build_server.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist ${{ inputs.new_tag == 'blank' && '--snapshot' || '' }}
+          args: release ${{ inputs.new_tag == 'blank' && '--snapshot' || '' }}
           workdir: server
         env:
           GORELEASER_CURRENT_TAG: ${{ inputs.new_tag == 'blank' && '0.0.0' || inputs.new_tag }}


### PR DESCRIPTION
# Overview

Same to https://github.com/reearth/reearth-classic/pull/36. It doesn't have this argument.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
