### PR TITLE
feat(web): add story panel to plugin-playground

### DIFF
--- a/web/src/beta/features/PluginPlayground/Code/hook.ts
+++ b/web/src/beta/features/PluginPlayground/Code/hook.ts
@@ -174,18 +174,15 @@ export default ({ files }: Props) => {
         return prv;
       }
 
-      return [
-        ...prv,
-        {
-          id: cur.id,
-          name: cur.name,
-          description: cur.description,
-          __REEARTH_SOURCECODE: file.sourceCode,
-          extensionId: cur.id,
-          pluginId: cur.id,
-          extensionType: "storyBlock"
-        }
-      ];
+      prv.push({
+        id: cur.id,
+        name: cur.name,
+        description: cur.description,
+        __REEARTH_SOURCECODE: file.sourceCode,
+        extensionId: cur.id,
+        pluginId: cur.id
+      });
+      return prv;
     }, []);
 
     setStory({

--- a/web/src/beta/features/PluginPlayground/Code/hook.ts
+++ b/web/src/beta/features/PluginPlayground/Code/hook.ts
@@ -3,6 +3,7 @@ import { useNotification } from "@reearth/services/state";
 import * as yaml from "js-yaml";
 import { ComponentProps, useCallback, useState } from "react";
 
+import { Story } from "../../Visualizer/Crust/StoryPanel/types";
 import { WidgetLocation } from "../../Visualizer/Crust/Widgets/types";
 import { FileType } from "../Plugins/constants";
 
@@ -37,6 +38,8 @@ type CustomInfoboxBlock = {
   pluginId: string;
 };
 
+type CustomStoryBlock = CustomInfoboxBlock;
+
 type Props = {
   files: FileType[];
 };
@@ -60,6 +63,7 @@ const getYmlJson = (file: FileType) => {
 
 export default ({ files }: Props) => {
   const [infoboxBlocks, setInfoboxBlocks] = useState<CustomInfoboxBlock[]>();
+  const [story, setStory] = useState<Story>();
   const [widgets, setWidgets] = useState<Widgets>();
   const [, setNotification] = useNotification();
 
@@ -158,11 +162,50 @@ export default ({ files }: Props) => {
     }, []);
 
     setInfoboxBlocks(infoboBlockFromExtension);
+
+    const storyBlocksFromExtension = ymlJson.extensions.reduce<
+      CustomStoryBlock[]
+    >((prv, cur) => {
+      if (cur.type !== "storyBlock") return prv;
+
+      const file = files.find((file) => file.title === `${cur.id}.js`);
+
+      if (!file) {
+        return prv;
+      }
+
+      return [
+        ...prv,
+        {
+          id: cur.id,
+          name: cur.name,
+          description: cur.description,
+          __REEARTH_SOURCECODE: file.sourceCode,
+          extensionId: cur.id,
+          pluginId: cur.id,
+          extensionType: "storyBlock"
+        }
+      ];
+    }, []);
+
+    setStory({
+      id: "story",
+      title: "First Story",
+      position: "left",
+      bgColor: "#f0f0f0",
+      pages: [
+        {
+          id: "page",
+          blocks: storyBlocksFromExtension
+        }
+      ]
+    });
   }, [files, setNotification]);
 
   return {
     executeCode,
     infoboxBlocks,
+    story,
     widgets
   };
 };

--- a/web/src/beta/features/PluginPlayground/Code/hook.ts
+++ b/web/src/beta/features/PluginPlayground/Code/hook.ts
@@ -5,6 +5,7 @@ import { ComponentProps, useCallback, useState } from "react";
 
 import { Story } from "../../Visualizer/Crust/StoryPanel/types";
 import { WidgetLocation } from "../../Visualizer/Crust/Widgets/types";
+import { DEFAULT_LAYERS_PLUGIN_PLAYGROUND } from "../LayerList/constants";
 import { FileType } from "../Plugins/constants";
 
 type Widgets = ComponentProps<typeof Visualizer>["widgets"];
@@ -193,7 +194,8 @@ export default ({ files }: Props) => {
       pages: [
         {
           id: "page",
-          blocks: storyBlocksFromExtension
+          blocks: storyBlocksFromExtension,
+          layerIds: DEFAULT_LAYERS_PLUGIN_PLAYGROUND.map((l) => l.id)
         }
       ]
     });

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/custom/myPlugin.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/custom/myPlugin.ts
@@ -22,7 +22,7 @@ extensions:
     name: Demo Infobox Block 1
   - id: demo-infobox-block-2
     type: infoboxBlock
