### PR TITLE
fix(server): attempt to fix golang lint file error

### DIFF
--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -6,5 +6,6 @@ linters:
     - gofmt
     - goimports
 
-goimports:
-  local-prefixes: github.com/reearth/reearth-backend
+linters-settings:
+  goimports:
+    local-prefixes: github.com/reearth/reearth-backend


### PR DESCRIPTION
# Overview
This PR attempts to fix the `ci-server-lint` error experienced in the CI build. From research looks like there is a change to the indentation required for `golangci.yml` regarding `goimports`. Will need backend team to confirm if this change is correct.

Screenshot of error 
<img width="910" alt="Screenshot 2025-02-17 at 9 43 17 AM" src="https://github.com/user-attachments/assets/62ade79d-1b64-4e04-91f8-6d6794411ff3" />

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
