### PR TITLE
chore(server): enable to set visualizer db name by .env

### DIFF
--- a/server/internal/app/config/config.go
+++ b/server/internal/app/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	Dev              bool              `pp:",omitempty"`
 	DB               string            `default:"mongodb://localhost"`
 	DB_Account       string            `pp:",omitempty"`
+	DB_Visualizer    string            `pp:",omitempty"`
 	DB_Users         []appx.NamedURI   `pp:",omitempty"`
 	GraphQL          GraphQLConfig     `pp:",omitempty"`
 	Published        PublishedConfig   `pp:",omitempty"`

--- a/server/internal/app/repo.go
+++ b/server/internal/app/repo.go
@@ -25,7 +25,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo"
 )
 
-const databaseName = "reearth"
+const defaultDatabase = "reearth"
 
 func initReposAndGateways(ctx context.Context, conf *config.Config, debug bool) (*repo.Container, *gateway.Container, *accountrepo.Container, *accountgateway.Container) {
 	gateways := &gateway.Container{}
@@ -42,11 +42,11 @@ func initReposAndGateways(ctx context.Context, conf *config.Config, debug bool) 
 		log.Fatalf("mongo error: %+v\n", err)
 	}
 
-	// repos
+	// for account database
 	accountDatabase := conf.DB_Account
 	accountRepoCompat := false
 	if accountDatabase == "" {
-		accountDatabase = databaseName
+		accountDatabase = defaultDatabase
 		accountRepoCompat = true
 	}
 
@@ -66,7 +66,13 @@ func initReposAndGateways(ctx context.Context, conf *config.Config, debug bool) 
 		log.Fatalf("Failed to init mongo: %+v\n", err)
 	}
 
-	repos, err := mongorepo.NewWithExtensions(ctx, client.Database(databaseName), accountRepos, txAvailable, conf.Ext_Plugin)
+	// for reearth database
+	visualizerDatabase := conf.DB_Visualizer
+	if visualizerDatabase == "" {
+		visualizerDatabase = defaultDatabase
+	}
+
+	repos, err := mongorepo.NewWithExtensions(ctx, client.Database(visualizerDatabase), accountRepos, txAvailable, conf.Ext_Plugin)
 	if err != nil {
 		log.Fatalf("Failed to init mongo: %+v\n", err)
 	}


### PR DESCRIPTION
# Overview
There are problem we can't set database of mongo db by env file.

## What I've done
- if you set value on REEARTH_DB_VISUALIZER variable of .env,  you can switch database defined on .env value.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
