### PR TITLE
refactor(web): update plugin playground preset plugin list

### DIFF
--- a/web/src/beta/features/PluginPlayground/Plugins/index.tsx
+++ b/web/src/beta/features/PluginPlayground/Plugins/index.tsx
@@ -1,4 +1,4 @@
-import { Collapse, IconButton } from "@reearth/beta/lib/reearth-ui";
+import { Collapse, IconButton, Typography } from "@reearth/beta/lib/reearth-ui";
 import { EntryItem } from "@reearth/beta/ui/components";
 import { styled } from "@reearth/services/styled";
 import { FC, useState } from "react";
@@ -40,15 +40,10 @@ const Plugins: FC<Props> = ({
 }) => {
   const [isAddingNewFile, setIsAddingNewFile] = useState(false);
 
-  const handleShareIconClicked = (): void => {
+  const handlePluginShare = (): void => {
     if (!selectedPlugin) return;
     encodeAndSharePlugin(selectedPlugin.id);
   };
-
-  const customPlugin = presetPlugins.find((plugin) => plugin.id === "custom");
-  const pluginsWithoutCustom = presetPlugins.filter(
-    (plugin) => plugin.id !== "custom"
-  );
 
   const PluginEntryItem: FC<{
     plugin: { id: string; title: string };
@@ -85,53 +80,62 @@ const Plugins: FC<Props> = ({
         <IconButton
           appearance="simple"
           icon="paperPlaneTilt"
-          onClick={handleShareIconClicked}
+          onClick={handlePluginShare}
         />
       </IconList>
       <PluginListWrapper>
         <PluginList>
-          {customPlugin && (
+          {sharedPlugin && (
             <div>
-              {customPlugin.plugins.map((plugin) => (
-                <PluginEntryItem
-                  plugin={plugin}
-                  key={plugin.id}
-                  selectedPluginId={selectedPlugin.id}
-                  onSelect={selectPlugin}
-                />
-              ))}
-            </div>
-          )}
-          {pluginsWithoutCustom.map((category) => (
-            <PresetPluginWrapper key={category.id}>
               <Collapse
-                collapsed
+                key={"shared"}
                 iconPosition="left"
                 size="small"
-                title={category.title}
+                title={"Shared"}
+                noPadding
               >
-                {category.plugins.map((plugin) => (
+                <PluginSubList>
                   <PluginEntryItem
-                    plugin={plugin}
-                    key={plugin.id}
+                    plugin={sharedPlugin}
+                    key={sharedPlugin.id}
                     selectedPluginId={selectedPlugin.id}
                     onSelect={selectPlugin}
                   />
-                ))}
+                </PluginSubList>
               </Collapse>
-            </PresetPluginWrapper>
+            </div>
+          )}
+          {presetPlugins.map((category) => (
+            <div key={category.id}>
+              <Collapse
+                key={category.id}
+                collapsed={category.id !== "custom"}
+                iconPosition="left"
+                size="small"
+                title={category.title}
+                noPadding
+              >
+                <PluginSubList>
+                  {category.plugins.length > 0 ? (
+                    category.plugins.map((plugin) => (
+                      <PluginEntryItem
+                        plugin={plugin}
+                        key={plugin.id}
+                        selectedPluginId={selectedPlugin.id}
+                        onSelect={selectPlugin}
+                      />
+                    ))
+                  ) : (
+                    <EmptyTip>
+                      <Typography size="body" color="weak" trait="italic">
+                        No plugins
+                      </Typography>
+                    </EmptyTip>
+                  )}
+                </PluginSubList>
+              </Collapse>
+            </div>
           ))}
-          <div>
-            <CategoryTitle>Shared</CategoryTitle>
-            {sharedPlugin && (
-              <PluginEntryItem
-                plugin={sharedPlugin}
-                key={sharedPlugin.id}
-                selectedPluginId={selectedPlugin.id}
-                onSelect={selectPlugin}
-              />
-            )}
-          </div>
         </PluginList>
         <FileListWrapper>
           <FileList>
@@ -173,19 +177,28 @@ const Wrapper = styled("div")(() => ({
 const PluginList = styled("div")(({ theme }) => ({
   width: "50%",
   paddingRight: theme.spacing.small,
+
   display: "flex",
   flexDirection: "column",
-  gap: theme.spacing.small
+  gap: theme.spacing.smallest
 }));
 
-const PluginListWrapper = styled("div")(() => ({
+const PluginListWrapper = styled("div")(({ theme }) => ({
   display: "flex",
-  height: "100%"
+  height: "100%",
+  marginLeft: -theme.spacing.smallest
 }));
 
-const CategoryTitle = styled("div")(({ theme }) => ({
-  padding: `${theme.spacing.smallest}px 0`,
-  fontSize: theme.fonts.sizes.body
+const PluginSubList = styled("div")(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  gap: theme.spacing.smallest,
+  paddingLeft: 24
+}));
+
+const EmptyTip = styled("div")(({ theme }) => ({
+  padding: theme.spacing.smallest,
+  paddingLeft: theme.spacing.small
 }));
 
 const FileListWrapper = styled("div")(({ theme }) => ({
@@ -208,10 +221,6 @@ const IconList = styled("div")(({ theme }) => ({
   alignItems: "center",
   gap: theme.spacing.small,
   marginBottom: theme.spacing.small
-}));
-
-const PresetPluginWrapper = styled("div")(({ theme }) => ({
-  marginLeft: -theme.spacing.normal
 }));
 
 export default Plugins;

--- a/web/src/beta/features/PluginPlayground/Plugins/index.tsx
+++ b/web/src/beta/features/PluginPlayground/Plugins/index.tsx
@@ -177,7 +177,6 @@ const Wrapper = styled("div")(() => ({
 const PluginList = styled("div")(({ theme }) => ({
   width: "50%",
   paddingRight: theme.spacing.small,
-
   display: "flex",
   flexDirection: "column",
   gap: theme.spacing.smallest
@@ -193,7 +192,8 @@ const PluginSubList = styled("div")(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
   gap: theme.spacing.smallest,
-  paddingLeft: 24
+  paddingLeft: 24,
+  paddingTop: theme.spacing.smallest
 }));
 
 const EmptyTip = styled("div")(({ theme }) => ({

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
@@ -24,11 +24,47 @@ export const presetPlugins: PresetPlugins = [
   {
     id: "ui",
     title: "User Interface",
-    plugins: [responsivePanel, sidebar, header, uiExtensionMessenger]
+    plugins: [responsivePanel, sidebar, header]
+  },
+  {
+    id: "communication",
+    title: "Communication",
+    plugins: [uiExtensionMessenger]
+  },
+  {
+    id: "viewerScene",
+    title: "Viewer & Scene Settings",
+    plugins: []
   },
   {
     id: "layers",
-    title: "Layers",
+    title: "Manage Layer",
     plugins: [addGeojson]
+  },
+  {
+    id: "layerStyles",
+    title: "Manage Layer Style",
+    plugins: []
+  },
+
+  {
+    id: "camera",
+    title: "Camera",
+    plugins: []
+  },
+  {
+    id: "timeline",
+    title: "Timeline",
+    plugins: []
+  },
+  {
+    id: "dataStorage",
+    title: "Data Storage",
+    plugins: []
+  },
+  {
+    id: "sketch",
+    title: "Sketch",
+    plugins: []
   }
 ];

--- a/web/src/beta/features/PluginPlayground/Plugins/usePlugins.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/usePlugins.ts
@@ -27,7 +27,11 @@ export default () => {
   const sharedPlugin = sharedPluginUrl
     ? (() => {
         try {
-          return decodePluginURL(sharedPluginUrl);
+          const decoded = decodePluginURL(sharedPluginUrl);
+          return {
+            ...decoded,
+            id: `shared-${decoded.id}`
+          };
         } catch (_error) {
           setNotification({ type: "error", text: "Invalid shared plugin URL" });
           return null;
@@ -63,6 +67,7 @@ export default () => {
 
   const selectPlugin = useCallback((pluginId: string) => {
     setSelectedPluginId(pluginId);
+    setSelectedFileId("");
   }, []);
 
   const selectFile = useCallback((fileId: string) => {


### PR DESCRIPTION
# Overview

This PR:
- Added the preset categories.
- Updated the styles on preset plugin list
- Simplified the logic around showing custom plugin & shared plugin, now they have the same appearence in list compare with other preset plugins
- Reorder the shared plugin at the top, since once user is visiting a shared link, the shared one is the most important.
- Fix the shared plugin id issue since it could be duplicate with preset ones.
- Fix the logic of select file, when select plugin the selected file should be reset.

![image](https://github.com/user-attachments/assets/96779236-f623-42b9-9b70-e9624e757ac5)


## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced plugin management with new plugin categories
  - Improved shared plugin handling and display

- **Bug Fixes**
  - Reset file selection when switching plugins
  - Improved handling of shared plugin URL decoding

- **Style**
  - Updated plugin list layout and styling
  - Added empty state messaging for plugin categories

- **Chores**
  - Renamed plugin-related methods for clarity
  - Streamlined plugin rendering logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->