### PR TITLE
fix(web): layer style boolean selector field doesn't work properly with string value

### DIFF
--- a/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/StyleNode/Field/BooleanSelectorInput.tsx
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/StyleNode/Field/BooleanSelectorInput.tsx
@@ -15,9 +15,11 @@ const BooleanSelectorInput: FC<Props> = ({ value, onChange }) => {
   return (
     <Selector
       value={
-        value === true || value === "true"
+        value === true ||
+        (typeof value === "string" && value.toLowerCase() === "true")
           ? "true"
-          : value === false || value === "false"
+          : value === false ||
+              (typeof value === "string" && value.toLowerCase() === "false")
             ? "false"
             : ""
       }

--- a/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/StyleNode/Field/BooleanSelectorInput.tsx
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/Editor/StyleInterface/StyleNode/Field/BooleanSelectorInput.tsx
@@ -7,14 +7,20 @@ const booleanOptions = [
 ];
 
 type Props = {
-  value: boolean | undefined;
+  value: boolean | string | undefined;
   onChange: (value: boolean | undefined) => void;
 };
 
 const BooleanSelectorInput: FC<Props> = ({ value, onChange }) => {
   return (
     <Selector
-      value={value === true ? "true" : value === false ? "false" : ""}
+      value={
+        value === true || value === "true"
+          ? "true"
+          : value === false || value === "false"
+            ? "false"
+            : ""
+      }
       options={booleanOptions}
       onChange={(v) =>
         onChange(v === "true" ? true : v === "false" ? false : undefined)


### PR DESCRIPTION
# Overview

The incoming value for boolean could be in type of string, this PR supports check value with string `true` `false`.

## What I've done

## What I haven't done

## How I tested

Story: https://www.notion.so/eukarya/visualizer-reearth-io-User-Stories-V2-13a16e0fb165800ba026f7569c8dd4b2?p=13b16e0fb16580408611c56dd9d0aa23&pm=s

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `BooleanSelectorInput` to accept both boolean and string representations of boolean values.
  
- **Bug Fixes**
	- Improved handling of `value` prop to ensure proper conversion between string and boolean types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->