### PR TITLE
feat(server): modify query response

### DIFF
--- a/server/e2e/common.go
+++ b/server/e2e/common.go
@@ -120,13 +120,14 @@ type GraphQLRequest struct {
 	Variables     map[string]any `json:"variables"`
 }
 
-func StartGQLServer(t *testing.T, cfg *config.Config, useMongo bool, seeder Seeder) (*httpexpect.Expect, *accountrepo.Container) {
-	e, r := StartGQLServerAndRepos(t, cfg, useMongo, seeder)
-	return e, r
-}
-
-func StartGQLServerAndRepos(t *testing.T, cfg *config.Config, useMongo bool, seeder Seeder) (*httpexpect.Expect, *accountrepo.Container) {
-	repos := initRepos(t, useMongo, seeder)
+func StartGQLServerAndRepos(t *testing.T, seeder Seeder) (*httpexpect.Expect, *accountrepo.Container) {
+	cfg := &config.Config{
+		Origins: []string{"https://example.com"},
+		AuthSrv: config.AuthSrvConfig{
+			Disabled: true,
+		},
+	}
+	repos := initRepos(t, true, seeder)
 	acRepos := repos.AccountRepos()
 	return StartGQLServerWithRepos(t, cfg, repos, acRepos), acRepos
 }

--- a/server/e2e/gql_user_test.go
+++ b/server/e2e/gql_user_test.go
@@ -2,12 +2,9 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"testing"
 
-	"github.com/reearth/reearth/server/internal/app/config"
 	"github.com/reearth/reearth/server/internal/usecase/repo"
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/account/accountdomain/user"
@@ -96,49 +93,23 @@ func baseSeederUser(ctx context.Context, r *repo.Container) error {
 }
 
 // func TestSignUp(t *testing.T) {
-// 	e, _ := StartGQLServer(t, &config.Config{
-// 		Origins: []string{"https://example.com"},
-// 		AuthSrv: config.AuthSrvConfig{
-// 			Disabled: true,
-// 		},
-// 	}, true, baseSeederUser)
+// 	e, _ := StartGQLServerAndRepos(t, baseSeederUser)
 // 	query := `mutation { signup(input: {lang: "ja",theme: DEFAULT,secret: "Ajsownndww1"}){ user{ id name email } }}`
 // 	request := GraphQLRequest{
 // 		Query: query,
 // 	}
-// 	jsonData, err := json.Marshal(request)
-// 	if err != nil {
-// 		assert.NoError(t, err)
-// 	}
-// 	o := e.POST("/api/graphql").
-// 		WithHeader("authorization", "Bearer test").
-// 		WithHeader("Content-Type", "application/json").
-// 		WithHeader("X-Reearth-Debug-User", uId1.String()).
-// 		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object().Value("data").Object().Value("signup").Object().Value("user").Object()
+// 	o := Request(e, uId1.String(), request).Object().Value("data").Object().Value("signup").Object().Value("user").Object()
 // 	o.Value("name").String().Equal("updated")
 // 	o.Value("email").String().Equal("hoge@test.com")
 // }
 
 func TestUpdateMe(t *testing.T) {
-	e, _ := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, _ := StartGQLServerAndRepos(t, baseSeederUser)
 	query := `mutation { updateMe(input: {name: "updated",email:"hoge@test.com",lang: "ja",theme: DEFAULT,password: "Ajsownndww1",passwordConfirmation: "Ajsownndww1"}){ me{ id name email lang theme } }}`
 	request := GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object().Value("data").Object().Value("updateMe").Object().Value("me").Object()
+	o := Request(e, uId1.String(), request).Object().Value("data").Object().Value("updateMe").Object().Value("me").Object()
 	o.Value("name").String().Equal("updated")
 	o.Value("email").String().Equal("hoge@test.com")
 	o.Value("lang").String().Equal("ja")
@@ -146,12 +117,7 @@ func TestUpdateMe(t *testing.T) {
 }
 
 func TestRemoveMyAuth(t *testing.T) {
-	e, r := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, r := StartGQLServerAndRepos(t, baseSeederUser)
 	u, err := r.User.FindByID(context.Background(), uId1)
 	assert.Nil(t, err)
 	assert.Equal(t, &user.Auth{Provider: "reearth", Sub: "reearth|" + uId1.String()}, u.Auths().GetByProvider("reearth"))
@@ -160,15 +126,7 @@ func TestRemoveMyAuth(t *testing.T) {
 	request := GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	Request(e, uId1.String(), request).Object()
 
 	u, err = r.User.FindByID(context.Background(), uId1)
 	assert.Nil(t, err)
@@ -176,12 +134,7 @@ func TestRemoveMyAuth(t *testing.T) {
 }
 
 func TestDeleteMe(t *testing.T) {
-	e, r := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, r := StartGQLServerAndRepos(t, baseSeederUser)
 	u, err := r.User.FindByID(context.Background(), uId1)
 	assert.Nil(t, err)
 	assert.NotNil(t, u)
@@ -190,40 +143,19 @@ func TestDeleteMe(t *testing.T) {
 	request := GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	Request(e, uId1.String(), request).Object()
 
 	_, err = r.User.FindByID(context.Background(), uId1)
 	assert.Equal(t, rerror.ErrNotFound, err)
 }
 
 func TestSearchUser(t *testing.T) {
-	e, _ := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, _ := StartGQLServerAndRepos(t, baseSeederUser)
 	query := fmt.Sprintf(` { searchUser(nameOrEmail: "%s"){ id name email } }`, "e2e")
 	request := GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object().Value("data").Object().Value("searchUser").Object()
+	o := Request(e, uId1.String(), request).Object().Value("data").Object().Value("searchUser").Object()
 	o.Value("id").String().Equal(uId1.String())
 	o.Value("name").String().Equal("e2e")
 	o.Value("email").String().Equal("e2e@e2e.com")
@@ -232,60 +164,28 @@ func TestSearchUser(t *testing.T) {
 	request = GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err = json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object().
-		Value("data").Object().Value("searchUser").Null()
+	resp := Request(e, uId1.String(), request).Object()
+	resp.Value("data").Object().Value("searchUser").Null()
+
+	resp.NotContainsKey("errors") // not exist
 }
 
 func TestNode(t *testing.T) {
-	e, _ := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, _ := StartGQLServerAndRepos(t, baseSeederUser)
 	query := fmt.Sprintf(` { node(id: "%s", type: USER){ id } }`, uId1.String())
 	request := GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object().Value("data").Object().Value("node").Object()
+	o := Request(e, uId1.String(), request).Object().Value("data").Object().Value("node").Object()
 	o.Value("id").String().Equal(uId1.String())
 }
 
 func TestNodes(t *testing.T) {
-	e, _ := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, _ := StartGQLServerAndRepos(t, baseSeederUser)
 	query := fmt.Sprintf(` { nodes(id: "%s", type: USER){ id } }`, uId1.String())
 	request := GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object().Value("data").Object().Value("nodes")
+	o := Request(e, uId1.String(), request).Object().Value("data").Object().Value("nodes")
 	o.Array().Contains(map[string]string{"id": uId1.String()})
 }

--- a/server/e2e/gql_user_test.go
+++ b/server/e2e/gql_user_test.go
@@ -92,17 +92,6 @@ func baseSeederUser(ctx context.Context, r *repo.Container) error {
 	return nil
 }
 
-// func TestSignUp(t *testing.T) {
-// 	e, _ := StartGQLServerAndRepos(t, baseSeederUser)
-// 	query := `mutation { signup(input: {lang: "ja",theme: DEFAULT,secret: "Ajsownndww1"}){ user{ id name email } }}`
-// 	request := GraphQLRequest{
-// 		Query: query,
-// 	}
-// 	o := Request(e, uId1.String(), request).Object().Value("data").Object().Value("signup").Object().Value("user").Object()
-// 	o.Value("name").String().Equal("updated")
-// 	o.Value("email").String().Equal("hoge@test.com")
-// }
-
 func TestUpdateMe(t *testing.T) {
 	e, _ := StartGQLServerAndRepos(t, baseSeederUser)
 	query := `mutation { updateMe(input: {name: "updated",email:"hoge@test.com",lang: "ja",theme: DEFAULT,password: "Ajsownndww1",passwordConfirmation: "Ajsownndww1"}){ me{ id name email lang theme } }}`

--- a/server/e2e/gql_workspace_test.go
+++ b/server/e2e/gql_workspace_test.go
@@ -2,12 +2,9 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"testing"
 
-	"github.com/reearth/reearth/server/internal/app/config"
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
 	"github.com/reearth/reearthx/rerror"
@@ -15,49 +12,24 @@ import (
 )
 
 func TestCreateTeam(t *testing.T) {
-	e, _ := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, _ := StartGQLServerAndRepos(t, baseSeederUser)
 	query := `mutation { createTeam(input: {name: "test"}){ team{ id name } }}`
 	request := GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	o := Request(e, uId1.String(), request).Object()
 	o.Value("data").Object().Value("createTeam").Object().Value("team").Object().Value("name").String().Equal("test")
 }
 
 func TestDeleteTeam(t *testing.T) {
-	e, r := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, r := StartGQLServerAndRepos(t, baseSeederUser)
 	_, err := r.Workspace.FindByID(context.Background(), wId1)
 	assert.Nil(t, err)
 	query := fmt.Sprintf(`mutation { deleteTeam(input: {teamId: "%s"}){ teamId }}`, wId1)
 	request := GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err := json.Marshal(request)
-	assert.Nil(t, err)
-
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	o := Request(e, uId1.String(), request).Object()
 	o.Value("data").Object().Value("deleteTeam").Object().Value("teamId").String().Equal(wId1.String())
 
 	_, err = r.Workspace.FindByID(context.Background(), wId1)
@@ -67,25 +39,13 @@ func TestDeleteTeam(t *testing.T) {
 	request = GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err = json.Marshal(request)
-	assert.Nil(t, err)
-
-	o = e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	o = Request(e, uId1.String(), request).Object()
 
 	o.Value("errors").Array().First().Object().Value("message").Equal("input: deleteTeam operation denied")
 }
 
 func TestUpdateTeam(t *testing.T) {
-	e, r := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, r := StartGQLServerAndRepos(t, baseSeederUser)
 
 	w, err := r.Workspace.FindByID(context.Background(), wId1)
 	assert.Nil(t, err)
@@ -95,15 +55,7 @@ func TestUpdateTeam(t *testing.T) {
 	request := GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.Nil(t, err)
-	}
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	o := Request(e, uId1.String(), request).Object()
 	o.Value("data").Object().Value("updateTeam").Object().Value("team").Object().Value("name").String().Equal("updated")
 
 	w, err = r.Workspace.FindByID(context.Background(), wId1)
@@ -114,25 +66,12 @@ func TestUpdateTeam(t *testing.T) {
 	request = GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err = json.Marshal(request)
-	if err != nil {
-		assert.Nil(t, err)
-	}
-	o = e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	o = Request(e, uId1.String(), request).Object()
 	o.Value("errors").Array().First().Object().Value("message").Equal("input: updateTeam not found")
 }
 
 func TestAddMemberToTeam(t *testing.T) {
-	e, r := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, r := StartGQLServerAndRepos(t, baseSeederUser)
 
 	w, err := r.Workspace.FindByID(context.Background(), wId1)
 	assert.Nil(t, err)
@@ -142,15 +81,7 @@ func TestAddMemberToTeam(t *testing.T) {
 	request := GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.Nil(t, err)
-	}
-	e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK)
+	Request(e, uId1.String(), request)
 
 	w, err = r.Workspace.FindByID(context.Background(), wId1)
 	assert.Nil(t, err)
@@ -161,25 +92,12 @@ func TestAddMemberToTeam(t *testing.T) {
 	request = GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err = json.Marshal(request)
-	if err != nil {
-		assert.Nil(t, err)
-	}
-	e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object().
+	Request(e, uId1.String(), request).Object().
 		Value("errors").Array().First().Object().Value("message").Equal("input: addMemberToTeam user already joined")
 }
 
 func TestRemoveMemberFromTeam(t *testing.T) {
-	e, r := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, r := StartGQLServerAndRepos(t, baseSeederUser)
 
 	w, err := r.Workspace.FindByID(context.Background(), wId2)
 	assert.Nil(t, err)
@@ -189,35 +107,18 @@ func TestRemoveMemberFromTeam(t *testing.T) {
 	request := GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.Nil(t, err)
-	}
-	e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK)
+	Request(e, uId1.String(), request)
 
 	w, err = r.Workspace.FindByID(context.Background(), wId1)
 	assert.Nil(t, err)
 	assert.False(t, w.Members().HasUser(uId3))
 
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	o := Request(e, uId1.String(), request).Object()
 	o.Value("errors").Array().First().Object().Value("message").Equal("input: removeMemberFromTeam target user does not exist in the workspace")
 }
 
 func TestUpdateMemberOfTeam(t *testing.T) {
-	e, r := StartGQLServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeederUser)
+	e, r := StartGQLServerAndRepos(t, baseSeederUser)
 
 	w, err := r.Workspace.FindByID(context.Background(), wId2)
 	assert.Nil(t, err)
@@ -226,15 +127,7 @@ func TestUpdateMemberOfTeam(t *testing.T) {
 	request := GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err := json.Marshal(request)
-	if err != nil {
-		assert.Nil(t, err)
-	}
-	e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK)
+	Request(e, uId1.String(), request)
 
 	w, err = r.Workspace.FindByID(context.Background(), wId2)
 	assert.Nil(t, err)
@@ -244,14 +137,6 @@ func TestUpdateMemberOfTeam(t *testing.T) {
 	request = GraphQLRequest{
 		Query: query,
 	}
-	jsonData, err = json.Marshal(request)
-	if err != nil {
-		assert.Nil(t, err)
-	}
-	o := e.POST("/api/graphql").
-		WithHeader("authorization", "Bearer test").
-		WithHeader("Content-Type", "application/json").
-		WithHeader("X-Reearth-Debug-User", uId1.String()).
-		WithBytes(jsonData).Expect().Status(http.StatusOK).JSON().Object()
+	o := Request(e, uId1.String(), request).Object()
 	o.Value("errors").Array().First().Object().Value("message").Equal("input: updateMemberOfTeam operation denied")
 }

--- a/server/internal/adapter/gql/loader_user.go
+++ b/server/internal/adapter/gql/loader_user.go
@@ -2,7 +2,6 @@ package gql
 
 import (
 	"context"
-	"errors"
 
 	"github.com/reearth/reearth/server/internal/adapter/gql/gqldataloader"
 	"github.com/reearth/reearth/server/internal/adapter/gql/gqlmodel"
@@ -50,7 +49,7 @@ func (c *UserLoader) SearchUser(ctx context.Context, nameOrEmail string) (*gqlmo
 		}
 	}
 
-	return nil, errors.New("user not found.")
+	return nil, nil
 }
 
 // data loader


### PR DESCRIPTION
# Overview
The user search query response has been changed to something different from what it was in the past.
https://www.notion.so/eukarya/BUG-BE-GetUserBySearch-Query-response-with-an-errors-field-when-user-not-found-14b16e0fb16580f3b9a8f8c862109a86

## What I've done

The cause was that errors were being returned, which were added to the response.
We have modified it so that errors are no longer returned.

```diff
-	return nil, errors.New("user not found.")
+	return nil, nil
```
result
```json
{"data":{"searchUser":null}}
```
```json
{
  "data": {
    "searchUser": {
      "id": "01jfy8y5htr2fzsp2qrkwdwj5w",
      "name": "Mock User2",
      "email": "mock@example2.com",
      "__typename": "User"
    }
  }
}
```


## What I haven't done

## How I tested
Updated the test cases.
```diff
func TestSearchUser(t *testing.T) {
    ...
+    resp.NotContainsKey("errors") // not exist
```
## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a simplified method for starting the GraphQL server and its repositories.
	- Updated request handling for GraphQL operations to streamline the process.

- **Bug Fixes**
	- Adjusted error handling in the user search functionality to improve clarity.

- **Refactor**
	- Removed redundant JSON marshaling in test cases.
	- Updated test functions to utilize the new request handling method.
	- Streamlined server initialization in test cases.

- **Chores**
	- Cleaned up import statements related to error handling in user loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->