### PR TITLE
chore(server): install air and add dev command for hotreload

### DIFF
--- a/server/.air.toml
+++ b/server/.air.toml
@@ -1,0 +1,26 @@
+# project root directory
+root = "."
+tmp_dir = "tmp"
+
+[build]
+# execute command
+cmd = "go build -o ./tmp/api ./cmd/reearth"
+bin = "tmp/api"
+full_bin = "tmp/api"
+delay = 1000 # ms
+stop_on_error = true
+send_interrupt = false
+kill_delay = 1000 # ms
+
+# include file extensions
+include_ext = ["go"]
+
+# exclude directories
+exclude_dir = ["e2e", "tmp"]
+
+# exclude files
+exclude_file = ["*_test.go"]
+
+[log]
+# Air log settings
+level = "debug"

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -28,3 +28,4 @@ __debug_bin
 !/.env.example
 /coverage.txt
 /web
+tmp

--- a/server/Makefile
+++ b/server/Makefile
@@ -48,7 +48,7 @@ else
 endif
 
 dev: dev-install
-	air -d
+	air
 
 run-app:
 	go run ./cmd/reearth

--- a/server/Makefile
+++ b/server/Makefile
@@ -38,9 +38,9 @@ e2e:
 build:
 	go build ./cmd/reearth
 
-REFLEX_BIN := $(shell which air)
+AIR_BIN := $(shell which air)
 dev-install:
-ifndef REFLEX_BIN
+ifndef AIR_BIN
 	@echo "reflex is not installed. Installing..."
 	@go install github.com/air-verse/air@v1.61.5
 else

--- a/server/Makefile
+++ b/server/Makefile
@@ -3,6 +3,8 @@ TEST_DIR ?= ./...
 SCHEMATYPER := github.com/idubinskiy/schematyper
 MANIFEST_DIR := pkg/plugin/manifest
 
+default: help
+
 help:
 	@echo "Usage:"
 	@echo "  make <target>"
@@ -13,6 +15,8 @@ help:
 	@echo "  failcheck         Run unit tests with fail-fast and no parallel execution"
 	@echo "  e2e               Run end-to-end tests"
 	@echo "  build             Build the project"
+	@echo "  dev-install       Install tools for make dev - behavior not confirmed in windows."
+	@echo "  dev               Run the application with hot reloading"
 	@echo "  run-app           Run the application"
 	@echo "  run-db            Run the MongoDB database using Docker Compose"
 	@echo "  gql               Generate GraphQL code include dataloader"
@@ -34,6 +38,18 @@ e2e:
 build:
 	go build ./cmd/reearth
 
+REFLEX_BIN := $(shell which air)
+dev-install:
+ifndef REFLEX_BIN
+	@echo "reflex is not installed. Installing..."
+	@go install github.com/air-verse/air@v1.61.5
+else
+	@echo "air is already installed."
+endif
+
+dev: dev-install
+	air -d
+
 run-app:
 	go run ./cmd/reearth
 
@@ -51,4 +67,4 @@ schematyper:
 	go run $(SCHEMATYPER) -o $(MANIFEST_DIR)/schema_translation.go --package manifest --prefix Translation ./schemas/plugin_manifest_translation.json
 	go run $(SCHEMATYPER) -o $(MANIFEST_DIR)/schema_gen.go --package manifest ./schemas/plugin_manifest.json
 
-.PHONY: lint test failcheck e2e build run-app run-db gql mockuser schematyper
+.PHONY: lint test failcheck e2e build dev-install dev run-app run-db gql mockuser schematyper

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -129,7 +129,7 @@ func initEcho(ctx context.Context, cfg *ServerConfig) *echo.Echo {
 	apiPrivate.GET("/layers/:param", ExportLayer(), AuthRequiredMiddleware())
 	apiPrivate.GET("/datasets/:datasetSchemaId", http2.ExportDataset(), AuthRequiredMiddleware())
 	apiPrivate.POST("/signup", Signup())
-
+	log.Infofc(ctx, "auth: config: %#v", cfg.Config.AuthSrv)
 	if !cfg.Config.AuthSrv.Disabled {
 		apiPrivate.POST("/signup/verify", StartSignupVerify())
 		apiPrivate.POST("/signup/verify/:code", SignupVerify())


### PR DESCRIPTION
# Overview

I tried to create local Makefile for introduce hotreload feature. 
https://github.com/reearth/reearth-visualizer/pull/1336

But we decided to include hotreload feature in this repo code for dev.

## What I've done
- add command for installing air  
- add command for executing air 


## What I haven't done
- behavior not confirmed in windows

## How I tested
- run `make dev` and confirmed whether it worked as expected or not. 

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added configuration for hot reloading during development
  - Updated Makefile with new development commands for easier setup and execution
  - Enhanced logging for improved visibility of authentication server configuration
  - Updated `.gitignore` to exclude temporary build files and directories
<!-- end of auto-generated comment: release notes by coderabbit.ai -->