### PR TITLE
fix(web): members management allow owner update owner [VIZ-1399]

### DIFF
--- a/web/src/beta/features/Dashboard/ContentsContainer/Members/ListItem.tsx
+++ b/web/src/beta/features/Dashboard/ContentsContainer/Members/ListItem.tsx
@@ -11,12 +11,14 @@ const ListItem: FC<{
   setSelectedMember: (member: TeamMember) => void;
   setDeleteMemerModalVisible: (visible: boolean) => void;
   meRole: string | undefined;
+  meId: string | undefined;
 }> = ({
   member,
   setUpdateRoleModalVisible,
   setSelectedMember,
   setDeleteMemerModalVisible,
-  meRole
+  meRole,
+  meId
 }) => {
   const t = useT();
   const memerRoleTranslation = {
@@ -77,26 +79,14 @@ const ListItem: FC<{
                 icon: "arrowLeftRight",
                 id: "changeRole",
                 title: t("Change Role"),
-                disabled:
-                  meRole === Role.Reader ||
-                  meRole === Role.Writer ||
-                  member.role === Role.Owner ||
-                  // (meRole === Role.Maintainer && member.role === Role.Owner),
-                  //maintainer can't change member role for now
-                  meRole === Role.Maintainer,
+                disabled: meRole !== Role.Owner || meId === member.userId,
                 onClick: () => handleUpdateRole(member)
               },
               {
                 icon: "close",
                 id: "remove",
                 title: t("Remove"),
-                disabled:
-                  meRole === Role.Reader ||
-                  meRole === Role.Writer ||
-                  member.role === Role.Owner ||
-                  // (meRole === Role.Maintainer && member.role === Role.Owner),
-                  //maintainer can't remove member for now
-                  meRole === Role.Maintainer,
+                disabled: meRole !== Role.Owner || meId === member.userId,
                 onClick: () => handleDeleteRole(member)
               }
             ]}

--- a/web/src/beta/features/Dashboard/ContentsContainer/Members/UpdateRoleModal.tsx
+++ b/web/src/beta/features/Dashboard/ContentsContainer/Members/UpdateRoleModal.tsx
@@ -28,14 +28,14 @@ const UpdateRoleModal: FC<UpdateRoleModalProps> = ({
       return [
         { value: "READER", label: t("READER") },
         { value: "WRITER", label: t("WRITER") },
-        { value: "MAINTAINER", label: t("MAINTAINER") + "(WIP)" },
+        { value: "MAINTAINER", label: t("MAINTAINER") + " (WIP)" },
         { value: "OWNER", label: t("OWNER") }
       ];
     } else if (meRole === "MAINTAINER") {
       return [
         { value: "READER", label: t("READER") },
         { value: "WRITER", label: t("WRITER") },
-        { value: "MAINTAINER", label: t("MAINTAINER") + "(WIP)" }
+        { value: "MAINTAINER", label: t("MAINTAINER") + " (WIP)" }
       ];
     } else return [];
   }, [meRole, t]);

--- a/web/src/beta/features/Dashboard/ContentsContainer/Members/index.tsx
+++ b/web/src/beta/features/Dashboard/ContentsContainer/Members/index.tsx
@@ -107,6 +107,7 @@ const Members: FC<Props> = ({ currentWorkspace }) => {
               setSelectedMember={setSelectedMember}
               setDeleteMemerModalVisible={setDeleteMemerModalVisible}
               meRole={meRole}
+              meId={meId}
             />
           ))
         ) : (


### PR DESCRIPTION
# Overview

The permissions were not correct.

Owner should be able to update owner.

## What I've done

Auth table. -> will be next task.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a user identifier property to the member list, enabling refined permission controls that better manage the availability of actions like "Change Role" and "Remove."

- **Style**
  - Revised the formatting of role labels in the role selection modal to improve clarity (e.g., displaying "MAINTAINER (WIP)" with proper spacing).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->