-    name: Demo Second Infobox
+    name: Demo Infobox Block 2
   - id: demo-story
     type: storyBlock
     name: Demo Story

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/custom/myPlugin.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/custom/myPlugin.ts
@@ -23,9 +23,9 @@ extensions:
   - id: demo-infobox-block-2
     type: infoboxBlock
     name: Demo Infobox Block 2
-  - id: demo-story
+  - id: demo-story-block
     type: storyBlock
-    name: Demo Story
+    name: Demo Story Block
   `,
   disableEdit: true,
   disableDelete: true

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/custom/myPlugin.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/custom/myPlugin.ts
@@ -22,7 +22,10 @@ extensions:
     name: Demo Infobox Block 1
   - id: demo-infobox-block-2
     type: infoboxBlock
-    name: Demo Infobox Block 2
+    name: Demo Second Infobox
+  - id: demo-story
+    type: storyBlock
+    name: Demo Story
   `,
   disableEdit: true,
   disableDelete: true
@@ -61,8 +64,25 @@ const demoInfoboxBlock2File: FileType = {
 \`); `
 };
 
+const demoStoryFile: FileType = {
+  id: "custom-my-plugin-demo-story",
+  title: "demo-story.js",
+  sourceCode: `reearth.ui.show(\`
+  ${PRESET_PLUGIN_COMMON_STYLE}
+  <div id="wrapper">
+    <h2 style="text-align: center;">Demo Story</h2>
+  </div>  
+\`); `
+};
+
 export const myPlugin: PluginType = {
   id: "my-plugin",
   title: "My Plugin",
-  files: [widgetFile, demoInfoboxBlock1File, demoInfoboxBlock2File, yamlFile]
+  files: [
+    widgetFile,
+    demoInfoboxBlock1File,
+    demoInfoboxBlock2File,
+    demoStoryFile,
+    yamlFile
+  ]
 };

--- a/web/src/beta/features/PluginPlayground/SettingsList/index.tsx
+++ b/web/src/beta/features/PluginPlayground/SettingsList/index.tsx
@@ -5,8 +5,15 @@ import { FC } from "react";
 type Props = {
   infoboxEnabled: boolean;
   setInfoboxEnabled: (infoBoxEnabled: boolean) => void;
+  setShowStoryPanel: (showStoryPanel: boolean) => void;
+  showStoryPanel: boolean;
 };
