### PR TITLE
fix(server): Trimming Quotation

### DIFF
--- a/server/internal/infrastructure/mongo/migration/250305230545_asset_project_association.go
+++ b/server/internal/infrastructure/mongo/migration/250305230545_asset_project_association.go
@@ -173,8 +173,9 @@ func searchAssetURL(ctx context.Context, c DBClient, project string, data any, a
 	case map[string]any:
 		for key, value := range v {
 			if str, ok := value.(string); ok {
-				if strings.HasPrefix(str, assetURLPrefix) {
-					if _, err := updateAssetProject(ctx, c, project, str, collectionName, key); err != nil {
+				cleanedStr := strings.Trim(str, "'")
+				if strings.HasPrefix(cleanedStr, assetURLPrefix) {
+					if _, err := updateAssetProject(ctx, c, project, cleanedStr, collectionName, key); err != nil {
 						return err
 					}
 				}
@@ -187,8 +188,9 @@ func searchAssetURL(ctx context.Context, c DBClient, project string, data any, a
 	case []any:
 		for _, item := range v {
 			if str, ok := item.(string); ok {
-				if strings.HasPrefix(str, assetURLPrefix) {
-					if _, err := updateAssetProject(ctx, c, project, str, collectionName, ""); err != nil {
+				cleanedStr := strings.Trim(str, "'")
+				if strings.HasPrefix(cleanedStr, assetURLPrefix) {
+					if _, err := updateAssetProject(ctx, c, project, cleanedStr, collectionName, ""); err != nil {
 						return err
 					}
 				}


### PR DESCRIPTION
# Overview

Quotation not trimmed

## What I've done

I was checking the beginning of the URL, but I didn't account for quotation marks.

I have now handled such cases.
![スクリーンショット 2025-03-14 17 02 02](https://github.com/user-attachments/assets/a6f6afda-b9b4-43f2-aaf5-99cc8820e0ff)
<img width="649" alt="スクリーンショット 2025-03-14 17 02 21" src="https://github.com/user-attachments/assets/7a2351c8-f4d3-479d-b6c8-227dbb014fab" />


## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined asset URL handling to ensure consistent updates when extra formatting characters are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->