### PR TITLE
fix(web): check the zip format by extension on plugin playground[VIZ-1376]

### DIFF
--- a/web/src/beta/features/PluginPlayground/Plugins/usePlugins.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/usePlugins.ts
@@ -183,7 +183,7 @@ export default () => {
         return;
       }
 
-      if (file.type !== "application/zip") {
+      if (!file.name.toLowerCase().endsWith(".zip")) {
         setNotification({
           type: "error",
           text: t("Only zip files are supported")


### PR DESCRIPTION
# Overview
- I fixed bug that file import would fail on Windows PC

## What I've done
- Check the zip format by extension
  - It caused by different mime types for different OS. Windows uses the non-standard MIME type application/x-zip-compressed for .zip files

## What I haven't done

## How I tested
manually(both windows and mac)

## Which point I want you to review particularly

## Memo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the plugin upload process by enhancing ZIP file validation to correctly recognize files based on their filename extension, ensuring a smoother experience when importing plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->