-const SettingsList: FC<Props> = ({ infoboxEnabled, setInfoboxEnabled }) => {
+const SettingsList: FC<Props> = ({
+  infoboxEnabled,
+  setInfoboxEnabled,
+  setShowStoryPanel,
+  showStoryPanel
+}) => {
   return (
     <Wrapper>
       <Row>
@@ -18,12 +25,15 @@ const SettingsList: FC<Props> = ({ infoboxEnabled, setInfoboxEnabled }) => {
           Enable Infobox
         </Typography>
       </Row>
-      {/* <Row>
-        <CheckBox />
+      <Row>
+        <CheckBox
+          value={showStoryPanel}
+          onChange={() => setShowStoryPanel(!showStoryPanel)}
+        />
         <Typography size="body" otherProperties={{ paddingLeft: 4 }}>
           Enable Story Panel
         </Typography>
-      </Row> */}
+      </Row>
     </Wrapper>
   );
 };

--- a/web/src/beta/features/PluginPlayground/Viewer/index.tsx
+++ b/web/src/beta/features/PluginPlayground/Viewer/index.tsx
@@ -2,15 +2,25 @@ import Visualizer from "@reearth/beta/features/Visualizer";
 import { Layer, MapRef } from "@reearth/core";
 import { ComponentProps, FC, MutableRefObject } from "react";
 
+import { Story } from "../../Visualizer/Crust/StoryPanel";
+
 import useHooks from "./hooks";
 
 type Props = {
   layers: Layer[];
-  widgets: ComponentProps<typeof Visualizer>["widgets"];
+  showStoryPanel: boolean;
+  story: Story | undefined;
   visualizerRef: MutableRefObject<MapRef | null>;
+  widgets: ComponentProps<typeof Visualizer>["widgets"];
 };
 
-const Viewer: FC<Props> = ({ layers, widgets, visualizerRef }) => {
+const Viewer: FC<Props> = ({
+  layers,
+  showStoryPanel,
+  story,
+  visualizerRef,
+  widgets
+}) => {
   const { currentCamera, engineMeta, ready, setCurrentCamera, viewerProperty } =
     useHooks({ visualizerRef });
 
@@ -25,6 +35,8 @@ const Viewer: FC<Props> = ({ layers, widgets, visualizerRef }) => {
       currentCamera={currentCamera}
       onCameraChange={setCurrentCamera}
       widgets={widgets}
+      story={story}
+      showStoryPanel={showStoryPanel}
     />
   );
 };

--- a/web/src/beta/features/PluginPlayground/hooks.tsx
+++ b/web/src/beta/features/PluginPlayground/hooks.tsx
@@ -37,7 +37,9 @@ export default () => {
   const [infoboxEnabled, setInfoboxEnabled] = useState(true);
   const [selectedLayerId, setSelectedLayerId] = useState("");
   const [showStoryPanel, setShowStoryPanel] = useState(false);
-  const [visibleLayerIds, setVisibleLayerIds] = useState<string[]>(["1", "2"]); // Note: the layerIds in web/src/beta/features/PluginPlayground/LayerList/constants.ts
+  const [visibleLayerIds, setVisibleLayerIds] = useState<string[]>(
+    DEFAULT_LAYERS_PLUGIN_PLAYGROUND.map((l) => l.id)
+  );
 
   const layers = useMemo(() => {
     return DEFAULT_LAYERS_PLUGIN_PLAYGROUND.map((layer) => {

--- a/web/src/beta/features/PluginPlayground/hooks.tsx
+++ b/web/src/beta/features/PluginPlayground/hooks.tsx
@@ -30,15 +30,14 @@ export default () => {
     sharedPlugin
   } = usePlugins();
 
-  const { infoboxBlocks, widgets, executeCode } = useCode({
+  const { executeCode, infoboxBlocks, story, widgets } = useCode({
     files: selectedPlugin.files
   });
 
-  const [selectedLayerId, setSelectedLayerId] = useState("");
-  const [visibleLayerIds, setVisibleLayerIds] = useState<string[]>(
-    DEFAULT_LAYERS_PLUGIN_PLAYGROUND.map((l) => l.id)
-  );
   const [infoboxEnabled, setInfoboxEnabled] = useState(true);
+  const [selectedLayerId, setSelectedLayerId] = useState("");
+  const [showStoryPanel, setShowStoryPanel] = useState(false);
+  const [visibleLayerIds, setVisibleLayerIds] = useState<string[]>(["1", "2"]); // Note: the layerIds in web/src/beta/features/PluginPlayground/LayerList/constants.ts
 
   const layers = useMemo(() => {
     return DEFAULT_LAYERS_PLUGIN_PLAYGROUND.map((layer) => {
@@ -82,13 +81,15 @@ export default () => {
         children: (
           <Viewer
             layers={layers}
-            widgets={widgets}
+            story={story}
+            showStoryPanel={showStoryPanel}
             visualizerRef={visualizerRef}
+            widgets={widgets}
           />
         )
       }
     ],
-    [layers, widgets]
+    [layers, showStoryPanel, story, widgets]
   );
 
   const LayersPanel: FC = () => (
@@ -167,6 +168,8 @@ export default () => {
     <SettingsList
       infoboxEnabled={infoboxEnabled}
       setInfoboxEnabled={setInfoboxEnabled}
+      setShowStoryPanel={setShowStoryPanel}
+      showStoryPanel={showStoryPanel}
     />
   );
 


### PR DESCRIPTION
# Overview
Added functionality to display story panel in plugin-playground. The story panel displays the html from the `demo-story.js` file. The story panel displays after the plugin is executed ( clicking the button to run the plugin ) and checking the checkbox to enable the story panel.
## What I've done
<img width="1279" alt="Screenshot 2025-01-16 at 9 19 53 AM" src="https://github.com/user-attachments/assets/eb0caaf2-2117-4067-a570-7ae0a4cd116d" />

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced story block functionality in the Plugin Playground.
  - Added ability to toggle story panel visibility.
  - Implemented story data management within the application.

- **Improvements**
  - Enhanced plugin configuration to support story blocks.
  - Updated UI components to handle story-related interactions.

- **User Interface**
  - New checkbox added to control story panel display.
  - Story panel can now be enabled/disabled through settings.

The release adds a new story feature with improved customization and interaction capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->