### PR TITLE
feat(web): update story custom domain extension

### DIFF
--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
@@ -5,6 +5,10 @@ import { AssetField, InputField, SwitchField } from "@reearth/beta/ui/fields";
 import TextAreaField from "@reearth/beta/ui/fields/TextareaField";
 import { Story } from "@reearth/services/api/storytellingApi/utils";
 import { useAuth } from "@reearth/services/auth";
+import {
+  ProjectPublicationExtensionProps,
+  StoryPublicationExtensionProps
+} from "@reearth/services/config/extensions";
 import { useLang, useT } from "@reearth/services/i18n";
 import {
   NotificationType,
@@ -103,6 +107,18 @@ const PublicSettingsDetail: React.FC<Props> = ({
     },
     [setNotification]
   );
+
+  const ExtensionComponent = (
+    props: ProjectPublicationExtensionProps | StoryPublicationExtensionProps
+  ) => {
+    const type = props.typename.toLocaleLowerCase();
+    const extensionId = `custom-${type}-domain`;
+    const Component = extensions?.find((e) => e.id === extensionId)?.component;
+    if (!Component) {
+      return null;
+    }
+    return <Component {...props} />;
+  };
 
   return (
     <>
@@ -233,22 +249,39 @@ const PublicSettingsDetail: React.FC<Props> = ({
           </ButtonWrapper>
         </SettingsFields>
       </Collapse>
-      {extensions && extensions.length > 0 && accessToken && (
-        <Collapse title={t("Custom Domain")} size="large">
-          {extensions.map((ext) => (
-            <ext.component
-              key={ext.id}
-              projectId={settingsItem.id}
-              projectAlias={settingsItem.alias}
-              lang={currentLang}
-              theme={currentTheme}
-              accessToken={accessToken}
-              onNotificationChange={onNotificationChange}
-              version={"visualizer"}
-            />
-          ))}
-        </Collapse>
-      )}
+      {extensions &&
+        extensions.length > 0 &&
+        settingsItem.__typename &&
+        accessToken && (
+          <Collapse title={t("Custom Domain")} size="large">
+            {settingsItem.__typename === "Project" && (
+              <ExtensionComponent
+                typename={settingsItem.__typename}
+                key={settingsItem.id}
+                projectId={settingsItem.id}
+                projectAlias={settingsItem.alias}
+                lang={currentLang}
+                theme={currentTheme}
+                accessToken={accessToken}
+                onNotificationChange={() => onNotificationChange}
+                version={"visualizer"}
+              />
+            )}
+            {settingsItem.__typename === "Story" && (
+              <ExtensionComponent
+                typename={settingsItem.__typename}
+                key={settingsItem.id}
+                storyId={settingsItem.id}
+                storyAlias={settingsItem.alias}
+                lang={currentLang}
+                theme={currentTheme}
+                accessToken={accessToken}
+                onNotificationChange={() => onNotificationChange}
+                version={"visualizer"}
+              />
+            )}
+          </Collapse>
+        )}
     </>
   );
 };

--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
@@ -254,32 +254,24 @@ const PublicSettingsDetail: React.FC<Props> = ({
         settingsItem.__typename &&
         accessToken && (
           <Collapse title={t("Custom Domain")} size="large">
-            {settingsItem.__typename === "Project" && (
-              <ExtensionComponent
-                typename={settingsItem.__typename}
-                key={settingsItem.id}
-                projectId={settingsItem.id}
-                projectAlias={settingsItem.alias}
-                lang={currentLang}
-                theme={currentTheme}
-                accessToken={accessToken}
-                onNotificationChange={() => onNotificationChange}
-                version={"visualizer"}
-              />
-            )}
-            {settingsItem.__typename === "Story" && (
-              <ExtensionComponent
-                typename={settingsItem.__typename}
-                key={settingsItem.id}
-                storyId={settingsItem.id}
-                storyAlias={settingsItem.alias}
-                lang={currentLang}
-                theme={currentTheme}
-                accessToken={accessToken}
-                onNotificationChange={() => onNotificationChange}
-                version={"visualizer"}
-              />
-            )}
+            <ExtensionComponent
+              typename={settingsItem.__typename}
+              key={settingsItem.id}
+              {...(settingsItem.__typename === "Project"
+                ? {
+                    projectId: settingsItem.id,
+                    projectAlias: settingsItem.alias
+                  }
+                : {
+                    storyId: settingsItem.id,
+                    storyAlias: settingsItem.alias
+                  })}
+              lang={currentLang}
+              theme={currentTheme}
+              accessToken={accessToken}
+              onNotificationChange={onNotificationChange}
+              version="visualizer"
+            />
           </Collapse>
         )}
     </>

--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
@@ -251,13 +251,13 @@ const PublicSettingsDetail: React.FC<Props> = ({
       </Collapse>
       {extensions &&
         extensions.length > 0 &&
-        settingsItem.__typename &&
+        settingsItem.typename &&
         accessToken && (
           <Collapse title={t("Custom Domain")} size="large">
             <ExtensionComponent
-              typename={settingsItem.__typename}
+              typename={settingsItem.typename}
               key={settingsItem.id}
-              {...(settingsItem.__typename === "Project"
+              {...(settingsItem.typename === "Project"
                 ? {
                     projectId: settingsItem.id,
                     projectAlias: settingsItem.alias

--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
@@ -52,6 +52,7 @@ export type SettingsProject = {
   isArchived: boolean;
   enableGa: boolean;
   trackingId: string;
+  __typename: string;
 };
 
 type Props = {

--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
@@ -52,7 +52,7 @@ export type SettingsProject = {
   isArchived: boolean;
   enableGa: boolean;
   trackingId: string;
-  __typename: string;
+  __typename?: string;
 };
 
 type Props = {

--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
@@ -52,7 +52,7 @@ export type SettingsProject = {
   isArchived: boolean;
   enableGa: boolean;
   trackingId: string;
-  __typename?: string;
+  typename?: "Project";
 };
 
 type Props = {

--- a/web/src/services/api/storytellingApi/utils.ts
+++ b/web/src/services/api/storytellingApi/utils.ts
@@ -43,7 +43,7 @@ export type Story = {
   pages?: Page[];
   trackingId?: string; // Not supported yet
   enableGa?: boolean; // Not supported yet
-  __typename: string;
+  typename?: "Story";
 };
 
 export const getStories = (rawScene?: GetSceneQuery) => {

--- a/web/src/services/api/storytellingApi/utils.ts
+++ b/web/src/services/api/storytellingApi/utils.ts
@@ -43,6 +43,7 @@ export type Story = {
   pages?: Page[];
   trackingId?: string; // Not supported yet
   enableGa?: boolean; // Not supported yet
+  __typename: string;
 };
 
 export const getStories = (rawScene?: GetSceneQuery) => {

--- a/web/src/services/config/extensions.ts
+++ b/web/src/services/config/extensions.ts
@@ -29,6 +29,14 @@ export type ProjectPublicationExtensionProps = {
   projectId: string;
   projectAlias?: string;
   publishDisabled?: boolean;
+  typename: string;
+} & SharedExtensionProps;
+
+export type StoryPublicationExtensionProps = {
+  storyId: string;
+  storyAlias?: string;
+  publishDisabled?: boolean;
+  typename: string;
 } & SharedExtensionProps;
 
 export type PluginExtensionProps = {
@@ -50,7 +58,9 @@ export type GlobalModalProps = {
 
 export type ExtensionProps = {
   "dataset-import": DatasetImportExtensionProps;
-  publication: ProjectPublicationExtensionProps;
+  publication:
+    | ProjectPublicationExtensionProps
+    | StoryPublicationExtensionProps;
   "plugin-library": PluginExtensionProps;
   "plugin-installed": PluginExtensionProps;
   "global-modal": GlobalModalProps;


### PR DESCRIPTION
# Overview
Added custom domain for stories.

## What I've done
I have added a new extension to reearth-cloud.js.
https://github.com/eukarya-inc/reearth-cloud/pull/95/files#diff-a4fc01cb110b1ca5c89a7624b5c8a4a455f52bd40eddfc554632625665b61ae4

As a result, it is necessary to update the extension of reearth-visualizer:
```diff
{
  type: "publication",
-  id: "custom-domain",
+  id: "custom-project-domain",
  component: CustomDomainSection,
},
+{
+  type: "publication",
+  id: "custom-story-domain",
+  component: CustomStoryDomainSection,
+},
```
Currently, both use the custom-domain extension, but I have modified it so that the custom-story-domain is used for stories.
## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced support for project and story type extensions in publication settings.
  - Improved type-specific rendering of extension components.

- **Improvements**
  - Added `typename` property to support more precise type identification.
  - Refined conditional rendering logic for publication settings.
  - Increased flexibility in handling different types of publication extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->