### PR TITLE
feat(web): add example of show selected feature information in plugin playground

### DIFF
--- a/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
@@ -10,6 +10,7 @@ import { addOsm3dTiles } from "./layers/add-OSM-3DTiles";
 import { addGooglePhotorealistic3dTiles } from "./layers/add-google-photorealistic-3d-tiles";
 import { addWms } from "./layers/add-wms";
 import { hideFlyToDeleteLayer } from "./layers/hideFlyToDeleteLayer";
+import { showFeaturesInfo } from "./layers/showSelectedFeaturesInformation";
 import { header } from "./ui/header";
 import { responsivePanel } from "./ui/responsivePanel";
 import { sidebar } from "./ui/sidebar";
@@ -56,7 +57,8 @@ export const presetPlugins: PresetPlugins = [
       addOsm3dTiles,
       addWms,
       addGooglePhotorealistic3dTiles,
-      hideFlyToDeleteLayer
+      hideFlyToDeleteLayer,
+      showFeaturesInfo
     ]
   },
   {

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
@@ -25,32 +25,17 @@ extensions:
 const widgetFile: FileType = {
   id: "show-features-info",
   title: "show-features-info.js",
-  sourceCode: `const infoboxLayer = {
-  type: "simple",
-  data: {
-    type: "csv",
-    url: "https://reearth.github.io/visualizer-plugin-sample-data/public/csv/marker.csv",
-    csv: {
-      latColumn: "latitude",
-      lngColumn: "longitude",
-    },
-  },
-  marker: {},
-  infobox: {
-    default: {
-      id: "block-text-1",
-      pluginId:"show-features-info",
-      extensionId: "show-features-info-plugin",
-      extensionType: "infoboxBlock",
-      property: {
-        default: "test",
-      },
-    },
-  },
-};
-
-reearth.layers.add(infoboxLayer);
-`
+  sourceCode: `reearth.ui.show(\`
+  ${PRESET_PLUGIN_COMMON_STYLE}
+  <style>
+  </style>
+    <div id="wrapper">
+      <h3>Click to show Building ID</h3>
+      <div class="coordinates">
+        <p>Building ID: <span id="lat" class="coordinate-value">-</span></p>
+      </div>
+    </div>
+  \`); `
 };
 
 export const showFeaturesInfo: PluginType = {

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
@@ -25,7 +25,8 @@ extensions:
 const widgetFile: FileType = {
   id: "show-features-info",
   title: "show-features-info.js",
-  sourceCode: `reearth.ui.show(\`
+  sourceCode: `// Configure the UI side of the Plug-in
+  reearth.ui.show(\`
   ${PRESET_PLUGIN_COMMON_STYLE}
   <style>
   .displayId {
@@ -39,14 +40,13 @@ const widgetFile: FileType = {
       box-sizing: border-box;     
       margin-top: 10px; 
     }
-
   </style>
     <div id="wrapper">
       <h3>Click to show Building ID</h3>
       <span id="message" class="displayId"></span></p>
     </div>
   <script>
-    // プラグイン側からのメッセージを受け取って、建物IDを表示する
+    // Receive messages and display the building ID
     window.addEventListener('message', function(e) {
       if (e.data?.action === "buildingClick") {
         const gmlId = e.data.payload?.gmlId || "";
@@ -57,15 +57,19 @@ const widgetFile: FileType = {
     });
   </script>
   \`);
-  
-  // Add 3D Tiles Layer
-  const layer3dTiles = {
+// Plug-in UI side setting description completed
+
+// Describe settings on Re:Earth (Web Assembly) side
+
+// Define 3D Tiles Layer
+const layer3dTiles = {
   type: "simple", // Required
   data: {
     type: "3dtiles",
     url: "https://assets.cms.plateau.reearth.io/assets/8b/cce097-2d4a-46eb-a98b-a78e7178dc30/13103_minato-ku_pref_2023_citygml_1_op_bldg_3dtiles_13103_minato-ku_lod2_no_texture/tileset.json", // URL of 3D Tiles
   },
-  "3dtiles": { // Settings for the 3D Tiles style.
+  "3dtiles": {
+    // Settings for the 3D Tiles style.
     pbr: false, //invalid Physically Based Rendering
     selectedFeatureColor: "red", // If you select a feature, it will change color
   },
@@ -81,8 +85,8 @@ reearth.viewer.overrideProperty({
   },
 });
 
+// Define the camera position to be moved to
 reearth.camera.flyTo(
-  // Define the camera position to be moved to
   {
     heading: 4.022965234428543,
     height: 1616.524859060678,
@@ -97,29 +101,28 @@ reearth.camera.flyTo(
   }
 );
 
-  function handleLayerSelect(layerId, featureId) {
-    if (!layerId || !featureId) {
-      // 何も選択されていない場合は空文字を送る
-      reearth.ui.postMessage({
-        action: "buildingClick",
-        payload: { gmlId: "" },
-      });
-      return;
-    }
-
-    // 選択された建物(feature)の情報を取得
-    const feature = reearth.layers.findFeatureById(layerId, featureId);
-    const gml_id = feature?.properties?.gml_id || "";
-
-    // プラグインUIに選択されたIDを送信する
+function handleLayerSelect(layerId, featureId) {
+  // If nothing is selected, send an empty string
+  if (!layerId || !featureId) {
     reearth.ui.postMessage({
       action: "buildingClick",
-      payload: { gmlId: gml_id },
+      payload: { gmlId: "" },
     });
+    return;
   }
 
-  reearth.layers.on("select", handleLayerSelect);
-  `
+  // Get information about the selected building (feature)
+  const feature = reearth.layers.findFeatureById(layerId, featureId);
+  const gml_id = feature?.properties?.gml_id || "";
+
+  // Send selected ID to plugin UI
+  reearth.ui.postMessage({
+    action: "buildingClick",
+    payload: { gmlId: gml_id },
+  });
+}
+// Set "handleLayerSelect" to work when a feature is selected
+reearth.layers.on("select", handleLayerSelect);`
 };
 
 export const showFeaturesInfo: PluginType = {

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
@@ -25,7 +25,31 @@ extensions:
 const widgetFile: FileType = {
   id: "show-features-info",
   title: "show-features-info.js",
-  sourceCode: `TBD
+  sourceCode: `const infoboxLayer = {
+  type: "simple",
+  data: {
+    type: "csv",
+    url: "https://reearth.github.io/visualizer-plugin-sample-data/public/csv/marker.csv",
+    csv: {
+      latColumn: "latitude",
+      lngColumn: "longitude",
+    },
+  },
+  marker: {},
+  infobox: {
+    default: {
+      id: "block-text-1",
+      pluginId:"show-features-info",
+      extensionId: "show-features-info-plugin",
+      extensionType: "infoboxBlock",
+      property: {
+        default: "test",
+      },
+    },
+  },
+};
+
+reearth.layers.add(infoboxLayer);
 `
 };
 

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
@@ -1,0 +1,36 @@
+import { FileType, PluginType } from "../../constants";
+import { PRESET_PLUGIN_COMMON_STYLE } from "../common";
+
+const yamlFile: FileType = {
+  id: "layers-show-features-info-reearth-yml",
+  title: "reearth.yml",
+  sourceCode: `id: show-features-info-plugin
+name: Show Selected Features Information
+version: 1.0.0
+extensions:
+  - id: show-features-info
+    type: widget
+    name: Show Selected Features Information Widget
+    description: Selected Feature Information Widget
+    widgetLayout:
+      defaultLocation:
+        zone: outer
+        section: center
+        area: top
+  `,
+  disableEdit: true,
+  disableDelete: true
+};
+
+const widgetFile: FileType = {
+  id: "show-features-info",
+  title: "show-features-info.js",
+  sourceCode: `TBD
+`
+};
+
+export const showFeaturesInfo: PluginType = {
+  id: "show-features-info",
+  title: "Show Selected Features Information",
+  files: [widgetFile, yamlFile]
+};

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
@@ -59,7 +59,7 @@ const widgetFile: FileType = {
   \`);
 // Plug-in UI side setting description completed
 
-// Describe settings on Re:Earth (Web Assembly) side
+// Describe settings on Re:Earth (Web Assembly) side below
 
 // Define 3D Tiles Layer
 const layer3dTiles = {
@@ -101,6 +101,7 @@ reearth.camera.flyTo(
   }
 );
 
+// the function to send information about the selected feature to the plug-in
 function handleLayerSelect(layerId, featureId) {
   // If nothing is selected, send an empty string
   if (!layerId || !featureId) {

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
@@ -28,30 +28,35 @@ const widgetFile: FileType = {
   sourceCode: `reearth.ui.show(\`
   ${PRESET_PLUGIN_COMMON_STYLE}
   <style>
-  .border {
-  border: 1px solid #ccc; 
-  border-radius: 4px;      
-  padding: 8px;            
-  margin-bottom: 12px;
-}
+  .displayId {
+      display: block;             
+      width: 100%;               
+      min-height: 52px;          
+      background-color: #FAFAFA;
+      border-radius: 4px;
+      padding: 8px;
+      word-wrap: break-word;      
+      box-sizing: border-box;     
+      margin-top: 10px; 
+    }
+
   </style>
     <div id="wrapper">
-      <h3>Click to show features property ID</h3>
-      <div class="coordinates">
-        <p>Building ID:</p>
-        <p><span id="message" class="border">"Click buildings"</span></p>
-      </div>
+      <h3>Click to show Building ID</h3>
+      <span id="message" class="displayId"></span></p>
     </div>
   <script>
     // プラグイン側からのメッセージを受け取って、建物IDを表示する
     window.addEventListener('message', function(e) {
       if (e.data?.action === "buildingClick") {
         const gmlId = e.data.payload?.gmlId || "";
-        document.getElementById("message").textContent = gmlId;
+        const messageEl = document.getElementById("message");
+        messageEl.textContent = gmlId;
+        
       }
     });
   </script>
-  \`,{ width: 450, height: 200 });
+  \`);
   
   // Add 3D Tiles Layer
   const layer3dTiles = {


### PR DESCRIPTION
# Overview
This is PR for adding example in Plugin Playground. This example shows how to show selected features information. 

## What I've done
- I created example of "Show Selected Features Information" in Manege Layer
- User can understanding how to get information that feature have. 
- This example is used 3D Tiles（PLATEAU）to show that

## What I haven't done

## How I tested
I tested my local environment. This is demo gif.
<img src="https://github.com/user-attachments/assets/63941389-0e0c-49f4-884c-3ec020b06101" width="700">

## Which point I want you to review particularly
- Whether the UI is appropriate
- A comment is easy for read or not
- Whether a script is not too complicated

## Memo



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new plugin for displaying selected feature information in Re:Earth
	- Implemented feature to show building details when a feature is clicked
	- Enhanced "Manage Layer" category with new feature information display functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->