### PR TITLE
ci: remove GCS upload for nightly releases

### DIFF
--- a/.github/workflows/deploy_server_nightly.yml
+++ b/.github/workflows/deploy_server_nightly.yml
@@ -6,20 +6,17 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 env:
+  GCP_REGION: asia-northeast1
   IMAGE: reearth/reearth-visualizer-api:nightly
   IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-visualizer-api:nightly
-  GCP_REGION: asia-northeast1
 jobs:
   deploy_test:
-    name: Deploy app to test env
     runs-on: ubuntu-latest
     if: github.event.repository.full_name == 'reearth/reearth-visualizer'
     steps:
       - uses: google-github-actions/auth@v0
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
       - name: Configure docker
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
       - name: docker push

--- a/.github/workflows/deploy_web_nightly.yml
+++ b/.github/workflows/deploy_web_nightly.yml
@@ -2,35 +2,14 @@ name: deploy-web-nightly
 on:
   workflow_dispatch:
   workflow_call:
-
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 env:
-  REEARTH_URL: visualizer.test.reearth.dev
   GCP_REGION: us-central1
-  GCS_DEST: gs://reearth-visualizer-oss-static-bucket/
-
   IMAGE: reearth/reearth-visualizer-web:nightly
   IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-visualizer-web:nightly
-
 jobs:
-  # TODO: Remove later after migrating to Cloud Run
-  deploy_test_old:
-    runs-on: ubuntu-latest
-    if: github.event.repository.full_name == 'reearth/reearth-visualizer'
-    steps:
-      - uses: google-github-actions/auth@v0
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
-      - uses: dsaltares/fetch-gh-release-asset@master
-        with:
-          version: tags/nightly
-          file: reearth-web_nightly.tar.gz
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - run: tar -xvf reearth-web_nightly.tar.gz
-      - name: rsync
-        run: gsutil -m -h "Cache-Control:no-store" rsync -x "^reearth_config\\.json$|^cesium_ion_token\\.txt$" -dr reearth-web/ $GCS_DEST
-
   deploy_test:
     runs-on: ubuntu-latest
     if: github.event.repository.full_name == 'reearth/reearth-visualizer'
@@ -38,8 +17,6 @@ jobs:
       - uses: google-github-actions/auth@v0
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
       - name: Configure docker
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
       - name: docker push


### PR DESCRIPTION
# Overview

Remove the decommisioned job that uploads the artifacts to GCS.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Workflow Updates**
	- Added concurrency control to web deployment workflow
	- Removed `REEARTH_URL` and `GCS_DEST` environment variables
	- Simplified deployment process for server and web applications
	- Removed Cloud SDK setup steps in deployment workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->