### PR TITLE
fix(web): Set maxHeight on story show layer button edit panel layer selector & Apply layer order[VIZ-1370]

### DIFF
--- a/web/src/beta/features/Visualizer/Crust/StoryPanel/Block/builtin/Layer/Content.tsx
+++ b/web/src/beta/features/Visualizer/Crust/StoryPanel/Block/builtin/Layer/Content.tsx
@@ -1,6 +1,7 @@
 import { BlockContext } from "@reearth/beta/features/Visualizer/shared/components/BlockWrapper";
 import { useBlockContext } from "@reearth/beta/features/Visualizer/shared/contexts/blockContext";
 import Button from "@reearth/beta/ui/widgetui/Button";
+import { NLSLayer } from "@reearth/services/api/layersApi/utils";
 import { useT } from "@reearth/services/i18n";
 import { styled } from "@reearth/services/theme";
 import { FC, useCallback, useContext, useState } from "react";
@@ -34,6 +35,7 @@ type Props = {
     schemaGroupId?: string,
     itemId?: string
   ) => Promise<void>;
+  nlsLayers?: NLSLayer[];
 };
 
 const Content: FC<Props> = ({
@@ -43,7 +45,8 @@ const Content: FC<Props> = ({
   onPropertyUpdate,
   onPropertyItemAdd,
   onPropertyItemDelete,
-  onPropertyItemMove
+  onPropertyItemMove,
+  nlsLayers
 }) => {
   const t = useT();
   const [selected, setSelected] = useState<string>(layerButtons[0]?.id);
@@ -99,6 +102,7 @@ const Content: FC<Props> = ({
           onPropertyItemAdd={onPropertyItemAdd}
           onPropertyItemMove={onPropertyItemMove}
           onPropertyItemDelete={onPropertyItemDelete}
+          nlsLayers={nlsLayers}
         />
       )}
     </Wrapper>

--- a/web/src/beta/features/Visualizer/Crust/StoryPanel/Block/builtin/Layer/Editor/hooks.ts
+++ b/web/src/beta/features/Visualizer/Crust/StoryPanel/Block/builtin/Layer/Editor/hooks.ts
@@ -1,4 +1,4 @@
-import { useVisualizer } from "@reearth/core";
+import { NLSLayer } from "@reearth/services/api/layersApi/utils";
 import { useT } from "@reearth/services/i18n";
 import { debounce } from "lodash-es";
 import { useCallback, useMemo } from "react";
@@ -19,7 +19,8 @@ export default ({
   onPropertyUpdate,
   onPropertyItemAdd,
   onPropertyItemDelete,
-  onPropertyItemMove
+  onPropertyItemMove,
+  nlsLayers
 }: {
   items: LayerBlock[];
   propertyId?: string;
@@ -47,18 +48,23 @@ export default ({
     schemaGroupId?: string,
     itemId?: string
   ) => Promise<void>;
+  nlsLayers?: NLSLayer[];
 }) => {
-  const visualizer = useVisualizer();
   const t = useT();
 
   const layers = useMemo(
     () =>
-      visualizer.current?.layers?.layers()?.map(({ id, title }) => ({
-        value: id,
-        label: title ?? `Layer: ${id}`
-      })) || [],
-    [visualizer]
+      nlsLayers
+        ?.sort((a, b) => {
+          return (a?.index ?? 0) - (b?.index ?? 0);
+        })
+        .map(({ id, title }) => ({
+          value: id,
+          label: title ?? `Layer: ${id}`
+        })) || [],
+    [nlsLayers]
   );
+
   const editorProperties = useMemo(
     () => items.find((i) => i.id === selected),
     [items, selected]

--- a/web/src/beta/features/Visualizer/Crust/StoryPanel/Block/builtin/Layer/Editor/index.tsx
+++ b/web/src/beta/features/Visualizer/Crust/StoryPanel/Block/builtin/Layer/Editor/index.tsx
@@ -4,6 +4,7 @@ import {
   ListField,
   SelectField
 } from "@reearth/beta/ui/fields";
+import { NLSLayer } from "@reearth/services/api/layersApi/utils";
 import { useT } from "@reearth/services/i18n";
 import { styled } from "@reearth/services/theme";
 import { FC } from "react";
@@ -40,6 +41,7 @@ export type Props = {
     schemaGroupId?: string,
     itemId?: string
   ) => Promise<void>;
+  nlsLayers?: NLSLayer[];
 };
 
 const CameraBlockEditor: FC<Props> = ({
@@ -50,7 +52,8 @@ const CameraBlockEditor: FC<Props> = ({
   onPropertyUpdate,
   onPropertyItemAdd,
   onPropertyItemDelete,
-  onPropertyItemMove
+  onPropertyItemMove,
+  nlsLayers
 }) => {
   const t = useT();
   const {
@@ -68,7 +71,8 @@ const CameraBlockEditor: FC<Props> = ({
     onPropertyUpdate,
     onPropertyItemAdd,
     onPropertyItemDelete,
-    onPropertyItemMove
+    onPropertyItemMove,
+    nlsLayers
   });
 
   return (
@@ -122,6 +126,7 @@ const CameraBlockEditor: FC<Props> = ({
           onChange={(value) =>
             debounceOnUpdate(selected, "showLayers", "array", value)
           }
+          maxHeight={300}
           multiple
         />
       </FieldGroup>

--- a/web/src/beta/features/Visualizer/Crust/StoryPanel/Block/builtin/Layer/index.tsx
+++ b/web/src/beta/features/Visualizer/Crust/StoryPanel/Block/builtin/Layer/index.tsx
@@ -1,5 +1,6 @@
 import BlockWrapper from "@reearth/beta/features/Visualizer/shared/components/BlockWrapper";
 import type { CommonBlockProps as BlockProps } from "@reearth/beta/features/Visualizer/shared/types";
+import type { NLSLayer } from "@reearth/services/api/layersApi/utils";
 import { useMemo, useEffect } from "react";
 
 import { StoryBlock } from "../../../types";
@@ -46,7 +47,7 @@ const LayerBlock: React.FC<Props> = ({
         onPropertyUpdate={props.onPropertyUpdate}
         onPropertyItemAdd={onPropertyItemAdd}
         onPropertyItemMove={props.onPropertyItemMove}
-        onPropertyItemDelete={props.onPropertyItemDelete}
+        nlsLayers={props.nlsLayers as NLSLayer[] | undefined}
       />
     </BlockWrapper>
   );

--- a/web/src/beta/features/Visualizer/Crust/StoryPanel/Block/index.tsx
+++ b/web/src/beta/features/Visualizer/Crust/StoryPanel/Block/index.tsx
@@ -3,6 +3,7 @@ import type {
   BlockProps
 } from "@reearth/beta/features/Visualizer/shared/types";
 import type { Layer } from "@reearth/core";
+import { NLSLayer } from "@reearth/services/api/layersApi/utils";
 import { useCallback, type ComponentType, type ReactNode } from "react";
 
 import BlockWrapper from "../../../shared/components/BlockWrapper";
@@ -14,6 +15,7 @@ export type Props = {
   renderBlock?: (block: BlockProps<StoryBlock>) => ReactNode;
   layer?: Layer;
   pageId?: string;
+  nlsLayers?: NLSLayer[];
 } & CommonBlockProps<StoryBlock>;
 
 export type Component = ComponentType<CommonBlockProps<StoryBlock>>;
@@ -51,7 +53,8 @@ export default function StoryBlockComponent({
       {renderBlock?.({
         block: props.block,
         layer: props.layer,
-        onClick: props.onClick
+        onClick: props.onClick,
+        nlsLayers: props.nlsLayers
       })}
     </BlockWrapper>
   ) : null;

--- a/web/src/beta/features/Visualizer/Crust/StoryPanel/Page/index.tsx
+++ b/web/src/beta/features/Visualizer/Crust/StoryPanel/Page/index.tsx
@@ -4,6 +4,7 @@ import SelectableArea from "@reearth/beta/features/Visualizer/shared/components/
 import { useElementOnScreen } from "@reearth/beta/features/Visualizer/shared/hooks/useElementOnScreen";
 import { DragAndDropList } from "@reearth/beta/lib/reearth-ui";
 import type { ValueType, ValueTypes } from "@reearth/beta/utils/value";
+import { NLSLayer } from "@reearth/services/api/layersApi/utils";
 import type { InstallableStoryBlock } from "@reearth/services/api/storytellingApi/blocks";
 import { useT } from "@reearth/services/i18n";
 import { styled } from "@reearth/services/theme";
@@ -77,6 +78,7 @@ type Props = {
     itemId?: string
   ) => Promise<void>;
   renderBlock?: (block: BlockProps<StoryBlockType>) => ReactNode;
+  nlsLayers?: NLSLayer[];
 };
 const PAGE_DRAG_HANDLE_CLASS_NAME =
   "reearth-visualizer-editor-page-drag-handle";
@@ -103,7 +105,8 @@ const StoryPanel: FC<Props> = ({
   onPropertyItemAdd,
   onPropertyItemMove,
   onPropertyItemDelete,
-  renderBlock
+  renderBlock,
+  nlsLayers
 }) => {
   const t = useT();
 
@@ -180,6 +183,7 @@ const StoryPanel: FC<Props> = ({
               onPropertyItemDelete={onPropertyItemDelete}
               renderBlock={renderBlock}
               padding={panelSettings?.padding?.value}
+              nlsLayers={nlsLayers}
             />
             {isEditable && !disableSelection && (
               <BlockAddBar
@@ -209,6 +213,7 @@ const StoryPanel: FC<Props> = ({
       renderBlock,
       panelSettings?.padding?.value,
       panelSettings?.gap?.value,
+      nlsLayers,
       disableSelection,
       openBlocksIndex,
       installableStoryBlocks,
@@ -271,6 +276,7 @@ const StoryPanel: FC<Props> = ({
               onPropertyItemMove={onPropertyItemMove}
               onPropertyItemDelete={onPropertyItemDelete}
               renderBlock={renderBlock}
+              nlsLayers={nlsLayers}
             />
           )}
           {isEditable && !disableSelection && (

--- a/web/src/beta/features/Visualizer/Crust/StoryPanel/PanelContent/index.tsx
+++ b/web/src/beta/features/Visualizer/Crust/StoryPanel/PanelContent/index.tsx
@@ -1,4 +1,5 @@
 import { ValueType, ValueTypes } from "@reearth/beta/utils/value";
+import { NLSLayer } from "@reearth/services/api/layersApi/utils";
 import type { InstallableStoryBlock } from "@reearth/services/api/storytellingApi/blocks";
 import { styled } from "@reearth/services/theme";
 import { FC, MutableRefObject, ReactNode } from "react";
@@ -64,6 +65,7 @@ export type Props = {
     itemId?: string
   ) => Promise<void>;
   renderBlock?: (block: BlockProps<StoryBlock>) => ReactNode;
+  nlsLayers?: NLSLayer[];
 };
 
 const StoryContent: FC<Props> = ({
@@ -87,7 +89,8 @@ const StoryContent: FC<Props> = ({
   onPropertyItemAdd,
   onPropertyItemMove,
   onPropertyItemDelete,
-  renderBlock
+  renderBlock,
+  nlsLayers
 }) => {
   const {
     pageGap,
@@ -130,6 +133,7 @@ const StoryContent: FC<Props> = ({
           onPropertyItemMove={onPropertyItemMove}
           onPropertyItemDelete={onPropertyItemDelete}
           renderBlock={renderBlock}
+          nlsLayers={nlsLayers}
         >
           <PageGap height={pageGap} onClick={() => onPageSelect?.(p.id)} />
         </StoryPage>

--- a/web/src/beta/features/Visualizer/Crust/StoryPanel/index.tsx
+++ b/web/src/beta/features/Visualizer/Crust/StoryPanel/index.tsx
@@ -5,6 +5,7 @@ import {
   InstallableBlock
 } from "@reearth/beta/features/Visualizer/shared/types";
 import { ValueType, ValueTypes } from "@reearth/beta/utils/value";
+import { NLSLayer } from "@reearth/services/api/layersApi/utils";
 import { styled } from "@reearth/services/theme";
 import { forwardRef, memo, ReactNode, Ref, RefObject, useMemo } from "react";
 import { createPortal } from "react-dom";
@@ -63,6 +64,7 @@ export type StoryPanelProps = {
     itemId?: string
   ) => Promise<void>;
   renderBlock?: (block: BlockProps<StoryBlock>) => ReactNode;
+  nlsLayers?: NLSLayer[];
 };
 
 export const StoryPanel = memo(
@@ -81,7 +83,8 @@ export const StoryPanel = memo(
         onPropertyItemAdd,
         onPropertyItemMove,
         onPropertyItemDelete,
-        renderBlock
+        renderBlock,
+        nlsLayers
       },
       ref: Ref<StoryPanelRef>
     ) => {
@@ -182,6 +185,7 @@ export const StoryPanel = memo(
                       onPropertyItemMove={onPropertyItemMove}
                       onPropertyItemDelete={onPropertyItemDelete}
                       renderBlock={renderBlock}
+                      nlsLayers={nlsLayers}
                     />
                   </PanelWrapper>
                 </BlockProvider>

--- a/web/src/beta/features/Visualizer/Crust/index.tsx
+++ b/web/src/beta/features/Visualizer/Crust/index.tsx
@@ -387,6 +387,7 @@ export default function Crust({
           onPropertyItemMove={onPropertyItemMove}
           onPropertyItemDelete={onPropertyItemDelete}
           renderBlock={renderBlock}
+          nlsLayers={nlsLayers}
         />
       )}
       <PhotoOverlay

--- a/web/src/beta/features/Visualizer/shared/types.ts
+++ b/web/src/beta/features/Visualizer/shared/types.ts
@@ -1,6 +1,7 @@
 import { Theme } from "@reearth/beta/features/Visualizer/Crust/types";
 import { ValueType, ValueTypes } from "@reearth/beta/utils/value";
 import type { ComputedFeature, FlyTo, Layer } from "@reearth/core";
+import { NLSLayer } from "@reearth/services/api/layersApi/utils";
 
 export type InstallableBlock = {
   name: string;
@@ -17,6 +18,7 @@ export type BlockProps<T = any> = {
   layer?: Layer;
   onClick?: () => void;
   onBlockDoubleClick?: () => void;
+  nlsLayers?: NLSLayer[];
 };
 
 export type CommonBlockProps<T = any> = {
@@ -64,4 +66,5 @@ export type CommonBlockProps<T = any> = {
     itemId?: string
   ) => Promise<void>;
   onFlyTo?: FlyTo;
+  nlsLayers?: NLSLayer[];
 };

--- a/web/src/beta/lib/reearth-ui/components/Selector/index.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Selector/index.tsx
@@ -119,14 +119,16 @@ export const Selector: FC<SelectorProps> = ({
     [selectedValue, onChange]
   );
 
-  const selectedLabels = useMemo(() => {
-    if (displayLabel) return [displayLabel];
+  const selectedItems: { value: string; label?: string }[] = useMemo(() => {
+    if (displayLabel) return [{ value: "__fixedLabel__", label: displayLabel }];
     if (Array.isArray(selectedValue)) {
-      return selectedValue.map(
-        (val) => optionValues.find((item) => item.value === val)?.label
-      );
+      return selectedValue
+        .map((val) => optionValues.find((item) => item.value === val))
+        .filter((item): item is { value: string; label: string } => !!item);
     }
-    return [optionValues.find((item) => item.value === selectedValue)?.label];
+    return [optionValues.find((item) => item.value === selectedValue)].filter(
+      (item): item is { value: string; label: string } => !!item
+    );
   }, [optionValues, selectedValue, displayLabel]);
 
   const renderTrigger = () => {
@@ -144,13 +146,13 @@ export const Selector: FC<SelectorProps> = ({
           </Typography>
         ) : multiple ? (
           <SelectedItems>
-            {selectedLabels.map((val) => (
-              <SelectedItem key={val}>
+            {selectedItems.map((item) => (
+              <SelectedItem key={item.value}>
                 <Typography
                   size="body"
                   color={disabled ? theme.content.weaker : theme.content.main}
                 >
-                  {val}
+                  {item.label}
                 </Typography>
                 {!disabled && (
                   <Button
@@ -159,7 +161,7 @@ export const Selector: FC<SelectorProps> = ({
                     appearance="simple"
                     size="small"
                     onClick={(e: MouseEvent<HTMLElement>) =>
-                      handleUnselect(e, val)
+                      handleUnselect(e, item.value)
                     }
                   />
                 )}
@@ -175,7 +177,7 @@ export const Selector: FC<SelectorProps> = ({
                 : theme.content.main
             }
           >
-            {selectedLabels[0]}
+            {selectedItems[0].label}
           </Typography>
         )}
         <Icon


### PR DESCRIPTION
# Overview
Set maxHeight on story show layer button edit panel layer selector & Apply layer order

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded layer management across visualizer and story panel components by integrating support for additional localized layer data.
  - Improved the dropdown component for layer selection with a fixed maximum height, enhancing the user interface for selecting layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->