### PR TITLE
chore(server): upgrade go version to 1.23.5

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.4"
+          go-version: "1.23.5"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         # TODO: fix error=archive named dist/reearth_0.0.0-SNAPSHOT-xxxxxxxx.tar.gz already exists. Check your archive name template

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -2,7 +2,7 @@ name: ci-server
 on:
   workflow_call:
 env:
-  GO_VERSION: "1.23.4"
+  GO_VERSION: "1.23.5"
 
 jobs:
   ci-server-lint:

--- a/go.work
+++ b/go.work
@@ -1,3 +1,3 @@
-go 1.23.4
+go 1.23.5
 
 use ./server

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4-alpine AS build
+FROM golang:1.23.5-alpine AS build
 ARG TAG=release
 ARG VERSION
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -171,4 +171,4 @@ require (
 	moul.io/http2curl v1.0.1-0.20190925090545-5cd742060b0e // indirect
 )
 
-go 1.23.4
+go 1.23.5


### PR DESCRIPTION
# Overview

> go1.23.5 (released 2025-01-16) includes security fixes to the crypto/x509 and net/http packages, as well as bug fixes to the compiler, the runtime, and the net package. See the [Go 1.23.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.5+label%3ACherryPickApproved) on our issue tracker for details.

https://go.dev/doc/devel/release#go1.23.0


## What I've done
- upgrade go version to 1.23.5 from 1.23.4.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Go version from 1.23.4 to 1.23.5 across project infrastructure
	- Updated GitHub Actions workflow configurations
	- Updated Dockerfile base image
	- Updated Go module version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->