### PR TITLE
feat(web): reset visualizer when plugin is executed

### DIFF
--- a/web/src/beta/features/PluginPlayground/Code/hook.ts
+++ b/web/src/beta/features/PluginPlayground/Code/hook.ts
@@ -43,6 +43,7 @@ type CustomStoryBlock = CustomInfoboxBlock;
 
 type Props = {
   files: FileType[];
+  resetVisualizer: () => void;
 };
 
 const getYmlJson = (file: FileType) => {
@@ -62,13 +63,14 @@ const getYmlJson = (file: FileType) => {
   }
 };
 
-export default ({ files }: Props) => {
+export default ({ files, resetVisualizer }: Props) => {
   const [infoboxBlocks, setInfoboxBlocks] = useState<CustomInfoboxBlock[]>();
   const [story, setStory] = useState<Story>();
   const [widgets, setWidgets] = useState<Widgets>();
   const [, setNotification] = useNotification();
 
   const executeCode = useCallback(() => {
+    resetVisualizer();
     const ymlFile = files.find((file) => file.title.endsWith(".yml"));
 
     if (!ymlFile) return;
@@ -199,7 +201,7 @@ export default ({ files }: Props) => {
         }
       ]
     });
-  }, [files, setNotification]);
+  }, [files, resetVisualizer, setNotification]);
 
   return {
     executeCode,

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
@@ -1,11 +1,11 @@
 import { PluginType } from "../constants";
 
 import { myPlugin } from "./custom/myPlugin";
-import { addGeojson } from "./layers/add-geojson";
-import { addCzml } from "./layers/add-czml";
-import { addKml } from "./layers/add-kml";
-import { addCsv } from "./layers/add-csv";
 import { add3dTiles } from "./layers/add-3Dtiles";
+import { addCsv } from "./layers/add-csv";
+import { addCzml } from "./layers/add-czml";
+import { addGeojson } from "./layers/add-geojson";
+import { addKml } from "./layers/add-kml";
 import { addOsm3dTiles } from "./layers/add-OSM-3DTiles";
 import { addWms } from "./layers/add-wms";
 import { header } from "./ui/header";

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/layers/add-geojson.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/layers/add-geojson.ts
@@ -74,7 +74,7 @@ const layerGeojsonInline = {
   marker: {},
 };
 
-// Difine the GeoJSON with URL
+// Define the GeoJSON with URL
 const layerGeojsonFromUrl = {
   type: "simple",
   data: {

--- a/web/src/beta/features/PluginPlayground/Viewer/hooks.ts
+++ b/web/src/beta/features/PluginPlayground/Viewer/hooks.ts
@@ -10,14 +10,22 @@ import {
 } from "react";
 
 export default ({
-  visualizerRef
+  visualizerRef,
+  enabledVisualizer
 }: {
   visualizerRef: MutableRefObject<MapRef | null>;
+  enabledVisualizer: boolean;
 }) => {
   const [ready, setReady] = useState(false);
   const [currentCamera, setCurrentCamera] = useState<Camera | undefined>(
     undefined
   );
+
+  useEffect(() => {
+    if (!enabledVisualizer) {
+      setCurrentCamera(undefined);
+    }
+  }, [enabledVisualizer]);
 
   const handleIsVisualizerUpdate = useCallback(
     (value: boolean) => setReady(value),

--- a/web/src/beta/features/PluginPlayground/Viewer/index.tsx
+++ b/web/src/beta/features/PluginPlayground/Viewer/index.tsx
@@ -7,6 +7,7 @@ import { Story } from "../../Visualizer/Crust/StoryPanel";
 import useHooks from "./hooks";
 
 type Props = {
+  enabledVisualizer: boolean;
   layers: Layer[];
   showStoryPanel: boolean;
   story: Story | undefined;
@@ -15,6 +16,7 @@ type Props = {
 };
 
 const Viewer: FC<Props> = ({
+  enabledVisualizer,
   layers,
   showStoryPanel,
   story,
@@ -25,19 +27,21 @@ const Viewer: FC<Props> = ({
     useHooks({ visualizerRef });
 
   return (
-    <Visualizer
-      engine="cesium"
-      visualizerRef={visualizerRef}
-      viewerProperty={viewerProperty}
-      ready={ready}
-      layers={layers}
-      engineMeta={engineMeta}
-      currentCamera={currentCamera}
-      onCameraChange={setCurrentCamera}
-      widgets={widgets}
-      story={story}
-      showStoryPanel={showStoryPanel}
-    />
+    enabledVisualizer && (
+      <Visualizer
+        engine="cesium"
+        visualizerRef={visualizerRef}
+        viewerProperty={viewerProperty}
+        ready={ready}
+        layers={layers}
+        engineMeta={engineMeta}
+        currentCamera={currentCamera}
+        onCameraChange={setCurrentCamera}
+        widgets={widgets}
+        story={story}
+        showStoryPanel={showStoryPanel}
+      />
+    )
   );
 };
 

--- a/web/src/beta/features/PluginPlayground/Viewer/index.tsx
+++ b/web/src/beta/features/PluginPlayground/Viewer/index.tsx
@@ -24,7 +24,7 @@ const Viewer: FC<Props> = ({
   widgets
 }) => {
   const { currentCamera, engineMeta, ready, setCurrentCamera, viewerProperty } =
-    useHooks({ visualizerRef });
+    useHooks({ visualizerRef, enabledVisualizer });
 
   return (
     enabledVisualizer && (

--- a/web/src/beta/features/PluginPlayground/hooks.tsx
+++ b/web/src/beta/features/PluginPlayground/hooks.tsx
@@ -18,10 +18,11 @@ export default () => {
 
   // NOTE: This to reset the Visualizer component when selecting a new plugin and triggered when `executeCode` is called.
   const resetVisualizer = useCallback(() => {
-    setTimeout(() => {
-      setEnabledVisualizer(true);
-    }, 300);
     setEnabledVisualizer(false);
+    const timeoutId = setTimeout(() => {
+      setEnabledVisualizer(true);
+    }, 0);
+    return () => clearTimeout(timeoutId);
   }, []);
 
   const {

--- a/web/src/beta/features/PluginPlayground/hooks.tsx
+++ b/web/src/beta/features/PluginPlayground/hooks.tsx
@@ -1,6 +1,6 @@
 import { TabItem } from "@reearth/beta/lib/reearth-ui";
 import { MapRef } from "@reearth/core";
-import { FC, useMemo, useRef, useState } from "react";
+import { FC, useCallback, useMemo, useRef, useState } from "react";
 
 import Code from "./Code";
 import useCode from "./Code/hook";
@@ -13,6 +13,16 @@ import Viewer from "./Viewer";
 
 export default () => {
   const visualizerRef = useRef<MapRef | null>(null);
+
+  const [enabledVisualizer, setEnabledVisualizer] = useState(true);
+
+  // NOTE: This to reset the Visualizer component when selecting a new plugin and triggered when `executeCode` is called.
+  const resetVisualizer = useCallback(() => {
+    setTimeout(() => {
+      setEnabledVisualizer(true);
+    }, 300);
+    setEnabledVisualizer(false);
+  }, []);
 
   const {
     presetPlugins,
@@ -31,7 +41,8 @@ export default () => {
   } = usePlugins();
 
   const { executeCode, infoboxBlocks, story, widgets } = useCode({
-    files: selectedPlugin.files
+    files: selectedPlugin.files,
+    resetVisualizer
   });
 
   const [infoboxEnabled, setInfoboxEnabled] = useState(true);
@@ -82,6 +93,7 @@ export default () => {
         name: "Viewer",
         children: (
           <Viewer
+            enabledVisualizer={enabledVisualizer}
             layers={layers}
             story={story}
             showStoryPanel={showStoryPanel}
@@ -91,7 +103,7 @@ export default () => {
         )
       }
     ],
-    [layers, showStoryPanel, story, widgets]
+    [enabledVisualizer, layers, showStoryPanel, story, widgets]
   );
 
   const LayersPanel: FC = () => (


### PR DESCRIPTION
# Overview
Added a solution to reset the plugin before it is executed. This helps clear any previous layers or widgets added before another plugin is executed or ran whilst maintaining the state of the checkboxes for infobox and story-panel in the settings panel.
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a visualizer reset functionality.
	- Enhanced plugin management with new layer types (CSV, 3D Tiles).

- **Bug Fixes**
	- Corrected a typo in a GeoJSON comment.

- **Improvements**
	- Implemented conditional rendering for the visualizer.
	- Added more flexible control over the visualizer state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->