### PR TITLE
chore(server): fix docker/build-push-action version

### DIFF
--- a/.github/workflows/build_server.yml
+++ b/.github/workflows/build_server.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Extract reearth/web
         run: tar -xvf reearth-web.tar.gz; mv reearth-web web; ls
       - name: Build and push docker image
-        uses: docker/build-push-action@6
+        uses: docker/build-push-action@v6
         with:
           context: server
           platforms: ${{ steps.options.outputs.platforms }}


### PR DESCRIPTION
# Overview
specified version is wrong.
https://github.com/reearth/reearth-visualizer/actions/runs/13106731425/job/36562741012

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the container build automation to use a new version reference, ensuring consistency with current best practices while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->