### PR TITLE
feat(web): add viewer and scene settings example

### DIFF
--- a/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
@@ -30,6 +30,7 @@ import { timeDrivenPath } from "./timeline/timeDrivenPath";
 import { enableShadowStyle } from "./viewerAndSceneSettings/enableShadowStyle";
 import { enableTerrain } from "./viewerAndSceneSettings/enableTerrain";
 import { showLabel } from "./viewerAndSceneSettings/showLabel";
+import { takeScreenshot } from "./viewerAndSceneSettings/takeScreenshot";
 import { header } from "./ui/header";
 import { responsivePanel } from "./ui/responsivePanel";
 import { sidebar } from "./ui/sidebar";
@@ -61,7 +62,7 @@ export const presetPlugins: PresetPlugins = [
   {
     id: "viewerScene",
     title: "Viewer & Scene Settings",
-    plugins: [enableShadowStyle,enableTerrain,showLabel]
+    plugins: [enableShadowStyle,enableTerrain,showLabel,takeScreenshot]
   },
   {
     id: "layers",

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/index.ts
@@ -29,6 +29,7 @@ import { timeDrivenFeatures } from "./timeline/timeDrivenFeatures";
 import { timeDrivenPath } from "./timeline/timeDrivenPath";
 import { enableShadowStyle } from "./viewerAndSceneSettings/enableShadowStyle";
 import { enableTerrain } from "./viewerAndSceneSettings/enableTerrain";
+import { showLabel } from "./viewerAndSceneSettings/showLabel";
 import { header } from "./ui/header";
 import { responsivePanel } from "./ui/responsivePanel";
 import { sidebar } from "./ui/sidebar";
@@ -60,7 +61,7 @@ export const presetPlugins: PresetPlugins = [
   {
     id: "viewerScene",
     title: "Viewer & Scene Settings",
-    plugins: [enableShadowStyle,enableTerrain]
+    plugins: [enableShadowStyle,enableTerrain,showLabel]
   },
   {
     id: "layers",

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/viewerAndSceneSettings/showLabel.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/viewerAndSceneSettings/showLabel.ts
@@ -46,7 +46,9 @@ reearth.camera.flyTo(
   {
     duration: 2.0,
   }
-);`
+);
+
+// Data Attribution: 国土地理院最適化ベクトルタイル //`
 };
 
 export const showLabel: PluginType = {

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/viewerAndSceneSettings/showLabel.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/viewerAndSceneSettings/showLabel.ts
@@ -1,0 +1,56 @@
+import { FileType, PluginType } from "../../constants";
+
+const yamlFile: FileType = {
+  id: "show-label-reearth-yml",
+  title: "reearth.yml",
+  sourceCode: `id: show-label-plugin
+name: Show Label
+version: 1.0.0
+extensions:
+  - id: show-label
+    type: widget
+    name: Show Label
+    description: Show Label
+  `,
+  disableEdit: true,
+  disableDelete: true
+};
+
+const widgetFile: FileType = {
+  id: "show-label",
+  title: "show-label.js",
+  sourceCode: `// This example shows how to show label //
+// Re:Earth currently supports labels only in Japan //
+
+// Enable label display
+reearth.viewer.overrideProperty({
+  tileLabels: [
+    {
+      labelType: "japan_gsi_optimal_bvmap",
+    },
+  ],
+});
+
+// Define the camera position to be moved to
+reearth.camera.flyTo(
+  // Define the camera position to be moved to
+  {
+    heading: 0.023912810765794212,
+    height: 86462.83801302341,
+    lat: 34.29235030757275,
+    lng: 138.88051742499604,
+    pitch: -0.6411851780116606,
+    roll: 6.283038605616017,
+  },
+  // Define camera movement time
+  {
+    duration: 2.0,
+  }
+);`
+};
+
+export const showLabel: PluginType = {
+  id: "show-label",
+  title: "Show Label",
+  files: [widgetFile, yamlFile]
+};

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/viewerAndSceneSettings/takeScreenshot.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/viewerAndSceneSettings/takeScreenshot.ts
@@ -1,0 +1,119 @@
+import { FileType, PluginType } from "../../constants";
+import { PRESET_PLUGIN_COMMON_STYLE } from "../common";
+
+const yamlFile: FileType = {
+  id: "take-screenshot-reearth-yml",
+  title: "reearth.yml",
+  sourceCode: `id: take-screenshot-plugin
+name: Take Screenshot
+version: 1.0.0
+extensions:
+  - id: take-screenshot
+    type: widget
+    name: Take Screenshot
+    description: Take Screenshot
+  `,
+  disableEdit: true,
+  disableDelete: true
+};
+
+const widgetFile: FileType = {
+  id: "take-screenshot",
+  title: "take-screenshot.js",
+  sourceCode: `// This example shows how to take a Screenshot //
+
+// ================================
+// Define Plug-in UI side (iframe)
+// ================================
+  
+reearth.ui.show(\`
+${PRESET_PLUGIN_COMMON_STYLE}
+<style>
+  .btn {
+    padding: 8px;
+    border-radius: 4px;
+    border: 1px solid #808080;
+    background: #ffffff;
+    color: #000000;
+    cursor: pointer;
+    width: 150px;
+    height: 30px;
+    font-size: 11px 
+  }
+  .btn:active {
+    background: #dcdcdc;
+  }
+
+  #button-container {
+  display: flex;
+  gap: 8px;           
+  }
+</style>
+<div id = "wrapper">
+  <h3 id="message"></h3>
+  <div id="button-container">
+    <button class="btn" id="screenshot">ScreenShot</button>
+    <button class="btn" id="download">Download</button>
+  </div>
+</div>
+
+  
+<script>
+  const screenshotBtn = document.getElementById("screenshot");
+  const downloadBtn = document.getElementById("download");
+  const message = document.getElementById("message");
+
+  let screenshotDataUri = null;
+
+  screenshotBtn.addEventListener("click", () => {
+    parent.postMessage({ action: "takeScreenshot" }, "*");
+  });
+
+  // 2. Extension(プラグイン本体)からのメッセージを受け取る
+  window.addEventListener("message", e => {
+    const { action, data } = e.data || {};
+    if (action === "screenshotCaptured" && data) {
+      screenshotDataUri = data;
+      message.textContent = "Capture complete!";
+    }
+  });
+
+  downloadBtn.addEventListener("click", () => {
+    downloadImage(screenshotDataUri, "screenshot.png");
+    message.textContent = ""
+  });
+
+  // ダウンロード用の関数 (Base64を実際にファイルとして保存)
+  function downloadImage(uri, filename) {
+    const a = document.createElement("a");
+    a.href = uri;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  }
+</script>
+\`);
+
+// ================================
+// Define Re:Earth(Web Assembly) side
+// ================================
+
+reearth.extension.on("message", async (msg) => {
+  const { action } = msg;
+  if (action === "takeScreenshot") {
+    const screenShot = reearth.viewer.capture("image/png");
+    reearth.ui.postMessage({
+      action: "screenshotCaptured",
+      data: screenShot,
+    });
+  }
+});
+`
+};
+
+export const takeScreenshot: PluginType = {
+  id: "take-screenshot",
+  title: "Take Screenshot",
+  files: [widgetFile, yamlFile]
+};

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/viewerAndSceneSettings/takeScreenshot.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/viewerAndSceneSettings/takeScreenshot.ts
@@ -20,7 +20,8 @@ extensions:
 const widgetFile: FileType = {
   id: "take-screenshot",
   title: "take-screenshot.js",
-  sourceCode: `// This example shows how to take a Screenshot //
+  sourceCode: `// This example shows how to take a screenshot //
+// Adjust the view angle, then click "Screenshot," and finally click "Download" to save the image locally //
 
 // ================================
 // Define Plug-in UI side (iframe)
@@ -50,48 +51,53 @@ ${PRESET_PLUGIN_COMMON_STYLE}
   }
 </style>
 <div id = "wrapper">
-  <h3 id="message"></h3>
+  <h3 id="message">Adjust the screen angle</h3>
   <div id="button-container">
     <button class="btn" id="screenshot">ScreenShot</button>
     <button class="btn" id="download">Download</button>
   </div>
 </div>
 
-  
 <script>
-  const screenshotBtn = document.getElementById("screenshot");
-  const downloadBtn = document.getElementById("download");
-  const message = document.getElementById("message");
+const screenshotBtn = document.getElementById("screenshot");
+const downloadBtn = document.getElementById("download");
+const message = document.getElementById("message");
 
-  let screenshotDataUri = null;
+let screenshotDataUri = null;
 
-  screenshotBtn.addEventListener("click", () => {
-    parent.postMessage({ action: "takeScreenshot" }, "*");
-  });
+// Add an EventListener for the Screenshot button
+screenshotBtn.addEventListener("click", () => {
+  parent.postMessage({ action: "takeScreenshot" }, "*");
+});
 
-  // 2. Extension(プラグイン本体)からのメッセージを受け取る
-  window.addEventListener("message", e => {
-    const { action, data } = e.data || {};
-    if (action === "screenshotCaptured" && data) {
-      screenshotDataUri = data;
-      message.textContent = "Capture complete!";
-    }
-  });
-
-  downloadBtn.addEventListener("click", () => {
-    downloadImage(screenshotDataUri, "screenshot.png");
-    message.textContent = ""
-  });
-
-  // ダウンロード用の関数 (Base64を実際にファイルとして保存)
-  function downloadImage(uri, filename) {
-    const a = document.createElement("a");
-    a.href = uri;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
+// Receive messages from extension side
+window.addEventListener("message", e => {
+  const { action, data } = e.data || {};
+  if (action === "screenshotCaptured" && data) {
+    screenshotDataUri = data;
+    message.textContent = "Capture complete!";
   }
+});
+
+// Define a function to download images
+function downloadImage(uri, filename) {
+  if (!uri) {
+    return;
+  }
+  const a = document.createElement("a");
+  a.href = uri; 
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+// Add an event listener for the Download butto
+downloadBtn.addEventListener("click", () => {
+  downloadImage(screenshotDataUri, "screenshot.png");
+  message.textContent = "Adjust the screen angle"
+});
+
 </script>
 \`);
 
@@ -102,14 +108,15 @@ ${PRESET_PLUGIN_COMMON_STYLE}
 reearth.extension.on("message", async (msg) => {
   const { action } = msg;
   if (action === "takeScreenshot") {
+    // Execute a screenshot using "reearth.viewer.capture"
     const screenShot = reearth.viewer.capture("image/png");
+    // Send image data to the plugin UI
     reearth.ui.postMessage({
       action: "screenshotCaptured",
       data: screenShot,
     });
   }
-});
-`
+});`
 };
 
 export const takeScreenshot: PluginType = {


### PR DESCRIPTION
# Overview
This is PR for adding Viewer & Scene Settings examples in Plugin Playground.

## What I've done
**Show Label**
<img src="https://github.com/user-attachments/assets/54d6a7f6-6a2b-4712-9a84-2ceec527060d" width= 700>

**Take Screenshot**
<img src="https://github.com/user-attachments/assets/0a9ca6ae-b2a2-4b72-8023-94d78b4fd0c0" width= 700>

## What I haven't done
- mouse events（click）

## How I tested
Local environment

## Which point I want you to review particularly
- UI and help comments in script are suitable for user or not

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded the viewer scene with enhanced label display for improved visual context.
  - Introduced a screenshot tool that allows users to capture and download images seamlessly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->