### PR TITLE
chore: add bind mounts tailwind and postcss config on docker build for web

### DIFF
--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -11,3 +11,5 @@
 !published.html
 !vite.config.ts
 !yarn.lock
+!tailwind.config.js
+!postcss.config.js

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -23,6 +23,8 @@ RUN --mount=type=bind,source=.yarnrc.yml,target=.yarnrc.yml \
     --mount=type=bind,source=published.html,target=published.html \
     --mount=type=bind,source=tsconfig.json,target=tsconfig.json \
     --mount=type=bind,source=vite.config.ts,target=vite.config.ts \
+    --mount=type=bind,source=tailwind.config.js,target=tailwind.config.js \
+    --mount=type=bind,source=postcss.config.js,target=postcss.config.js \
     --mount=type=bind,source=src,target=src \
     --mount=type=cache,target=/root/.yarn,sharing=locked \
     yarn build


### PR DESCRIPTION
# Overview

Recently we introduced tailwind for web, the config of tailwind and postcss might be necessary for the build process.

## What I've done

## What I haven't done

## How I tested

Build docker image on my local and check the built files.

## Which point I want you to review particularly

## Memo
