### PR TITLE
chore(server): always set the useLegacyStructure flag to false

### DIFF
--- a/server/internal/app/config/config.go
+++ b/server/internal/app/config/config.go
@@ -29,9 +29,9 @@ type Config struct {
 	Host_Web         string            `pp:",omitempty"`
 	Dev              bool              `pp:",omitempty"`
 	DB               string            `default:"mongodb://localhost"`
-	DB_Account       string            `pp:",omitempty"`
+	DB_Account       string            `default:"reearth_account" pp:",omitempty"`
 	DB_Users         []appx.NamedURI   `pp:",omitempty"`
-	DB_Vis           string            `pp:",omitempty"`
+	DB_Vis           string            `default:"reearth" pp:",omitempty"`
 	GraphQL          GraphQLConfig     `pp:",omitempty"`
 	Published        PublishedConfig   `pp:",omitempty"`
 	GCPProject       string            `envconfig:"GOOGLE_CLOUD_PROJECT" pp:",omitempty"`

--- a/server/internal/app/repo.go
+++ b/server/internal/app/repo.go
@@ -25,8 +25,39 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo"
 )
 
-const defaultVisDatabase = "reearth"
-const defaultAccountDatabase = "reearth_account"
+func initAccountDatabase(client *mongo.Client, txAvailable bool, ctx context.Context, conf *config.Config) *accountrepo.Container {
+	accountDatabase := conf.DB_Account
+	log.Infof("accountDatabase: %s", accountDatabase)
+
+	accountUsers := make([]accountrepo.User, 0, len(conf.DB_Users))
+	for _, u := range conf.DB_Users {
+		c, err := mongo.Connect(ctx, options.Client().ApplyURI(u.URI).SetMonitor(otelmongo.NewMonitor()))
+		if err != nil {
+			log.Fatalf("mongo error: %+v\n", err)
+		}
+		accountUsers = append(accountUsers, accountmongo.NewUserWithHost(mongox.NewClient(accountDatabase, c), u.Name))
+	}
+
+	// this flag is for old database structure compatibility
+	// on this service, it is always false
+	useLegacyStructure := false
+	accountRepos, err := accountmongo.New(ctx, client, accountDatabase, txAvailable, useLegacyStructure, accountUsers)
+	if err != nil {
+		log.Fatalf("Failed to init mongo database account: %+v\n", err)
+	}
+	return accountRepos
+}
+
+func initVisDatabase(client *mongo.Client, txAvailable bool, accountRepos *accountrepo.Container, ctx context.Context, conf *config.Config) *repo.Container {
+	visDatabase := conf.DB_Vis
+	log.Infof("visDatabase: %s", visDatabase)
+
+	repos, err := mongorepo.NewWithExtensions(ctx, client.Database(visDatabase), accountRepos, txAvailable, conf.Ext_Plugin)
+	if err != nil {
+		log.Fatalf("Failed to init mongo database visualizer: %+v\n", err)
+	}
+	return repos
+}
 
 func initReposAndGateways(ctx context.Context, conf *config.Config, debug bool) (*repo.Container, *gateway.Container, *accountrepo.Container, *accountgateway.Container) {
 	gateways := &gateway.Container{}
@@ -42,41 +73,9 @@ func initReposAndGateways(ctx context.Context, conf *config.Config, debug bool) 
 	if err != nil {
 		log.Fatalf("mongo error: %+v\n", err)
 	}
-
-	// for account database
-	accountDatabase := conf.DB_Account
-	accountRepoCompat := false
-	if accountDatabase == "" {
-		accountDatabase = defaultAccountDatabase
-		accountRepoCompat = true
-	}
-
-	accountUsers := make([]accountrepo.User, 0, len(conf.DB_Users))
-	for _, u := range conf.DB_Users {
-		c, err := mongo.Connect(ctx, options.Client().ApplyURI(u.URI).SetMonitor(otelmongo.NewMonitor()))
-		if err != nil {
-			log.Fatalf("mongo error: %+v\n", err)
-		}
-		accountUsers = append(accountUsers, accountmongo.NewUserWithHost(mongox.NewClient(accountDatabase, c), u.Name))
-	}
-
 	txAvailable := mongox.IsTransactionAvailable(conf.DB)
-
-	accountRepos, err := accountmongo.New(ctx, client, accountDatabase, txAvailable, accountRepoCompat, accountUsers)
-	if err != nil {
-		log.Fatalf("Failed to init mongo: %+v\n", err)
-	}
-
-	// for reearth visualizer database
-	visDatabase := conf.DB_Vis
-	if visDatabase == "" {
-		visDatabase = defaultVisDatabase
-	}
-
-	repos, err := mongorepo.NewWithExtensions(ctx, client.Database(visDatabase), accountRepos, txAvailable, conf.Ext_Plugin)
-	if err != nil {
-		log.Fatalf("Failed to init mongo: %+v\n", err)
-	}
+	accountRepos := initAccountDatabase(client, txAvailable, ctx, conf)
+	visRepos := initVisDatabase(client, txAvailable, accountRepos, ctx, conf)
 
 	// File
 	gateways.File = initFile(ctx, conf)
@@ -99,11 +98,11 @@ func initReposAndGateways(ctx context.Context, conf *config.Config, debug bool) 
 	}
 
 	// release lock of all scenes
-	if err := repos.SceneLock.ReleaseAllLock(context.Background()); err != nil {
+	if err := visRepos.SceneLock.ReleaseAllLock(context.Background()); err != nil {
 		log.Fatalf("repo initialization error: %v", err)
 	}
 
-	return repos, gateways, accountRepos, acGateways
+	return visRepos, gateways, accountRepos, acGateways
 }
 
 func initFile(ctx context.Context, conf *config.Config) (fileRepo gateway.File) {


### PR DESCRIPTION
# Overview
We do not need to have compatibility for the old account structure on this application.
The code of flags for compatibility was confusing to developers.

## What I've done
- always set the flag to false if the old account structure is to be made compatible
- separate function for initialization of each database
- rename variables name  to `useLegacyStructure` from `accountRepoCompat`
- defined default value on `config.go`

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added default values for database account and visualization configurations
	- Improved configuration handling with predefined database names

- **Database Initialization**
	- Restructured database initialization process
	- Enhanced error logging for database connections
	- Implemented more modular approach to database setup

- **Code Structure**
	- Simplified database initialization functions
	- Updated function signatures for improved clarity and error management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->