### PR TITLE
chore(web): validate Re:Earth configuration on container startup

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -68,6 +68,9 @@ ENV REEARTH_PUBLISHED=null
 ENV REEARTH_TITLE=
 ENV REEARTH_UNSAFE_PLUGIN_URLS=[]
 
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk add --no-cache jq
+
 COPY --from=builder --chown=nginx:nginx /app/dist /usr/share/nginx/html
 COPY --chown=nginx:nginx docker/nginx.conf.template /etc/nginx/templates/nginx.conf.template
 COPY --chown=nginx:nginx docker/40-envsubst-on-reearth-config.sh /docker-entrypoint.d

--- a/web/docker/40-envsubst-on-reearth-config.sh
+++ b/web/docker/40-envsubst-on-reearth-config.sh
@@ -36,3 +36,7 @@ wrap_reearth_variables() {
 
 wrap_reearth_variables "$@"
 envsubst < "$_REEARTH_CONFIG_TEMPLATE_FILE" > "$_REEARTH_CONFIG_OUTPUT_FILE"
+if ! jq empty "$_REEARTH_CONFIG_OUTPUT_FILE" > /dev/null 2>&1; then
+  echo "Invalid JSON configuration file $_REEARTH_CONFIG_OUTPUT_FILE" >&2
+  exit 1
+fi


### PR DESCRIPTION
# Overview

## What I've done

I added `jq` to the Dockerfile so that the container can validate the Re:Earth configuration file (format: JSON) on startup.

This will prevent the container from starting when the required environment variables aren't configured and improve the reliability of our deployment workflow.
In the current implementation, the container will start and run even if the configuration file is broken.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

`jq` for Alpine is about `650` KB, which is comparatively tiny and worth adding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `jq` utility installation in the Dockerfile to support JSON parsing.

- **Bug Fixes**
	- Improved configuration file validation by adding JSON parsing check in the deployment script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->