### PR TITLE
chore(web): update reearth core versionto 0.0.7-alpha.28

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -129,7 +129,7 @@
     "@monaco-editor/react": "4.6.0",
     "@popperjs/core": "2.11.8",
     "@radix-ui/react-slot": "1.1.0",
-    "@reearth/core": "0.0.7-alpha.27",
+    "@reearth/core": "0.0.7-alpha.28",
     "@rot1024/use-transition": "1.0.0",
     "@sentry/browser": "7.77.0",
     "@seznam/compose-react-refs": "1.0.6",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -8453,9 +8453,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reearth/core@npm:0.0.7-alpha.27":
-  version: 0.0.7-alpha.27
-  resolution: "@reearth/core@npm:0.0.7-alpha.27"
+"@reearth/core@npm:0.0.7-alpha.28":
+  version: 0.0.7-alpha.28
+  resolution: "@reearth/core@npm:0.0.7-alpha.28"
   dependencies:
     "@radix-ui/react-checkbox": "npm:1.1.1"
     "@radix-ui/react-dialog": "npm:1.1.1"
@@ -8510,7 +8510,7 @@ __metadata:
     cesium: 1.118.x
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 10c0/5c0421b1c8e2964bcacd4931e32632cfec19710923dcd3f03da8e61e0a28d6419c57fb48bb9180079d0e57f00d01c138d31306953543ee1893aa722372183d9c
+  checksum: 10c0/f56d943de33abd8a8fb79c4f1380570e1fe0b293672cabbb4a167d97229d49e9698d1f02f33844a914ba53cb4afd820add13d4b15c5cfcd0d28a1dd771162cc3
   languageName: node
   linkType: hard
 
@@ -8559,7 +8559,7 @@ __metadata:
     "@playwright/test": "npm:1.46.1"
     "@popperjs/core": "npm:2.11.8"
     "@radix-ui/react-slot": "npm:1.1.0"
-    "@reearth/core": "npm:0.0.7-alpha.27"
+    "@reearth/core": "npm:0.0.7-alpha.28"
     "@rollup/plugin-yaml": "npm:4.1.2"
     "@rot1024/use-transition": "npm:1.0.0"
     "@sentry/browser": "npm:7.77.0"


### PR DESCRIPTION
# Overview
Update reearth core versionto 0.0.7-alpha.28

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `@reearth/core` dependency to version `0.0.7-alpha.28`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->