### PR TITLE
feat(server): sync sketch layer properties 

### DIFF
--- a/server/e2e/common.go
+++ b/server/e2e/common.go
@@ -258,7 +258,7 @@ func JSONEqRegexp(t *testing.T, actual string, expected string) bool {
 func RegexpJSONEReadCloser(t *testing.T, actual io.ReadCloser, expected string) bool {
 	defer func() {
 		if err := actual.Close(); err != nil {
-			fmt.Printf("failed to close: %v", err)
+			t.Errorf("failed to close reader: %v", err)
 		}
 	}()
 	actualBuf := new(bytes.Buffer)

--- a/server/e2e/common.go
+++ b/server/e2e/common.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -255,6 +256,7 @@ func JSONEqRegexp(t *testing.T, actual string, expected string) bool {
 }
 
 func RegexpJSONEReadCloser(t *testing.T, actual io.ReadCloser, expected string) bool {
+	defer actual.Close()
 	actualBuf := new(bytes.Buffer)
 	_, err := actualBuf.ReadFrom(actual)
 	assert.NoError(t, err)
@@ -269,7 +271,7 @@ func JSONEqRegexpInterface(t *testing.T, actual interface{}, expected string) bo
 
 func aligningJSON(t *testing.T, str string) string {
 	// Unmarshal and Marshal to make the JSON format consistent
-	var obj map[string]interface{}
+	var obj interface{}
 	err := json.Unmarshal([]byte(str), &obj)
 	assert.Nil(t, err)
 	strBytes, err := json.Marshal(obj)
@@ -277,7 +279,10 @@ func aligningJSON(t *testing.T, str string) string {
 	return string(strBytes)
 }
 
-func toJSONString(v interface{}) string {
-	jsonData, _ := json.Marshal(v)
-	return string(jsonData)
+func toJSONString(v interface{}) (string, error) {
+	jsonData, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+	return string(jsonData), nil
 }

--- a/server/e2e/common.go
+++ b/server/e2e/common.go
@@ -256,7 +256,11 @@ func JSONEqRegexp(t *testing.T, actual string, expected string) bool {
 }
 
 func RegexpJSONEReadCloser(t *testing.T, actual io.ReadCloser, expected string) bool {
-	defer actual.Close()
+	defer func() {
+		if err := actual.Close(); err != nil {
+			fmt.Printf("failed to close: %v", err)
+		}
+	}()
 	actualBuf := new(bytes.Buffer)
 	_, err := actualBuf.ReadFrom(actual)
 	assert.NoError(t, err)

--- a/server/e2e/gql_asset_test.go
+++ b/server/e2e/gql_asset_test.go
@@ -130,7 +130,7 @@ func createAsset(t *testing.T, e *httpexpect.Expect, filePath string, coreSuppor
 		"query": CreateAssetMutation,
 	}
 	operations, err := toJSONString(requestBody)
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 	return e.POST("/api/graphql").
 		WithHeader("Origin", "https://example.com").
 		WithHeader("authorization", "Bearer test").

--- a/server/e2e/gql_asset_test.go
+++ b/server/e2e/gql_asset_test.go
@@ -129,12 +129,14 @@ func createAsset(t *testing.T, e *httpexpect.Expect, filePath string, coreSuppor
 		},
 		"query": CreateAssetMutation,
 	}
+	operations, err := toJSONString(requestBody)
+	assert.NotNil(t, err)
 	return e.POST("/api/graphql").
 		WithHeader("Origin", "https://example.com").
 		WithHeader("authorization", "Bearer test").
 		WithHeader("X-Reearth-Debug-User", uID.String()).
 		WithMultipart().
-		WithFormField("operations", toJSONString(requestBody)).
+		WithFormField("operations", operations).
 		WithFormField("map", `{"0": ["variables.file"]}`).
 		WithFile("0", filePath).
 		Expect().

--- a/server/e2e/gql_custom_property_test.go
+++ b/server/e2e/gql_custom_property_test.go
@@ -1,0 +1,411 @@
+package e2e
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/gavv/httpexpect/v2"
+)
+
+func TestUpdateCustomProperties(t *testing.T) {
+	e := Server(t, baseSeeder)
+	pId := createProject(e, "test")
+	_, _, sId := createScene(e, pId)
+	lId := addTestNLSLayerSimple(e, sId)
+
+	proId1 := RandomString(10)
+	fId1 := addTestGeoJSONFeature(e, lId, proId1)
+	updateTestGeoJSONFeature(e, lId, fId1, proId1)
+
+	proId2 := RandomString(10)
+	fId2 := addTestGeoJSONFeature(e, lId, proId2)
+	updateTestGeoJSONFeature(e, lId, fId2, proId2)
+
+	// check GetScene
+	res := getNewLayersOfScene(e, sId)
+	JSONEqRegexpInterface(t, res.Path("$.sketch.customPropertySchema").Raw(), `
+{
+	"AAA": "Text_1",
+	"BBB": "Int_2",
+	"XXX": "URL_3",
+	"YYY": "Boolean_4"
+}`)
+	JSONEqRegexpInterface(t, res.Path("$.sketch.featureCollection").Raw(), `
+{
+    "__typename": "FeatureCollection",
+    "features": [
+        {
+            "__typename": "Feature",
+            "geometry": {
+                "__typename": "Point",
+                "pointCoordinates": [
+                    139.75315007107542,
+                    35.68233694131118
+                ],
+                "type": "Point"
+            },
+            "id": ".*",
+            "properties": {
+                "AAA": "aaa",
+                "BBB": 123,
+                "XXX": "xxx",
+                "YYY": true,
+                "extrudedHeight": 0,
+                "id": ".*",
+                "positions": [
+                    [
+                        -3958794.0678944187,
+                        3350992.944211698,
+                        3699619.2576891473
+                    ]
+                ],
+                "type": "marker"
+            },
+            "type": "Feature"
+        },
+        {
+            "__typename": "Feature",
+            "geometry": {
+                "__typename": "Point",
+                "pointCoordinates": [
+                    139.75315007107542,
+                    35.68233694131118
+                ],
+                "type": "Point"
+            },
+            "id": ".*",
+            "properties": {
+                "AAA": "aaa",
+                "BBB": 123,
+                "XXX": "xxx",
+                "YYY": true,
+                "extrudedHeight": 0,
+                "id": ".*",
+                "positions": [
+                    [
+                        -3958794.0678944187,
+                        3350992.944211698,
+                        3699619.2576891473
+                    ]
+                ],
+                "type": "marker"
+            },
+            "type": "Feature"
+        }
+    ],
+    "type": "FeatureCollection"
+}`)
+}
+
+func TestChangeCustomPropertyTitle(t *testing.T) {
+	e := Server(t, baseSeeder)
+	sId, lId, _, _ := setupTestData(e)
+	// change XXX -> ZZZ
+	requestBody := GraphQLRequest{
+		OperationName: "ChangeCustomPropertyTitle",
+		Query: `
+			mutation ChangeCustomPropertyTitle($input: ChangeCustomPropertyTitleInput!) {
+				changeCustomPropertyTitle(input: $input) {
+					layer {
+						id
+					}
+				}
+			}
+		`,
+		Variables: map[string]any{
+			"input": map[string]interface{}{
+				"layerId": lId,
+				"schema": map[string]any{
+					"AAA": "Text_1",
+					"BBB": "Int_2",
+					"ZZZ": "URL_3", // XXX -> ZZZ
+					"YYY": "Boolean_4",
+				},
+				"oldTitle": "XXX", // XXX -> ZZZ
+				"newTitle": "ZZZ", // XXX -> ZZZ
+			},
+		},
+	}
+	Request(e, uID.String(), requestBody)
+
+	// check GetScene
+	res := getNewLayersOfScene(e, sId)
+	JSONEqRegexpInterface(t, res.Path("$.sketch.customPropertySchema").Raw(), `
+{
+	"AAA": "Text_1",
+	"BBB": "Int_2",
+	"ZZZ": "URL_3",
+	"YYY": "Boolean_4"
+}`)
+
+	features := res.Path("$.sketch.featureCollection.features").Array()
+	features.Length().Equal(2)
+	feature0 := features.Element(0).Object()
+	feature1 := features.Element(1).Object()
+
+	JSONEqRegexpInterface(t, feature0.Raw(), `
+{
+	"AAA": "aaa",
+	"BBB": 123,
+	"ZZZ": "xxx",
+	"YYY": true,
+	"extrudedHeight": 0,
+	"id": ".*",
+	"positions": [
+		[
+			-3958794.0678944187,
+			3350992.944211698,
+			3699619.2576891473
+		]
+	],
+	"type": "marker"
+}`)
+	JSONEqRegexpInterface(t, feature1.Raw(), `
+{
+	"AAA": "aaa",
+	"BBB": 123,
+	"ZZZ": "xxx",
+	"YYY": true,
+	"extrudedHeight": 0,
+	"id": ".*",
+	"positions": [
+		[
+			-3958794.0678944187,
+			3350992.944211698,
+			3699619.2576891473
+		]
+	],
+	"type": "marker"
+}`)
+}
+
+func TestRemoveCustomProperty(t *testing.T) {
+	e := Server(t, baseSeeder)
+	sId, lId, _, _ := setupTestData(e)
+	// remove XXX
+	requestBody := GraphQLRequest{
+		OperationName: "RemoveCustomProperty",
+		Query: `
+			mutation RemoveCustomProperty($input: RemoveCustomPropertyInput!) {
+				removeCustomProperty(input: $input) {
+					layer {
+						id
+					}
+				}
+			}
+		`,
+		Variables: map[string]any{
+			"input": map[string]interface{}{
+				"layerId": lId,
+				"schema": map[string]any{
+					"AAA": "Text_1",
+					"BBB": "Int_2",
+					// "XXX": "URL_3", remove
+					"YYY": "Boolean_3",
+				},
+				"removedTitle": "XXX",
+			},
+		},
+	}
+	Request(e, uID.String(), requestBody)
+
+	// check GetScene
+	res := getNewLayersOfScene(e, sId)
+	JSONEqRegexpInterface(t, res.Path("$.sketch.customPropertySchema").Raw(), `
+{
+	"AAA": "Text_1",
+	"BBB": "Int_2",
+	"YYY": "Boolean_3"
+}`)
+
+	features := res.Path("$.sketch.featureCollection.features").Array()
+	features.Length().Equal(2)
+	feature0 := features.Element(0).Object()
+	feature1 := features.Element(1).Object()
+
+	JSONEqRegexpInterface(t, feature0.Raw(), `
+	
+		{
+			"AAA": "aaa",
+			"BBB": 123,
+			"YYY": true,
+			"extrudedHeight": 0,
+			"id": ".*",
+			"positions": [
+				[
+					-3958794.0678944187,
+					3350992.944211698,
+					3699619.2576891473
+				]
+			],
+			"type": "marker"
+		}`)
+
+	JSONEqRegexpInterface(t, feature1.Raw(), `
+	
+		{
+			"AAA": "aaa",
+			"BBB": 123,
+			"YYY": true,
+			"extrudedHeight": 0,
+			"id": ".*",
+			"positions": [
+				[
+					-3958794.0678944187,
+					3350992.944211698,
+					3699619.2576891473
+				]
+			],
+			"type": "marker"
+		}`)
+}
+
+// below Common functions -----------------------------------------------------
+
+func setupTestData(e *httpexpect.Expect) (sId string, lId string, fId1 string, fId2 string) {
+	pId := createProject(e, "test")
+	_, _, sId = createScene(e, pId)
+	lId = addTestNLSLayerSimple(e, sId)
+
+	proId1 := RandomString(10)
+	fId1 = addTestGeoJSONFeature(e, lId, proId1)
+	updateTestGeoJSONFeature(e, lId, fId1, proId1)
+
+	proId2 := RandomString(10)
+	fId2 = addTestGeoJSONFeature(e, lId, proId2)
+	updateTestGeoJSONFeature(e, lId, fId2, proId2)
+	return
+}
+
+func getNewLayersOfScene(e *httpexpect.Expect, sId string) *httpexpect.Object {
+	requestBody := GraphQLRequest{
+		OperationName: "GetScene",
+		Query:         "query GetScene($sceneId: ID!, $lang: Lang) { node(id: $sceneId, type: SCENE) { id ... on Scene { rootLayerId teamId projectId property { id ...PropertyFragment __typename } clusters { id name propertyId property { id ...PropertyFragment __typename } __typename } tags { id label ... on TagGroup { tags { id label __typename } __typename } __typename } plugins { property { id ...PropertyFragment __typename } plugin { ...PluginFragment __typename } __typename } widgets { id enabled extended pluginId extensionId property { id ...PropertyFragment __typename } __typename } widgetAlignSystem { ...WidgetAlignSystemFragment __typename } stories { ...StoryFragment __typename } newLayers { ...NLSLayerCommon __typename } styles { ...NLSLayerStyle __typename } __typename } __typename }}fragment PropertyFieldLink on PropertyFieldLink { datasetId datasetSchemaId datasetSchemaFieldId __typename}fragment PropertyFieldFragment on PropertyField { id fieldId type value links { ...PropertyFieldLink __typename } __typename}fragment PropertyGroupFragment on PropertyGroup { id schemaGroupId fields { ...PropertyFieldFragment __typename } __typename}fragment PropertyItemFragment on PropertyItem { ... on PropertyGroupList { id schemaGroupId groups { ...PropertyGroupFragment __typename } __typename } ... on PropertyGroup { ...PropertyGroupFragment __typename } __typename}fragment PropertyFragmentWithoutSchema on Property { id items { ...PropertyItemFragment __typename } __typename}fragment PropertySchemaFieldFragment on PropertySchemaField { fieldId title description placeholder translatedTitle(lang: $lang) translatedDescription(lang: $lang) translatedPlaceholder(lang: $lang) prefix suffix type defaultValue ui min max choices { key icon title translatedTitle(lang: $lang) __typename } isAvailableIf { fieldId type value __typename } __typename}fragment PropertySchemaGroupFragment on PropertySchemaGroup { schemaGroupId title collection translatedTitle(lang: $lang) isList representativeFieldId isAvailableIf { fieldId type value __typename } fields { ...PropertySchemaFieldFragment __typename } __typename}fragment WidgetAreaFragment on WidgetArea { widgetIds align padding { top bottom left right __typename } gap centered background __typename}fragment WidgetSectionFragment on WidgetSection { top { ...WidgetAreaFragment __typename } middle { ...WidgetAreaFragment __typename } bottom { ...WidgetAreaFragment __typename } __typename}fragment WidgetZoneFragment on WidgetZone { left { ...WidgetSectionFragment __typename } center { ...WidgetSectionFragment __typename } right { ...WidgetSectionFragment __typename } __typename}fragment PropertyFragment on Property { id ...PropertyFragmentWithoutSchema schema { id groups { ...PropertySchemaGroupFragment __typename } __typename } __typename}fragment StoryPageFragment on StoryPage { id title swipeable propertyId property { id ...PropertyFragment __typename } layersIds blocks { id pluginId extensionId property { id ...PropertyFragment __typename } __typename } __typename}fragment FeatureFragment on Feature { id type properties geometry { ... on Point { type pointCoordinates __typename } ... on LineString { type lineStringCoordinates __typename } ... on Polygon { type polygonCoordinates __typename } ... on MultiPolygon { type multiPolygonCoordinates __typename } ... on GeometryCollection { type geometries { ... on Point { type pointCoordinates __typename } ... on LineString { type lineStringCoordinates __typename } ... on Polygon { type polygonCoordinates __typename } ... on MultiPolygon { type multiPolygonCoordinates __typename } __typename } __typename } __typename } __typename}fragment PluginFragment on Plugin { id name extensions { extensionId description name translatedDescription(lang: $lang) translatedName(lang: $lang) icon singleOnly type widgetLayout { extendable { vertically horizontally __typename } extended floating defaultLocation { zone section area __typename } __typename } __typename } __typename}fragment WidgetAlignSystemFragment on WidgetAlignSystem { outer { ...WidgetZoneFragment __typename } inner { ...WidgetZoneFragment __typename } __typename}fragment StoryFragment on Story { id title panelPosition bgColor isBasicAuthActive basicAuthUsername basicAuthPassword alias publicTitle publicDescription publishmentStatus publicImage publicNoIndex pages { ...StoryPageFragment __typename } __typename}fragment NLSLayerCommon on NLSLayer { id index layerType sceneId config title visible infobox { sceneId layerId propertyId property { id ...PropertyFragment __typename } blocks { id pluginId extensionId propertyId property { id ...PropertyFragment __typename } __typename } __typename } isSketch sketch { customPropertySchema featureCollection { type features { ...FeatureFragment __typename } __typename } __typename } ... on NLSLayerGroup { children { id __typename } __typename } __typename}fragment NLSLayerStyle on Style { id name value __typename}",
+		Variables: map[string]any{
+			"sceneId": sId,
+			"lang":    "en",
+		},
+	}
+	res := Request(e, uID.String(), requestBody)
+	newLayers := res.Path("$.data.node.newLayers").Array()
+	newLayers.Length().Equal(1)
+	return newLayers.Element(0).Object()
+}
+
+func addTestNLSLayerSimple(e *httpexpect.Expect, sId string) string {
+	requestBody := GraphQLRequest{
+		OperationName: "AddNLSLayerSimple",
+		Query:         "mutation AddNLSLayerSimple($input: AddNLSLayerSimpleInput!) { addNLSLayerSimple(input: $input) { layers { id __typename } __typename }}",
+		Variables: map[string]any{
+			"input": map[string]any{
+				"sceneId": sId,
+				"config": map[string]any{
+					"properties": map[string]any{
+						"name": "TestLayer",
+					},
+					"layerStyleId": "",
+					"data": map[string]any{
+						"type": "geojson",
+					},
+				},
+				"visible":   true,
+				"layerType": "simple",
+				"title":     "TestLayer",
+				"index":     0,
+				"schema": map[string]any{
+					"AAA": "Text_1",
+					"BBB": "Int_2",
+					"XXX": "URL_3",
+					"YYY": "Boolean_4",
+				},
+			},
+		},
+	}
+	res := Request(e, uID.String(), requestBody)
+	return res.Path("$.data.addNLSLayerSimple.layers.id").Raw().(string)
+}
+
+func addTestGeoJSONFeature(e *httpexpect.Expect, lId string, proId string) string {
+	requestBody := GraphQLRequest{
+		OperationName: "AddGeoJSONFeature",
+		Query:         "mutation AddGeoJSONFeature($input: AddGeoJSONFeatureInput!) { addGeoJSONFeature(input: $input) { id type properties __typename }}",
+		Variables: map[string]any{
+			"input": map[string]any{
+				"layerId": lId,
+				"geometry": map[string]any{
+					"type": "Point",
+					"coordinates": []float64{
+						139.75315007107542,
+						35.68233694131118,
+					},
+				},
+				"type": "Feature",
+				"properties": map[string]any{
+					"id":   proId,
+					"type": "marker",
+					"positions": [][]float64{
+						{
+							-3958794.0678944187,
+							3350992.944211698,
+							3699619.2576891473,
+						},
+					},
+					"extrudedHeight": 0,
+				},
+			},
+		},
+	}
+	res := Request(e, uID.String(), requestBody)
+	featureId := res.Path("$.data.addGeoJSONFeature.id").Raw().(string)
+	return featureId
+}
+
+func updateTestGeoJSONFeature(e *httpexpect.Expect, lId string, fId string, proId string) {
+	requestBody := GraphQLRequest{
+		OperationName: "UpdateGeoJSONFeature",
+		Query:         "mutation UpdateGeoJSONFeature($input: UpdateGeoJSONFeatureInput!) { updateGeoJSONFeature(input: $input) { id type properties __typename }}",
+		Variables: map[string]any{
+			"input": map[string]any{
+				"layerId":   lId,
+				"featureId": fId,
+				"geometry": map[string]any{
+					"type": "Point",
+					"coordinates": []float64{
+						139.75315007107542,
+						35.68233694131118,
+					},
+				},
+				"properties": map[string]any{
+					"extrudedHeight": 0,
+					"id":             proId,
+					"positions": [][]float64{
+						{
+							-3958794.0678944187,
+							3350992.944211698,
+							3699619.2576891473,
+						},
+					},
+					"type": "marker",
+					"AAA":  "aaa",
+					"BBB":  123,
+					"XXX":  "xxx",
+					"YYY":  true,
+				},
+			},
+		},
+	}
+	Request(e, uID.String(), requestBody)
+}
+
+const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func RandomString(n int) string {
+	src := rand.NewSource(time.Now().UnixNano())
+	r := rand.New(src)
+	result := make([]byte, n)
+	for i := range result {
+		result[i] = letters[r.Intn(len(letters))]
+	}
+	return string(result)
+}

--- a/server/e2e/gql_nlslayer_test.go
+++ b/server/e2e/gql_nlslayer_test.go
@@ -734,15 +734,15 @@ func TestInfoboxBlocksCRUD(t *testing.T) {
 		Value("updatedAt").NotEqual(notUpdatedProjectUpdatedAt)
 }
 
-func addCustomProperties(
+func updateCustomProperties(
 	e *httpexpect.Expect,
 	layerId string,
 	schema map[string]any,
 ) (GraphQLRequest, *httpexpect.Value) {
 	requestBody := GraphQLRequest{
-		OperationName: "AddCustomProperties",
-		Query: `mutation AddCustomProperties($input: AddCustomPropertySchemaInput!) {
-			addCustomProperties(input: $input) {
+		OperationName: "UpdateCustomProperties",
+		Query: `mutation UpdateCustomProperties($input: UpdateCustomPropertySchemaInput!) {
+			updateCustomProperties(input: $input) {
 				layer {
 					id
 					sketch {
@@ -807,7 +807,7 @@ func TestCustomProperties(t *testing.T) {
 		"extrudedHeight": 0,
 		"positions":      []float64{1, 2, 3},
 	}
-	addCustomProperties(e, layerId, schema1)
+	updateCustomProperties(e, layerId, schema1)
 
 	_, res3 := fetchSceneForNewLayers(e, sId)
 	res3.Object().
@@ -830,7 +830,7 @@ func TestCustomProperties(t *testing.T) {
 		"extrudedHeight": 10,
 		"positions":      []float64{4, 5, 6},
 	}
-	addCustomProperties(e, layerId, schema2)
+	updateCustomProperties(e, layerId, schema2)
 
 	_, res4 := fetchSceneForNewLayers(e, sId)
 	res4.Object().

--- a/server/e2e/gql_project_import_test.go
+++ b/server/e2e/gql_project_import_test.go
@@ -68,7 +68,7 @@ func importProject(t *testing.T, e *httpexpect.Expect, filePath string) *httpexp
         }`,
 	}
 	operations, err := toJSONString(requestBody)
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 	r := e.POST("/api/graphql").
 		WithHeader("Origin", "https://example.com").
 		WithHeader("authorization", "Bearer test").

--- a/server/e2e/gql_project_import_test.go
+++ b/server/e2e/gql_project_import_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"encoding/json"
 	"net/http"
 	"os"
 	"testing"
@@ -106,11 +105,6 @@ func getScene(e *httpexpect.Expect, s string, l string) *httpexpect.Object {
 	v := r.Value("data").Object().Value("node")
 	v.NotNull()
 	return v.Object()
-}
-
-func toJSONString(v interface{}) string {
-	jsonData, _ := json.Marshal(v)
-	return string(jsonData)
 }
 
 const GetSceneGuery = `

--- a/server/e2e/gql_project_import_test.go
+++ b/server/e2e/gql_project_import_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gavv/httpexpect/v2"
 	"github.com/reearth/reearth/server/internal/app/config"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/text/language"
 )
 
@@ -66,12 +67,14 @@ func importProject(t *testing.T, e *httpexpect.Expect, filePath string) *httpexp
             } 
         }`,
 	}
+	operations, err := toJSONString(requestBody)
+	assert.NotNil(t, err)
 	r := e.POST("/api/graphql").
 		WithHeader("Origin", "https://example.com").
 		WithHeader("authorization", "Bearer test").
 		WithHeader("X-Reearth-Debug-User", uID.String()).
 		WithMultipart().
-		WithFormField("operations", toJSONString(requestBody)).
+		WithFormField("operations", operations).
 		WithFormField("map", `{"0": ["variables.file"]}`).
 		WithFile("0", filePath).
 		Expect().

--- a/server/e2e/gql_storytelling_test.go
+++ b/server/e2e/gql_storytelling_test.go
@@ -1,14 +1,9 @@
 package e2e
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/gavv/httpexpect/v2"
@@ -40,14 +35,7 @@ func createProject(e *httpexpect.Expect, name string) string {
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	return res.Path("$.data.createProject.project.id").Raw().(string)
 }
@@ -69,14 +57,7 @@ func createScene(e *httpexpect.Expect, pID string) (GraphQLRequest, *httpexpect.
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	sID := res.Path("$.data.createScene.scene.id").Raw().(string)
 	return requestBody, res, sID
@@ -131,14 +112,7 @@ func fetchSceneForStories(e *httpexpect.Expect, sID string) (GraphQLRequest, *ht
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(fetchSceneRequestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), fetchSceneRequestBody)
 
 	return fetchSceneRequestBody, res
 }
@@ -163,14 +137,7 @@ func createStory(e *httpexpect.Expect, sID, name string, index int) (GraphQLRequ
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -204,14 +171,7 @@ func updateStory(e *httpexpect.Expect, storyID, sID string) (GraphQLRequest, *ht
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -236,14 +196,7 @@ func deleteStory(e *httpexpect.Expect, storyID, sID string) (GraphQLRequest, *ht
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -271,14 +224,7 @@ func publishStory(e *httpexpect.Expect, storyID, alias string) (GraphQLRequest, 
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -315,14 +261,7 @@ func createPage(e *httpexpect.Expect, sID, storyID, name string, swipeable bool)
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -358,14 +297,7 @@ func updatePage(e *httpexpect.Expect, sID, storyID, pageID, name string, swipeab
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -399,14 +331,7 @@ func movePage(e *httpexpect.Expect, storyID, pageID string, idx int) (GraphQLReq
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -437,14 +362,7 @@ func deletePage(e *httpexpect.Expect, sID, storyID, pageID string) (GraphQLReque
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -480,14 +398,7 @@ func duplicatePage(e *httpexpect.Expect, sID, storyID, pageID string) (GraphQLRe
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	pID := res.Object().
 		Value("data").Object().
@@ -529,14 +440,7 @@ func addLayerToPage(e *httpexpect.Expect, sId, storyId, pageId, layerId string, 
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	pageRes := res.Object().
 		Value("data").Object().
@@ -585,14 +489,7 @@ func removeLayerToPage(e *httpexpect.Expect, sId, storyId, pageId, layerId strin
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	pageRes := res.Object().
 		Value("data").Object().
@@ -644,14 +541,7 @@ func createBlock(e *httpexpect.Expect, sID, storyID, pageID, pluginId, extension
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("data").Object().
@@ -691,14 +581,7 @@ func removeBlock(e *httpexpect.Expect, storyID, pageID, blockID string) (GraphQL
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Path("$.data.removeStoryBlock.page.blocks[:].id").Array().NotContains(blockID)
@@ -736,14 +619,7 @@ func moveBlock(e *httpexpect.Expect, storyID, pageID, blockID string, index int)
 		},
 	}
 
-	res := e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res := Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Path("$.data.moveStoryBlock.page.blocks[:].id").Array().Contains(blockID)
@@ -752,12 +628,7 @@ func moveBlock(e *httpexpect.Expect, storyID, pageID, blockID string, index int)
 }
 
 func TestStoryCRUD(t *testing.T) {
-	e := StartServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeeder)
+	e := Server(t, baseSeeder)
 
 	pID := createProject(e, "test")
 
@@ -798,12 +669,7 @@ func TestStoryCRUD(t *testing.T) {
 }
 
 func TestStoryPageCRUD(t *testing.T) {
-	e := StartServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeeder)
+	e := Server(t, baseSeeder)
 
 	pID := createProject(e, "test")
 
@@ -839,14 +705,7 @@ func TestStoryPageCRUD(t *testing.T) {
 
 	// update page with invalid page id
 	requestBody.Variables["pageId"] = id.NewPageID().String()
-	res = e.POST("/api/graphql").
-		WithHeader("Origin", "https://example.com").
-		WithHeader("X-Reearth-Debug-User", uID.String()).
-		WithHeader("Content-Type", "application/json").
-		WithJSON(requestBody).
-		Expect().
-		Status(http.StatusOK).
-		JSON()
+	res = Request(e, uID.String(), requestBody)
 
 	res.Object().
 		Value("errors").Array().
@@ -892,12 +751,7 @@ func TestStoryPageCRUD(t *testing.T) {
 }
 
 func TestStoryPageLayersCRUD(t *testing.T) {
-	e := StartServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeeder)
+	e := Server(t, baseSeeder)
 
 	pID := createProject(e, "test")
 
@@ -929,12 +783,7 @@ func TestStoryPageLayersCRUD(t *testing.T) {
 }
 
 func TestStoryPageBlocksCRUD(t *testing.T) {
-	e := StartServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeeder)
+	e := Server(t, baseSeeder)
 
 	pID := createProject(e, "test")
 
@@ -977,12 +826,7 @@ func TestStoryPageBlocksCRUD(t *testing.T) {
 }
 
 func TestStoryPageBlocksProperties(t *testing.T) {
-	e := StartServer(t, &config.Config{
-		Origins: []string{"https://example.com"},
-		AuthSrv: config.AuthSrvConfig{
-			Disabled: true,
-		},
-	}, true, baseSeeder)
+	e := Server(t, baseSeeder)
 
 	pID := createProject(e, "test")
 
@@ -1138,7 +982,7 @@ func TestStoryPublishing(t *testing.T) {
     ]
 }`, sID, storyID, extensionId, blockID, pageID, pluginId)
 
-	RegexpJSONEq(t, rc, expected)
+	RegexpJSONEReadCloser(t, rc, expected)
 
 	resString := e.GET("/p/test-alias/data.json").
 		WithHeader("Origin", "https://example.com").
@@ -1147,52 +991,6 @@ func TestStoryPublishing(t *testing.T) {
 		Body().
 		Raw()
 
-	RegexpJSONEqStr(t, resString, expected)
+	JSONEqRegexp(t, resString, expected)
 
-}
-
-func RegexpJSONEq(t *testing.T, rc io.ReadCloser, expected string) {
-
-	buf := new(bytes.Buffer)
-	_, err := buf.ReadFrom(rc)
-	assert.NoError(t, err)
-
-	var obj1 map[string]interface{}
-	err = json.Unmarshal(buf.Bytes(), &obj1)
-	assert.Nil(t, err)
-
-	obj2, err := json.Marshal(obj1)
-	assert.Nil(t, err)
-
-	var obj3 map[string]interface{}
-	err = json.Unmarshal([]byte(expected), &obj3)
-	assert.Nil(t, err)
-
-	obj4, err := json.Marshal(obj3)
-	assert.Nil(t, err)
-
-	pub := regexp.MustCompile(strings.ReplaceAll(string(obj4), "[", "\\["))
-
-	assert.Regexp(t, pub, string(obj2))
-}
-
-func RegexpJSONEqStr(t *testing.T, buf string, expected string) {
-
-	var obj1 map[string]interface{}
-	err := json.Unmarshal([]byte(buf), &obj1)
-	assert.Nil(t, err)
-
-	obj2, err := json.Marshal(obj1)
-	assert.Nil(t, err)
-
-	var obj3 map[string]interface{}
-	err = json.Unmarshal([]byte(expected), &obj3)
-	assert.Nil(t, err)
-
-	obj4, err := json.Marshal(obj3)
-	assert.Nil(t, err)
-
-	pub := regexp.MustCompile(strings.ReplaceAll(string(obj4), "[", "\\["))
-
-	assert.Regexp(t, pub, string(obj2))
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -171,4 +171,4 @@ require (
 	moul.io/http2curl v1.0.1-0.20190925090545-5cd742060b0e // indirect
 )
 
-go 1.21
+go 1.23.4

--- a/server/go.mod
+++ b/server/go.mod
@@ -171,6 +171,4 @@ require (
 	moul.io/http2curl v1.0.1-0.20190925090545-5cd742060b0e // indirect
 )
 
-go 1.23.4
-
-toolchain go1.23.4
+go 1.21

--- a/server/gql/newlayer.graphql
+++ b/server/gql/newlayer.graphql
@@ -128,14 +128,22 @@ input DuplicateNLSLayerInput {
   layerId: ID!
 }
 
-input AddCustomPropertySchemaInput {
+input UpdateCustomPropertySchemaInput {
   layerId: ID!
   schema: JSON
 }
 
-input UpdateCustomPropertySchemaInput {
+input ChangeCustomPropertyTitleInput {
   layerId: ID!
   schema: JSON
+  oldTitle: String!
+  newTitle: String!
+}
+
+input RemoveCustomPropertyInput {
+  layerId: ID!
+  schema: JSON
+  removedTitle: String!
 }
 
 # Payload
@@ -199,10 +207,13 @@ extend type Mutation {
     input: RemoveNLSInfoboxBlockInput!
   ): RemoveNLSInfoboxBlockPayload
   duplicateNLSLayer(input: DuplicateNLSLayerInput!): DuplicateNLSLayerPayload!
-  addCustomProperties(
-    input: AddCustomPropertySchemaInput!
-  ): UpdateNLSLayerPayload!
   updateCustomProperties(
     input: UpdateCustomPropertySchemaInput!
+  ): UpdateNLSLayerPayload!
+  changeCustomPropertyTitle(
+    input: ChangeCustomPropertyTitleInput!
+  ): UpdateNLSLayerPayload!
+  removeCustomProperty(
+    input: RemoveCustomPropertyInput!
   ): UpdateNLSLayerPayload!
 }

--- a/server/internal/adapter/gql/generated.go
+++ b/server/internal/adapter/gql/generated.go
@@ -625,7 +625,6 @@ type ComplexityRoot struct {
 
 	Mutation struct {
 		AddCluster                   func(childComplexity int, input gqlmodel.AddClusterInput) int
-		AddCustomProperties          func(childComplexity int, input gqlmodel.AddCustomPropertySchemaInput) int
 		AddDatasetSchema             func(childComplexity int, input gqlmodel.AddDatasetSchemaInput) int
 		AddGeoJSONFeature            func(childComplexity int, input gqlmodel.AddGeoJSONFeatureInput) int
 		AddInfoboxField              func(childComplexity int, input gqlmodel.AddInfoboxFieldInput) int
@@ -640,6 +639,7 @@ type ComplexityRoot struct {
 		AddWidget                    func(childComplexity int, input gqlmodel.AddWidgetInput) int
 		AttachTagItemToGroup         func(childComplexity int, input gqlmodel.AttachTagItemToGroupInput) int
 		AttachTagToLayer             func(childComplexity int, input gqlmodel.AttachTagToLayerInput) int
+		ChangeCustomPropertyTitle    func(childComplexity int, input gqlmodel.ChangeCustomPropertyTitleInput) int
 		CreateAsset                  func(childComplexity int, input gqlmodel.CreateAssetInput) int
 		CreateInfobox                func(childComplexity int, input gqlmodel.CreateInfoboxInput) int
 		CreateNLSInfobox             func(childComplexity int, input gqlmodel.CreateNLSInfoboxInput) int
@@ -679,6 +679,7 @@ type ComplexityRoot struct {
 		PublishStory                 func(childComplexity int, input gqlmodel.PublishStoryInput) int
 		RemoveAsset                  func(childComplexity int, input gqlmodel.RemoveAssetInput) int
 		RemoveCluster                func(childComplexity int, input gqlmodel.RemoveClusterInput) int
+		RemoveCustomProperty         func(childComplexity int, input gqlmodel.RemoveCustomPropertyInput) int
 		RemoveDatasetSchema          func(childComplexity int, input gqlmodel.RemoveDatasetSchemaInput) int
 		RemoveInfobox                func(childComplexity int, input gqlmodel.RemoveInfoboxInput) int
 		RemoveInfoboxField           func(childComplexity int, input gqlmodel.RemoveInfoboxFieldInput) int
@@ -1575,8 +1576,9 @@ type MutationResolver interface {
 	MoveNLSInfoboxBlock(ctx context.Context, input gqlmodel.MoveNLSInfoboxBlockInput) (*gqlmodel.MoveNLSInfoboxBlockPayload, error)
 	RemoveNLSInfoboxBlock(ctx context.Context, input gqlmodel.RemoveNLSInfoboxBlockInput) (*gqlmodel.RemoveNLSInfoboxBlockPayload, error)
 	DuplicateNLSLayer(ctx context.Context, input gqlmodel.DuplicateNLSLayerInput) (*gqlmodel.DuplicateNLSLayerPayload, error)
-	AddCustomProperties(ctx context.Context, input gqlmodel.AddCustomPropertySchemaInput) (*gqlmodel.UpdateNLSLayerPayload, error)
 	UpdateCustomProperties(ctx context.Context, input gqlmodel.UpdateCustomPropertySchemaInput) (*gqlmodel.UpdateNLSLayerPayload, error)
+	ChangeCustomPropertyTitle(ctx context.Context, input gqlmodel.ChangeCustomPropertyTitleInput) (*gqlmodel.UpdateNLSLayerPayload, error)
+	RemoveCustomProperty(ctx context.Context, input gqlmodel.RemoveCustomPropertyInput) (*gqlmodel.UpdateNLSLayerPayload, error)
 	InstallPlugin(ctx context.Context, input gqlmodel.InstallPluginInput) (*gqlmodel.InstallPluginPayload, error)
 	UninstallPlugin(ctx context.Context, input gqlmodel.UninstallPluginInput) (*gqlmodel.UninstallPluginPayload, error)
 	UploadPlugin(ctx context.Context, input gqlmodel.UploadPluginInput) (*gqlmodel.UploadPluginPayload, error)
@@ -3939,18 +3941,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.AddCluster(childComplexity, args["input"].(gqlmodel.AddClusterInput)), true
 
-	case "Mutation.addCustomProperties":
-		if e.complexity.Mutation.AddCustomProperties == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_addCustomProperties_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.AddCustomProperties(childComplexity, args["input"].(gqlmodel.AddCustomPropertySchemaInput)), true
-
 	case "Mutation.addDatasetSchema":
 		if e.complexity.Mutation.AddDatasetSchema == nil {
 			break
@@ -4118,6 +4108,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.AttachTagToLayer(childComplexity, args["input"].(gqlmodel.AttachTagToLayerInput)), true
+
+	case "Mutation.changeCustomPropertyTitle":
+		if e.complexity.Mutation.ChangeCustomPropertyTitle == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_changeCustomPropertyTitle_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.ChangeCustomPropertyTitle(childComplexity, args["input"].(gqlmodel.ChangeCustomPropertyTitleInput)), true
 
 	case "Mutation.createAsset":
 		if e.complexity.Mutation.CreateAsset == nil {
@@ -4586,6 +4588,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.RemoveCluster(childComplexity, args["input"].(gqlmodel.RemoveClusterInput)), true
+
+	case "Mutation.removeCustomProperty":
+		if e.complexity.Mutation.RemoveCustomProperty == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_removeCustomProperty_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RemoveCustomProperty(childComplexity, args["input"].(gqlmodel.RemoveCustomPropertyInput)), true
 
 	case "Mutation.removeDatasetSchema":
 		if e.complexity.Mutation.RemoveDatasetSchema == nil {
@@ -8335,7 +8349,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	ec := executionContext{rc, e, 0, 0, make(chan graphql.DeferredResult)}
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputAddClusterInput,
-		ec.unmarshalInputAddCustomPropertySchemaInput,
 		ec.unmarshalInputAddDatasetSchemaInput,
 		ec.unmarshalInputAddGeoJSONFeatureInput,
 		ec.unmarshalInputAddInfoboxFieldInput,
@@ -8350,6 +8363,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputAssetSort,
 		ec.unmarshalInputAttachTagItemToGroupInput,
 		ec.unmarshalInputAttachTagToLayerInput,
+		ec.unmarshalInputChangeCustomPropertyTitleInput,
 		ec.unmarshalInputCreateAssetInput,
 		ec.unmarshalInputCreateInfoboxInput,
 		ec.unmarshalInputCreateNLSInfoboxInput,
@@ -8393,6 +8407,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputPublishStoryInput,
 		ec.unmarshalInputRemoveAssetInput,
 		ec.unmarshalInputRemoveClusterInput,
+		ec.unmarshalInputRemoveCustomPropertyInput,
 		ec.unmarshalInputRemoveDatasetSchemaInput,
 		ec.unmarshalInputRemoveInfoboxFieldInput,
 		ec.unmarshalInputRemoveInfoboxInput,
@@ -9432,14 +9447,22 @@ input DuplicateNLSLayerInput {
   layerId: ID!
 }
 
-input AddCustomPropertySchemaInput {
+input UpdateCustomPropertySchemaInput {
   layerId: ID!
   schema: JSON
 }
 
-input UpdateCustomPropertySchemaInput {
+input ChangeCustomPropertyTitleInput {
   layerId: ID!
   schema: JSON
+  oldTitle: String!
+  newTitle: String!
+}
+
+input RemoveCustomPropertyInput {
+  layerId: ID!
+  schema: JSON
+  removedTitle: String!
 }
 
 # Payload
@@ -9503,11 +9526,14 @@ extend type Mutation {
     input: RemoveNLSInfoboxBlockInput!
   ): RemoveNLSInfoboxBlockPayload
   duplicateNLSLayer(input: DuplicateNLSLayerInput!): DuplicateNLSLayerPayload!
-  addCustomProperties(
-    input: AddCustomPropertySchemaInput!
-  ): UpdateNLSLayerPayload!
   updateCustomProperties(
     input: UpdateCustomPropertySchemaInput!
+  ): UpdateNLSLayerPayload!
+  changeCustomPropertyTitle(
+    input: ChangeCustomPropertyTitleInput!
+  ): UpdateNLSLayerPayload!
+  removeCustomProperty(
+    input: RemoveCustomPropertyInput!
   ): UpdateNLSLayerPayload!
 }
 `, BuiltIn: false},
@@ -10988,21 +11014,6 @@ func (ec *executionContext) field_Mutation_addCluster_args(ctx context.Context, 
 	return args, nil
 }
 
-func (ec *executionContext) field_Mutation_addCustomProperties_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 gqlmodel.AddCustomPropertySchemaInput
-	if tmp, ok := rawArgs["input"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
-		arg0, err = ec.unmarshalNAddCustomPropertySchemaInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐAddCustomPropertySchemaInput(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["input"] = arg0
-	return args, nil
-}
-
 func (ec *executionContext) field_Mutation_addDatasetSchema_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -11205,6 +11216,21 @@ func (ec *executionContext) field_Mutation_attachTagToLayer_args(ctx context.Con
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalNAttachTagToLayerInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐAttachTagToLayerInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_changeCustomPropertyTitle_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 gqlmodel.ChangeCustomPropertyTitleInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNChangeCustomPropertyTitleInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐChangeCustomPropertyTitleInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -11790,6 +11816,21 @@ func (ec *executionContext) field_Mutation_removeCluster_args(ctx context.Contex
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalNRemoveClusterInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐRemoveClusterInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_removeCustomProperty_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 gqlmodel.RemoveCustomPropertyInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNRemoveCustomPropertyInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐRemoveCustomPropertyInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -31497,65 +31538,6 @@ func (ec *executionContext) fieldContext_Mutation_duplicateNLSLayer(ctx context.
 	return fc, nil
 }
 
-func (ec *executionContext) _Mutation_addCustomProperties(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_addCustomProperties(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().AddCustomProperties(rctx, fc.Args["input"].(gqlmodel.AddCustomPropertySchemaInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*gqlmodel.UpdateNLSLayerPayload)
-	fc.Result = res
-	return ec.marshalNUpdateNLSLayerPayload2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUpdateNLSLayerPayload(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mutation_addCustomProperties(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "layer":
-				return ec.fieldContext_UpdateNLSLayerPayload_layer(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type UpdateNLSLayerPayload", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_addCustomProperties_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Mutation_updateCustomProperties(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_updateCustomProperties(ctx, field)
 	if err != nil {
@@ -31609,6 +31591,124 @@ func (ec *executionContext) fieldContext_Mutation_updateCustomProperties(ctx con
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_updateCustomProperties_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_changeCustomPropertyTitle(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_changeCustomPropertyTitle(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().ChangeCustomPropertyTitle(rctx, fc.Args["input"].(gqlmodel.ChangeCustomPropertyTitleInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*gqlmodel.UpdateNLSLayerPayload)
+	fc.Result = res
+	return ec.marshalNUpdateNLSLayerPayload2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUpdateNLSLayerPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_changeCustomPropertyTitle(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "layer":
+				return ec.fieldContext_UpdateNLSLayerPayload_layer(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UpdateNLSLayerPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_changeCustomPropertyTitle_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_removeCustomProperty(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_removeCustomProperty(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RemoveCustomProperty(rctx, fc.Args["input"].(gqlmodel.RemoveCustomPropertyInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*gqlmodel.UpdateNLSLayerPayload)
+	fc.Result = res
+	return ec.marshalNUpdateNLSLayerPayload2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐUpdateNLSLayerPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_removeCustomProperty(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "layer":
+				return ec.fieldContext_UpdateNLSLayerPayload_layer(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UpdateNLSLayerPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_removeCustomProperty_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -59393,40 +59493,6 @@ func (ec *executionContext) unmarshalInputAddClusterInput(ctx context.Context, o
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputAddCustomPropertySchemaInput(ctx context.Context, obj interface{}) (gqlmodel.AddCustomPropertySchemaInput, error) {
-	var it gqlmodel.AddCustomPropertySchemaInput
-	asMap := map[string]interface{}{}
-	for k, v := range obj.(map[string]interface{}) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"layerId", "schema"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "layerId":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("layerId"))
-			data, err := ec.unmarshalNID2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐID(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.LayerID = data
-		case "schema":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("schema"))
-			data, err := ec.unmarshalOJSON2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐJSON(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Schema = data
-		}
-	}
-
-	return it, nil
-}
-
 func (ec *executionContext) unmarshalInputAddDatasetSchemaInput(ctx context.Context, obj interface{}) (gqlmodel.AddDatasetSchemaInput, error) {
 	var it gqlmodel.AddDatasetSchemaInput
 	asMap := map[string]interface{}{}
@@ -60093,6 +60159,54 @@ func (ec *executionContext) unmarshalInputAttachTagToLayerInput(ctx context.Cont
 				return it, err
 			}
 			it.LayerID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputChangeCustomPropertyTitleInput(ctx context.Context, obj interface{}) (gqlmodel.ChangeCustomPropertyTitleInput, error) {
+	var it gqlmodel.ChangeCustomPropertyTitleInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"layerId", "schema", "oldTitle", "newTitle"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "layerId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("layerId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.LayerID = data
+		case "schema":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("schema"))
+			data, err := ec.unmarshalOJSON2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐJSON(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Schema = data
+		case "oldTitle":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("oldTitle"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OldTitle = data
+		case "newTitle":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("newTitle"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.NewTitle = data
 		}
 	}
 
@@ -61821,6 +61935,47 @@ func (ec *executionContext) unmarshalInputRemoveClusterInput(ctx context.Context
 				return it, err
 			}
 			it.SceneID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputRemoveCustomPropertyInput(ctx context.Context, obj interface{}) (gqlmodel.RemoveCustomPropertyInput, error) {
+	var it gqlmodel.RemoveCustomPropertyInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"layerId", "schema", "removedTitle"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "layerId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("layerId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.LayerID = data
+		case "schema":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("schema"))
+			data, err := ec.unmarshalOJSON2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐJSON(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Schema = data
+		case "removedTitle":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("removedTitle"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RemovedTitle = data
 		}
 	}
 
@@ -70288,16 +70443,23 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "addCustomProperties":
+		case "updateCustomProperties":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_addCustomProperties(ctx, field)
+				return ec._Mutation_updateCustomProperties(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "updateCustomProperties":
+		case "changeCustomPropertyTitle":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_updateCustomProperties(ctx, field)
+				return ec._Mutation_changeCustomPropertyTitle(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "removeCustomProperty":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_removeCustomProperty(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -78172,11 +78334,6 @@ func (ec *executionContext) unmarshalNAddClusterInput2githubᚗcomᚋreearthᚋr
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalNAddCustomPropertySchemaInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐAddCustomPropertySchemaInput(ctx context.Context, v interface{}) (gqlmodel.AddCustomPropertySchemaInput, error) {
-	res, err := ec.unmarshalInputAddCustomPropertySchemaInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
 func (ec *executionContext) unmarshalNAddDatasetSchemaInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐAddDatasetSchemaInput(ctx context.Context, v interface{}) (gqlmodel.AddDatasetSchemaInput, error) {
 	res, err := ec.unmarshalInputAddDatasetSchemaInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -78395,6 +78552,11 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNChangeCustomPropertyTitleInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐChangeCustomPropertyTitleInput(ctx context.Context, v interface{}) (gqlmodel.ChangeCustomPropertyTitleInput, error) {
+	res, err := ec.unmarshalInputChangeCustomPropertyTitleInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalNCluster2ᚕᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐClusterᚄ(ctx context.Context, sel ast.SelectionSet, v []*gqlmodel.Cluster) graphql.Marshaler {
@@ -80928,6 +81090,11 @@ func (ec *executionContext) unmarshalNRemoveAssetInput2githubᚗcomᚋreearthᚋ
 
 func (ec *executionContext) unmarshalNRemoveClusterInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐRemoveClusterInput(ctx context.Context, v interface{}) (gqlmodel.RemoveClusterInput, error) {
 	res, err := ec.unmarshalInputRemoveClusterInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNRemoveCustomPropertyInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐRemoveCustomPropertyInput(ctx context.Context, v interface{}) (gqlmodel.RemoveCustomPropertyInput, error) {
+	res, err := ec.unmarshalInputRemoveCustomPropertyInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/server/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/server/internal/adapter/gql/gqlmodel/models_gen.go
@@ -84,11 +84,6 @@ type AddClusterPayload struct {
 	Cluster *Cluster `json:"cluster"`
 }
 
-type AddCustomPropertySchemaInput struct {
-	LayerID ID   `json:"layerId"`
-	Schema  JSON `json:"schema,omitempty"`
-}
-
 type AddDatasetSchemaInput struct {
 	SceneID             ID     `json:"sceneId"`
 	Name                string `json:"name"`
@@ -273,6 +268,13 @@ type Camera struct {
 	Pitch    float64 `json:"pitch"`
 	Roll     float64 `json:"roll"`
 	Fov      float64 `json:"fov"`
+}
+
+type ChangeCustomPropertyTitleInput struct {
+	LayerID  ID     `json:"layerId"`
+	Schema   JSON   `json:"schema,omitempty"`
+	OldTitle string `json:"oldTitle"`
+	NewTitle string `json:"newTitle"`
 }
 
 type Cluster struct {
@@ -1386,6 +1388,12 @@ type RemoveClusterInput struct {
 type RemoveClusterPayload struct {
 	Scene     *Scene `json:"scene"`
 	ClusterID ID     `json:"clusterId"`
+}
+
+type RemoveCustomPropertyInput struct {
+	LayerID      ID     `json:"layerId"`
+	Schema       JSON   `json:"schema,omitempty"`
+	RemovedTitle string `json:"removedTitle"`
 }
 
 type RemoveDatasetSchemaInput struct {

--- a/server/internal/adapter/gql/resolver_mutation_nlslayer.go
+++ b/server/internal/adapter/gql/resolver_mutation_nlslayer.go
@@ -218,7 +218,7 @@ func (r *mutationResolver) RemoveNLSInfoboxBlock(ctx context.Context, input gqlm
 	}, nil
 }
 
-func (r *mutationResolver) AddCustomProperties(ctx context.Context, input gqlmodel.AddCustomPropertySchemaInput) (*gqlmodel.UpdateNLSLayerPayload, error) {
+func (r *mutationResolver) UpdateCustomProperties(ctx context.Context, input gqlmodel.UpdateCustomPropertySchemaInput) (*gqlmodel.UpdateNLSLayerPayload, error) {
 	lid, err := gqlmodel.ToID[id.NLSLayer](input.LayerID)
 	if err != nil {
 		return nil, err
@@ -237,16 +237,35 @@ func (r *mutationResolver) AddCustomProperties(ctx context.Context, input gqlmod
 	}, nil
 }
 
-func (r *mutationResolver) UpdateCustomProperties(ctx context.Context, input gqlmodel.UpdateCustomPropertySchemaInput) (*gqlmodel.UpdateNLSLayerPayload, error) {
+func (r *mutationResolver) ChangeCustomPropertyTitle(ctx context.Context, input gqlmodel.ChangeCustomPropertyTitleInput) (*gqlmodel.UpdateNLSLayerPayload, error) {
 	lid, err := gqlmodel.ToID[id.NLSLayer](input.LayerID)
 	if err != nil {
 		return nil, err
 	}
 
-	layer, err := usecases(ctx).NLSLayer.AddOrUpdateCustomProperties(ctx, interfaces.AddOrUpdateCustomPropertiesInput{
+	layer, err := usecases(ctx).NLSLayer.ChangeCustomPropertyTitle(ctx, interfaces.AddOrUpdateCustomPropertiesInput{
 		LayerID: lid,
 		Schema:  input.Schema,
-	}, getOperator(ctx))
+	}, input.OldTitle, input.NewTitle, getOperator(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	return &gqlmodel.UpdateNLSLayerPayload{
+		Layer: gqlmodel.ToNLSLayer(layer, nil),
+	}, nil
+}
+
+func (r *mutationResolver) RemoveCustomProperty(ctx context.Context, input gqlmodel.RemoveCustomPropertyInput) (*gqlmodel.UpdateNLSLayerPayload, error) {
+	lid, err := gqlmodel.ToID[id.NLSLayer](input.LayerID)
+	if err != nil {
+		return nil, err
+	}
+
+	layer, err := usecases(ctx).NLSLayer.RemoveCustomProperty(ctx, interfaces.AddOrUpdateCustomPropertiesInput{
+		LayerID: lid,
+		Schema:  input.Schema,
+	}, input.RemovedTitle, getOperator(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/usecase/interactor/nlslayer.go
+++ b/server/internal/usecase/interactor/nlslayer.go
@@ -704,9 +704,6 @@ func (i *NLSLayer) ChangeCustomPropertyTitle(ctx context.Context, inp interfaces
 	if err != nil {
 		return nil, err
 	}
-	if err := i.CanWriteScene(layer.Scene(), operator); err != nil {
-		return nil, interfaces.ErrOperationDenied
-	}
 
 	if layer.Sketch() == nil || layer.Sketch().FeatureCollection() == nil {
 		return nil, interfaces.ErrSketchNotFound

--- a/server/internal/usecase/interactor/nlslayer.go
+++ b/server/internal/usecase/interactor/nlslayer.go
@@ -749,7 +749,7 @@ func (i *NLSLayer) RemoveCustomProperty(ctx context.Context, inp interfaces.AddO
 
 	for _, feature := range layer.Sketch().FeatureCollection().Features() {
 		if props := feature.Properties(); props != nil {
-			for k, _ := range *props {
+			for k := range *props {
 				if k == removedTitle {
 					delete(*props, k)
 				}

--- a/server/internal/usecase/interactor/nlslayer.go
+++ b/server/internal/usecase/interactor/nlslayer.go
@@ -711,6 +711,9 @@ func (i *NLSLayer) ChangeCustomPropertyTitle(ctx context.Context, inp interfaces
 	if layer.Sketch() == nil || layer.Sketch().FeatureCollection() == nil {
 		return nil, interfaces.ErrSketchNotFound
 	}
+	if err := i.CanWriteScene(layer.Scene(), operator); err != nil {
+		return nil, interfaces.ErrOperationDenied
+	}
 
 	// Check if oldTitle exists and newTitle doesn't conflict
 	titleExists := false

--- a/server/internal/usecase/interactor/nlslayer.go
+++ b/server/internal/usecase/interactor/nlslayer.go
@@ -653,6 +653,9 @@ func (i *NLSLayer) AddOrUpdateCustomProperties(ctx context.Context, inp interfac
 	if err != nil {
 		return nil, err
 	}
+	if err := i.CanWriteScene(layer.Scene(), operator); err != nil {
+		return nil, interfaces.ErrOperationDenied
+	}
 
 	if layer.Sketch() == nil {
 		featureCollection := nlslayer.NewFeatureCollection(
@@ -701,6 +704,10 @@ func (i *NLSLayer) ChangeCustomPropertyTitle(ctx context.Context, inp interfaces
 	if err != nil {
 		return nil, err
 	}
+	if err := i.CanWriteScene(layer.Scene(), operator); err != nil {
+		return nil, interfaces.ErrOperationDenied
+	}
+
 	if layer.Sketch() == nil || layer.Sketch().FeatureCollection() == nil {
 		return nil, interfaces.ErrSketchNotFound
 	}

--- a/server/internal/usecase/interfaces/nlslayer.go
+++ b/server/internal/usecase/interfaces/nlslayer.go
@@ -85,6 +85,8 @@ type NLSLayer interface {
 	RemoveNLSInfoboxBlock(context.Context, RemoveNLSInfoboxBlockParam, *usecase.Operator) (id.InfoboxBlockID, nlslayer.NLSLayer, error)
 	Duplicate(context.Context, id.NLSLayerID, *usecase.Operator) (nlslayer.NLSLayer, error)
 	AddOrUpdateCustomProperties(context.Context, AddOrUpdateCustomPropertiesInput, *usecase.Operator) (nlslayer.NLSLayer, error)
+	ChangeCustomPropertyTitle(context.Context, AddOrUpdateCustomPropertiesInput, string, string, *usecase.Operator) (nlslayer.NLSLayer, error)
+	RemoveCustomProperty(context.Context, AddOrUpdateCustomPropertiesInput, string, *usecase.Operator) (nlslayer.NLSLayer, error)
 	AddGeoJSONFeature(context.Context, AddNLSLayerGeoJSONFeatureParams, *usecase.Operator) (nlslayer.Feature, error)
 	UpdateGeoJSONFeature(context.Context, UpdateNLSLayerGeoJSONFeatureParams, *usecase.Operator) (nlslayer.Feature, error)
 	DeleteGeoJSONFeature(context.Context, DeleteNLSLayerGeoJSONFeatureParams, *usecase.Operator) (id.FeatureID, error)


### PR DESCRIPTION
# Overview

Synchronize data updates in the sketch layer.

## What I've done

To synchronize the data, the server needs to know about title renames and deleted titles.
Therefore, the API has been updated.

### Updated GraphQL:

* Removed addCustomProperties.
* Added changeCustomPropertyTitle and removeCustomProperty.    

**Note: Since addCustomProperties is identical to updateCustomProperties, please call updateCustomProperties instead.**
```diff

-input AddCustomPropertySchemaInput {
-  layerId: ID!
-  schema: JSON
-}

 input UpdateCustomPropertySchemaInput {
   layerId: ID!
   schema: JSON
 }

+input ChangeCustomPropertyTitleInput {
+  layerId: ID!
+  schema: JSON
+  oldTitle: String!
+  newTitle: String!
+}

+input RemoveCustomPropertyInput {
+  layerId: ID!
+  schema: JSON
+  removedTitle: String!
+}

 extend type Mutation {
-  addCustomProperties(
-    input: AddCustomPropertySchemaInput!
-  ): UpdateNLSLayerPayload!
   updateCustomProperties(
     input: UpdateCustomPropertySchemaInput!
   ): UpdateNLSLayerPayload!
+  changeCustomPropertyTitle(
+    input: ChangeCustomPropertyTitleInput!
+  ): UpdateNLSLayerPayload!
+  removeCustomProperty(
+    input: RemoveCustomPropertyInput!
+  ): UpdateNLSLayerPayload!
 }
```

## What I haven't done
The GeoJSON format check will be implemented in a separate pull request.

## How I tested
I added a method to use assert.Regexp for checking with regular expressions in tests:
func JSONEqRegexp(t *testing.T, actual string, expected string) bool

Using this, I created the following end-to-end (e2e) tests:
https://github.com/reearth/reearth-visualizer/pull/1348/files#diff-b1a67b8e570b786682445adb6c015cc17d86ce6af88589b785e110089b289e1b

## Which point I want you to review particularly
When changing the type of a custom property, the value remains unchanged.
Therefore, along with calling UpdateCustomProperties, you also need to update the value using UpdateGeoJSONFeature.
```
# CustomProperties
"AAA": "Text_1"
↓↓↓
"AAA": "Int_1"

# GeoJSONFeature
"updateGeoJSONFeature": {
    "properties": {
        "AAA": "aaa",
↓↓↓
"updateGeoJSONFeature": {
    "properties": {
        "AAA": 123,
```
## Memo
The implementation details for the web have been documented in Notion.
https://www.notion.so/eukarya/BE-Support-synchronization-of-properties-after-schema-changes-of-sketch-layer-17716e0fb165806eb2d1eef2fb6244e3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced custom property management for layers
    - Added ability to change custom property titles
    - Added functionality to remove custom properties from layers

- **Improvements**
  - Streamlined JSON comparison and handling in testing utilities
  - Simplified test setup and request handling
  - Refined GraphQL schema for custom property operations
  - Introduced error handling for JSON serialization processes

- **Testing**
  - Added comprehensive end-to-end tests for custom property management
  - Improved test utility functions for JSON processing and comparison

- **Chores**
  - Downgraded Go version from 1.23.4 to 1.21 in the module configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->