### PR TITLE
fix(web): missing one example on plugin playground

### DIFF
--- a/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
@@ -13,11 +13,11 @@ import { addOsm3dTiles } from "./layers/add-OSM-3DTiles";
 import { addWms } from "./layers/add-wms";
 import { hideFlyToDeleteLayer } from "./layers/hideFlyToDeleteLayer";
 import { showFeaturesInfo } from "./layers/showSelectedFeaturesInformation";
-import { overrideStyle } from "./manageLayerStyle/overrideStyle";
-import { styleWithCondition } from "./manageLayerStyle/styleWithCondition";
 import { layerStylingExamples } from "./layerStyles/layerStylingExamples";
 import { featureStyle3dModel } from "./manageLayerStyle/featureStyle3dmodel";
 import { featureStyle3dTiles } from "./manageLayerStyle/featureStyle3dTiles";
+import { overrideStyle } from "./manageLayerStyle/overrideStyle";
+import { styleWithCondition } from "./manageLayerStyle/styleWithCondition";
 import { header } from "./ui/header";
 import { responsivePanel } from "./ui/responsivePanel";
 import { sidebar } from "./ui/sidebar";
@@ -70,11 +70,14 @@ export const presetPlugins: PresetPlugins = [
   {
     id: "layerStyles",
     title: "Manage Layer Style",
-
-    plugins: [featureStyle3dTiles, featureStyle3dModel,featureStyle3dModel,overrideStyle,styleWithCondition]
-
+    plugins: [
+      layerStylingExamples,
+      featureStyle3dTiles,
+      featureStyle3dModel,
+      overrideStyle,
+      styleWithCondition
+    ]
   },
-
   {
     id: "camera",
     title: "Camera",


### PR DESCRIPTION
# Overview

One example missing and lead to ci error due to unused var.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reorganized the display order of layer styling presets in the Plugin Playground to showcase examples first, offering a clearer and more intuitive selection experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->