### PR TITLE
ci: upgrade Goreleaser to use v2 configuration

### DIFF
--- a/.github/workflows/build_server.yml
+++ b/.github/workflows/build_server.yml
@@ -38,8 +38,8 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
-          version: latest
-          args: release ${{ inputs.new_tag == 'blank' && '--snapshot' || '' }}
+          version: ~> v2
+          args: release --clean ${{ inputs.new_tag == 'blank' && '--snapshot' || '' }}
           workdir: server
         env:
           GORELEASER_CURRENT_TAG: ${{ inputs.new_tag == 'blank' && '0.0.0' || inputs.new_tag }}

--- a/server/.goreleaser.yml
+++ b/server/.goreleaser.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
 project_name: reearth
 before:
   hooks:
@@ -26,8 +28,8 @@ archives:
       - goos: windows
         format: zip
 changelog:
-  skip: true
+  disable: true
 release:
   disable: true
 snapshot:
-  name_template: "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}"
+  version_template: "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}"


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

* [Announcing GoReleaser v2](https://goreleaser.com/blog/goreleaser-v2/)