### PR TITLE
feat(web): add rotate camera example

### DIFF
--- a/web/src/beta/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
@@ -48,7 +48,7 @@ ${PRESET_PLUGIN_COMMON_STYLE}
 </style>
 
 <div id="wrapper">
-  <h3>Rotate Camera Angle</h2>
+  <h3>Rotate Camera Angle</h3>
     <div id= "button-container">
       <button id="rotateBtn">Click here</button>
     </div>

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
@@ -20,18 +20,22 @@ extensions:
 const widgetFile: FileType = {
   id: "camera-rotation",
   title: "camera-rotation.js",
-  sourceCode: `reearth.ui.show(\`
+  sourceCode: `// ================================
+// Define Plug-in UI side (iframe)
+// ================================
+
+reearth.ui.show(\`
 ${PRESET_PLUGIN_COMMON_STYLE}
 <style>
 #rotateBtn {
+  border: 1.5px solid #dcdcdc;
   padding: 0;           
-  border-radius: 4px;
-  border: none;
+  border-radius: 5px;
   background: #ffffff;
   color: #000000;
   cursor: pointer;
   width: 200px;
-  height: 30px;           
+  height: 40px;           
   font-size: 16px;      
 }
 #rotateBtn:active {
@@ -55,20 +59,28 @@ let rotating = false;
 let intervalId;
 const rotateBtn = document.getElementById("rotateBtn");
 
+// Set up an event listener
 rotateBtn.addEventListener("click", () => {
+  // Toggle the rotation state
   rotating = !rotating;
   if (rotating) {
     rotateBtn.textContent = "Stop Rotation";
+    // Send 60 postMessages per second (60fps)
     intervalId = setInterval(() => {
       parent.postMessage({ action: "rotateCamera" }, "*");
     }, 1000 / 60);
   } else {
+    // Stop sending messages
     rotateBtn.textContent = "Start Rotation";
     clearInterval(intervalId);
   }
 });
 </script>
 \`);
+
+// ================================
+// Define Re:Earth(Web Assembly) side
+// ================================
 
 // Define a 3D Tiles layer
 const sample3dTiles = {
@@ -115,10 +127,11 @@ reearth.camera.flyTo(
   }
 );
 
-// Set the timeline to a morning hour so that building colors are easy to see
+// Listen for messages from the UI to trigger camera rotation
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
   if (action === "rotateCamera"){
+    // Rotate the camera by a specified angle in radians
     reearth.camera.rotateAround(0.001);
   }
 })`

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
@@ -1,4 +1,5 @@
 import { FileType, PluginType } from "../../constants";
+import { PRESET_PLUGIN_COMMON_STYLE } from "../common";
 
 const yamlFile: FileType = {
   id: "camera-rotation-reearth-yml",
@@ -19,8 +20,55 @@ extensions:
 const widgetFile: FileType = {
   id: "camera-rotation",
   title: "camera-rotation.js",
-  sourceCode: `// This example demonstrates how to apply conditional styling.
-// The color is determined based on building height.
+  sourceCode: `reearth.ui.show(\`
+${PRESET_PLUGIN_COMMON_STYLE}
+<style>
+#rotateBtn {
+  padding: 0;           
+  border-radius: 4px;
+  border: none;
+  background: #ffffff;
+  color: #000000;
+  cursor: pointer;
+  width: 200px;
+  height: 30px;           
+  font-size: 16px;      
+}
+#rotateBtn:active {
+  background: #dcdcdc;
+}
+#button-container {
+  display: flex;  
+  justify-content: center;                
+}
+</style>
+
+<div id="wrapper">
+  <h3>Rotate Camera Angle</h2>
+    <div id= "button-container">
+      <button id="rotateBtn">Click here</button>
+    </div>
+</div>
+
+<script>
+let rotating = false;
+let intervalId;
+const rotateBtn = document.getElementById("rotateBtn");
+
+rotateBtn.addEventListener("click", () => {
+  rotating = !rotating;
+  if (rotating) {
+    rotateBtn.textContent = "Stop Rotation";
+    intervalId = setInterval(() => {
+      parent.postMessage({ action: "rotateCamera" }, "*");
+    }, 1000 / 60);
+  } else {
+    rotateBtn.textContent = "Start Rotation";
+    clearInterval(intervalId);
+  }
+});
+</script>
+\`);
 
 // Define a 3D Tiles layer
 const sample3dTiles = {
@@ -31,25 +79,8 @@ const sample3dTiles = {
   },
   "3dtiles": {
     // Styling settings for the 3D Tiles
-    color: {
-      expression: {
-        // Define conditions for coloring
-        conditions: [
-          ["\${_zmax} > 200", "color('#1d558d')"],
-          ["\${_zmax} > 150", "color('#236ab1')"],
-          ["\${_zmax} > 100", "color('#4e95dc')"],
-          ["\${_zmax} > 50", "color('#95bfea')"],
-          ["\${_zmax} > 0", "color('#edf4fc')"],
-          ["true", "color('#0e2b47')"],
-
-          // You can also use comparison operators, for example:
-          // ["(\${_zmax} >= 50) && (\${feature['bldg:usage']} === '共同住宅')", "color('#923b2d')"]
-        ],
-      },
-    },
-
+    color:"#fffafa",
     pbr: false, // Enable or disable Physically Based Rendering
-    selectedFeatureColor: "red", // Color of selected features
   },
 };
 
@@ -85,12 +116,12 @@ reearth.camera.flyTo(
 );
 
 // Set the timeline to a morning hour so that building colors are easy to see
-reearth.timeline.setTime({
-    start: new Date("2023-01-01T00:00:00Z"),
-    stop: new Date("2023-01-01T10:00:00Z"),
-    current: new Date("2023-01-01T02:00:00Z"),
-  })
-`
+reearth.extension.on("message", (msg) => {
+  const { action } = msg;
+  if (action === "rotateCamera"){
+    reearth.camera.rotateAround(0.001);
+  }
+})`
 };
 
 export const cameraRotation: PluginType = {

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
@@ -75,6 +75,13 @@ rotateBtn.addEventListener("click", () => {
     clearInterval(intervalId);
   }
 });
+
+// To prevent memory leaks, stop "setInterval" when the page is closed or navigated away from
+window.addEventListener("unload", () => {
+  if (intervalId) {
+    clearInterval(intervalId); 
+  }
+});
 </script>
 \`);
 

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
@@ -1,0 +1,100 @@
+import { FileType, PluginType } from "../../constants";
+
+const yamlFile: FileType = {
+  id: "camera-rotation-reearth-yml",
+  title: "reearth.yml",
+  sourceCode: `id: camera-rotation-plugin
+name: Camera Rotation
+version: 1.0.0
+extensions:
+  - id: camera-rotation
+    type: widget
+    name: Camera Rotation
+    description: Camera Rotation
+  `,
+  disableEdit: true,
+  disableDelete: true
+};
+
+const widgetFile: FileType = {
+  id: "camera-rotation",
+  title: "camera-rotation.js",
+  sourceCode: `// This example demonstrates how to apply conditional styling.
+// The color is determined based on building height.
+
+// Define a 3D Tiles layer
+const sample3dTiles = {
+  type: "simple", // Required
+  data: {
+    type: "3dtiles", // Data type
+    url: "https://assets.cms.plateau.reearth.io/assets/4a/c9fb39-9c97-4da6-af8f-e08751a2f269/14100_yokohama-shi_city_2023_citygml_1_op_bldg_3dtiles_14103_nishi-ku_lod2_no_texture/tileset.json", // URL of the 3D Tiles
+  },
+  "3dtiles": {
+    // Styling settings for the 3D Tiles
+    color: {
+      expression: {
+        // Define conditions for coloring
+        conditions: [
+          ["\${_zmax} > 200", "color('#1d558d')"],
+          ["\${_zmax} > 150", "color('#236ab1')"],
+          ["\${_zmax} > 100", "color('#4e95dc')"],
+          ["\${_zmax} > 50", "color('#95bfea')"],
+          ["\${_zmax} > 0", "color('#edf4fc')"],
+          ["true", "color('#0e2b47')"],
+
+          // You can also use comparison operators, for example:
+          // ["(\${_zmax} >= 50) && (\${feature['bldg:usage']} === '共同住宅')", "color('#923b2d')"]
+        ],
+      },
+    },
+
+    pbr: false, // Enable or disable Physically Based Rendering
+    selectedFeatureColor: "red", // Color of selected features
+  },
+};
+
+// Add the 3D Tiles layer to Re:Earth
+reearth.layers.add(sample3dTiles);
+
+reearth.viewer.overrideProperty({
+  // Enable Cesium World Terrain
+  terrain: {
+    enabled: true,
+  },
+  // Prevent buildings from floating above the terrain
+  globe: {
+    depthTestAgainstTerrain: true,
+  },
+});
+
+// Move the camera to the specified position
+reearth.camera.flyTo(
+  {
+    // Define the camera's target position
+    heading: 0.10193671933979864,
+    height: 563.1469223768704,
+    lat: 35.44726736967154,
+    lng: 139.62880155152584,
+    pitch: -0.4516366842962034,
+    roll: 0.0000432060048165539,
+  },
+  {
+    // Define the duration of the camera movement (in seconds)
+    duration: 2.0,
+  }
+);
+
+// Set the timeline to a morning hour so that building colors are easy to see
+reearth.timeline.setTime({
+    start: new Date("2023-01-01T00:00:00Z"),
+    stop: new Date("2023-01-01T10:00:00Z"),
+    current: new Date("2023-01-01T02:00:00Z"),
+  })
+`
+};
+
+export const cameraRotation: PluginType = {
+  id: "camera-rotation",
+  title: "Camera Rotation",
+  files: [widgetFile, yamlFile]
+};

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
@@ -18,6 +18,7 @@ import { featureStyle3dModel } from "./manageLayerStyle/featureStyle3dmodel";
 import { featureStyle3dTiles } from "./manageLayerStyle/featureStyle3dTiles";
 import { overrideStyle } from "./manageLayerStyle/overrideStyle";
 import { styleWithCondition } from "./manageLayerStyle/styleWithCondition";
+import { cameraRotation } from "./camera/cameraRotation";
 import { header } from "./ui/header";
 import { responsivePanel } from "./ui/responsivePanel";
 import { sidebar } from "./ui/sidebar";
@@ -81,7 +82,7 @@ export const presetPlugins: PresetPlugins = [
   {
     id: "camera",
     title: "Camera",
-    plugins: []
+    plugins: [cameraRotation]
   },
   {
     id: "timeline",


### PR DESCRIPTION
# Overview
This is PR for adding "Camera Rotation" example in Plugin Playground

## What I've done
I have made "Camera Rotation" example. When user click a button, a camera angle rotates.
<img src="https://github.com/user-attachments/assets/57a1b077-01aa-4635-b7d2-da623a2ce954" width="600">

## What I haven't done

## How I tested
I have tested in my local environment

## Which point I want you to review particularly
- UI are appropriate and kind for user or not
- Comments in script are appropriate or not

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an interactive camera rotation plugin that allows you to toggle camera motion via a responsive button.
  - Integrated smooth camera transitions and enhanced visual layers for a more immersive experience.
  - Updated the camera category to include the new camera rotation plugin, improving functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->