### PR TITLE
ci: add `build-release` workflow and decouple Goreleaser

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,0 +1,77 @@
+name: build-release
+on:
+  workflow_call:
+    inputs:
+      sha_short:
+        type: string
+        required: true
+      new_tag:
+        type: string
+        required: true
+      new_tag_short:
+        type: string
+        required: true
+      name:
+        type: string
+        required: true
+      sha:
+        type: string
+        required: true
+
+jobs:
+  server:
+    name: Build and release server
+    runs-on: ubuntu-latest
+    if: inputs.name || inputs.new_tag
+    env:
+      ARTIFACTS: server/dist/reearth_*.*
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: ~> v2
+          args: release --clean ${{ inputs.new_tag == '' && '--snapshot' || '' }}
+          workdir: server
+        env:
+          GORELEASER_CURRENT_TAG: ${{ inputs.new_tag == '' && '0.0.0' || inputs.new_tag }}
+      - name: Rename artifacts
+        if: ${{ inputs.name != '' }}
+        run: for f in $ARTIFACTS; do mv $f $(echo $f | sed -E 's/_0\.0\.0-SNAPSHOT-[^_]*/_${{ inputs.name }}/'); done
+      - name: List artifacts
+        run: ls -l server/dist
+      - name: Release nightly/rc
+        if: ${{ inputs.name != '' }}
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: ${{ env.ARTIFACTS }}
+          commit: ${{ inputs.sha }}
+          name: ${{ inputs.name }}
+          tag: ${{ inputs.name }}
+          body: ${{ inputs.sha_short }}
+          prerelease: true
+      - name: Download latest changelog
+        if: ${{ inputs.new_tag != '' }}
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: release.yml
+          name: changelog-${{ inputs.new_tag }}
+      - name: Create GitHub release
+        if: ${{ inputs.new_tag != '' }}
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: ${{ env.ARTIFACTS }}
+          commit: ${{ inputs.sha }}
+          name: ${{ inputs.new_tag }}
+          tag: ${{ inputs.new_tag}}
+          bodyFile: CHANGELOG_latest.md

--- a/.github/workflows/build_server.yml
+++ b/.github/workflows/build_server.yml
@@ -19,63 +19,6 @@ on:
         required: true
 
 jobs:
-  build-server:
-    name: Build and release server
-    runs-on: ubuntu-latest
-    if: inputs.name || inputs.new_tag
-    env:
-      ARTIFACTS: server/dist/reearth_*.*
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.21"
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          distribution: goreleaser
-          version: ~> v2
-          args: release --clean ${{ inputs.new_tag == '' && '--snapshot' || '' }}
-          workdir: server
-        env:
-          GORELEASER_CURRENT_TAG: ${{ inputs.new_tag == '' && '0.0.0' || inputs.new_tag }}
-      - name: Rename artifacts
-        if: ${{ inputs.name != '' }}
-        run: for f in $ARTIFACTS; do mv $f $(echo $f | sed -E 's/_0\.0\.0-SNAPSHOT-[^_]*/_${{ inputs.name }}/'); done
-      - name: List artifacts
-        run: ls -l server/dist
-      - name: Release nightly/rc
-        if: ${{ inputs.name != '' }}
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          artifacts: ${{ env.ARTIFACTS }}
-          commit: ${{ inputs.sha }}
-          name: ${{ inputs.name }}
-          tag: ${{ inputs.name }}
-          body: ${{ inputs.sha_short }}
-          prerelease: true
-      - name: Download latest changelog
-        if: ${{ inputs.new_tag != '' }}
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: release.yml
-          name: changelog-${{ inputs.new_tag }}
-      - name: Create GitHub release
-        if: ${{ inputs.new_tag != '' }}
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          artifacts: ${{ env.ARTIFACTS }}
-          commit: ${{ inputs.sha }}
-          name: ${{ inputs.new_tag }}
-          tag: ${{ inputs.new_tag}}
-          bodyFile: CHANGELOG_latest.md
-
   build-docker-image:
     name: Build and push Docker image
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
     secrets: inherit
 
   build-release:
-    needs: [build-prepare, build-server]
+    needs: [ci-server, build-prepare]
     uses: ./.github/workflows/build_release.yml
     with:
       sha_short: ${{ needs.build-prepare.outputs.sha_short }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,17 @@ jobs:
       sha: ${{ github.sha }}
     secrets: inherit
 
+  build-release:
+    needs: [build-prepare, build-server]
+    uses: ./.github/workflows/build_release.yml
+    with:
+      sha_short: ${{ needs.build-prepare.outputs.sha_short }}
+      new_tag: ${{ needs.build-prepare.outputs.new_tag }}
+      new_tag_short: ${{ needs.build-prepare.outputs.new_tag_short }}
+      name: ${{ needs.build-prepare.outputs.name }}
+      sha: ${{ github.sha }}
+    secrets: inherit
+
   deploy-web:
     needs: build-web
     uses: ./.github/workflows/deploy_web_nightly.yml


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow for automated building and releasing of software versions.
	- Added a `build-release` job to the CI workflow, enhancing the release process.
  
- **Bug Fixes**
	- Removed the outdated `build-server` job to streamline the workflow.

- **Chores**
	- Updated conditions for the `build-docker-image` job to improve execution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->