### PR TITLE
fix(server): project import export

### DIFF
--- a/server/internal/infrastructure/memory/asset.go
+++ b/server/internal/infrastructure/memory/asset.go
@@ -32,6 +32,23 @@ func (r *Asset) Filtered(f repo.WorkspaceFilter) repo.Asset {
 	}
 }
 
+func (r *Asset) FindByURL(_ context.Context, path string) (*asset.Asset, error) {
+	var result *asset.Asset
+	r.data.Range(func(id id.AssetID, asset *asset.Asset) bool {
+		if asset.URL() == path {
+			if r.f.CanRead(asset.Workspace()) {
+				result = asset
+				return false
+			}
+		}
+		return true
+	})
+	if result != nil {
+		return result, nil
+	}
+	return &asset.Asset{}, rerror.ErrNotFound
+}
+
 func (r *Asset) FindByID(_ context.Context, id id.AssetID) (*asset.Asset, error) {
 	d, ok := r.data.Load(id)
 	if ok && r.f.CanRead(d.Workspace()) {

--- a/server/internal/infrastructure/mongo/asset.go
+++ b/server/internal/infrastructure/mongo/asset.go
@@ -44,6 +44,12 @@ func (r *Asset) Filtered(f repo.WorkspaceFilter) repo.Asset {
 	}
 }
 
+func (r *Asset) FindByURL(ctx context.Context, path string) (*asset.Asset, error) {
+	return r.findOne(ctx, bson.M{
+		"url": path,
+	})
+}
+
 func (r *Asset) FindByID(ctx context.Context, id id.AssetID) (*asset.Asset, error) {
 	return r.findOne(ctx, bson.M{
 		"id": id.String(),

--- a/server/internal/infrastructure/mongo/property_schema.go
+++ b/server/internal/infrastructure/mongo/property_schema.go
@@ -137,7 +137,10 @@ func (r *PropertySchema) findOne(ctx context.Context, filter any) (*property.Sch
 	if err := r.client.FindOne(ctx, filter, c); err != nil {
 		return nil, err
 	}
-	return c.Result[0], nil
+	if len(c.Result) > 0 {
+		return c.Result[0], nil
+	}
+	return nil, nil
 }
 
 // func (r *PropertySchema) readFilter(filter any) any {

--- a/server/internal/usecase/interactor/nlslayer.go
+++ b/server/internal/usecase/interactor/nlslayer.go
@@ -1032,7 +1032,7 @@ func (i *NLSLayer) DeleteGeoJSONFeature(ctx context.Context, inp interfaces.Dele
 	return inp.FeatureID, nil
 }
 
-func (i *NLSLayer) ImportNLSLayers(ctx context.Context, sceneID idx.ID[id.Scene], sceneData map[string]interface{}) (nlslayer.NLSLayerList, map[string]idx.ID[id.NLSLayer], error) {
+func (i *NLSLayer) ImportNLSLayers(ctx context.Context, sceneID idx.ID[id.Scene], sceneData map[string]interface{}, replaceStyleIDs map[string]id.StyleID) (nlslayer.NLSLayerList, map[string]idx.ID[id.NLSLayer], error) {
 	sceneJSON, err := builder.ParseSceneJSON(ctx, sceneData)
 	if err != nil {
 		return nil, nil, err
@@ -1046,7 +1046,7 @@ func (i *NLSLayer) ImportNLSLayers(ctx context.Context, sceneID idx.ID[id.Scene]
 	writableFilter := repo.SceneFilter{Writable: scene.IDList{sceneID}}
 
 	nlayerIDs := idx.List[id.NLSLayer]{}
-	replaceNLSLayerIDs := make(map[string]idx.ID[id.NLSLayer])
+	replaceNLSLayerIDs := make(map[string]id.NLSLayerID)
 	for _, nlsLayerJSON := range sceneJSON.NLSLayers {
 		newNLSLayerID := id.NewNLSLayerID()
 		nlayerIDs = append(nlayerIDs, newNLSLayerID)
@@ -1072,6 +1072,14 @@ func (i *NLSLayer) ImportNLSLayers(ctx context.Context, sceneID idx.ID[id.Scene]
 							urlVal.Scheme = "https"
 						}
 						data["url"] = urlVal.String()
+					}
+				}
+			}
+
+			if oldId, ok := config["layerStyleId"].(string); ok {
+				for oldId2, newId := range replaceStyleIDs {
+					if oldId == oldId2 {
+						config["layerStyleId"] = newId.String()
 					}
 				}
 			}

--- a/server/internal/usecase/interactor/nlslayer.go
+++ b/server/internal/usecase/interactor/nlslayer.go
@@ -1148,6 +1148,7 @@ func (i *NLSLayer) ImportNLSLayers(ctx context.Context, sceneID idx.ID[id.Scene]
 
 		// SketchInfo --------
 		if nlsLayerJSON.SketchInfo != nil {
+
 			features := make([]nlslayer.Feature, 0)
 			for _, featureJSON := range nlsLayerJSON.SketchInfo.FeatureCollection.Features {
 				var geometry nlslayer.Geometry
@@ -1167,6 +1168,7 @@ func (i *NLSLayer) ImportNLSLayers(ctx context.Context, sceneID idx.ID[id.Scene]
 				if err != nil {
 					return nil, nil, err
 				}
+
 				feature.UpdateProperties(featureJSON.Properties)
 				features = append(features, *feature)
 			}

--- a/server/internal/usecase/interactor/nlslayer_test.go
+++ b/server/internal/usecase/interactor/nlslayer_test.go
@@ -316,7 +316,7 @@ func TestImportNLSLayers(t *testing.T) {
 	assert.NoError(t, err)
 
 	// invoke the target function
-	result, _, err := ifl.ImportNLSLayers(ctx, scene.ID(), sceneData)
+	result, _, err := ifl.ImportNLSLayers(ctx, scene.ID(), sceneData, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 

--- a/server/internal/usecase/interactor/plugin.go
+++ b/server/internal/usecase/interactor/plugin.go
@@ -372,7 +372,12 @@ func (i *Plugin) ImportPlugins(ctx context.Context, sce *scene.Scene, pluginsDat
 	return plgs, pss, nil
 }
 
-func (i *Plugin) ImporPluginFile(ctx context.Context, pid id.PluginID, name string, zipFile *zip.File) error {
+func (i *Plugin) ImporPluginFile(ctx context.Context, newPluginId string, name string, zipFile *zip.File) error {
+
+	pid, err := id.PluginIDFrom(newPluginId)
+	if err != nil {
+		return err
+	}
 
 	readCloser, err := zipFile.Open()
 	if err != nil {

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -523,7 +523,7 @@ func (i *Project) ExportProjectData(ctx context.Context, projectID id.ProjectID,
 
 	// project image
 	if prj.ImageURL() != nil {
-		err := AddZipAsset(ctx, i.file, zipWriter, prj.ImageURL().Path)
+		err := AddZipAsset(ctx, i.assetRepo, i.file, zipWriter, prj.ImageURL().Path)
 		if err != nil {
 			return nil, err
 		}
@@ -624,11 +624,13 @@ func updateProjectUpdatedAtByScene(ctx context.Context, sceneID id.SceneID, r re
 	return nil
 }
 
-func AddZipAsset(ctx context.Context, file gateway.File, zipWriter *zip.Writer, path string) error {
-	fileName := strings.TrimPrefix(path, "/assets/")
+// If the given path is the URL of an Asset, it will be added to the ZIP.
+func AddZipAsset(ctx context.Context, assetRepo repo.Asset, file gateway.File, zipWriter *zip.Writer, path string) error {
+	parts := strings.Split(path, "/")
+	fileName := parts[len(parts)-1]
 	stream, err := file.ReadAsset(ctx, fileName)
 	if err != nil {
-		return nil // skip if external URL
+		return nil // skip if not available
 	}
 	defer func() {
 		if cerr := stream.Close(); cerr != nil {

--- a/server/internal/usecase/interactor/style_test.go
+++ b/server/internal/usecase/interactor/style_test.go
@@ -54,7 +54,7 @@ func TestImportStyles(t *testing.T) {
 	assert.NoError(t, err)
 
 	// invoke the target function
-	result, err := ifs.ImportStyles(ctx, scene.ID(), sceneData)
+	result, _, err := ifs.ImportStyles(ctx, scene.ID(), sceneData)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 

--- a/server/internal/usecase/interfaces/nlslayer.go
+++ b/server/internal/usecase/interfaces/nlslayer.go
@@ -90,5 +90,5 @@ type NLSLayer interface {
 	AddGeoJSONFeature(context.Context, AddNLSLayerGeoJSONFeatureParams, *usecase.Operator) (nlslayer.Feature, error)
 	UpdateGeoJSONFeature(context.Context, UpdateNLSLayerGeoJSONFeatureParams, *usecase.Operator) (nlslayer.Feature, error)
 	DeleteGeoJSONFeature(context.Context, DeleteNLSLayerGeoJSONFeatureParams, *usecase.Operator) (id.FeatureID, error)
-	ImportNLSLayers(context.Context, idx.ID[id.Scene], map[string]interface{}) (nlslayer.NLSLayerList, map[string]idx.ID[id.NLSLayer], error)
+	ImportNLSLayers(context.Context, idx.ID[id.Scene], map[string]interface{}, map[string]id.StyleID) (nlslayer.NLSLayerList, map[string]idx.ID[id.NLSLayer], error)
 }

--- a/server/internal/usecase/interfaces/plugin.go
+++ b/server/internal/usecase/interfaces/plugin.go
@@ -25,5 +25,5 @@ type Plugin interface {
 	UploadFromRemote(context.Context, *url.URL, id.SceneID, *usecase.Operator) (*plugin.Plugin, *scene.Scene, error)
 	ExportPlugins(context.Context, *scene.Scene, *zip.Writer) ([]*plugin.Plugin, []*property.Schema, error)
 	ImportPlugins(context.Context, *scene.Scene, []interface{}, []interface{}) ([]*plugin.Plugin, property.SchemaList, error)
-	ImporPluginFile(context.Context, id.PluginID, string, *zip.File) error
+	ImporPluginFile(context.Context, string, string, *zip.File) error
 }

--- a/server/internal/usecase/interfaces/style.go
+++ b/server/internal/usecase/interfaces/style.go
@@ -6,7 +6,6 @@ import (
 	"github.com/reearth/reearth/server/internal/usecase"
 	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearth/server/pkg/scene"
-	"github.com/reearth/reearthx/idx"
 )
 
 type AddStyleInput struct {
@@ -28,5 +27,5 @@ type Style interface {
 	UpdateStyle(context.Context, UpdateStyleInput, *usecase.Operator) (*scene.Style, error)
 	RemoveStyle(context.Context, id.StyleID, *usecase.Operator) (id.StyleID, error)
 	DuplicateStyle(context.Context, id.StyleID, *usecase.Operator) (*scene.Style, error)
-	ImportStyles(context.Context, idx.ID[id.Scene], map[string]interface{}) (scene.StyleList, error)
+	ImportStyles(context.Context, id.SceneID, map[string]interface{}) (scene.StyleList, map[string]id.StyleID, error)
 }

--- a/server/internal/usecase/repo/asset.go
+++ b/server/internal/usecase/repo/asset.go
@@ -18,6 +18,7 @@ type AssetFilter struct {
 type Asset interface {
 	Filtered(WorkspaceFilter) Asset
 	FindByWorkspaceProject(context.Context, accountdomain.WorkspaceID, *id.ProjectID, AssetFilter) ([]*asset.Asset, *usecasex.PageInfo, error)
+	FindByURL(context.Context, string) (*asset.Asset, error)
 	FindByID(context.Context, id.AssetID) (*asset.Asset, error)
 	FindByIDs(context.Context, id.AssetIDList) ([]*asset.Asset, error)
 	TotalSizeByWorkspace(context.Context, accountdomain.WorkspaceID) (int64, error)


### PR DESCRIPTION
# Overview

Project export import Bug Fix(Only a part)

## What I've done

Invalid error occurs upon import
→ Skip deleted layers

Layer styles are reset
→ Not replacing with the new StyleID

Plugins are not found after import
→ In MongoDB access, empty data does not cause an error, but c.Result[0] is referenced directly

Style images and 3D model resources are not exported
→ Added them to the export file

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved import processes across projects, layers, plugins, storytelling, and styles with more consistent identifier mapping and refined error messaging.
  - Added new methods for retrieving assets by URL, enhancing asset management capabilities.
- **Bug Fixes**
  - Strengthened error handling to prevent issues when expected data is missing, ensuring a smoother data import experience.
- **Tests**
  - Updated validations to align with the new import workflows, supporting reliable and robust performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->