### PR TITLE
feat(web): add zoom in out example

### DIFF
--- a/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
@@ -71,77 +71,21 @@ ${PRESET_PLUGIN_COMMON_STYLE}
   </script>
   \`);
 
-// Define Re:Earth(Web Assembly) side //
-
-// Define a 3D Tiles layer
-const sample3dTiles = {
-  type: "simple", // Required
-  data: {
-    type: "3dtiles", // Data type
-    url: "https://assets.cms.plateau.reearth.io/assets/8b/cce097-2d4a-46eb-a98b-a78e7178dc30/13103_minato-ku_pref_2023_citygml_1_op_bldg_3dtiles_13103_minato-ku_lod2_no_texture/tileset.json", // URL of the 3D Tiles
-  },
-  "3dtiles": {
-    // Styling settings for the 3D Tiles
-    color: "#f8f8ff", // Initial 3D Tiles color
-    pbr: false, // Enable or disable Physically Based Rendering
-  },
-};
-
-// Add the 3D Tiles layer to Re:Earth
-const layerId = reearth.layers.add(sample3dTiles);
-
-reearth.viewer.overrideProperty({
-  // Enable Cesium World Terrain
-  terrain: {
-    enabled: true,
-  },
-  // Prevent buildings from floating above the terrain
-  globe: {
-    depthTestAgainstTerrain: true,
-  },
-});
-
-// Move the camera to the specified position
-reearth.camera.flyTo(
-  {
-    // Define the camera's target position
-    heading: 4.427049010960799,
-    height: 1182.6187185313975,
-    lat: 35.66552094432892,
-    lng: 139.77065176741144,
-    pitch: -0.4754550303679297,
-    roll: 0.00009119480271468916,
-  },
-  {
-    // Define the duration of the camera movement (in seconds)
-    duration: 2.0,
-  }
-);
-
-// Listen for messages from the UI and override the style for "Cool Style or "Warm Style"
+// Listen for messages from the UI and override the style for "zoomIn" or "zoomOut"
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
   if (action === "zoomIn") {
-    reearth.camera.zoomIn(1, {
-      duration: 1, 
+    reearth.camera.zoomIn(2, {
+      duration: 0.5, 
       withoutAnimation: false, // Enable animation
-      easing: (t) => t * t, // Custom easing function for slower start
     });   
   } else if (action === "zoomOut") {
-    reearth.camera.zoomOut(1, {
-      duration: 1, 
+    reearth.camera.zoomOut(2, {
+      duration: 0.5, 
       withoutAnimation: false, // Enable animation
-      easing: (t) => t * t, // Custom easing function for slower start
     });
   }
-});
-
-// Set the timeline to a morning hour so that building colors are easy to see
-reearth.timeline.setTime({
-    start: new Date("2023-01-01T00:00:00Z"),
-    stop: new Date("2023-01-01T10:00:00Z"),
-    current: new Date("2023-01-01T02:00:00Z"),
-  })`
+});`
 };
 
 export const zoomInOut: PluginType = {

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
@@ -1,0 +1,197 @@
+import { FileType, PluginType } from "../../constants";
+import { PRESET_PLUGIN_COMMON_STYLE } from "../common";
+
+const yamlFile: FileType = {
+  id: "zoom-in-out-reearth-yml",
+  title: "reearth.yml",
+  sourceCode: `id: zoom-in-out-plugin
+name: Zoom In / Out
+version: 1.0.0
+extensions:
+  - id: zoom-in-out
+    type: widget
+    name: Zoom In / Out
+    description: Zoom In / Out
+  `,
+  disableEdit: true,
+  disableDelete: true
+};
+
+const widgetFile: FileType = {
+  id: "zoom-in-out",
+  title: "zoom-in-out.js",
+  sourceCode: `// This example demonstrates how to Zoom In / Out
+
+// Click the buttons to switch between different 3D Tiles color gradients
+
+// Define the plug-in UI //
+reearth.ui.show(\`
+${PRESET_PLUGIN_COMMON_STYLE}
+  <style>
+    .coolBtn {
+      padding: 8px;
+      border-radius: 4px;
+      border: none;
+      background: #f0ffff;
+      color: #000000;
+      cursor: pointer;
+      width: 200px;
+      height: 40px;
+      font-size: 16px 
+    }
+    .scaleBtn:active {
+      background: #dcdcdc;
+    }
+    .warmBtn {
+      padding: 8px;
+      border-radius: 4px;
+      border: none;
+      background:#ffe4e1;
+      color: #000000;
+      cursor: pointer;
+      width: 200px;
+      height: 40px;
+      font-size: 16px 
+    }
+    .scaleBtn:active {
+      background: #dcdcdc;
+    }
+
+    .button-container {
+    display: flex;        
+    gap: 8px;           
+    }
+
+    p {
+      text-align: center; 
+    }
+
+  </style>
+  <div id="wrapper">
+    <h2>Color by Height</h2>
+    <p>Choose your preferred color scheme<p>
+    <div class="button-container">
+      <button class = "coolBtn" id="cool">Cool Style</button>
+      <button class = "warmBtn" id="warm">Warm Style</button>
+    </div>
+  </div>
+  
+  <script>
+  const coolStyle = document.getElementById("cool");
+  const warmStyle  = document.getElementById("warm");
+
+  // Click a button to send a postMessage to Re:Earth(Web Assembly) side.
+  coolStyle.addEventListener("click",() =>{
+    parent.postMessage({
+      action: "updateStyleCool",
+    }, "*");
+    })
+  
+  warmStyle.addEventListener("click",() =>{
+    parent.postMessage({
+      action: "updateStyleWarm",
+    }, "*");
+    })
+  </script>
+  \`);
+
+// Define Re:Earth(Web Assembly) side //
+
+// Define a 3D Tiles layer
+const sample3dTiles = {
+  type: "simple", // Required
+  data: {
+    type: "3dtiles", // Data type
+    url: "https://assets.cms.plateau.reearth.io/assets/8b/cce097-2d4a-46eb-a98b-a78e7178dc30/13103_minato-ku_pref_2023_citygml_1_op_bldg_3dtiles_13103_minato-ku_lod2_no_texture/tileset.json", // URL of the 3D Tiles
+  },
+  "3dtiles": {
+    // Styling settings for the 3D Tiles
+    color: "#f8f8ff", // Initial 3D Tiles color
+    pbr: false, // Enable or disable Physically Based Rendering
+  },
+};
+
+// Add the 3D Tiles layer to Re:Earth
+const layerId = reearth.layers.add(sample3dTiles);
+
+reearth.viewer.overrideProperty({
+  // Enable Cesium World Terrain
+  terrain: {
+    enabled: true,
+  },
+  // Prevent buildings from floating above the terrain
+  globe: {
+    depthTestAgainstTerrain: true,
+  },
+});
+
+// Move the camera to the specified position
+reearth.camera.flyTo(
+  {
+    // Define the camera's target position
+    heading: 4.427049010960799,
+    height: 1182.6187185313975,
+    lat: 35.66552094432892,
+    lng: 139.77065176741144,
+    pitch: -0.4754550303679297,
+    roll: 0.00009119480271468916,
+  },
+  {
+    // Define the duration of the camera movement (in seconds)
+    duration: 2.0,
+  }
+);
+
+// Listen for messages from the UI and override the style for "Cool Style or "Warm Style"
+reearth.extension.on("message", (msg) => {
+  const { action } = msg;
+  if (action === "updateStyleCool") {
+    reearth.layers.override(layerId, {
+      "3dtiles": {
+        color: {
+          expression: {
+            conditions: [
+              ["\${_zmax} > 200", "color('#005f8d')"],
+              ["\${_zmax} > 150", "color('#008cdd')"],
+              ["\${_zmax} > 100", "color('#33baff')"],
+              ["\${_zmax} > 50", "color('#7cd8ff')"],
+              ["\${_zmax} > 0", "color('#d5f2ff')"],
+              ["true", "color('#003f66')"],
+            ],
+          },
+        },
+      },
+    });
+  } else if (action === "updateStyleWarm") {
+    reearth.layers.override(layerId, {
+      "3dtiles": {
+        color: {
+          expression: {
+            conditions: [
+              ["\${_zmax} > 200", "color('#f5220f')"],
+              ["\${_zmax} > 150", "color('#ff5e47')"],
+              ["\${_zmax} > 100", "color('#ff9586')"],
+              ["\${_zmax} > 50", "color('#ffc1b8')"],
+              ["\${_zmax} > 0", "color('#ffe5e0')"],
+              ["true", "color('#a1140a')"],
+            ],
+          },
+        },
+      },
+    });
+  }
+});
+
+// Set the timeline to a morning hour so that building colors are easy to see
+reearth.timeline.setTime({
+    start: new Date("2023-01-01T00:00:00Z"),
+    stop: new Date("2023-01-01T10:00:00Z"),
+    current: new Date("2023-01-01T02:00:00Z"),
+  })`
+};
+
+export const zoomInOut: PluginType = {
+  id: "zoom-in-out",
+  title: "Zoom In / Out",
+  files: [widgetFile, yamlFile]
+};

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
@@ -121,39 +121,17 @@ reearth.camera.flyTo(
 // Listen for messages from the UI and override the style for "Cool Style or "Warm Style"
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
-  if (action === "updateStyleCool") {
-    reearth.layers.override(layerId, {
-      "3dtiles": {
-        color: {
-          expression: {
-            conditions: [
-              ["\${_zmax} > 200", "color('#005f8d')"],
-              ["\${_zmax} > 150", "color('#008cdd')"],
-              ["\${_zmax} > 100", "color('#33baff')"],
-              ["\${_zmax} > 50", "color('#7cd8ff')"],
-              ["\${_zmax} > 0", "color('#d5f2ff')"],
-              ["true", "color('#003f66')"],
-            ],
-          },
-        },
-      },
-    });
-  } else if (action === "updateStyleWarm") {
-    reearth.layers.override(layerId, {
-      "3dtiles": {
-        color: {
-          expression: {
-            conditions: [
-              ["\${_zmax} > 200", "color('#f5220f')"],
-              ["\${_zmax} > 150", "color('#ff5e47')"],
-              ["\${_zmax} > 100", "color('#ff9586')"],
-              ["\${_zmax} > 50", "color('#ffc1b8')"],
-              ["\${_zmax} > 0", "color('#ffe5e0')"],
-              ["true", "color('#a1140a')"],
-            ],
-          },
-        },
-      },
+  if (action === "zoomIn") {
+    reearth.camera.zoomIn(1, {
+      duration: 1, 
+      withoutAnimation: false, // Enable animation
+      easing: (t) => t * t, // Custom easing function for slower start
+    });   
+  } else if (action === "zoomOut") {
+    reearth.camera.zoomOut(1, {
+      duration: 1, 
+      withoutAnimation: false, // Enable animation
+      easing: (t) => t * t, // Custom easing function for slower start
     });
   }
 });

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
@@ -28,68 +28,44 @@ const widgetFile: FileType = {
 reearth.ui.show(\`
 ${PRESET_PLUGIN_COMMON_STYLE}
   <style>
-    .coolBtn {
+    .zoomBtn {
       padding: 8px;
       border-radius: 4px;
       border: none;
-      background: #f0ffff;
+      background: #ffffff;
       color: #000000;
       cursor: pointer;
-      width: 200px;
+      width: 100px;
       height: 40px;
-      font-size: 16px 
+      font-size: 24px 
     }
     .scaleBtn:active {
       background: #dcdcdc;
-    }
-    .warmBtn {
-      padding: 8px;
-      border-radius: 4px;
-      border: none;
-      background:#ffe4e1;
-      color: #000000;
-      cursor: pointer;
-      width: 200px;
-      height: 40px;
-      font-size: 16px 
-    }
-    .scaleBtn:active {
-      background: #dcdcdc;
-    }
-
-    .button-container {
-    display: flex;        
-    gap: 8px;           
-    }
-
-    p {
-      text-align: center; 
     }
 
   </style>
   <div id="wrapper">
-    <h2>Color by Height</h2>
-    <p>Choose your preferred color scheme<p>
-    <div class="button-container">
-      <button class = "coolBtn" id="cool">Cool Style</button>
-      <button class = "warmBtn" id="warm">Warm Style</button>
+    <h2>Zoom Level</h2>
+    <div class="flex-center">
+      <button class = "zoomBtn" id="zoomIn">+</button>
+      <button class = "zoomBtn" id="zoomOut">-</button>
     </div>
   </div>
   
   <script>
-  const coolStyle = document.getElementById("cool");
-  const warmStyle  = document.getElementById("warm");
+  const zoomIn = document.getElementById("zoomIn");
+  const zoomOut  = document.getElementById("zoomOut");
 
   // Click a button to send a postMessage to Re:Earth(Web Assembly) side.
-  coolStyle.addEventListener("click",() =>{
+  zoomIn.addEventListener("click",() =>{
     parent.postMessage({
-      action: "updateStyleCool",
+      action: "zoomIn",
     }, "*");
     })
   
-  warmStyle.addEventListener("click",() =>{
+  zoomOut.addEventListener("click",() =>{
     parent.postMessage({
-      action: "updateStyleWarm",
+      action: "zoomOut",
     }, "*");
     })
   </script>

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
@@ -21,14 +21,18 @@ const widgetFile: FileType = {
   id: "zoom-in-out",
   title: "zoom-in-out.js",
   sourceCode: `// This example demonstrates how to Zoom In / Out
+// Click the buttons to change zoom level
 
-// Click the buttons to switch between different 3D Tiles color gradients
-
-// Define the plug-in UI //
+// ================================
+// Define Plug-in UI side (iframe)
+// ================================
 reearth.ui.show(\`
 ${PRESET_PLUGIN_COMMON_STYLE}
   <style>
     .zoomBtn {
+      display: flex;  
+      align-items: center;    
+      justify-content: center;
       padding: 8px;
       border-radius: 4px;
       border: none;
@@ -37,18 +41,27 @@ ${PRESET_PLUGIN_COMMON_STYLE}
       cursor: pointer;
       width: 100px;
       height: 40px;
-      font-size: 24px 
+      font-size: 29px 
     }
     .zoomBtn:active {
       background: #dcdcdc;
+    }
+    .zoomBtn img {
+    display: block;
+    width: 20px;
+    height: 20px;
     }
 
   </style>
   <div id="wrapper">
     <h2>Zoom Level</h2>
     <div class="flex-center">
-      <button class = "zoomBtn" id="zoomIn">+</button>
-      <button class = "zoomBtn" id="zoomOut">−</button>
+      <button class="zoomBtn" id="zoomIn">
+        <img src="https://reearth.github.io/visualizer-plugin-sample-data/public/image/plus.svg" alt="Zoom In" />
+      </button>
+      <button class="zoomBtn" id="zoomOut">
+        <img src="https://reearth.github.io/visualizer-plugin-sample-data/public/image/minus.svg" alt="Zoom Out" />
+      </button>
     </div>
   </div>
   
@@ -71,19 +84,18 @@ ${PRESET_PLUGIN_COMMON_STYLE}
   </script>
   \`);
 
-// Listen for messages from the UI and override the style for "zoomIn" or "zoomOut"
+// ================================
+// Define Re:Earth(Web Assembly) side
+// ================================
+
+// Listen for messages from the UI and update zoom level
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
   if (action === "zoomIn") {
-    reearth.camera.zoomIn(2, {
-      duration: 0.5, 
-      withoutAnimation: false, // Enable animation
-    });   
+    // Increasing the value increases the change to zoom
+    reearth.camera.zoomIn(2);   
   } else if (action === "zoomOut") {
-    reearth.camera.zoomOut(2, {
-      duration: 0.5, 
-      withoutAnimation: false, // Enable animation
-    });
+    reearth.camera.zoomOut(2);
   }
 });`
 };

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
@@ -39,7 +39,7 @@ ${PRESET_PLUGIN_COMMON_STYLE}
       height: 40px;
       font-size: 24px 
     }
-    .scaleBtn:active {
+    .zoomBtn:active {
       background: #dcdcdc;
     }
 
@@ -48,7 +48,7 @@ ${PRESET_PLUGIN_COMMON_STYLE}
     <h2>Zoom Level</h2>
     <div class="flex-center">
       <button class = "zoomBtn" id="zoomIn">+</button>
-      <button class = "zoomBtn" id="zoomOut">-</button>
+      <button class = "zoomBtn" id="zoomOut">−</button>
     </div>
   </div>
   

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
@@ -39,22 +39,20 @@ ${PRESET_PLUGIN_COMMON_STYLE}
       background: #ffffff;
       color: #000000;
       cursor: pointer;
-      width: 100px;
+      width: 90px;
       height: 40px;
-      font-size: 29px 
     }
     .zoomBtn:active {
       background: #dcdcdc;
     }
     .zoomBtn img {
     display: block;
-    width: 20px;
-    height: 20px;
+    width: 22px;
+    height: 22px;
     }
-
   </style>
   <div id="wrapper">
-    <h2>Zoom Level</h2>
+    <h3>Zoom Level</h3>
     <div class="flex-center">
       <button class="zoomBtn" id="zoomIn">
         <img src="https://reearth.github.io/visualizer-plugin-sample-data/public/image/plus.svg" alt="Zoom In" />

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
@@ -18,6 +18,7 @@ import { featureStyle3dModel } from "./manageLayerStyle/featureStyle3dmodel";
 import { featureStyle3dTiles } from "./manageLayerStyle/featureStyle3dTiles";
 import { overrideStyle } from "./manageLayerStyle/overrideStyle";
 import { styleWithCondition } from "./manageLayerStyle/styleWithCondition";
+import { zoomInOut } from "./camera/zoomInOut";
 import { header } from "./ui/header";
 import { responsivePanel } from "./ui/responsivePanel";
 import { sidebar } from "./ui/sidebar";
@@ -81,7 +82,7 @@ export const presetPlugins: PresetPlugins = [
   {
     id: "camera",
     title: "Camera",
-    plugins: []
+    plugins: [zoomInOut]
   },
   {
     id: "timeline",

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
@@ -1,7 +1,5 @@
 import { PluginType } from "../constants";
 
-import { cameraPosition } from "./camera/cameraPosition";
-import { cameraRotation } from "./camera/cameraRotation";
 import { extensionExtensionMessenger } from "./communication/extensionExtensionMessenger";
 import { uiExtensionMessenger } from "./communication/uiExtensionMessenger";
 import { myPlugin } from "./custom/myPlugin";
@@ -22,6 +20,7 @@ import { overrideStyle } from "./manageLayerStyle/overrideStyle";
 import { styleWithCondition } from "./manageLayerStyle/styleWithCondition";
 import { zoomInOut } from "./camera/zoomInOut";
 import { cameraRotation } from "./camera/cameraRotation";
+import { cameraPosition } from "./camera/cameraPosition";
 import { header } from "./ui/header";
 import { responsivePanel } from "./ui/responsivePanel";
 import { sidebar } from "./ui/sidebar";


### PR DESCRIPTION
# Overview
This is PR for adding “Zoom In / Out” example in Plugin Playground.

## What I've done
I have made “Zoom In / Out” example. User can change zoom level when button is clicked.
<img src="https://github.com/user-attachments/assets/4db09597-4a6a-4a07-ad62-a94ba472aed8" width="600">

## What I haven't done
- move(reearth.camera.on())
- show viewport size, lon, lat and height（getGlobeIntersection())

## How I tested
my local environment

## Which point I want you to review particularly
- Whether UI is appropriate and easy to understand for user
- Help comment is  appropriate or not

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a zoom control plugin for intuitive camera zooming in the Re:Earth environment.
  - Added user-friendly buttons to quickly execute zoom in/out actions, enhancing navigation.
  - Expanded camera functionalities by integrating the new zoom feature alongside existing rotation and position tools.
  - Enabled more dynamic and precise control of camera views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->