### PR TITLE
feat(web): plugin playground presets - create data storage plugin example

### DIFF
--- a/web/src/beta/features/PluginPlayground/Code/hook.ts
+++ b/web/src/beta/features/PluginPlayground/Code/hook.ts
@@ -1,6 +1,5 @@
 import { useNotification } from "@reearth/services/state";
 import { useCallback, useState } from "react";
-import { v4 } from "uuid";
 
 import { Story } from "../../Visualizer/Crust/StoryPanel/types";
 import { DEFAULT_LAYERS_PLUGIN_PLAYGROUND } from "../LayerList/constants";
@@ -117,7 +116,7 @@ export default ({
                   widgets: [
                     ...(areaAlignSystem.widgets ?? []),
                     {
-                      id: v4(),
+                      id: `${ymlJson.id}-${cur.id}`,
                       name: cur.name,
                       extensionId: cur.id,
                       pluginId: ymlJson.id,
@@ -159,12 +158,12 @@ export default ({
       return [
         ...prv,
         {
-          id: cur.id,
+          id: `${ymlJson.id}-${cur.id}`,
           name: cur.name,
           description: cur.description,
           __REEARTH_SOURCECODE: file.sourceCode,
           extensionId: cur.id,
-          pluginId: cur.id,
+          pluginId: ymlJson.id,
           extensionType: "infoboxBlock",
           propertyForPluginAPI: generateProperty(
             cur.schema,
@@ -190,12 +189,12 @@ export default ({
       }
 
       prv.push({
-        id: cur.id,
+        id: `${ymlJson.id}-${cur.id}`,
         name: cur.name,
         description: cur.description,
         __REEARTH_SOURCECODE: file.sourceCode,
         extensionId: cur.id,
-        pluginId: cur.id,
+        pluginId: ymlJson.id,
         extensionType: "storyBlock",
         propertyForPluginAPI: generateProperty(
           cur.schema,

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/dataStorage/themeSelector.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/dataStorage/themeSelector.ts
@@ -23,7 +23,11 @@ const widgetFile: FileType = {
   sourceCode: `reearth.ui.show(\`
   ${PRESET_PLUGIN_COMMON_STYLE}
   <style>
-    .theme-content {
+  html{
+    width: 300px;
+  }
+  
+  .theme-content {
     transition: all 0.3s ease;
     border-radius: 4px;
     overflow: hidden;

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/dataStorage/themeSelector.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/dataStorage/themeSelector.ts
@@ -1,0 +1,255 @@
+import { FileType, PluginType } from "../../constants";
+import { PRESET_PLUGIN_COMMON_STYLE } from "../common";
+
+const yamlFile: FileType = {
+  id: "theme-selector-reearth-yml",
+  title: "reearth.yml",
+  sourceCode: `id: theme-selector-plugin
+name: Theme Selector
+version: 1.0.0
+extensions:
+  - id: theme-selector
+    type: widget
+    name: Theme Selector
+    description: Theme Selector
+  `,
+  disableEdit: true,
+  disableDelete: true
+};
+
+const widgetFile: FileType = {
+  id: "theme-selector",
+  title: "theme-selector.js",
+  sourceCode: `reearth.ui.show(\`
+  ${PRESET_PLUGIN_COMMON_STYLE}
+  <style>
+    .theme-content {
+    transition: all 0.3s ease;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  .theme-content.light {
+    color: #333333;
+  }
+
+  .theme-content.dark {
+    color: #ffffff;
+    background: #333333;
+  }
+
+  .theme-toggle {
+    background: #4CAF50;
+    color: white;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-top: 16px;
+  }
+
+  .theme-toggle:hover {
+    background: #45a049;
+  }
+
+  .storage-display {
+    background: rgba(255, 255, 255, 0.1);
+    padding: 12px;
+    border-radius: 4px;
+    margin-top: 16px;
+    font-family: monospace;
+  }
+
+  .storage-display h4 {
+    margin: 0 0 8px 0;
+    font-size: 14px;
+  }
+
+  .storage-op {
+    margin: 8px 0;
+    padding: 8px;
+    background: rgba(0, 0, 0, 0.1);
+    border-radius: 4px;
+    font-size: 13px;
+  }
+
+  #storageOps {
+    max-height: 200px;
+    overflow-y: auto;
+    margin-bottom: 16px;
+  }
+
+  .divider {
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
+    margin: 16px 0;
+  }
+
+  #currentStorage {
+    background: rgba(0, 0, 0, 0.05);
+    padding: 8px;
+    border-radius: 4px;
+    margin-bottom: 16px;
+  }
+
+  .storage-actions {
+    margin-top: 16px;
+  }
+  </style>
+
+  <div id="wrapper">
+    <h3>Theme Selector - Client Storage Demo</h3>
+
+    <div class="theme-content light">
+      <div class="flex-center">
+        <button id="themeToggle" class="theme-toggle">Switch to Dark Theme</button>
+      </div>
+
+      <div class="divider"></div>
+
+      <div class="storage-display" id="storageDisplay">
+        <h4>Current Storage State:</h4>
+        <div id="currentStorage">Loading...</div>
+
+        <h4>Storage Operations Log:</h4>
+        <div id="storageOps"></div>
+
+        <div class="flex-center storage-actions">
+          <button id="viewKeys" class="theme-toggle">View All Keys</button>
+          <button id="clearStorage" class="theme-toggle">Clear Storage</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const THEME_KEY = "user_theme_preference";
+    const themeContent = document.querySelector('.theme-content');
+    const toggleBtn = document.getElementById("themeToggle");
+    const storageDisplay = document.getElementById("storageDisplay");
+    const currentStorage = document.getElementById("currentStorage");
+    const storageOps = document.getElementById("storageOps");
+
+    function logOperation(operation) {
+      const opDiv = document.createElement('div');
+      opDiv.className = 'storage-op ' + themeContent.className;
+      opDiv.textContent = \\\`[\\\${new Date().toLocaleTimeString()}] \\\${operation}\\\`;
+      storageOps.insertBefore(opDiv, storageOps.firstChild);
+    }
+
+    function updateThemeUI(isDark) {
+      themeContent.className = 'theme-content ' + (isDark ? "dark" : "light");
+      storageDisplay.className = "storage-display " + (isDark ? "dark" : "light");
+      const ops = document.querySelectorAll('.storage-op');
+      ops.forEach(op => op.className = 'storage-op ' + (isDark ? "dark" : "light"));
+      toggleBtn.textContent = isDark ? "Switch to Light Theme" : "Switch to Dark Theme";
+    }
+
+    // Initialize theme from storage
+    parent.postMessage({ type: "getTheme" }, "*");
+
+    // Theme toggle
+    toggleBtn.addEventListener("click", () => {
+      const isDark = themeContent.className.includes("dark");
+      parent.postMessage({
+        type: "setTheme",
+        theme: isDark ? "light" : "dark"
+      }, "*");
+    });
+
+    // View all keys
+    document.getElementById("viewKeys").addEventListener("click", () => {
+      parent.postMessage({ type: "viewKeys" }, "*");
+    });
+
+    // Clear storage
+    document.getElementById("clearStorage").addEventListener("click", () => {
+      parent.postMessage({ type: "clearStorage" }, "*");
+    });
+
+    // Listen for messages
+    window.addEventListener("message", e => {
+      const msg = e.data;
+      if (msg.type === "themeUpdate") {
+        updateThemeUI(msg.theme === "dark");
+
+      }
+      else if (msg.type === "storageUpdate") {
+    const themeValue = msg.data[THEME_KEY];
+    currentStorage.textContent = \\\`User Theme Preference: \\\${themeValue || "Not Set"}\\\`;
+
+    // Log the operation
+const storedTheme = msg.data[THEME_KEY];
+
+logOperation(\\\`Storage updated: Theme preference is \\\${storedTheme ? \\\`set to \\\${storedTheme}\\\` : 'not set'}\\\`);
+
+}
+      else if (msg.type === "keysUpdate") {
+    logOperation(\\\`Available storage keys: \\\${msg.keys.length ? msg.keys.join(', ') : 'none'}\\\`);
+}
+      else if (msg.type === "storageCleared") {
+      currentStorage.textContent = "User Theme Preference: Not Set";
+    storageOps.innerHTML = "";
+    logOperation("Storage cleared");
+      }
+    });
+  </script>
+\`);
+
+const THEME_KEY = "user_theme_preference";
+
+async function updateStorageDisplay() {
+  const theme = await reearth.data.clientStorage.getAsync(THEME_KEY);
+  reearth.ui.postMessage({
+    type: "storageUpdate",
+    data: { [THEME_KEY]: theme }
+  });
+}
+
+reearth.extension.on("message", async msg => {
+  try {
+    switch (msg.type) {
+      case "getTheme":
+        const savedTheme = await reearth.data.clientStorage.getAsync(THEME_KEY);
+        reearth.ui.postMessage({
+          type: "themeUpdate",
+          theme: savedTheme || "light"
+        });
+        await updateStorageDisplay();
+        break;
+
+      case "setTheme":
+        await reearth.data.clientStorage.setAsync(THEME_KEY, msg.theme);
+        reearth.ui.postMessage({
+          type: "themeUpdate",
+          theme: msg.theme
+        });
+        await updateStorageDisplay();
+        break;
+
+      case "viewKeys":
+        const keys = await reearth.data.clientStorage.keysAsync();
+        reearth.ui.postMessage({
+          type: "keysUpdate",
+          keys: keys
+        });
+        break;
+
+      case "clearStorage":
+        await reearth.data.clientStorage.dropStoreAsync();
+        reearth.ui.postMessage({
+          type: "storageCleared"
+        });
+        break;
+    }
+  } catch (error) {
+    console.error("Storage operation error:", error);
+  }
+});
+  `
+};
+
+export const themeSelector: PluginType = {
+  id: "theme-selector",
+  title: "Theme Selector",
+  files: [widgetFile, yamlFile]
+};

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
@@ -6,6 +6,7 @@ import { zoomInOut } from "./camera/zoomInOut";
 import { extensionExtensionMessenger } from "./communication/extensionExtensionMessenger";
 import { uiExtensionMessenger } from "./communication/uiExtensionMessenger";
 import { myPlugin } from "./custom/myPlugin";
+import { themeSelector } from "./dataStorage/themeSelector";
 import { extensionProperty } from "./extension/extensionProperty";
 import { add3dTiles } from "./layers/add-3Dtiles";
 import { addCsv } from "./layers/add-csv";
@@ -97,21 +98,16 @@ export const presetPlugins: PresetPlugins = [
   {
     id: "timeline",
     title: "Timeline",
-    plugins: [playbackControl,timeDrivenFeatures,timeDrivenPath]
+    plugins: [playbackControl, timeDrivenFeatures, timeDrivenPath]
   },
   {
     id: "dataStorage",
     title: "Data Storage",
-    plugins: []
+    plugins: [themeSelector]
   },
   {
     id: "extension",
     title: "Extension",
     plugins: [extensionProperty]
-  },
-  {
-    id: "sketch",
-    title: "Sketch",
-    plugins: []
   }
 ];


### PR DESCRIPTION
# Overview
A client storage demo plugin to help users understand how to manage client-side storage in Re:Earth plugins.

## What I've done
- Created a theme selector demo showcasing client storage API methods
- Implemented interactive UI with real-time storage state display
- Added storage operations logging
- Demonstrated usage of getAsync, setAsync, keysAsync, and dropStoreAsync

## What I haven't done
- Didn't implement the deleteAsync method demonstration

## How I tested
Locally

## Which point I want you to review particularly
- The approach of this plugin as regards the task requirement.

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive theme selector that lets users toggle between light and dark modes, with controls to view and clear storage settings.

- **Refactor**
  - Updated the plugin offerings by integrating the new theme selector and removing an unused category, streamlining the overall selection experience.

- **Bug Fixes**
  - Improved ID generation for widgets, infobox blocks, and story blocks, enhancing data structure consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->