### PR TITLE
chore(server): upgrade go version to 1.23.4

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -31,9 +31,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.23.4"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         # TODO: fix error=archive named dist/reearth_0.0.0-SNAPSHOT-xxxxxxxx.tar.gz already exists. Check your archive name template

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -2,7 +2,7 @@ name: ci-server
 on:
   workflow_call:
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.23.4"
 
 jobs:
   ci-server-lint:
@@ -12,14 +12,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: set up
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.55
+          version: v1.63.4
           args: --timeout=10m
           working-directory: server
 
@@ -34,7 +34,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: set up
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: server/go.sum

--- a/go.work
+++ b/go.work
@@ -1,3 +1,3 @@
-go 1.21
+go 1.23.4
 
 use ./server

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS build
+FROM golang:1.23.4-alpine AS build
 ARG TAG=release
 ARG VERSION
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -171,6 +171,6 @@ require (
 	moul.io/http2curl v1.0.1-0.20190925090545-5cd742060b0e // indirect
 )
 
-go 1.21
+go 1.23.4
 
-toolchain go1.21.0
+toolchain go1.23.4

--- a/server/pkg/property/group_list.go
+++ b/server/pkg/property/group_list.go
@@ -97,7 +97,7 @@ func (g *GroupList) IsDatasetLinked(s DatasetSchemaID, i DatasetID) bool {
 }
 
 func (g *GroupList) IsEmpty() bool {
-	return g != nil && (g.groups == nil || len(g.groups) == 0)
+	return g != nil && (len(g.groups) == 0)
 }
 
 func (g *GroupList) Prune() (res bool) {


### PR DESCRIPTION
# Overview
upgrade go version to 1.23.4

## What I've done
[main]
- change go version on Dockerfile
- change go version on go.mod
- change go version on go.work
- change go version on github actions
- fix src code because app have lint error.
   - S1009: should omit nil check; len() for []*github.com/reearth/reearth/server/pkg/property.Group is defined as zero (gosimple)

[other]
- update actions/setup-go to v5 from v4
- update golangci/golangci-lint-action to v6 from v3
   - update golint to v1.63.4 from v1.55 

## What I haven't done

## How I tested
- run application on local
- pass test on local
- build docker image on local
- pass ci on github actions

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Go version from 1.21 to 1.23.4 in build environment and module configuration
	- Updated project toolchain to the latest Go version
<!-- end of auto-generated comment: release notes by coderabbit.ai -->