### PR TITLE
fix(web): add missing "extended" prop to plugin

### DIFF
--- a/web/src/beta/features/PluginPlayground/Code/hook.ts
+++ b/web/src/beta/features/PluginPlayground/Code/hook.ts
@@ -18,6 +18,7 @@ type ReearthYML = {
     name: string;
     description: string;
     widgetLayout?: {
+      extended: boolean;
       defaultLocation: {
         zone: WidgetLocation["zone"];
         section: WidgetLocation["section"];
@@ -144,6 +145,8 @@ export default ({ files }: Props) => {
           area: "top"
         };
 
+        const extended = cur.widgetLayout?.extended ?? false;
+
         const zoneAlignSystem = prv?.alignSystem?.[zone] ?? {};
         const sectionAlignSystem = zoneAlignSystem[section] ?? {};
         const areaAlignSystem = sectionAlignSystem[area] ?? { widgets: [] };
@@ -162,7 +165,8 @@ export default ({ files }: Props) => {
                     ...(areaAlignSystem.widgets ?? []),
                     {
                       id: cur.id,
-                      __REEARTH_SOURCECODE: file.sourceCode
+                      __REEARTH_SOURCECODE: file.sourceCode,
+                      extended
                     }
                   ]
                 }


### PR DESCRIPTION
# Overview
Adding this prop so that its possible to use "extended" feature for plugin. 
## What I've done
After applying the change in this PR, I tested my changing the values in `reearth.yml` file in the `My Plugin` folder in the Plugin Playground as below
```
id: my-plugin
name: My plugin
version: 1.0.0
extensions:
  - id: demo-widget
    type: widget
    name: Demo Widget
    description: Demo widget
    widgetLayout:
      extended: true
      defaultLocation:
        zone: outer
        section: left
        area: middle  
```

In the changes above, the `extended: true` value is added and the `area` is changed to `middle`. I also made these changes in the `demo-widget.js` file to test:
``` 
 html,
  body {
    width: 300px;
    height: 100%;
  }
```

And to the `wrapper` class, I added `height: 100%;` 

Below is a screenshot of the change in plugin playground
<img width="1277" alt="Screenshot 2024-12-23 at 10 52 50 AM" src="https://github.com/user-attachments/assets/10f31155-cb6f-4a4f-9a30-447e145e0fcc" />

And here is a screenshot of the change in editor. I noticed that on editor, the plugin didn't take the full height on inital load but only after re-sizing the browser screen (i.e opening the browser console )
<img width="1274" alt="Screenshot 2024-12-23 at 11 48 13 AM" src="https://github.com/user-attachments/assets/aa3b8043-e014-4a6a-b436-824b2c4e13c0" />

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `extended` property to enhance widget configuration options.
- **Bug Fixes**
	- Improved widget object construction to include the `extended` state without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->