### PR TITLE
fix(server): project import export3 [VIZ-1360]

### DIFF
--- a/server/internal/usecase/interactor/asset.go
+++ b/server/internal/usecase/interactor/asset.go
@@ -2,7 +2,9 @@ package interactor
 
 import (
 	"archive/zip"
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -15,8 +17,8 @@ import (
 	"github.com/reearth/reearth/server/pkg/asset"
 	"github.com/reearth/reearth/server/pkg/file"
 	"github.com/reearth/reearth/server/pkg/id"
+	"github.com/reearth/reearth/server/pkg/project"
 	"github.com/reearth/reearthx/account/accountdomain"
-	"github.com/reearth/reearthx/idx"
 	"github.com/reearth/reearthx/usecasex"
 )
 
@@ -151,45 +153,74 @@ func (i *Asset) Remove(ctx context.Context, aid id.AssetID, operator *usecase.Op
 	)
 }
 
-func (i *Asset) ImportAssetFiles(ctx context.Context, realName string, zipFile *zip.File, workspace idx.ID[accountdomain.Workspace], project *id.ProjectID) (*url.URL, int64, error) {
+func (i *Asset) ImportAssetFiles(ctx context.Context, assets map[string]*zip.File, data []byte, newProject *project.Project) ([]byte, error) {
 
-	readCloser, err := zipFile.Open()
-	if err != nil {
-		return nil, 0, fmt.Errorf("error opening zip file entry: %w", err)
+	var d map[string]any
+	if err := json.Unmarshal(data, &d); err != nil {
+		return nil, err
 	}
-	defer func() {
-		if cerr := readCloser.Close(); cerr != nil {
-			fmt.Printf("Error closing file: %v\n", cerr)
+
+	assetNames := make(map[string]string)
+	for beforeName, realName := range d["assets"].(map[string]any) {
+		if realName, ok := realName.(string); ok {
+			assetNames[beforeName] = realName
 		}
-	}()
-
-	contentType := http.DetectContentType([]byte(zipFile.Name))
-	file := &file.File{
-		Content:     readCloser,
-		Path:        realName,
-		Size:        int64(zipFile.UncompressedSize64),
-		ContentType: contentType,
-	}
-	url, size, err := i.gateways.File.UploadAsset(ctx, file)
-	if err != nil {
-		return nil, 0, err
 	}
 
-	a, err := asset.New().
-		NewID().
-		Workspace(workspace).
-		Project(project).
-		Name(path.Base(realName)).
-		Size(size).
-		URL(url.String()).
-		CoreSupport(true).
-		Build()
-	if err != nil {
-		return nil, 0, err
-	}
-	if err := i.repos.Asset.Save(ctx, a); err != nil {
-		return nil, 0, err
+	for beforeName, zipFile := range assets {
+		realName := assetNames[beforeName]
+		readCloser, err := zipFile.Open()
+		if err != nil {
+			return nil, err
+		}
+
+		defer func() {
+			if cerr := readCloser.Close(); cerr != nil {
+				fmt.Printf("Error closing file: %v\n", cerr)
+			}
+		}()
+
+		file := &file.File{
+			Content:     readCloser,
+			Path:        realName,
+			Size:        int64(zipFile.UncompressedSize64),
+			ContentType: http.DetectContentType([]byte(zipFile.Name)),
+		}
+
+		url, size, err := i.gateways.File.UploadAsset(ctx, file)
+		if err != nil {
+			return nil, err
+		}
+
+		if newProject.ImageURL() != nil {
+			if path.Base(newProject.ImageURL().Path) == beforeName {
+				newProject.SetImageURL(url)
+				err := i.repos.Project.Save(ctx, newProject)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		a, err := asset.New().
+			NewID().
+			Workspace(newProject.Workspace()).
+			Project(newProject.ID().Ref()).
+			Name(path.Base(realName)).
+			Size(size).
+			URL(url.String()).
+			CoreSupport(true).
+			Build()
+		if err != nil {
+			return nil, err
+		}
+
+		if err := i.repos.Asset.Save(ctx, a); err != nil {
+			return nil, err
+		}
+		afterName := path.Base(url.Path)
+		data = bytes.Replace(data, []byte(beforeName), []byte(afterName), -1)
 	}
 
-	return url, size, err
+	return data, nil
 }

--- a/server/internal/usecase/interactor/asset.go
+++ b/server/internal/usecase/interactor/asset.go
@@ -168,6 +168,9 @@ func (i *Asset) ImportAssetFiles(ctx context.Context, assets map[string]*zip.Fil
 	}
 
 	for beforeName, zipFile := range assets {
+		if zipFile.UncompressedSize64 == 0 {
+			continue
+		}
 		realName := assetNames[beforeName]
 		readCloser, err := zipFile.Open()
 		if err != nil {

--- a/server/internal/usecase/interactor/common.go
+++ b/server/internal/usecase/interactor/common.go
@@ -1,11 +1,8 @@
 package interactor
 
 import (
-	"archive/zip"
 	"context"
 	"errors"
-	"fmt"
-	"io"
 	"net/url"
 	"strings"
 
@@ -262,35 +259,4 @@ func ReplaceToCurrentHost(ctx context.Context, urlString string) string {
 	u.Scheme = u2.Scheme
 	u.Host = u2.Host
 	return u.String()
-}
-
-// If the given path is the URL of an Asset, it will be added to the ZIP.
-func AddZipAsset(ctx context.Context, assetRepo repo.Asset, file gateway.File, zipWriter *zip.Writer, urlString string) error {
-
-	if !IsCurrentHostAssets(ctx, urlString) {
-		return nil
-	}
-
-	parts := strings.Split(urlString, "/")
-	fileName := parts[len(parts)-1]
-	stream, err := file.ReadAsset(ctx, fileName)
-	if err != nil {
-		return nil // skip if not available
-	}
-	defer func() {
-		if cerr := stream.Close(); cerr != nil {
-			fmt.Printf("Error closing file: %v\n", cerr)
-		}
-	}()
-	zipEntryPath := fmt.Sprintf("assets/%s", fileName)
-	zipEntry, err := zipWriter.Create(zipEntryPath)
-	if err != nil {
-		return err
-	}
-	_, err = io.Copy(zipEntry, stream)
-	if err != nil {
-		_ = stream.Close()
-		return err
-	}
-	return nil
 }

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -7,9 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
+	"path"
+	"strings"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
+	"github.com/reearth/reearth/server/internal/adapter"
 	jsonmodel "github.com/reearth/reearth/server/internal/adapter/gql/gqlmodel"
 	"github.com/reearth/reearth/server/internal/usecase"
 	"github.com/reearth/reearth/server/internal/usecase/gateway"
@@ -22,7 +26,6 @@ import (
 	"github.com/reearth/reearth/server/pkg/visualizer"
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/account/accountusecase/accountrepo"
-	"github.com/reearth/reearthx/idx"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/reearth/reearthx/usecasex"
 	"github.com/spf13/afero"
@@ -520,23 +523,97 @@ func (i *Project) ExportProjectData(ctx context.Context, projectID id.ProjectID,
 		return nil, errors.New("This project is deleted")
 	}
 
-	// project image
-	if prj.ImageURL() != nil {
-		err := AddZipAsset(ctx, i.assetRepo, i.file, zipWriter, prj.ImageURL().Path)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return prj, nil
 }
 
+func SearchAssetURL(ctx context.Context, data any, assetRepo repo.Asset, file gateway.File, zipWriter *zip.Writer, assetNames map[string]string) error {
+	switch v := data.(type) {
+	case map[string]any:
+		for _, value := range v {
+			if err := SearchAssetURL(ctx, value, assetRepo, file, zipWriter, assetNames); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for _, item := range v {
+			if err := SearchAssetURL(ctx, item, assetRepo, file, zipWriter, assetNames); err != nil {
+				return err
+			}
+		}
+	case string:
+		if strings.HasPrefix(v, adapter.CurrentHost(ctx)) {
+			if err := AddZipAsset(ctx, assetRepo, file, zipWriter, v, assetNames); err != nil {
+				return err
+			}
+		}
+	default:
+
+	}
+	return nil
+}
+
+// If the given path is the URL of an Asset, it will be added to the ZIP.
+func AddZipAsset(ctx context.Context, assetRepo repo.Asset, file gateway.File, zipWriter *zip.Writer, urlString string, assetNames map[string]string) error {
+
+	if !IsCurrentHostAssets(ctx, urlString) {
+		return nil
+	}
+
+	parts := strings.Split(urlString, "/")
+	beforeUniversaName := parts[len(parts)-1]
+	stream, err := file.ReadAsset(ctx, beforeUniversaName)
+	if err != nil {
+		return nil // skip if not available
+	}
+	defer func() {
+		if cerr := stream.Close(); cerr != nil {
+			fmt.Printf("Error closing file: %v\n", cerr)
+		}
+	}()
+
+	zipEntryPath := fmt.Sprintf("assets/%s", beforeUniversaName)
+	zipEntry, err := zipWriter.Create(zipEntryPath)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(zipEntry, stream)
+	if err != nil {
+		_ = stream.Close()
+		return err
+	}
+	if a, err := assetRepo.FindByURL(ctx, urlString); a != nil && err == nil {
+		if parsedURL, err := url.Parse(urlString); err == nil {
+			assetNames[path.Base(parsedURL.Path)] = a.Name()
+		}
+	}
+
+	return nil
+}
+
 func (i *Project) UploadExportProjectZip(ctx context.Context, zipWriter *zip.Writer, zipFile afero.File, data map[string]interface{}, prj *project.Project) error {
+
+	assetNames := make(map[string]string)
+	if project, ok := data["project"].(map[string]interface{}); ok {
+		if imageUrl, ok := project["imageUrl"].(map[string]interface{}); ok {
+			if path, ok := imageUrl["Path"].(string); ok {
+				err := AddZipAsset(ctx, i.assetRepo, i.file, zipWriter, adapter.CurrentHost(ctx)+path, assetNames)
+				if err != nil {
+					fmt.Printf("not notfound asset file: %v\n", err)
+				}
+			}
+		}
+	}
+	err := SearchAssetURL(ctx, data, i.assetRepo, i.file, zipWriter, assetNames)
+	if err != nil {
+		fmt.Printf("not notfound asset file: %v\n", err)
+	}
+	data["assets"] = assetNames
+
 	fileWriter, err := zipWriter.Create("project.json")
 	if err != nil {
 		return err
 	}
-	jsonData, err := json.Marshal(data)
+	jsonData, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return err
 	}
@@ -562,11 +639,21 @@ func (i *Project) UploadExportProjectZip(ctx context.Context, zipWriter *zip.Wri
 	return nil
 }
 
-func (i *Project) ImportProjectData(ctx context.Context, workspace idx.ID[accountdomain.Workspace], projectData map[string]interface{}, op *usecase.Operator) (*project.Project, usecasex.Tx, error) {
+func (i *Project) ImportProjectData(ctx context.Context, workspace accountdomain.WorkspaceID, data []byte, op *usecase.Operator) (*project.Project, usecasex.Tx, error) {
 
 	tx, err := i.transaction.Begin(ctx)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	var d map[string]any
+	if err := json.Unmarshal(data, &d); err != nil {
+		return nil, nil, err
+	}
+
+	projectData, ok := d["project"].(map[string]any)
+	if !ok {
+		return nil, nil, errors.New("project parse error")
 	}
 
 	var input = jsonmodel.ToProjectExportFromJSON(projectData)

--- a/server/internal/usecase/interfaces/asset.go
+++ b/server/internal/usecase/interfaces/asset.go
@@ -4,14 +4,13 @@ import (
 	"archive/zip"
 	"context"
 	"errors"
-	"net/url"
 
 	"github.com/reearth/reearth/server/internal/usecase"
 	"github.com/reearth/reearth/server/pkg/asset"
 	"github.com/reearth/reearth/server/pkg/file"
 	"github.com/reearth/reearth/server/pkg/id"
+	"github.com/reearth/reearth/server/pkg/project"
 	"github.com/reearth/reearthx/account/accountdomain"
-	"github.com/reearth/reearthx/idx"
 	"github.com/reearth/reearthx/usecasex"
 )
 
@@ -40,5 +39,5 @@ type Asset interface {
 	Create(context.Context, CreateAssetParam, *usecase.Operator) (*asset.Asset, error)
 	Update(context.Context, id.AssetID, *id.ProjectID, *usecase.Operator) (id.AssetID, *id.ProjectID, error)
 	Remove(context.Context, id.AssetID, *usecase.Operator) (id.AssetID, error)
-	ImportAssetFiles(context.Context, string, *zip.File, idx.ID[accountdomain.Workspace], *id.ProjectID) (*url.URL, int64, error)
+	ImportAssetFiles(context.Context, map[string]*zip.File, []byte, *project.Project) ([]byte, error)
 }

--- a/server/internal/usecase/interfaces/plugin.go
+++ b/server/internal/usecase/interfaces/plugin.go
@@ -25,5 +25,5 @@ type Plugin interface {
 	UploadFromRemote(context.Context, *url.URL, id.SceneID, *usecase.Operator) (*plugin.Plugin, *scene.Scene, error)
 	ExportPlugins(context.Context, *scene.Scene, *zip.Writer) ([]*plugin.Plugin, []*property.Schema, error)
 	ImportPlugins(context.Context, *scene.Scene, []interface{}, []interface{}) ([]*plugin.Plugin, property.SchemaList, error)
-	ImporPluginFile(context.Context, string, string, *zip.File) error
+	ImporPluginFile(context.Context, map[string]*zip.File, string, string) error
 }

--- a/server/internal/usecase/interfaces/project.go
+++ b/server/internal/usecase/interfaces/project.go
@@ -72,6 +72,6 @@ type Project interface {
 	CheckAlias(context.Context, string) (bool, error)
 	Delete(context.Context, id.ProjectID, *usecase.Operator) error
 	ExportProjectData(context.Context, id.ProjectID, *zip.Writer, *usecase.Operator) (*project.Project, error)
-	ImportProjectData(context.Context, idx.ID[accountdomain.Workspace], map[string]interface{}, *usecase.Operator) (*project.Project, usecasex.Tx, error)
+	ImportProjectData(context.Context, idx.ID[accountdomain.Workspace], []byte, *usecase.Operator) (*project.Project, usecasex.Tx, error)
 	UploadExportProjectZip(context.Context, *zip.Writer, afero.File, map[string]interface{}, *project.Project) error
 }

--- a/server/internal/usecase/interfaces/scene.go
+++ b/server/internal/usecase/interfaces/scene.go
@@ -1,7 +1,6 @@
 package interfaces
 
 import (
-	"archive/zip"
 	"context"
 	"errors"
 
@@ -33,8 +32,8 @@ type Scene interface {
 	AddCluster(context.Context, id.SceneID, string, *usecase.Operator) (*scene.Scene, *scene.Cluster, error)
 	UpdateCluster(context.Context, UpdateClusterParam, *usecase.Operator) (*scene.Scene, *scene.Cluster, error)
 	RemoveCluster(context.Context, id.SceneID, id.ClusterID, *usecase.Operator) (*scene.Scene, error)
-	ExportScene(context.Context, *project.Project, *zip.Writer) (*scene.Scene, map[string]interface{}, error)
-	ImportScene(context.Context, *scene.Scene, *project.Project, []*plugin.Plugin, map[string]interface{}) (*scene.Scene, error)
+	ExportScene(context.Context, *project.Project) (*scene.Scene, map[string]any, error)
+	ImportScene(context.Context, *scene.Scene, *project.Project, []*plugin.Plugin, map[string]any) (*scene.Scene, error)
 }
 
 type UpdateWidgetParam struct {


### PR DESCRIPTION
# Overview

## What I've done
### 1. I refactored ImportProject() because it was complicated.

### 2. I modified the asset file retrieval to perform a full scan of sceneJSON using a recursive loop.
This ensures that no asset files are missed and eliminates the need to fetch them individually.
```
func SearchAssetURL(...) {
    AddZipAsset(...)
}
```
### 3.Since tracking exported data was difficult, I added exportedInfo:
```
"exportedInfo": {
    "host": "http://localhost:8080",
    "project": "01jnpsd9sep7p00e7nsdd7g1f6",
    "timestamp": "2025-03-07T08:58:18+09:00"
}
```

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined project export/import processing for improved reliability and clearer error messaging.
  - Upgraded asset and plugin handling to support multi-file imports, enhancing data processing.
  - Simplified scene export operations for more efficient project updates.
  - Enhanced type safety by transitioning from `interface{}` to `any` in several method signatures.
  - Removed unnecessary complexity in asset management during project operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->