### PR TITLE
refactor(web): add prefix to story tab item title & update settings layout [VIZ-1380]

### DIFF
--- a/web/src/beta/features/Editor/Publish/PublishToolsPanel/hooks.ts
+++ b/web/src/beta/features/Editor/Publish/PublishToolsPanel/hooks.ts
@@ -56,7 +56,7 @@ export default ({
         projectId: project.id,
         storyId: s.id,
         type: "story" as const,
-        buttonTitle: s.title !== "Default" && s.title ? s.title : t("Story"),
+        buttonTitle: `${t("Story")} ${s.title}`,
         alias: s.alias && s.alias !== project.alias ? s.alias : undefined, // correct existing alias, needs republish
         publishmentStatus: s.publishmentStatus,
         isPublished: isPublished(s.publishmentStatus)

--- a/web/src/beta/features/ProjectSettings/innerPages/GeneralSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/GeneralSettings/index.tsx
@@ -74,7 +74,7 @@ const GeneralSettings: FC<Props> = ({
         {project.isArchived ? (
           <ArchivedSettingNotice />
         ) : (
-          <Collapse size="large" title={t("Project Info")}>
+          <Collapse size="large" title={t("Project Info")} noShrink>
             <SettingsFields>
               <InputField
                 title={t("Project Name")}
@@ -113,7 +113,7 @@ const GeneralSettings: FC<Props> = ({
             </SettingsFields>
           </Collapse>
         )}
-        <Collapse size="large" title={t("Danger Zone")}>
+        <Collapse size="large" title={t("Danger Zone")} noShrink>
           <SettingsFields>
             <DangerItem>
               <Typography size="body" weight="bold">

--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
@@ -134,7 +134,7 @@ const PublicSettingsDetail: React.FC<Props> = ({
 
   return (
     <>
-      <Collapse title={t("Public Info")} size="large">
+      <Collapse title={t("Public Info")} size="large" noShrink>
         <SettingsFields>
           <InputField
             title={t("Title")}
@@ -181,7 +181,7 @@ const PublicSettingsDetail: React.FC<Props> = ({
           </ButtonWrapper>
         </SettingsFields>
       </Collapse>
-      <Collapse title={t("Basic Authorization")} size="large">
+      <Collapse title={t("Basic Authorization")} size="large" noShrink>
         <SettingsFields>
           <SwitchField
             title={t("Enable Basic Authorization")}
@@ -215,7 +215,7 @@ const PublicSettingsDetail: React.FC<Props> = ({
           </ButtonWrapper>
         </SettingsFields>
       </Collapse>
-      <Collapse title={t("Site Setting")} size="large">
+      <Collapse title={t("Site Setting")} size="large" noShrink>
         <SettingsFields>
           <InputField
             title={t("Site name")}
@@ -236,7 +236,7 @@ const PublicSettingsDetail: React.FC<Props> = ({
           </ButtonWrapper>
         </SettingsFields>
       </Collapse>
-      <Collapse title={t("Google Analytics")} size="large">
+      <Collapse title={t("Google Analytics")} size="large" noShrink>
         <SettingsFields>
           <SwitchField
             title={t("Enable Google Analytics")}

--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
@@ -262,7 +262,7 @@ const PublicSettingsDetail: React.FC<Props> = ({
         </SettingsFields>
       </Collapse>
       {extensions && extensions.length > 0 && accessToken && (
-        <Collapse title={t("Custom Domain")} size="large">
+        <Collapse title={t("Custom Domain")} size="large" noShrink>
           <ExtensionComponent
             typename={settingsItem.__typename || ""}
             {...(settingsItem.__typename === "Project"

--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
@@ -6,7 +6,7 @@ import {
 } from "@reearth/beta/ui/components/Sidebar";
 import { Story } from "@reearth/services/api/storytellingApi/utils";
 import { useT } from "@reearth/services/i18n";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import {
   InnerPage,
@@ -96,7 +96,7 @@ const PublicSettings: React.FC<Props> = ({
       },
       ...stories.map((s) => ({
         id: s.id,
-        title: !s.title || s.title === "Default" ? t("Story") : s.title,
+        title: `${t("Story")} ${s.title}`,
         icon: "sidebar" as const,
         path: `/settings/projects/${project.id}/public/${s.id}`,
         active: selectedTab === s.id
@@ -105,7 +105,18 @@ const PublicSettings: React.FC<Props> = ({
     [stories, selectedTab, project.id, t]
   );
 
-  const handleTabChange = useCallback((tab: string) => selectTab(tab), []);
+  const settingsWrapperRef = useRef<HTMLDivElement>(null);
+
+  const handleTabChange = useCallback(
+    (tab: string) => {
+      if (settingsWrapperRef.current) {
+        settingsWrapperRef.current.scrollTo(0, 0);
+      }
+      if (selectedTab === tab) return;
+      selectTab(tab);
+    },
+    [selectedTab]
+  );
 
   return (
     <InnerPage wide>
@@ -127,7 +138,7 @@ const PublicSettings: React.FC<Props> = ({
           </SidebarMainSection>
         </SidebarWrapper>
       </InnerSidebar>
-      <SettingsWrapper>
+      <SettingsWrapper ref={settingsWrapperRef}>
         {project.isArchived ? (
           <ArchivedSettingNotice />
         ) : selectedTab === currentStory?.id ? (

--- a/web/src/beta/features/ProjectSettings/innerPages/StorySettings/StorySettingsDetail.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/StorySettings/StorySettingsDetail.tsx
@@ -49,7 +49,7 @@ const StorySettingsDetail: React.FC<Props> = ({
   ];
 
   return (
-    <Collapse title={t("Story Panel")} size="large">
+    <Collapse title={t("Story Panel")} size="large" noShrink>
       <SettingsFields>
         <SettingsRow>
           <SettingsRowItem>

--- a/web/src/beta/features/ProjectSettings/innerPages/common.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/common.tsx
@@ -11,7 +11,8 @@ export const InnerPage = styled("div")<{
   width: "100%",
   maxWidth: wide ? 950 : 750,
   backgroundColor: transparent ? "none" : theme.bg[1],
-  borderRadius: theme.radius.normal
+  borderRadius: theme.radius.normal,
+  maxHeight: "100%"
 }));
 
 export const InnerSidebar = styled("div")(({ theme }) => ({
@@ -29,7 +30,8 @@ export const SettingsWrapper = styled("div")(({ theme }) => ({
   flex: 1,
   ["> div:not(:last-child)"]: {
     borderBottom: `1px solid ${theme.outline.weaker}`
-  }
+  },
+  overflowY: "auto"
 }));
 
 export const SettingsFields = styled("div")(({ theme }) => ({

--- a/web/src/beta/lib/reearth-ui/components/Collapse/index.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Collapse/index.tsx
@@ -14,8 +14,8 @@ export type CollapseProps = {
   weight?: "medium" | "regular" | "bold";
   collapsed?: boolean;
   noPadding?: boolean;
+  noShrink?: boolean;
   disabled?: boolean;
-
   actions?: ReactNode;
   children: ReactNode;
   onCollapse?: (collapsed: boolean) => void;
@@ -32,6 +32,7 @@ export const Collapse: FC<CollapseProps> = ({
   collapsed,
   disabled,
   noPadding,
+  noShrink,
   actions,
   children,
   onCollapse
@@ -49,7 +50,7 @@ export const Collapse: FC<CollapseProps> = ({
   }, [disabled, isCollapsed, onCollapse]);
 
   return (
-    <StyledWrapper>
+    <StyledWrapper isCollapsed={isCollapsed} noShrink={noShrink}>
       <StyledHeader
         onClick={handleCollapse}
         isCollapsed={isCollapsed}
@@ -90,11 +91,13 @@ export const Collapse: FC<CollapseProps> = ({
 
 const StyledWrapper = styled("div")<{
   background?: string;
-}>(({ theme }) => ({
+  isCollapsed?: boolean;
+  noShrink?: boolean;
+}>(({ theme, isCollapsed, noShrink }) => ({
   position: "relative",
   borderRadius: `${theme.radius.small}px`,
-  flexGrow: 1,
-  flexShrink: 1,
+  flexGrow: isCollapsed ? 0 : 1,
+  flexShrink: noShrink ? 0 : 1,
   display: "flex",
   flexDirection: "column",
   minHeight: 0


### PR DESCRIPTION
# Overview

We have some tabs refers to story item, using story title as the tab item title. 
Currently we add one default story when user create a project, with a default story title `Default` (or `ストーリー` if user's lang is ja). This default title could be misleading when put together with other tabs.

This PR added a prefix `Story` to these story tabs to make it easier to understand.
This PR also update some styles on settings page so that the scroll happens inside each tab content.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled automatic scrolling to the top when switching settings tabs.
  - Updated story title labels to consistently include a translated prefix.

- **Style**
  - Refined the behavior of collapsible panels to prevent unwanted shrinking.
  - Enhanced layout controls on settings pages with improved height and overflow management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->