### PR TITLE
fix(web): ensure new layer reorders correctly.

### DIFF
--- a/web/src/beta/features/Editor/hooks/useLayers.ts
+++ b/web/src/beta/features/Editor/hooks/useLayers.ts
@@ -86,16 +86,23 @@ export default function ({
 
   const [sortedLayerIds, setSortedLayerIds] = useState<string[]>([]);
 
-  useEffect(() => {
-    if (!originNlsLayers) return;
-    setSortedLayerIds((prev) =>
-      prev.length > 0
-        ? prev
-        : [...originNlsLayers]
-            .sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
-            .map((l) => l.id)
-    );
-  }, [originNlsLayers]);
+useEffect(() => {
+  if (!originNlsLayers) return;
+
+  setSortedLayerIds((prev) => {
+    const originIds = originNlsLayers.map((l) => l.id);
+    if (
+      prev.length === originIds.length &&
+      prev.every((id, idx) => id === originIds[idx])
+    ) {
+      return prev;
+    }
+    return [...originNlsLayers]
+      .sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
+      .map((l) => l.id);
+  });
+}, [originNlsLayers]);
+
 
   const nlsLayers: NLSLayer[] = useMemo(
     () =>


### PR DESCRIPTION
# Overview

- Fix reorder layer after creating new layer

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
	- Enhanced layer sorting mechanism to reduce unnecessary state updates and re-renders
	- Optimized state management for layer IDs to improve overall component efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->