### PR TITLE
fix(server): fix CustomProperty nil error

### DIFF
--- a/server/e2e/gql_custom_property_test.go
+++ b/server/e2e/gql_custom_property_test.go
@@ -341,21 +341,6 @@ func TestRemoveCustomProperty(t *testing.T) {
 
 // below Common functions -----------------------------------------------------
 
-// func setupTestData(e *httpexpect.Expect) (sId string, lId string, fId1 string, fId2 string) {
-// 	pId := createProject(e, "test")
-// 	_, _, sId = createScene(e, pId)
-// 	lId = addTestNLSLayerSimple(e, sId)
-
-// 	proId1 := RandomString(10)
-// 	fId1 = addTestGeoJSONFeature(e, lId, proId1)
-// 	updateTestGeoJSONFeature(e, lId, fId1, proId1)
-
-// 	proId2 := RandomString(10)
-// 	fId2 = addTestGeoJSONFeature(e, lId, proId2)
-// 	updateTestGeoJSONFeature(e, lId, fId2, proId2)
-// 	return
-// }
-
 func getNewLayersOfScene(e *httpexpect.Expect, sId string) *httpexpect.Object {
 	requestBody := GraphQLRequest{
 		OperationName: "GetScene",

--- a/server/e2e/gql_custom_property_test.go
+++ b/server/e2e/gql_custom_property_test.go
@@ -100,9 +100,49 @@ func TestUpdateCustomProperties(t *testing.T) {
 
 func TestChangeCustomPropertyTitle(t *testing.T) {
 	e := Server(t, baseSeeder)
-	sId, lId, _, _ := setupTestData(e)
+
+	pId := createProject(e, "test")
+	_, _, sId := createScene(e, pId)
+	lId := addTestNLSLayerSimple(e, sId)
+
 	// change XXX -> ZZZ
 	requestBody := GraphQLRequest{
+		OperationName: "ChangeCustomPropertyTitle",
+		Query: `
+			mutation ChangeCustomPropertyTitle($input: ChangeCustomPropertyTitleInput!) {
+				changeCustomPropertyTitle(input: $input) {
+					layer {
+						id
+					}
+				}
+			}
+		`,
+		Variables: map[string]any{
+			"input": map[string]interface{}{
+				"layerId": lId,
+				"schema": map[string]any{
+					"AAA": "Text_1",
+					"BBB": "Int_2",
+					"CCC": "URL_3", // XXX -> CCC
+					"YYY": "Boolean_4",
+				},
+				"oldTitle": "CCC", // XXX -> CCC
+				"newTitle": "ZZZ", // XXX -> ZZZ
+			},
+		},
+	}
+	Request(e, uID.String(), requestBody)
+
+	proId1 := RandomString(10)
+	fId1 := addTestGeoJSONFeature(e, lId, proId1)
+	updateTestGeoJSONFeature(e, lId, fId1, proId1)
+
+	proId2 := RandomString(10)
+	fId2 := addTestGeoJSONFeature(e, lId, proId2)
+	updateTestGeoJSONFeature(e, lId, fId2, proId2)
+
+	// change XXX -> ZZZ
+	requestBody = GraphQLRequest{
 		OperationName: "ChangeCustomPropertyTitle",
 		Query: `
 			mutation ChangeCustomPropertyTitle($input: ChangeCustomPropertyTitleInput!) {
@@ -182,9 +222,47 @@ func TestChangeCustomPropertyTitle(t *testing.T) {
 
 func TestRemoveCustomProperty(t *testing.T) {
 	e := Server(t, baseSeeder)
-	sId, lId, _, _ := setupTestData(e)
+	pId := createProject(e, "test")
+	_, _, sId := createScene(e, pId)
+	lId := addTestNLSLayerSimple(e, sId)
+
 	// remove XXX
 	requestBody := GraphQLRequest{
+		OperationName: "RemoveCustomProperty",
+		Query: `
+			mutation RemoveCustomProperty($input: RemoveCustomPropertyInput!) {
+				removeCustomProperty(input: $input) {
+					layer {
+						id
+					}
+				}
+			}
+		`,
+		Variables: map[string]any{
+			"input": map[string]interface{}{
+				"layerId": lId,
+				"schema": map[string]any{
+					"AAA": "Text_1",
+					"BBB": "Int_2",
+					// "XXX": "URL_3", remove
+					"YYY": "Boolean_3",
+				},
+				"removedTitle": "CCC",
+			},
+		},
+	}
+	Request(e, uID.String(), requestBody)
+
+	proId1 := RandomString(10)
+	fId1 := addTestGeoJSONFeature(e, lId, proId1)
+	updateTestGeoJSONFeature(e, lId, fId1, proId1)
+
+	proId2 := RandomString(10)
+	fId2 := addTestGeoJSONFeature(e, lId, proId2)
+	updateTestGeoJSONFeature(e, lId, fId2, proId2)
+
+	// remove XXX
+	requestBody = GraphQLRequest{
 		OperationName: "RemoveCustomProperty",
 		Query: `
 			mutation RemoveCustomProperty($input: RemoveCustomPropertyInput!) {
@@ -263,20 +341,20 @@ func TestRemoveCustomProperty(t *testing.T) {
 
 // below Common functions -----------------------------------------------------
 
-func setupTestData(e *httpexpect.Expect) (sId string, lId string, fId1 string, fId2 string) {
-	pId := createProject(e, "test")
-	_, _, sId = createScene(e, pId)
-	lId = addTestNLSLayerSimple(e, sId)
+// func setupTestData(e *httpexpect.Expect) (sId string, lId string, fId1 string, fId2 string) {
+// 	pId := createProject(e, "test")
+// 	_, _, sId = createScene(e, pId)
+// 	lId = addTestNLSLayerSimple(e, sId)
 
-	proId1 := RandomString(10)
-	fId1 = addTestGeoJSONFeature(e, lId, proId1)
-	updateTestGeoJSONFeature(e, lId, fId1, proId1)
+// 	proId1 := RandomString(10)
+// 	fId1 = addTestGeoJSONFeature(e, lId, proId1)
+// 	updateTestGeoJSONFeature(e, lId, fId1, proId1)
 
-	proId2 := RandomString(10)
-	fId2 = addTestGeoJSONFeature(e, lId, proId2)
-	updateTestGeoJSONFeature(e, lId, fId2, proId2)
-	return
-}
+// 	proId2 := RandomString(10)
+// 	fId2 = addTestGeoJSONFeature(e, lId, proId2)
+// 	updateTestGeoJSONFeature(e, lId, fId2, proId2)
+// 	return
+// }
 
 func getNewLayersOfScene(e *httpexpect.Expect, sId string) *httpexpect.Object {
 	requestBody := GraphQLRequest{

--- a/server/internal/usecase/interactor/nlslayer.go
+++ b/server/internal/usecase/interactor/nlslayer.go
@@ -731,10 +731,9 @@ func (i *NLSLayer) ChangeCustomPropertyTitle(ctx context.Context, inp interfaces
 		return nil, interfaces.ErrOperationDenied
 	}
 
-	// Check if oldTitle exists and newTitle doesn't conflict
 	titleExists := false
 	for _, feature := range layer.Sketch().FeatureCollection().Features() {
-		if props := feature.Properties(); props != nil {
+		if props := feature.Properties(); props != nil && *props != nil {
 			if _, ok := (*props)[oldTitle]; ok {
 				titleExists = true
 			}
@@ -744,17 +743,15 @@ func (i *NLSLayer) ChangeCustomPropertyTitle(ctx context.Context, inp interfaces
 		}
 	}
 
-	if !titleExists {
-		return nil, fmt.Errorf("property with title %s not found", oldTitle)
-	}
-
-	for _, feature := range layer.Sketch().FeatureCollection().Features() {
-		if props := feature.Properties(); props != nil {
-			for k, v := range *props {
-				if k == oldTitle {
-					value := v
-					delete(*props, k)
-					(*props)[newTitle] = value
+	if titleExists {
+		for _, feature := range layer.Sketch().FeatureCollection().Features() {
+			if props := feature.Properties(); props != nil {
+				for k, v := range *props {
+					if k == oldTitle {
+						value := v
+						delete(*props, k)
+						(*props)[newTitle] = value
+					}
 				}
 			}
 		}
@@ -808,15 +805,13 @@ func (i *NLSLayer) RemoveCustomProperty(ctx context.Context, inp interfaces.AddO
 		}
 	}
 
-	if !titleExists {
-		return nil, fmt.Errorf("property with title %s not found", removedTitle)
-	}
-
-	for _, feature := range layer.Sketch().FeatureCollection().Features() {
-		if props := feature.Properties(); props != nil {
-			for k := range *props {
-				if k == removedTitle {
-					delete(*props, k)
+	if titleExists {
+		for _, feature := range layer.Sketch().FeatureCollection().Features() {
+			if props := feature.Properties(); props != nil && *props != nil {
+				for k := range *props {
+					if k == removedTitle {
+						delete(*props, k)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
# Overview

If the value of CustomProperty was not set yet, it would return with an error.

## What I've done

I modified it to skip the process instead of returning an error response.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
    - Updated end-to-end GraphQL test cases for custom property management.
    - Simplified test data setup by removing separate setup function.
    - Enhanced test coverage for feature interactions.

- **Refactor**
    - Streamlined logic in custom property management methods.
    - Improved code readability by consolidating error checking and control flow.
    - Simplified existence checks for custom property operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->