### PR TITLE
refactor(web): infobox's customized property list.

### DIFF
--- a/web/src/beta/features/Visualizer/Crust/Infobox/Block/builtin/PropertyList/ListEditor/Item.tsx
+++ b/web/src/beta/features/Visualizer/Crust/Infobox/Block/builtin/PropertyList/ListEditor/Item.tsx
@@ -1,30 +1,39 @@
 import { Button, Icon, TextInput } from "@reearth/beta/lib/reearth-ui";
 import { useT } from "@reearth/services/i18n";
-import { styled } from "@reearth/services/theme";
+import { styled, useTheme } from "@reearth/services/theme";
 import { FC, useCallback, useState } from "react";
 
 import { PropertyListItem } from ".";
 
 type Props = {
   item: PropertyListItem;
+  isEditKey: boolean;
+  isEditValue: boolean;
   handleClassName?: string;
   onKeyBlur: (newValue?: string) => void;
   onValueBlur: (newValue?: string) => void;
   onItemRemove: () => void;
+  onDoubleClick?: (field: string) => void;
 };
 
 const EditorItem: FC<Props> = ({
   item,
   handleClassName,
+  isEditKey,
+  isEditValue,
   onKeyBlur,
   onValueBlur,
-  onItemRemove
+  onItemRemove,
+  onDoubleClick
 }) => {
-  const [currentKeyValue, setCurrentKeyValue] = useState<string>(item.key);
-  const [currentValue, setCurrentValue] = useState<string>(item.value);
+  const t = useT();
+  const theme = useTheme();
+
+  const [currentKeyItem, setCurrentKeyItem] = useState<string>(item.key);
+  const [currentValueItem, setCurrentValueItem] = useState<string>(item.value);
 
   const handleKeyChange = useCallback((newValue: string) => {
-    setCurrentKeyValue(newValue);
+    setCurrentKeyItem(newValue);
   }, []);
 
   const handleKeyBlur = useCallback(
@@ -35,7 +44,7 @@ const EditorItem: FC<Props> = ({
   );
 
   const handleValueChange = useCallback((newValue: string) => {
-    setCurrentValue(newValue);
+    setCurrentValueItem(newValue);
   }, []);
 
   const handleValueBlur = useCallback(
@@ -45,25 +54,45 @@ const EditorItem: FC<Props> = ({
     [onValueBlur]
   );
 
-  const t = useT();
-
   return (
     <Field>
-      <HandleIcon icon="dotsSixVertical" className={handleClassName} />
-      <TextInput
+      <Icon
+        className={handleClassName}
+        icon="dotsSixVertical"
+        color={theme.content.weak}
         size="small"
-        value={currentKeyValue}
-        placeholder={t("Display title")}
-        onChange={handleKeyChange}
-        onBlur={handleKeyBlur}
       />
-      <TextInput
-        size="small"
-        value={currentValue}
-        placeholder={t("${your property name}")}
-        onChange={handleValueChange}
-        onBlur={handleValueBlur}
-      />
+      <ItemCol>
+        {item.key === "" || isEditKey ? (
+          <TextInput
+            size="small"
+            value={currentKeyItem}
+            placeholder={t("Display title")}
+            onChange={handleKeyChange}
+            onBlur={handleKeyBlur}
+          />
+        ) : (
+          <TextWrapper onDoubleClick={() => onDoubleClick?.("key")}>
+            {currentKeyItem}
+          </TextWrapper>
+        )}
+      </ItemCol>
+      <ItemCol>
+        {item.value === "" || isEditValue ? (
+          <TextInput
+            size="small"
+            value={currentValueItem}
+            placeholder={t("${your property name}")}
+            onChange={handleValueChange}
+            onBlur={handleValueBlur}
+          />
+        ) : (
+          <TextWrapper onDoubleClick={() => onDoubleClick?.("value")}>
+            {currentValueItem}
+          </TextWrapper>
+        )}
+      </ItemCol>
+
       <Button
         icon="trash"
         iconButton
@@ -89,10 +118,16 @@ const Field = styled("div")(({ theme }) => ({
   borderRadius: theme.radius.smallest
 }));
 
-const HandleIcon = styled(Icon)(({ theme }) => ({
-  color: theme.content.weak,
-  cursor: "move",
-  "&:hover": {
-    color: theme.content.main
-  }
+const ItemCol = styled("div")(() => ({
+  flex: 1
+}));
+
+const TextWrapper = styled("div")(({ theme }) => ({
+  color: theme.content.main,
+  fontSize: theme.fonts.sizes.body,
+  fontWeight: theme.fonts.weight.regular,
+  padding: theme.spacing.micro,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap"
 }));

--- a/web/src/beta/features/Visualizer/Crust/Infobox/Block/builtin/PropertyList/ListEditor/index.tsx
+++ b/web/src/beta/features/Visualizer/Crust/Infobox/Block/builtin/PropertyList/ListEditor/index.tsx
@@ -70,13 +70,17 @@ const ListEditor: FC<Props> = ({
   const {
     displayOptions,
     currentPropertyList,
+    editValueIndex,
+    editKeyIndex,
     handleKeyBlur,
     handleValueBlur,
     handleDisplayTypeUpdate,
     handleItemAdd,
     handleMoveStart,
     handleMoveEnd,
-    handlePropertyValueRemove
+    handlePropertyValueRemove,
+    handleDoubleClick,
+    handlePropertyListUpdate
   } = useHooks({
     propertyId,
     propertyListField,
@@ -92,19 +96,17 @@ const ListEditor: FC<Props> = ({
           <EditorItem
             key={item.id}
             item={item}
+            isEditKey={editKeyIndex === idx}
+            isEditValue={editValueIndex === idx}
             onKeyBlur={handleKeyBlur(idx)}
             handleClassName={CURRENT_PROPERTY_LIST_DRAG_HANDLE_CLASS_NAME}
             onValueBlur={handleValueBlur(idx)}
+            onDoubleClick={(field: string) => handleDoubleClick(idx, field)}
             onItemRemove={() => handlePropertyValueRemove(idx)}
           />
         )
       })),
-    [
-      currentPropertyList,
-      handleKeyBlur,
-      handleValueBlur,
-      handlePropertyValueRemove
-    ]
+    [currentPropertyList, editKeyIndex, editValueIndex, handleKeyBlur, handleValueBlur, handleDoubleClick, handlePropertyValueRemove]
   );
 
   return (
@@ -131,13 +133,22 @@ const ListEditor: FC<Props> = ({
           </>
         )}
       {displayTypeField?.value === "custom" && (
-        <Button
-          title={t("New Field")}
-          icon="plus"
-          size="small"
-          onClick={handleItemAdd}
-          extendWidth
-        />
+        <ActionsWrapper>
+          <Button
+            title={t("New Field")}
+            icon="plus"
+            size="small"
+            onClick={handleItemAdd}
+            extendWidth
+          />
+          <Button
+            title={t("Save")}
+            icon="floppyDisk"
+            size="small"
+            onClick={() => handlePropertyListUpdate(currentPropertyList)}
+            extendWidth
+          />
+        </ActionsWrapper>
       )}
     </Wrapper>
   );
@@ -158,6 +169,12 @@ const FieldWrapper = styled("div")(({ theme }) => ({
   flexDirection: "column",
   justifyContent: "space-between",
   gap: theme.spacing.smallest,
+  boxSizing: "border-box"
+}));
+
+const ActionsWrapper = styled("div")(({ theme }) => ({
+  display: "flex",
+  gap: theme.spacing.smallest,
   alignItems: "center",
-  boxsizing: "border-box"
+  boxSizing: "border-box"
 }));


### PR DESCRIPTION
# Overview
- Add a save button to the Infobox property list block's custom property section to ensure user inputs are reliably saved

Related story 
[https://www.notion.so/eukarya/visualizer-reearth-io-User-Stories-V2-13a16e0fb165800ba026f7569c8dd4b2?p=14316e0fb16580c381ccc123fa58ea07&pm=s](url)

[https://www.notion.so/eukarya/visualizer-reearth-io-User-Stories-V2-13a16e0fb165800ba026f7569c8dd4b2?p=13b16e0fb16580aaa5d5dec5b1b87fb5&pm=s](url)

## What I've done
- Refactor add and remove custom property item
- Add save button

### Before
<img width="332" alt="before" src="https://github.com/user-attachments/assets/6e4f223b-ab55-48ac-8018-1a49100e8017" />

### After
<img width="302" alt="after" src="https://github.com/user-attachments/assets/08193656-7f4d-4fb2-aea4-3d6f49e91ccd" />

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced inline editing for key and value fields in the list editor.
	- Added new handlers for double-click interactions and property list updates.

- **Bug Fixes**
	- Improved state management for editing indices and synchronization logic.

- **Style**
	- Enhanced styling and layout for better user interface experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->