### PR TITLE
fix(web): plugin playground presets - add an hidden overflow to plugin titles

### DIFF
--- a/web/src/beta/features/PluginPlayground/Plugins/index.tsx
+++ b/web/src/beta/features/PluginPlayground/Plugins/index.tsx
@@ -179,10 +179,7 @@ const PluginList = styled("div")(({ theme }) => ({
   paddingRight: theme.spacing.small,
   display: "flex",
   flexDirection: "column",
-  gap: theme.spacing.smallest,
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap"
+  gap: theme.spacing.smallest
 }));
 
 const PluginListWrapper = styled("div")(({ theme }) => ({

--- a/web/src/beta/features/PluginPlayground/Plugins/index.tsx
+++ b/web/src/beta/features/PluginPlayground/Plugins/index.tsx
@@ -179,7 +179,10 @@ const PluginList = styled("div")(({ theme }) => ({
   paddingRight: theme.spacing.small,
   display: "flex",
   flexDirection: "column",
-  gap: theme.spacing.smallest
+  gap: theme.spacing.smallest,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap"
 }));
 
 const PluginListWrapper = styled("div")(({ theme }) => ({

--- a/web/src/beta/lib/reearth-ui/components/Collapse/index.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Collapse/index.tsx
@@ -56,7 +56,11 @@ export const Collapse: FC<CollapseProps> = ({
         iconPosition={iconPosition}
         disabled={disabled}
       >
-        <Typography size="body" weight={weight}>
+        <Typography
+          size="body"
+          weight={weight}
+          otherProperties={{ whiteSpace: "nowrap" }}
+        >
           {title}
         </Typography>
         <ActionsWrapper>

--- a/web/src/beta/lib/reearth-ui/components/Typography/index.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Typography/index.tsx
@@ -60,8 +60,7 @@ export const Typography: FC<TypographyProps> = ({
           ? color
           : theme.content.main,
       textOverflow: "ellipsis",
-      overflow: "hidden",
-      flexShrink: 0
+      overflow: "hidden"
     }),
     [otherProperties, color, theme]
   );

--- a/web/src/beta/ui/components/ManagerBase/ManagerHeader.tsx
+++ b/web/src/beta/ui/components/ManagerBase/ManagerHeader.tsx
@@ -170,7 +170,9 @@ export const ManagerHeader: FC<ManagerHeaderProps> = ({
         )}
         {!showDelete && sortOptions && (
           <Sort>
-            <Typography size="body">{t("Sort:")}</Typography>
+            <Typography size="body" otherProperties={{ flexShrink: 0 }}>
+              {t("Sort:")}
+            </Typography>
             <Selector
               value={sortValue}
               options={sortOptions}


### PR DESCRIPTION
# Overview
Fixed the issue of text overlapping for the plugin title list on Plugin Playground. Folder titles no longer overlap to the other side.
## What I've done
![Screenshot 2025-02-05 at 1 41 07 PM](https://github.com/user-attachments/assets/2ec3975e-6556-4d3d-9216-996f92fab428)

## What I haven't done

## How I tested
Locally
## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated header displays so that title text remains on one line, ensuring improved readability.
  - Adjusted text styling across components for consistent layout behavior when space is constrained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->