### PR TITLE
feat(server): Support reorder layer

### DIFF
--- a/server/e2e/gql_featureCollection_test.go
+++ b/server/e2e/gql_featureCollection_test.go
@@ -214,7 +214,7 @@ func TestFeatureCollectionCRUD(t *testing.T) {
 		Value("newLayers").Array().
 		Length().Equal(0)
 
-	_, _, layerId := addNLSLayerSimple(e, sId)
+	_, _, layerId := addNLSLayerSimple(e, sId, "someTitle", 1)
 
 	_, res2 := fetchSceneForNewLayers(e, sId)
 	res2.Object().

--- a/server/e2e/gql_layer_test.go
+++ b/server/e2e/gql_layer_test.go
@@ -1,8 +1,6 @@
 package e2e
 
 import (
-	"net/http"
-
 	"github.com/gavv/httpexpect/v2"
 )
 
@@ -31,14 +29,7 @@ func addLayerItemFromPrimitive(e *httpexpect.Expect, rootLayerId string) (GraphQ
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	return requestBody, res, res.Path("$.data.addLayerItem.layer.id").Raw().(string)
 }

--- a/server/e2e/gql_project_import_test.go
+++ b/server/e2e/gql_project_import_test.go
@@ -498,6 +498,7 @@ fragment StoryFragment on Story {
 }
 fragment NLSLayerCommon on NLSLayer {
   id
+  index
   layerType
   sceneId
   config

--- a/server/e2e/gql_property_test.go
+++ b/server/e2e/gql_property_test.go
@@ -1,8 +1,6 @@
 package e2e
 
 import (
-	"net/http"
-
 	"github.com/gavv/httpexpect/v2"
 )
 
@@ -10,35 +8,35 @@ func updatePropertyValue(e *httpexpect.Expect, propertyID, schemaGroupID, itemID
 	requestBody := GraphQLRequest{
 		OperationName: "UpdatePropertyValue",
 		Query: `mutation UpdatePropertyValue($propertyId: ID!, $schemaGroupId: ID, $itemId: ID, $fieldId: ID!, $value: Any, $type: ValueType!) {
-					updatePropertyValue( input: { propertyId: $propertyId, schemaGroupId: $schemaGroupId, itemId: $itemId, fieldId: $fieldId, value: $value, type: $type } ) {
-					  property {
-						id
-						schema{
-							id
-							groups{
-								fields{
-									fieldId
-									type
-									title
-									description
-									prefix
-									suffix
-									defaultValue
-									ui
-									min
-									max
-									placeholder
-								}
-							}
+			updatePropertyValue( input: { propertyId: $propertyId, schemaGroupId: $schemaGroupId, itemId: $itemId, fieldId: $fieldId, value: $value, type: $type } ) {
+				property {
+				id
+				schema{
+					id
+					groups{
+						fields{
+							fieldId
+							type
+							title
+							description
+							prefix
+							suffix
+							defaultValue
+							ui
+							min
+							max
+							placeholder
 						}
-					  }
-					  propertyField {	
-						id
-						type
-						value
-					  }
 					}
-			  	}`,
+				}
+				}
+				propertyField {	
+				id
+				type
+				value
+				}
+			}
+		}`,
 		Variables: map[string]any{
 			"propertyId":    propertyID,
 			"schemaGroupId": schemaGroupID,
@@ -49,14 +47,7 @@ func updatePropertyValue(e *httpexpect.Expect, propertyID, schemaGroupID, itemID
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	return requestBody, res
 }

--- a/server/e2e/gql_scene_test.go
+++ b/server/e2e/gql_scene_test.go
@@ -1,33 +1,13 @@
 package e2e
 
 import (
-	"context"
 	"testing"
 
-	"github.com/reearth/reearth/server/internal/app/config"
-	"github.com/reearth/reearth/server/internal/usecase/repo"
 	"golang.org/x/text/language"
 )
 
-// export REEARTH_DB=mongodb://localhost
-
-// go test -v -run TestGetScenePlaceholderEnglish ./e2e/...
 func TestGetScenePlaceholderEnglish(t *testing.T) {
-
-	e := StartServer(
-		t,
-		&config.Config{
-			Origins: []string{"https://example.com"},
-			AuthSrv: config.AuthSrvConfig{
-				Disabled: true,
-			},
-		},
-		true,
-		// English user Seeder
-		func(ctx context.Context, r *repo.Container) error {
-			return baseSeederWithLang(ctx, r, language.English)
-		},
-	)
+	e := ServerLanguage(t, language.English)
 	pID := createProjectWithExternalImage(e, "test")
 	_, _, sID := createScene(e, pID)
 	r := getScene(e, sID, language.English.String())
@@ -50,27 +30,10 @@ func TestGetScenePlaceholderEnglish(t *testing.T) {
 			}
 		}
 	}
-
 }
 
-// go test -v -run TestGetScenePlaceholderJapanese ./e2e/...
-
 func TestGetScenePlaceholderJapanese(t *testing.T) {
-
-	e := StartServer(
-		t,
-		&config.Config{
-			Origins: []string{"https://example.com"},
-			AuthSrv: config.AuthSrvConfig{
-				Disabled: true,
-			},
-		},
-		true,
-		// Japanese user Seeder
-		func(ctx context.Context, r *repo.Container) error {
-			return baseSeederWithLang(ctx, r, language.Japanese)
-		},
-	)
+	e := ServerLanguage(t, language.Japanese)
 	pID := createProjectWithExternalImage(e, "test")
 	_, _, sID := createScene(e, pID)
 	r := getScene(e, sID, language.Japanese.String())
@@ -93,5 +56,19 @@ func TestGetScenePlaceholderJapanese(t *testing.T) {
 			}
 		}
 	}
+}
+
+// go test -v -run TestGetScene ./e2e/...
+
+func TestGetSceneNLSLayer(t *testing.T) {
+	e := Server(t, baseSeeder)
+	pId := createProject(e, "test")
+	_, _, sId := createScene(e, pId)
+	_, _, lId := addNLSLayerSimple(e, sId, "someTitle99", 99)
+
+	r := getScene(e, sId, language.Und.String())
+	r.Value("newLayers").Array().First().Object().ValueEqual("id", lId)
+	r.Value("newLayers").Array().First().Object().ValueEqual("title", "someTitle99")
+	r.Value("newLayers").Array().First().Object().ValueEqual("index", 99)
 
 }

--- a/server/gql/newlayer.graphql
+++ b/server/gql/newlayer.graphql
@@ -1,6 +1,7 @@
 # TODO: Make LayerGroup Real
 interface NLSLayer {
   id: ID!
+  index: Int
   layerType: String!
   sceneId: ID!
   config: JSON
@@ -13,6 +14,7 @@ interface NLSLayer {
 
 type NLSLayerSimple implements NLSLayer {
   id: ID!
+  index: Int
   layerType: String!
   sceneId: ID!
   config: JSON
@@ -26,6 +28,7 @@ type NLSLayerSimple implements NLSLayer {
 
 type NLSLayerGroup implements NLSLayer {
   id: ID!
+  index: Int
   layerType: String!
   sceneId: ID!
   children: [NLSLayer]!
@@ -46,7 +49,7 @@ type NLSInfobox {
   propertyId: ID!
   blocks: [InfoboxBlock!]!
   property: Property
-  scene: Scene  
+  scene: Scene
 }
 
 type InfoboxBlock {
@@ -63,8 +66,8 @@ type InfoboxBlock {
 }
 
 type SketchInfo {
-	customPropertySchema: JSON
-	featureCollection: FeatureCollection
+  customPropertySchema: JSON
+  featureCollection: FeatureCollection
 }
 
 # InputType
@@ -84,10 +87,15 @@ input RemoveNLSLayerInput {
 }
 
 input UpdateNLSLayerInput {
+  index: Int
   layerId: ID!
   name: String
   visible: Boolean
   config: JSON
+}
+
+input UpdateNLSLayersInput {
+  layers: [UpdateNLSLayerInput!]!
 }
 
 input CreateNLSInfoboxInput {
@@ -144,6 +152,10 @@ type UpdateNLSLayerPayload {
   layer: NLSLayer!
 }
 
+type UpdateNLSLayersPayload {
+  layers: [NLSLayer!]!
+}
+
 type CreateNLSInfoboxPayload {
   layer: NLSLayer!
 }
@@ -176,6 +188,7 @@ extend type Mutation {
   addNLSLayerSimple(input: AddNLSLayerSimpleInput!): AddNLSLayerSimplePayload!
   removeNLSLayer(input: RemoveNLSLayerInput!): RemoveNLSLayerPayload!
   updateNLSLayer(input: UpdateNLSLayerInput!): UpdateNLSLayerPayload!
+  updateNLSLayers(input: UpdateNLSLayersInput!): UpdateNLSLayersPayload!
   createNLSInfobox(input: CreateNLSInfoboxInput!): CreateNLSInfoboxPayload
   removeNLSInfobox(input: RemoveNLSInfoboxInput!): RemoveNLSInfoboxPayload
   addNLSInfoboxBlock(input: AddNLSInfoboxBlockInput!): AddNLSInfoboxBlockPayload
@@ -186,6 +199,10 @@ extend type Mutation {
     input: RemoveNLSInfoboxBlockInput!
   ): RemoveNLSInfoboxBlockPayload
   duplicateNLSLayer(input: DuplicateNLSLayerInput!): DuplicateNLSLayerPayload!
-  addCustomProperties(input: AddCustomPropertySchemaInput!): UpdateNLSLayerPayload!
-  updateCustomProperties(input: UpdateCustomPropertySchemaInput!): UpdateNLSLayerPayload!
+  addCustomProperties(
+    input: AddCustomPropertySchemaInput!
+  ): UpdateNLSLayerPayload!
+  updateCustomProperties(
+    input: UpdateCustomPropertySchemaInput!
+  ): UpdateNLSLayerPayload!
 }

--- a/server/internal/adapter/gql/generated.go
+++ b/server/internal/adapter/gql/generated.go
@@ -708,6 +708,7 @@ type ComplexityRoot struct {
 		UpdateMe                     func(childComplexity int, input gqlmodel.UpdateMeInput) int
 		UpdateMemberOfTeam           func(childComplexity int, input gqlmodel.UpdateMemberOfTeamInput) int
 		UpdateNLSLayer               func(childComplexity int, input gqlmodel.UpdateNLSLayerInput) int
+		UpdateNLSLayers              func(childComplexity int, input gqlmodel.UpdateNLSLayersInput) int
 		UpdateProject                func(childComplexity int, input gqlmodel.UpdateProjectInput) int
 		UpdatePropertyItems          func(childComplexity int, input gqlmodel.UpdatePropertyItemInput) int
 		UpdatePropertyValue          func(childComplexity int, input gqlmodel.UpdatePropertyValueInput) int
@@ -738,6 +739,7 @@ type ComplexityRoot struct {
 		ChildrenIds func(childComplexity int) int
 		Config      func(childComplexity int) int
 		ID          func(childComplexity int) int
+		Index       func(childComplexity int) int
 		Infobox     func(childComplexity int) int
 		IsSketch    func(childComplexity int) int
 		LayerType   func(childComplexity int) int
@@ -751,6 +753,7 @@ type ComplexityRoot struct {
 	NLSLayerSimple struct {
 		Config    func(childComplexity int) int
 		ID        func(childComplexity int) int
+		Index     func(childComplexity int) int
 		Infobox   func(childComplexity int) int
 		IsSketch  func(childComplexity int) int
 		LayerType func(childComplexity int) int
@@ -1324,6 +1327,10 @@ type ComplexityRoot struct {
 		Layer func(childComplexity int) int
 	}
 
+	UpdateNLSLayersPayload struct {
+		Layers func(childComplexity int) int
+	}
+
 	UpdateStylePayload struct {
 		Style func(childComplexity int) int
 	}
@@ -1561,6 +1568,7 @@ type MutationResolver interface {
 	AddNLSLayerSimple(ctx context.Context, input gqlmodel.AddNLSLayerSimpleInput) (*gqlmodel.AddNLSLayerSimplePayload, error)
 	RemoveNLSLayer(ctx context.Context, input gqlmodel.RemoveNLSLayerInput) (*gqlmodel.RemoveNLSLayerPayload, error)
 	UpdateNLSLayer(ctx context.Context, input gqlmodel.UpdateNLSLayerInput) (*gqlmodel.UpdateNLSLayerPayload, error)
+	UpdateNLSLayers(ctx context.Context, input gqlmodel.UpdateNLSLayersInput) (*gqlmodel.UpdateNLSLayersPayload, error)
 	CreateNLSInfobox(ctx context.Context, input gqlmodel.CreateNLSInfoboxInput) (*gqlmodel.CreateNLSInfoboxPayload, error)
 	RemoveNLSInfobox(ctx context.Context, input gqlmodel.RemoveNLSInfoboxInput) (*gqlmodel.RemoveNLSInfoboxPayload, error)
 	AddNLSInfoboxBlock(ctx context.Context, input gqlmodel.AddNLSInfoboxBlockInput) (*gqlmodel.AddNLSInfoboxBlockPayload, error)
@@ -4927,6 +4935,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.UpdateNLSLayer(childComplexity, args["input"].(gqlmodel.UpdateNLSLayerInput)), true
 
+	case "Mutation.updateNLSLayers":
+		if e.complexity.Mutation.UpdateNLSLayers == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateNLSLayers_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateNLSLayers(childComplexity, args["input"].(gqlmodel.UpdateNLSLayersInput)), true
+
 	case "Mutation.updateProject":
 		if e.complexity.Mutation.UpdateProject == nil {
 			break
@@ -5160,6 +5180,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.NLSLayerGroup.ID(childComplexity), true
 
+	case "NLSLayerGroup.index":
+		if e.complexity.NLSLayerGroup.Index == nil {
+			break
+		}
+
+		return e.complexity.NLSLayerGroup.Index(childComplexity), true
+
 	case "NLSLayerGroup.infobox":
 		if e.complexity.NLSLayerGroup.Infobox == nil {
 			break
@@ -5229,6 +5256,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.NLSLayerSimple.ID(childComplexity), true
+
+	case "NLSLayerSimple.index":
+		if e.complexity.NLSLayerSimple.Index == nil {
+			break
+		}
+
+		return e.complexity.NLSLayerSimple.Index(childComplexity), true
 
 	case "NLSLayerSimple.infobox":
 		if e.complexity.NLSLayerSimple.Infobox == nil {
@@ -7991,6 +8025,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.UpdateNLSLayerPayload.Layer(childComplexity), true
 
+	case "UpdateNLSLayersPayload.layers":
+		if e.complexity.UpdateNLSLayersPayload.Layers == nil {
+			break
+		}
+
+		return e.complexity.UpdateNLSLayersPayload.Layers(childComplexity), true
+
 	case "UpdateStylePayload.style":
 		if e.complexity.UpdateStylePayload.Style == nil {
 			break
@@ -8379,6 +8420,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateMeInput,
 		ec.unmarshalInputUpdateMemberOfTeamInput,
 		ec.unmarshalInputUpdateNLSLayerInput,
+		ec.unmarshalInputUpdateNLSLayersInput,
 		ec.unmarshalInputUpdateProjectInput,
 		ec.unmarshalInputUpdatePropertyItemInput,
 		ec.unmarshalInputUpdatePropertyItemOperationInput,
@@ -9263,6 +9305,7 @@ extend type Mutation {
 	{Name: "../../../gql/newlayer.graphql", Input: `# TODO: Make LayerGroup Real
 interface NLSLayer {
   id: ID!
+  index: Int
   layerType: String!
   sceneId: ID!
   config: JSON
@@ -9275,6 +9318,7 @@ interface NLSLayer {
 
 type NLSLayerSimple implements NLSLayer {
   id: ID!
+  index: Int
   layerType: String!
   sceneId: ID!
   config: JSON
@@ -9288,6 +9332,7 @@ type NLSLayerSimple implements NLSLayer {
 
 type NLSLayerGroup implements NLSLayer {
   id: ID!
+  index: Int
   layerType: String!
   sceneId: ID!
   children: [NLSLayer]!
@@ -9308,7 +9353,7 @@ type NLSInfobox {
   propertyId: ID!
   blocks: [InfoboxBlock!]!
   property: Property
-  scene: Scene  
+  scene: Scene
 }
 
 type InfoboxBlock {
@@ -9325,8 +9370,8 @@ type InfoboxBlock {
 }
 
 type SketchInfo {
-	customPropertySchema: JSON
-	featureCollection: FeatureCollection
+  customPropertySchema: JSON
+  featureCollection: FeatureCollection
 }
 
 # InputType
@@ -9346,10 +9391,15 @@ input RemoveNLSLayerInput {
 }
 
 input UpdateNLSLayerInput {
+  index: Int
   layerId: ID!
   name: String
   visible: Boolean
   config: JSON
+}
+
+input UpdateNLSLayersInput {
+  layers: [UpdateNLSLayerInput!]!
 }
 
 input CreateNLSInfoboxInput {
@@ -9406,6 +9456,10 @@ type UpdateNLSLayerPayload {
   layer: NLSLayer!
 }
 
+type UpdateNLSLayersPayload {
+  layers: [NLSLayer!]!
+}
+
 type CreateNLSInfoboxPayload {
   layer: NLSLayer!
 }
@@ -9438,6 +9492,7 @@ extend type Mutation {
   addNLSLayerSimple(input: AddNLSLayerSimpleInput!): AddNLSLayerSimplePayload!
   removeNLSLayer(input: RemoveNLSLayerInput!): RemoveNLSLayerPayload!
   updateNLSLayer(input: UpdateNLSLayerInput!): UpdateNLSLayerPayload!
+  updateNLSLayers(input: UpdateNLSLayersInput!): UpdateNLSLayersPayload!
   createNLSInfobox(input: CreateNLSInfoboxInput!): CreateNLSInfoboxPayload
   removeNLSInfobox(input: RemoveNLSInfoboxInput!): RemoveNLSInfoboxPayload
   addNLSInfoboxBlock(input: AddNLSInfoboxBlockInput!): AddNLSInfoboxBlockPayload
@@ -9448,9 +9503,14 @@ extend type Mutation {
     input: RemoveNLSInfoboxBlockInput!
   ): RemoveNLSInfoboxBlockPayload
   duplicateNLSLayer(input: DuplicateNLSLayerInput!): DuplicateNLSLayerPayload!
-  addCustomProperties(input: AddCustomPropertySchemaInput!): UpdateNLSLayerPayload!
-  updateCustomProperties(input: UpdateCustomPropertySchemaInput!): UpdateNLSLayerPayload!
-}`, BuiltIn: false},
+  addCustomProperties(
+    input: AddCustomPropertySchemaInput!
+  ): UpdateNLSLayerPayload!
+  updateCustomProperties(
+    input: UpdateCustomPropertySchemaInput!
+  ): UpdateNLSLayerPayload!
+}
+`, BuiltIn: false},
 	{Name: "../../../gql/plugin.graphql", Input: `type Plugin {
   id: ID!
   sceneId: ID
@@ -12173,6 +12233,21 @@ func (ec *executionContext) field_Mutation_updateNLSLayer_args(ctx context.Conte
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_updateNLSLayers_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 gqlmodel.UpdateNLSLayersInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNUpdateNLSLayersInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUpdateNLSLayersInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_updateProject_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -14077,6 +14152,8 @@ func (ec *executionContext) fieldContext_AddNLSLayerSimplePayload_layers(ctx con
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_NLSLayerSimple_id(ctx, field)
+			case "index":
+				return ec.fieldContext_NLSLayerSimple_index(ctx, field)
 			case "layerType":
 				return ec.fieldContext_NLSLayerSimple_layerType(ctx, field)
 			case "sceneId":
@@ -31014,6 +31091,65 @@ func (ec *executionContext) fieldContext_Mutation_updateNLSLayer(ctx context.Con
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_updateNLSLayers(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updateNLSLayers(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateNLSLayers(rctx, fc.Args["input"].(gqlmodel.UpdateNLSLayersInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*gqlmodel.UpdateNLSLayersPayload)
+	fc.Result = res
+	return ec.marshalNUpdateNLSLayersPayload2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUpdateNLSLayersPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateNLSLayers(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "layers":
+				return ec.fieldContext_UpdateNLSLayersPayload_layers(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UpdateNLSLayersPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateNLSLayers_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_createNLSInfobox(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_createNLSInfobox(ctx, field)
 	if err != nil {
@@ -35330,6 +35466,47 @@ func (ec *executionContext) fieldContext_NLSLayerGroup_id(ctx context.Context, f
 	return fc, nil
 }
 
+func (ec *executionContext) _NLSLayerGroup_index(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.NLSLayerGroup) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NLSLayerGroup_index(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Index, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NLSLayerGroup_index(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NLSLayerGroup",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _NLSLayerGroup_layerType(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.NLSLayerGroup) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_NLSLayerGroup_layerType(ctx, field)
 	if err != nil {
@@ -35907,6 +36084,47 @@ func (ec *executionContext) fieldContext_NLSLayerSimple_id(ctx context.Context, 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NLSLayerSimple_index(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.NLSLayerSimple) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NLSLayerSimple_index(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Index, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NLSLayerSimple_index(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NLSLayerSimple",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -55129,6 +55347,50 @@ func (ec *executionContext) fieldContext_UpdateNLSLayerPayload_layer(ctx context
 	return fc, nil
 }
 
+func (ec *executionContext) _UpdateNLSLayersPayload_layers(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.UpdateNLSLayersPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UpdateNLSLayersPayload_layers(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Layers, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]gqlmodel.NLSLayer)
+	fc.Result = res
+	return ec.marshalNNLSLayer2ᚕgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐNLSLayerᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UpdateNLSLayersPayload_layers(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UpdateNLSLayersPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("FieldContext.Child cannot be called on type INTERFACE")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UpdateStylePayload_style(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.UpdateStylePayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UpdateStylePayload_style(ctx, field)
 	if err != nil {
@@ -62540,13 +62802,20 @@ func (ec *executionContext) unmarshalInputUpdateNLSLayerInput(ctx context.Contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"layerId", "name", "visible", "config"}
+	fieldsInOrder := [...]string{"index", "layerId", "name", "visible", "config"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "index":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("index"))
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Index = data
 		case "layerId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("layerId"))
 			data, err := ec.unmarshalNID2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐID(ctx, v)
@@ -62575,6 +62844,33 @@ func (ec *executionContext) unmarshalInputUpdateNLSLayerInput(ctx context.Contex
 				return it, err
 			}
 			it.Config = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUpdateNLSLayersInput(ctx context.Context, obj interface{}) (gqlmodel.UpdateNLSLayersInput, error) {
+	var it gqlmodel.UpdateNLSLayersInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"layers"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "layers":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("layers"))
+			data, err := ec.unmarshalNUpdateNLSLayerInput2ᚕᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUpdateNLSLayerInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Layers = data
 		}
 	}
 
@@ -69958,6 +70254,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "updateNLSLayers":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateNLSLayers(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "createNLSInfobox":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createNLSInfobox(ctx, field)
@@ -70444,6 +70747,8 @@ func (ec *executionContext) _NLSLayerGroup(ctx context.Context, sel ast.Selectio
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "index":
+			out.Values[i] = ec._NLSLayerGroup_index(ctx, field, obj)
 		case "layerType":
 			out.Values[i] = ec._NLSLayerGroup_layerType(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -70557,6 +70862,8 @@ func (ec *executionContext) _NLSLayerSimple(ctx context.Context, sel ast.Selecti
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "index":
+			out.Values[i] = ec._NLSLayerSimple_index(ctx, field, obj)
 		case "layerType":
 			out.Values[i] = ec._NLSLayerSimple_layerType(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -76780,6 +77087,45 @@ func (ec *executionContext) _UpdateNLSLayerPayload(ctx context.Context, sel ast.
 	return out
 }
 
+var updateNLSLayersPayloadImplementors = []string{"UpdateNLSLayersPayload"}
+
+func (ec *executionContext) _UpdateNLSLayersPayload(ctx context.Context, sel ast.SelectionSet, obj *gqlmodel.UpdateNLSLayersPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, updateNLSLayersPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UpdateNLSLayersPayload")
+		case "layers":
+			out.Values[i] = ec._UpdateNLSLayersPayload_layers(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var updateStylePayloadImplementors = []string{"UpdateStylePayload"}
 
 func (ec *executionContext) _UpdateStylePayload(ctx context.Context, sel ast.SelectionSet, obj *gqlmodel.UpdateStylePayload) graphql.Marshaler {
@@ -81413,6 +81759,28 @@ func (ec *executionContext) unmarshalNUpdateNLSLayerInput2githubᚗcomᚋreearth
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNUpdateNLSLayerInput2ᚕᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUpdateNLSLayerInputᚄ(ctx context.Context, v interface{}) ([]*gqlmodel.UpdateNLSLayerInput, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*gqlmodel.UpdateNLSLayerInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNUpdateNLSLayerInput2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUpdateNLSLayerInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNUpdateNLSLayerInput2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUpdateNLSLayerInput(ctx context.Context, v interface{}) (*gqlmodel.UpdateNLSLayerInput, error) {
+	res, err := ec.unmarshalInputUpdateNLSLayerInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) marshalNUpdateNLSLayerPayload2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUpdateNLSLayerPayload(ctx context.Context, sel ast.SelectionSet, v gqlmodel.UpdateNLSLayerPayload) graphql.Marshaler {
 	return ec._UpdateNLSLayerPayload(ctx, sel, &v)
 }
@@ -81425,6 +81793,25 @@ func (ec *executionContext) marshalNUpdateNLSLayerPayload2ᚖgithubᚗcomᚋreea
 		return graphql.Null
 	}
 	return ec._UpdateNLSLayerPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNUpdateNLSLayersInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUpdateNLSLayersInput(ctx context.Context, v interface{}) (gqlmodel.UpdateNLSLayersInput, error) {
+	res, err := ec.unmarshalInputUpdateNLSLayersInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUpdateNLSLayersPayload2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUpdateNLSLayersPayload(ctx context.Context, sel ast.SelectionSet, v gqlmodel.UpdateNLSLayersPayload) graphql.Marshaler {
+	return ec._UpdateNLSLayersPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUpdateNLSLayersPayload2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUpdateNLSLayersPayload(ctx context.Context, sel ast.SelectionSet, v *gqlmodel.UpdateNLSLayersPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UpdateNLSLayersPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNUpdateProjectInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUpdateProjectInput(ctx context.Context, v interface{}) (gqlmodel.UpdateProjectInput, error) {

--- a/server/internal/adapter/gql/gqlmodel/convert_nlslayer.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_nlslayer.go
@@ -14,6 +14,7 @@ func ToNLSLayerSimple(l *nlslayer.NLSLayerSimple) *NLSLayerSimple {
 
 	return &NLSLayerSimple{
 		ID:        IDFrom(l.ID()),
+		Index:     l.Index(),
 		SceneID:   IDFrom(l.Scene()),
 		Title:     l.Title(),
 		Visible:   l.IsVisible(),
@@ -52,6 +53,7 @@ func ToNLSLayerGroup(l *nlslayer.NLSLayerGroup, parent *id.NLSLayerID) *NLSLayer
 
 	return &NLSLayerGroup{
 		ID:          IDFrom(l.ID()),
+		Index:       l.Index(),
 		SceneID:     IDFrom(l.Scene()),
 		Title:       l.Title(),
 		Visible:     l.IsVisible(),

--- a/server/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/server/internal/adapter/gql/gqlmodel/models_gen.go
@@ -46,6 +46,7 @@ type LayerTag interface {
 type NLSLayer interface {
 	IsNLSLayer()
 	GetID() ID
+	GetIndex() *int
 	GetLayerType() string
 	GetSceneID() ID
 	GetConfig() JSON
@@ -1013,6 +1014,7 @@ type NLSInfobox struct {
 
 type NLSLayerGroup struct {
 	ID          ID          `json:"id"`
+	Index       *int        `json:"index,omitempty"`
 	LayerType   string      `json:"layerType"`
 	SceneID     ID          `json:"sceneId"`
 	Children    []NLSLayer  `json:"children"`
@@ -1028,6 +1030,7 @@ type NLSLayerGroup struct {
 
 func (NLSLayerGroup) IsNLSLayer()                  {}
 func (this NLSLayerGroup) GetID() ID               { return this.ID }
+func (this NLSLayerGroup) GetIndex() *int          { return this.Index }
 func (this NLSLayerGroup) GetLayerType() string    { return this.LayerType }
 func (this NLSLayerGroup) GetSceneID() ID          { return this.SceneID }
 func (this NLSLayerGroup) GetConfig() JSON         { return this.Config }
@@ -1039,6 +1042,7 @@ func (this NLSLayerGroup) GetSketch() *SketchInfo  { return this.Sketch }
 
 type NLSLayerSimple struct {
 	ID        ID          `json:"id"`
+	Index     *int        `json:"index,omitempty"`
 	LayerType string      `json:"layerType"`
 	SceneID   ID          `json:"sceneId"`
 	Config    JSON        `json:"config,omitempty"`
@@ -1052,6 +1056,7 @@ type NLSLayerSimple struct {
 
 func (NLSLayerSimple) IsNLSLayer()                  {}
 func (this NLSLayerSimple) GetID() ID               { return this.ID }
+func (this NLSLayerSimple) GetIndex() *int          { return this.Index }
 func (this NLSLayerSimple) GetLayerType() string    { return this.LayerType }
 func (this NLSLayerSimple) GetSceneID() ID          { return this.SceneID }
 func (this NLSLayerSimple) GetConfig() JSON         { return this.Config }
@@ -1846,6 +1851,7 @@ type UpdateMemberOfTeamPayload struct {
 }
 
 type UpdateNLSLayerInput struct {
+	Index   *int    `json:"index,omitempty"`
 	LayerID ID      `json:"layerId"`
 	Name    *string `json:"name,omitempty"`
 	Visible *bool   `json:"visible,omitempty"`
@@ -1854,6 +1860,14 @@ type UpdateNLSLayerInput struct {
 
 type UpdateNLSLayerPayload struct {
 	Layer NLSLayer `json:"layer"`
+}
+
+type UpdateNLSLayersInput struct {
+	Layers []*UpdateNLSLayerInput `json:"layers"`
+}
+
+type UpdateNLSLayersPayload struct {
+	Layers []NLSLayer `json:"layers"`
 }
 
 type UpdateProjectInput struct {

--- a/server/internal/adapter/gql/resolver_mutation_nlslayer.go
+++ b/server/internal/adapter/gql/resolver_mutation_nlslayer.go
@@ -59,6 +59,7 @@ func (r *mutationResolver) UpdateNLSLayer(ctx context.Context, input gqlmodel.Up
 
 	layer, err := usecases(ctx).NLSLayer.Update(ctx, interfaces.UpdateNLSLayerInput{
 		LayerID: lid,
+		Index:   input.Index,
 		Name:    input.Name,
 		Visible: input.Visible,
 		Config:  gqlmodel.ToNLSConfig(input.Config),
@@ -69,6 +70,34 @@ func (r *mutationResolver) UpdateNLSLayer(ctx context.Context, input gqlmodel.Up
 
 	return &gqlmodel.UpdateNLSLayerPayload{
 		Layer: gqlmodel.ToNLSLayer(layer, nil),
+	}, nil
+}
+
+func (r *mutationResolver) UpdateNLSLayers(ctx context.Context, input gqlmodel.UpdateNLSLayersInput) (*gqlmodel.UpdateNLSLayersPayload, error) {
+	var updatedLayers []gqlmodel.NLSLayer
+
+	for _, layerInput := range input.Layers {
+		lid, err := gqlmodel.ToID[id.NLSLayer](layerInput.LayerID)
+		if err != nil {
+			return nil, err
+		}
+
+		layer, err := usecases(ctx).NLSLayer.Update(ctx, interfaces.UpdateNLSLayerInput{
+			LayerID: lid,
+			Index:   layerInput.Index,
+			Name:    layerInput.Name,
+			Visible: layerInput.Visible,
+			Config:  gqlmodel.ToNLSConfig(layerInput.Config),
+		}, getOperator(ctx))
+		if err != nil {
+			return nil, err
+		}
+
+		updatedLayers = append(updatedLayers, gqlmodel.ToNLSLayer(layer, nil))
+	}
+
+	return &gqlmodel.UpdateNLSLayersPayload{
+		Layers: updatedLayers,
 	}, nil
 }
 

--- a/server/internal/infrastructure/mongo/mongodoc/layer.go
+++ b/server/internal/infrastructure/mongo/mongodoc/layer.go
@@ -11,6 +11,7 @@ import (
 
 type LayerDocument struct {
 	ID        string
+	Index     *int
 	Name      string
 	Visible   bool
 	Scene     string
@@ -100,6 +101,7 @@ func NewLayer(l layer.Layer) (*LayerDocument, string) {
 	id := l.ID().String()
 	return &LayerDocument{
 		ID:        id,
+		Index:     l.Index(),
 		Name:      l.Name(),
 		Visible:   l.IsVisible(),
 		Scene:     l.Scene().String(),

--- a/server/internal/infrastructure/mongo/mongodoc/nlslayer.go
+++ b/server/internal/infrastructure/mongo/mongodoc/nlslayer.go
@@ -12,6 +12,7 @@ import (
 
 type NLSLayerDocument struct {
 	ID        string
+	Index     *int
 	Title     string
 	Visible   bool
 	Scene     string
@@ -118,6 +119,7 @@ func NewNLSLayer(l nlslayer.NLSLayer) (*NLSLayerDocument, string) {
 	id := l.ID().String()
 	return &NLSLayerDocument{
 		ID:        id,
+		Index:     l.Index(),
 		Title:     l.Title(),
 		Visible:   l.IsVisible(),
 		Scene:     l.Scene().String(),
@@ -186,6 +188,7 @@ func (d *NLSLayerDocument) ModelSimple() (*nlslayer.NLSLayerSimple, error) {
 
 	return nlslayer.NewNLSLayerSimple().
 		ID(lid).
+		Index(d.Index).
 		Title(d.Title).
 		LayerType(NewNLSLayerType(d.LayerType)).
 		IsVisible(d.Visible).
@@ -227,6 +230,7 @@ func (d *NLSLayerDocument) ModelGroup() (*nlslayer.NLSLayerGroup, error) {
 
 	return nlslayer.NewNLSLayerGroup().
 		ID(lid).
+		Index(d.Index).
 		Title(d.Title).
 		LayerType(NewNLSLayerType(d.LayerType)).
 		IsVisible(d.Visible).

--- a/server/internal/usecase/interactor/nlslayer.go
+++ b/server/internal/usecase/interactor/nlslayer.go
@@ -268,6 +268,9 @@ func (i *NLSLayer) Update(ctx context.Context, inp interfaces.UpdateNLSLayerInpu
 		layer.UpdateConfig(inp.Config)
 	}
 
+	if inp.Index != nil {
+		layer.SetIndex(inp.Index)
+	}
 	err = i.nlslayerRepo.Save(ctx, layer)
 	if err != nil {
 		return nil, err

--- a/server/internal/usecase/interfaces/nlslayer.go
+++ b/server/internal/usecase/interfaces/nlslayer.go
@@ -22,6 +22,7 @@ type AddNLSLayerSimpleInput struct {
 
 type UpdateNLSLayerInput struct {
 	LayerID id.NLSLayerID
+	Index   *int
 	Name    *string
 	Visible *bool
 	Config  *nlslayer.Config

--- a/server/pkg/layer/layer.go
+++ b/server/pkg/layer/layer.go
@@ -14,6 +14,7 @@ var (
 
 type Layer interface {
 	ID() ID
+	Index() *int
 	Name() string
 	IsVisible() bool
 	Plugin() *PluginID
@@ -25,6 +26,7 @@ type Layer interface {
 	Scene() SceneID
 	Tags() *TagList
 	Rename(string)
+	SetIndex(*int)
 	SetVisible(bool)
 	SetInfobox(*Infobox)
 	SetPlugin(*PluginID)
@@ -70,6 +72,7 @@ func ToLayerItemRef(l *Layer) *Item {
 
 type layerBase struct {
 	id        ID
+	index     *int
 	name      string
 	visible   bool
 	plugin    *PluginID
@@ -82,6 +85,10 @@ type layerBase struct {
 
 func (l *layerBase) ID() ID {
 	return l.id
+}
+
+func (l *layerBase) Index() *int {
+	return l.index
 }
 
 func (l *layerBase) IDRef() *ID {
@@ -156,6 +163,13 @@ func (l *layerBase) Rename(name string) {
 		return
 	}
 	l.name = name
+}
+
+func (l *layerBase) SetIndex(index *int) {
+	if l == nil {
+		return
+	}
+	l.index = index
 }
 
 func (l *layerBase) SetVisible(visible bool) {

--- a/server/pkg/nlslayer/builder.go
+++ b/server/pkg/nlslayer/builder.go
@@ -21,6 +21,11 @@ func (b *Builder) ID(id ID) *Builder {
 	return b
 }
 
+func (b *Builder) Index(index *int) *Builder {
+	b.base.index = index
+	return b
+}
+
 func (b *Builder) NewID() *Builder {
 	b.base.id = NewID()
 	return b

--- a/server/pkg/nlslayer/group_builder.go
+++ b/server/pkg/nlslayer/group_builder.go
@@ -57,6 +57,11 @@ func (b *NLSLayerGroupBuilder) NewID() *NLSLayerGroupBuilder {
 	return b
 }
 
+func (b *NLSLayerGroupBuilder) Index(i *int) *NLSLayerGroupBuilder {
+	b.l.index = i
+	return b
+}
+
 func (b *NLSLayerGroupBuilder) LayerType(t LayerType) *NLSLayerGroupBuilder {
 	b.l.layerType = t
 	return b

--- a/server/pkg/nlslayer/nlslayer.go
+++ b/server/pkg/nlslayer/nlslayer.go
@@ -3,6 +3,7 @@ package nlslayer
 type NLSLayer interface {
 	Cloner
 	ID() ID
+	Index() *int
 	LayerType() LayerType
 	Scene() SceneID
 	Config() *Config
@@ -12,6 +13,7 @@ type NLSLayer interface {
 	HasInfobox() bool
 	Infobox() *Infobox
 	SetInfobox(*Infobox)
+	SetIndex(*int)
 	Rename(string)
 	UpdateConfig(*Config)
 	Duplicate() NLSLayer
@@ -60,6 +62,7 @@ func ToLayerSimpleRef(l *NLSLayer) *NLSLayerSimple {
 
 type layerBase struct {
 	id        ID
+	index     *int
 	layerType LayerType
 	scene     SceneID
 	title     string
@@ -72,6 +75,13 @@ type layerBase struct {
 
 func (l *layerBase) ID() ID {
 	return l.id
+}
+
+func (l *layerBase) Index() *int {
+	if l == nil {
+		return nil
+	}
+	return l.index
 }
 
 func (l *layerBase) IDRef() *ID {
@@ -138,6 +148,13 @@ func (l *layerBase) SetInfobox(infobox *Infobox) {
 	l.infobox = infobox
 }
 
+func (l *layerBase) SetIndex(index *int) {
+	if l == nil {
+		return
+	}
+	l.index = index
+}
+
 func (l *layerBase) Rename(name string) {
 	if l == nil {
 		return
@@ -172,6 +189,7 @@ func (l *layerBase) Clone() *layerBase {
 
 	cloned := &layerBase{
 		id:        l.id,
+		index:     l.index,
 		layerType: l.layerType,
 		scene:     l.scene,
 		title:     l.title,
@@ -203,6 +221,7 @@ func (l *layerBase) Duplicate() NLSLayer {
 
 	duplicated := &layerBase{
 		id:        NewID(),
+		index:     l.index,
 		layerType: l.layerType,
 		scene:     l.scene,
 		title:     l.title,

--- a/server/pkg/nlslayer/nlslayerops/intializer.go
+++ b/server/pkg/nlslayer/nlslayerops/intializer.go
@@ -17,7 +17,12 @@ type LayerSimple struct {
 }
 
 func (i LayerSimple) Initialize() (*nlslayer.NLSLayerSimple, error) {
-	builder := nlslayer.NewNLSLayerSimple().NewID().Scene(i.SceneID).LayerType(i.LayerType).Title(i.Title)
+	builder := nlslayer.NewNLSLayerSimple().
+		NewID().
+		Scene(i.SceneID).
+		LayerType(i.LayerType).
+		Title(i.Title).
+		Index(i.Index)
 
 	var err error
 	if i.Config != nil {

--- a/server/pkg/nlslayer/simple.go
+++ b/server/pkg/nlslayer/simple.go
@@ -12,6 +12,10 @@ func (l *NLSLayerSimple) ID() ID {
 	return l.layerBase.ID()
 }
 
+func (l *NLSLayerSimple) Index() *int {
+	return l.layerBase.index
+}
+
 func (l *NLSLayerSimple) IDRef() *ID {
 	if l == nil {
 		return nil

--- a/server/pkg/nlslayer/simple_builder.go
+++ b/server/pkg/nlslayer/simple_builder.go
@@ -57,6 +57,11 @@ func (b *NLSLayerSimpleBuilder) NewID() *NLSLayerSimpleBuilder {
 	return b
 }
 
+func (b *NLSLayerSimpleBuilder) Index(i *int) *NLSLayerSimpleBuilder {
+	b.l.index = i
+	return b
+}
+
 func (b *NLSLayerSimpleBuilder) LayerType(t LayerType) *NLSLayerSimpleBuilder {
 	b.l.layerType = t
 	return b

--- a/server/pkg/scene/builder/nlsLayer.go
+++ b/server/pkg/scene/builder/nlsLayer.go
@@ -9,6 +9,7 @@ import (
 
 type nlsLayerJSON struct {
 	ID         string          `json:"id"`
+	Index      *int            `json:"index,omitempty"`
 	Title      string          `json:"title,omitempty"`
 	LayerType  string          `json:"layerType,omitempty"`
 	Config     *configJSON     `json:"config,omitempty"`
@@ -113,6 +114,7 @@ func (b *Builder) getNLSLayerJSON(ctx context.Context, layer nlslayer.NLSLayer) 
 
 	return &nlsLayerJSON{
 		ID:         layer.ID().String(),
+		Index:      layer.Index(),
 		Title:      layer.Title(),
 		LayerType:  string(layer.LayerType()),
 		Config:     (*configJSON)(layer.Config()),


### PR DESCRIPTION
# Overview
## Added data for layer ordering
[Notion](https://www.notion.so/eukarya/BE-Support-reorder-layer-14d16e0fb16580a1a268eaddd1c14bd2)

## What I've done
### 1.Added Index to the NLSLayer data.
This change adds an Index field to NLSLayer.
The same applies to the mutations **AddNLSLayerSimple** and **UpdateNLSLayer**.
```diff
type NLSLayerSimple implements NLSLayer {
  ...
+  index: Int
  ...
}

input AddNLSLayerSimpleInput {
  ...
  index: Int
  ...
}

input UpdateNLSLayerInput {
  ...
+  index: Int
  ...
}

```
Note: While AddNLSLayerSimple already included an Index field, it was not processed on the server side (this has been fixed).

### 2.Introduced **UpdateNLSLayers**, 
which allows updating multiple **NLSLayer** simultaneously.
This is essentially an enhanced version of **UpdateNLSLayer**, where both the request and response now handle arrays.
```diff
input UpdateNLSLayerInput {
  index: Int
  layerId: ID!
  name: String
  visible: Boolean
  config: JSON
}

+input UpdateNLSLayersInput {
+  layers: [UpdateNLSLayerInput!]!
+}
```

### 3.Included Index in the newLayers field of **GetScene**.
This will likely be utilized on the web side.
```diff
{
 "data": {
    ...
   "newLayers": [
    {
     "id": "01jfc0awv1b8yb1vy0m0wsyphz",
+     "index": 0,
     "layerType": "simple",
```

## What I haven't done

## How I tested

### Testing through e2e tests
https://github.com/reearth/reearth-visualizer/pull/1321/files#diff-24ad6b984dd7d824485df99bc5f0afbad022e020e1f649feff78a5cdf2962af5R851-R870

## Which point I want you to review particularly

### 1.I'm not sure when exactly it should be called, but I think it would be ideal to call it with the array index right after the drag operation ends.

### 2.In web/src/beta/features/Editor/Map/LayersPanel/index.tsx, I was able to confirm this by having isDragging pass the index of the layers.
![スクリーンショット 2024-12-19 17 06 04](https://github.com/user-attachments/assets/a45b7235-0e16-498c-b437-9791cc62c440)

### 3.For the initial display of the screen, the layers need to be rearranged based on the index from GetScene.

## Memo

### 1. Add UPDATE_NLSLAYERS:
```
export const UPDATE_NLSLAYERS = gql(`
  mutation UpdateNLSLayers($input: UpdateNLSLayersInput!) {
    updateNLSLayers(input: $input) {
      layers {
        id
      }
    }
  }
`);
```

### 2. Add index to necessary parts such as GetScene:
```diff
export const nlsLayerSimpleFragment = gql`
  fragment NLSLayerCommon on NLSLayer {
    id
+    index
    layerType
`;
```

### 3.Run the GraphQL generator:
```
yarn gql
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced an `Index` field to various NLS layer types, allowing for enhanced management of layer indices.
  - Added the ability to update multiple NLS layers in a single operation through the new `UpdateNLSLayers` mutation.
  - Enhanced GraphQL queries and mutations to include the new `index` field in relevant operations.

- **Bug Fixes**
  - Improved handling of index values during layer updates and infobox block additions.

- **Documentation**
  - Updated GraphQL schema to reflect new fields and mutations related to NLS layers.

- **Refactor**
  - Simplified request handling in various test files and methods to enhance readability and maintainability.
  - Streamlined test setup processes for scene retrieval and project import operations.

- **Tests**
  - Expanded test coverage for NLS layer CRUD operations, ensuring comprehensive validation of new functionalities.
  - Introduced new tests for validating scene creation with NLS layers and their properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->