### PR TITLE
fix(server): enable CoreSupport

### DIFF
--- a/server/internal/usecase/interactor/asset.go
+++ b/server/internal/usecase/interactor/asset.go
@@ -159,6 +159,7 @@ func (i *Asset) UploadAssetFile(ctx context.Context, name string, zipFile *zip.F
 		Name(path.Base(name)).
 		Size(size).
 		URL(url.String()).
+		CoreSupport(true).
 		Build()
 	if err != nil {
 		return nil, 0, err

--- a/server/pkg/nlslayer/feature.go
+++ b/server/pkg/nlslayer/feature.go
@@ -45,6 +45,10 @@ func (f *Feature) Geometry() Geometry {
 }
 
 func (f *Feature) Properties() *map[string]any {
+	if f.properties == nil {
+		emptyMap := make(map[string]any)
+		return &emptyMap
+	}
 	return f.properties
 }
 


### PR DESCRIPTION
# Overview

The imported project assets are not displayed.

## What I've done

CoreSupport was not enabled for the assets.
Failed to create Mongodoc when the property was nil.

## What I haven't done

## How I tested
![スクリーンショット 2025-01-31 14 16 05](https://github.com/user-attachments/assets/81579122-f63c-47f9-9531-0a69509f6399)

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled core support by default for asset uploads
	- Improved feature properties handling to prevent nil returns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/reearth/reearth-visualizer/1392)
<!-- Reviewable:end -->
