### PR TITLE
fix(server): project import export2 [VIZ-1359]

### DIFF
--- a/server/internal/usecase/interactor/common.go
+++ b/server/internal/usecase/interactor/common.go
@@ -1,10 +1,15 @@
 package interactor
 
 import (
+	"archive/zip"
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net/url"
+	"strings"
 
+	"github.com/reearth/reearth/server/internal/adapter"
 	"github.com/reearth/reearth/server/internal/usecase"
 	"github.com/reearth/reearth/server/internal/usecase/gateway"
 	"github.com/reearth/reearth/server/internal/usecase/interfaces"
@@ -235,5 +240,57 @@ func (d ProjectDeleter) Delete(ctx context.Context, prj *project.Project, force 
 		return err
 	}
 
+	return nil
+}
+
+func IsCurrentHostAssets(ctx context.Context, u string) bool {
+	if strings.HasPrefix(u, "assets/") || strings.HasPrefix(u, "/assets") {
+		return true
+	}
+	return strings.HasPrefix(u, adapter.CurrentHost(ctx))
+}
+
+func ReplaceToCurrentHost(ctx context.Context, urlString string) string {
+	u, err := url.Parse(urlString)
+	if err != nil {
+		return urlString
+	}
+	u2, err := url.Parse(adapter.CurrentHost(ctx))
+	if err != nil {
+		return urlString
+	}
+	u.Scheme = u2.Scheme
+	u.Host = u2.Host
+	return u.String()
+}
+
+// If the given path is the URL of an Asset, it will be added to the ZIP.
+func AddZipAsset(ctx context.Context, assetRepo repo.Asset, file gateway.File, zipWriter *zip.Writer, urlString string) error {
+
+	if !IsCurrentHostAssets(ctx, urlString) {
+		return nil
+	}
+
+	parts := strings.Split(urlString, "/")
+	fileName := parts[len(parts)-1]
+	stream, err := file.ReadAsset(ctx, fileName)
+	if err != nil {
+		return nil // skip if not available
+	}
+	defer func() {
+		if cerr := stream.Close(); cerr != nil {
+			fmt.Printf("Error closing file: %v\n", cerr)
+		}
+	}()
+	zipEntryPath := fmt.Sprintf("assets/%s", fileName)
+	zipEntry, err := zipWriter.Create(zipEntryPath)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(zipEntry, stream)
+	if err != nil {
+		_ = stream.Close()
+		return err
+	}
 	return nil
 }

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -619,32 +618,6 @@ func updateProjectUpdatedAtByScene(ctx context.Context, sceneID id.SceneID, r re
 	}
 	err = updateProjectUpdatedAtByID(ctx, scene.Project(), r)
 	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// If the given path is the URL of an Asset, it will be added to the ZIP.
-func AddZipAsset(ctx context.Context, assetRepo repo.Asset, file gateway.File, zipWriter *zip.Writer, path string) error {
-	parts := strings.Split(path, "/")
-	fileName := parts[len(parts)-1]
-	stream, err := file.ReadAsset(ctx, fileName)
-	if err != nil {
-		return nil // skip if not available
-	}
-	defer func() {
-		if cerr := stream.Close(); cerr != nil {
-			fmt.Printf("Error closing file: %v\n", cerr)
-		}
-	}()
-	zipEntryPath := fmt.Sprintf("assets/%s", fileName)
-	zipEntry, err := zipWriter.Create(zipEntryPath)
-	if err != nil {
-		return err
-	}
-	_, err = io.Copy(zipEntry, stream)
-	if err != nil {
-		_ = stream.Close()
 		return err
 	}
 	return nil

--- a/server/internal/usecase/interactor/scene.go
+++ b/server/internal/usecase/interactor/scene.go
@@ -689,6 +689,28 @@ func (i *Scene) ExportScene(ctx context.Context, prj *project.Project, zipWriter
 	if err != nil {
 		return nil, nil, errors.New("Fail BuildResult :" + err.Error())
 	}
+	// plugin property
+	for _, v := range sceneJSON.Widgets {
+		for _, propInterface := range v.Property {
+			propSlice, ok := propInterface.([]interface{})
+			if !ok {
+				continue
+			}
+			for _, prop := range propSlice {
+				propMap, ok := prop.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if propType, exists := propMap["type"]; exists && propType == "url" {
+					if value, ok := propMap["value"].(string); ok {
+						if err := AddZipAsset(ctx, i.assetRepo, i.file, zipWriter, value); err != nil {
+							log.Infofc(ctx, "Fail nLayer config addZipAsset :", err.Error())
+						}
+					}
+				}
+			}
+		}
+	}
 
 	// nlsLayer file resources
 	for _, nLayer := range nlsLayers {

--- a/server/internal/usecase/interactor/scene.go
+++ b/server/internal/usecase/interactor/scene.go
@@ -701,9 +701,8 @@ func (i *Scene) ExportScene(ctx context.Context, prj *project.Project, zipWriter
 			actualConfig := *c
 			if data, ok := actualConfig["data"].(map[string]any); ok {
 				if urlStr, ok := data["url"].(string); ok {
-					u, _ := url.Parse(urlStr)
-					if err := AddZipAsset(ctx, i.assetRepo, i.file, zipWriter, u.Path); err != nil {
-						log.Infofc(ctx, "Fail nLayer addZipAsset :", err.Error())
+					if err := AddZipAsset(ctx, i.assetRepo, i.file, zipWriter, urlStr); err != nil {
+						log.Infofc(ctx, "Fail nLayer config addZipAsset :", err.Error())
 					}
 				}
 			}
@@ -716,14 +715,13 @@ func (i *Scene) ExportScene(ctx context.Context, prj *project.Project, zipWriter
 		}
 
 		for _, vFeature := range actualLayer.Sketch().FeatureCollection().Features() {
-			for key, value := range *vFeature.Properties() {
-				if key == "threed_model_url" {
-					if threed_model_url, ok := value.(string); ok {
-						if err := AddZipAsset(ctx, i.assetRepo, i.file, zipWriter, threed_model_url); err != nil {
-							log.Infofc(ctx, "Fail nLayer addZipAsset :", err.Error())
-						}
+			for _, value := range *vFeature.Properties() {
+				if v, ok := value.(string); ok {
+					if err := AddZipAsset(ctx, i.assetRepo, i.file, zipWriter, v); err != nil {
+						log.Infofc(ctx, "Fail Sketch feature addZipAsset :", err.Error())
 					}
 				}
+
 			}
 		}
 	}
@@ -735,7 +733,7 @@ func (i *Scene) ExportScene(ctx context.Context, prj *project.Project, zipWriter
 		if marker, ok := v["marker"].(map[string]any); ok {
 			if image, ok := marker["image"].(string); ok {
 				if err := AddZipAsset(ctx, i.assetRepo, i.file, zipWriter, image); err != nil {
-					log.Infofc(ctx, "Fail nLayer addZipAsset :", err.Error())
+					log.Infofc(ctx, "Fail nLayer style addZipAsset :", err.Error())
 				}
 			}
 		}


### PR DESCRIPTION
# Overview

Bug fix for project export/import.

## What I've done

I modified the export process to determine whether an asset belongs to reearth-visualizer and include it in the export file.

Assets used in custom plugins are also now included in the export ZIP.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced asset export functionality to support URL-based widget properties during scene export.
	- Unified URL validation and transformation for more consistent asset management.
- **Refactor**
	- Streamlined URL handling logic across export and import processes for improved reliability.
	- Removed outdated asset packaging code to simplify maintenance and reduce complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->