### PR TITLE
fix(web): naming typo on preset layer style category

### DIFF
--- a/web/src/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/index.tsx
+++ b/web/src/beta/features/Editor/Map/LayerStylePanel/PresetLayerStyle/index.tsx
@@ -116,8 +116,8 @@ const PresetLayerStyle: FC<PresetLayerStyleProps> = ({
       ]
     },
     {
-      id: "geometry",
-      title: "Geometry",
+      id: "geojson",
+      title: "GeoJSON",
       icon: "folderSimple",
       subItem: [
         {


### PR DESCRIPTION
# Overview
- Rename geometry to GeoJSON
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Changes**
	- Updated menu item terminology from "Geometry" to "GeoJSON" in the layer style panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->