### PR TITLE
fix(web): custom domain form

### DIFF
--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
@@ -28,12 +28,26 @@ import {
   SettingsProject
 } from ".";
 
+interface WithTypename {
+  __typename?: string;
+}
+
+type SettingsProjectWithTypename = SettingsProject & WithTypename;
+type StoryWithTypename = Story & WithTypename;
+
 type Props = {
-  settingsItem: SettingsProject | Story;
+  settingsItem: SettingsProjectWithTypename | StoryWithTypename;
   onUpdate: (settings: PublicSettingsType) => void;
   onUpdateBasicAuth: (settings: PublicBasicAuthSettingsType) => void;
   onUpdateAlias: (settings: PublicAliasSettingsType) => void;
   onUpdateGA?: (settings: PublicGASettingsType) => void;
+};
+
+type ExtensionComponentProps = (
+  | ProjectPublicationExtensionProps
+  | StoryPublicationExtensionProps
+) & {
+  typename: string;
 };
 
 const PublicSettingsDetail: React.FC<Props> = ({
@@ -108,9 +122,7 @@ const PublicSettingsDetail: React.FC<Props> = ({
     [setNotification]
   );
 
-  const ExtensionComponent = (
-    props: ProjectPublicationExtensionProps | StoryPublicationExtensionProps
-  ) => {
+  const ExtensionComponent = (props: ExtensionComponentProps) => {
     const type = props.typename.toLocaleLowerCase();
     const extensionId = `custom-${type}-domain`;
     const Component = extensions?.find((e) => e.id === extensionId)?.component;
@@ -249,31 +261,27 @@ const PublicSettingsDetail: React.FC<Props> = ({
           </ButtonWrapper>
         </SettingsFields>
       </Collapse>
-      {extensions &&
-        extensions.length > 0 &&
-        settingsItem.typename &&
-        accessToken && (
-          <Collapse title={t("Custom Domain")} size="large">
-            <ExtensionComponent
-              typename={settingsItem.typename}
-              key={settingsItem.id}
-              {...(settingsItem.typename === "Project"
-                ? {
-                    projectId: settingsItem.id,
-                    projectAlias: settingsItem.alias
-                  }
-                : {
-                    storyId: settingsItem.id,
-                    storyAlias: settingsItem.alias
-                  })}
-              lang={currentLang}
-              theme={currentTheme}
-              accessToken={accessToken}
-              onNotificationChange={onNotificationChange}
-              version="visualizer"
-            />
-          </Collapse>
-        )}
+      {extensions && extensions.length > 0 && accessToken && (
+        <Collapse title={t("Custom Domain")} size="large">
+          <ExtensionComponent
+            typename={settingsItem.__typename || ""}
+            {...(settingsItem.__typename === "Project"
+              ? {
+                  projectId: settingsItem.id,
+                  projectAlias: settingsItem.alias
+                }
+              : {
+                  storyId: settingsItem.id,
+                  storyAlias: settingsItem.alias
+                })}
+            lang={currentLang}
+            theme={currentTheme}
+            accessToken={accessToken}
+            onNotificationChange={onNotificationChange}
+            version="visualizer"
+          />
+        </Collapse>
+      )}
     </>
   );
 };

--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
@@ -52,7 +52,6 @@ export type SettingsProject = {
   isArchived: boolean;
   enableGa: boolean;
   trackingId: string;
-  typename?: "Project";
 };
 
 type Props = {

--- a/web/src/services/api/storytellingApi/utils.ts
+++ b/web/src/services/api/storytellingApi/utils.ts
@@ -43,7 +43,6 @@ export type Story = {
   pages?: Page[];
   trackingId?: string; // Not supported yet
   enableGa?: boolean; // Not supported yet
-  typename?: "Story";
 };
 
 export const getStories = (rawScene?: GetSceneQuery) => {

--- a/web/src/services/config/extensions.ts
+++ b/web/src/services/config/extensions.ts
@@ -29,14 +29,12 @@ export type ProjectPublicationExtensionProps = {
   projectId: string;
   projectAlias?: string;
   publishDisabled?: boolean;
-  typename: string;
 } & SharedExtensionProps;
 
 export type StoryPublicationExtensionProps = {
   storyId: string;
   storyAlias?: string;
   publishDisabled?: boolean;
-  typename: string;
 } & SharedExtensionProps;
 
 export type PluginExtensionProps = {


### PR DESCRIPTION
# Overview

Fixes an issue where custom domain extension components were not loading correctly.

## What I've done
The `typename` referenced in the separation of Project and Story was not being recognized correctly.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed optional `typename` properties from multiple type definitions across different files
	- Updated `PublicSettingsDetail` component with new function prop for Google Analytics settings

- **Chores**
	- Simplified type structures in project settings and API-related files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->