### PR TITLE
feat(server): add photoOverlay property  [VIZ-1340] 

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -79,6 +79,12 @@ dev: dev-install
 run-app:
 	go run ./cmd/reearth
 
+run-clean-start:
+	go clean -modcache
+	go clean -cache
+	go clean -testcache
+	go run ./cmd/reearth
+
 run-db:
 	docker compose -f ../docker-compose.yml up -d reearth-mongo
 

--- a/server/e2e/common.go
+++ b/server/e2e/common.go
@@ -53,6 +53,7 @@ func initRepos(t *testing.T, useMongo bool, seeder Seeder) (repos *repo.Containe
 
 	if useMongo {
 		db := mongotest.Connect(t)(t)
+		fmt.Println("db.Name():", db.Name())
 		accountRepos := lo.Must(accountmongo.New(ctx, db.Client(), db.Name(), false, false, nil))
 		repos = lo.Must(mongo.New(ctx, db, accountRepos, false))
 	} else {
@@ -189,6 +190,7 @@ type GraphQLRequest struct {
 }
 
 func Request(e *httpexpect.Expect, user string, requestBody GraphQLRequest) *httpexpect.Value {
+	// RequestDump(requestBody)
 	return e.POST("/api/graphql").
 		WithHeader("Origin", "https://example.com").
 		WithHeader("authorization", "Bearer test").
@@ -273,6 +275,12 @@ func aligningJSON(t *testing.T, str string) string {
 	strBytes, err := json.Marshal(obj)
 	assert.Nil(t, err)
 	return string(strBytes)
+}
+
+func RequestDump(requestBody GraphQLRequest) {
+	if jsonData, err := json.MarshalIndent(requestBody, "", "  "); err == nil {
+		fmt.Println(string(jsonData))
+	}
 }
 
 func ValueDump(val *httpexpect.Value) {

--- a/server/e2e/gql_project_export_import_test.go
+++ b/server/e2e/gql_project_export_import_test.go
@@ -174,7 +174,7 @@ func importProject(t *testing.T, e *httpexpect.Expect, filePath string) *httpexp
 func getScene(e *httpexpect.Expect, s string, l string) *httpexpect.Value {
 	requestBody := GraphQLRequest{
 		OperationName: "GetScene",
-		Query:         GetSceneGuery,
+		Query:         GetSceneQuery,
 		Variables: map[string]any{
 			"sceneId": s,
 			"lang":    l,
@@ -188,7 +188,7 @@ func getScene(e *httpexpect.Expect, s string, l string) *httpexpect.Value {
 	return v
 }
 
-const GetSceneGuery = `
+const GetSceneQuery = `
 query GetScene($sceneId: ID!, $lang: Lang) {
   node(id: $sceneId, type: SCENE) {
     id

--- a/server/e2e/gql_property_test.go
+++ b/server/e2e/gql_property_test.go
@@ -1,42 +1,110 @@
 package e2e
 
 import (
+	"testing"
+
 	"github.com/gavv/httpexpect/v2"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 )
 
 func updatePropertyValue(e *httpexpect.Expect, propertyID, schemaGroupID, itemID, fieldID string, value any, valueType any) (GraphQLRequest, *httpexpect.Value) {
 	requestBody := GraphQLRequest{
 		OperationName: "UpdatePropertyValue",
-		Query: `mutation UpdatePropertyValue($propertyId: ID!, $schemaGroupId: ID, $itemId: ID, $fieldId: ID!, $value: Any, $type: ValueType!) {
-			updatePropertyValue( input: { propertyId: $propertyId, schemaGroupId: $schemaGroupId, itemId: $itemId, fieldId: $fieldId, value: $value, type: $type } ) {
-				property {
-				id
-				schema{
-					id
-					groups{
-						fields{
-							fieldId
-							type
-							title
-							description
-							prefix
-							suffix
-							defaultValue
-							ui
-							min
-							max
-							placeholder
-						}
-					}
-				}
-				}
-				propertyField {	
-				id
-				type
-				value
-				}
-			}
-		}`,
+		Query: `mutation UpdatePropertyValue(
+  $propertyId: ID!
+  $schemaGroupId: ID
+  $itemId: ID
+  $fieldId: ID!
+  $value: Any
+  $type: ValueType!
+) {
+  updatePropertyValue(
+    input: {
+      propertyId: $propertyId
+      schemaGroupId: $schemaGroupId
+      itemId: $itemId
+      fieldId: $fieldId
+      value: $value
+      type: $type
+    }
+  ) {
+    property {
+      id
+      schema {
+        id
+        groups {
+          schemaGroupId
+          title
+          collection
+          isList
+          representativeFieldId
+          isAvailableIf {
+            fieldId
+            type
+            value
+          }
+          fields {
+            fieldId
+            title
+            description
+            placeholder
+            prefix
+            suffix
+            type
+            defaultValue
+            ui
+            min
+            max
+            choices {
+              key
+              icon
+              title
+            }
+            isAvailableIf {
+              fieldId
+              type
+              value
+            }
+          }
+        }
+      }
+      items {
+        ...PropertyItemFragment
+      }
+    }
+    propertyField {
+      id
+      type
+      value
+    }
+  }
+}
+
+fragment PropertyItemFragment on PropertyItem {
+  ... on PropertyGroupList {
+    id
+    schemaGroupId
+    groups {
+      ...PropertyGroupFragment
+    }
+  }
+  ... on PropertyGroup {
+    ...PropertyGroupFragment
+  }
+}
+
+fragment PropertyGroupFragment on PropertyGroup {
+  id
+  schemaGroupId
+  fields {
+    id
+    fieldId
+    type
+    value
+  }
+}`,
 		Variables: map[string]any{
 			"propertyId":    propertyID,
 			"schemaGroupId": schemaGroupID,
@@ -46,8 +114,154 @@ func updatePropertyValue(e *httpexpect.Expect, propertyID, schemaGroupID, itemID
 			"type":          valueType,
 		},
 	}
-
 	res := Request(e, uID.String(), requestBody)
-
 	return requestBody, res
+}
+
+func addPropertyItem(e *httpexpect.Expect, propertyID, schemaGroupID string) (GraphQLRequest, *httpexpect.Value, string, string) {
+	requestBody := GraphQLRequest{
+		OperationName: "AddPropertyItem",
+		Query: `mutation AddPropertyItem($propertyId: ID!, $schemaGroupId: ID!) {
+  addPropertyItem(input: { propertyId: $propertyId, schemaGroupId: $schemaGroupId }) {
+    property {
+      id
+      items {
+        ... on PropertyGroupList {
+          id
+          schemaGroupId
+          groups {
+            id
+            schemaGroupId
+          }
+        }
+        ... on PropertyGroup {
+          id
+          schemaGroupId
+        }
+      }
+    }
+  }
+}
+`,
+		Variables: map[string]any{
+			"propertyId":    propertyID,
+			"schemaGroupId": schemaGroupID,
+		},
+	}
+	res := Request(e, uID.String(), requestBody)
+	itemId := res.Path("$.data.addPropertyItem.property.items[0].id").Raw().(string)
+	groupId := res.Path("$.data.addPropertyItem.property.items[0].groups[0].id").Raw().(string)
+
+	return requestBody, res, itemId, groupId
+}
+
+func TestUpdateScenePropertyValue(t *testing.T) {
+	e := Server(t, fullSeeder)
+	sceneID := sID.String()
+	res := getScene(e, sceneID, language.Und.String())
+
+	// TODO: Write detailed tests
+
+	// Scene Property test ---------------------------------------
+	scenePropertySchemaGroups := res.Path("$.property.schema.groups")
+	assert.NotNil(t, scenePropertySchemaGroups)
+
+	// Widgets Property test ---------------------------------------
+	widgetPropertySchemaGroups := res.Path("$.widgets[0].property.schema.groups")
+	assert.NotNil(t, widgetPropertySchemaGroups)
+
+}
+
+func TestUpdateStoryPropertyValue(t *testing.T) {
+	e := Server(t, fullSeeder)
+	sceneID := sID.String()
+	res := getScene(e, sceneID, language.Und.String())
+	storyID := res.Object().Path("$.stories[0].id").Raw().(string)
+
+	// Page Property test ---------------------------------------
+	pagePropertyId := res.Object().Path("$.stories[0].pages[0].property.id").Raw().(string)
+	pageId := res.Object().Path("$.stories[0].pages[0].id").Raw().(string)
+
+	// title
+	_, r := updatePropertyValue(e, pagePropertyId, "title", "", "title", "test", "STRING")
+	r.Path("$.data.updatePropertyValue.propertyField.value").IsEqual("test")
+
+	// title color
+	_, r = updatePropertyValue(e, pagePropertyId, "title", "", "color", "#2914acff", "STRING")
+	r.Path("$.data.updatePropertyValue.propertyField.value").IsEqual("#2914acff")
+
+	camera := map[string]any{
+		// "height":      313.66307524391044,
+		// "aspectRatio": 0.42407108239095315,
+		"altitude": 313.66307524391044,
+		"fov":      1.0471975511965976,
+		"heading":  6.283185307179581,
+		"lat":      35.682290440916404,
+		"lng":      139.7529563415448,
+		"pitch":    -1.569091180503932,
+		"roll":     0,
+	}
+	_, r = updatePropertyValue(e, pagePropertyId, "cameraAnimation", "", "cameraPosition", camera, "CAMERA")
+	r.Path("$.data.updatePropertyValue.propertyField.value").IsEqual(camera)
+
+	// cameraDuration
+	_, r = updatePropertyValue(e, pagePropertyId, "cameraAnimation", "", "cameraDuration", 3, "NUMBER")
+	r.Path("$.data.updatePropertyValue.propertyField.value").IsEqual(3)
+
+	// timePoint
+	_, r = updatePropertyValue(e, pagePropertyId, "timePoint", "", "timePoint", "2025-03-06T11:05:44+09:00", "STRING")
+	r.Path("$.data.updatePropertyValue.propertyField.value").IsEqual("2025-03-06T11:05:44+09:00")
+
+	// Block Property test ---------------------------------------
+	blockPropertyId := res.Object().Path("$.stories[0].pages[0].blocks[0].property.id").Raw().(string)
+
+	_, r = updatePropertyValue(e, blockPropertyId, "default", "", "text", "test", "STRING")
+	r.Path("$.data.updatePropertyValue.propertyField.value").IsEqual("test")
+
+	// mdTextStoryBlock
+	_, _, _, blockPropertyId1 := createBlock(e, sceneID, storyID, pageId, "reearth", "mdTextStoryBlock", lo.ToPtr(1))
+	_, r = updatePropertyValue(e, blockPropertyId1, "default", "", "text", "test", "STRING")
+	r.Path("$.data.updatePropertyValue.propertyField.value").IsEqual("test")
+
+	// imageStoryBlock
+	_, _, _, blockPropertyId2 := createBlock(e, sceneID, storyID, pageId, "reearth", "imageStoryBlock", lo.ToPtr(2))
+	_, r = updatePropertyValue(e, blockPropertyId2, "default", "", "src", "http://localhost:8080/assets/01jn54nwbw1cwwma2z4e221zxf.png", "URL")
+	r.Path("$.data.updatePropertyValue.propertyField.value").IsEqual("http://localhost:8080/assets/01jn54nwbw1cwwma2z4e221zxf.png")
+
+	// videoStoryBlock
+	_, _, _, blockPropertyId3 := createBlock(e, sceneID, storyID, pageId, "reearth", "videoStoryBlock", lo.ToPtr(3))
+	_, r = updatePropertyValue(e, blockPropertyId3, "default", "", "src", "http://samplelib.com/lib/preview/mp4/sample-5s.mp4", "URL")
+	r.Path("$.data.updatePropertyValue.propertyField.value").IsEqual("http://samplelib.com/lib/preview/mp4/sample-5s.mp4")
+
+	// cameraButtonStoryBlock
+	_, _, _, blockPropertyId4 := createBlock(e, sceneID, storyID, pageId, "reearth", "cameraButtonStoryBlock", lo.ToPtr(4))
+	_, _, _, groupId4 := addPropertyItem(e, blockPropertyId4, "default")
+	_, r = updatePropertyValue(e, blockPropertyId4, "default", groupId4, "cameraPosition", camera, "CAMERA")
+	r.Path("$.data.updatePropertyValue.propertyField.value").IsEqual(camera)
+
+	// linkButtonStoryBlock
+	_, _, _, blockPropertyId5 := createBlock(e, sceneID, storyID, pageId, "reearth", "linkButtonStoryBlock", lo.ToPtr(5))
+	_, _, _, groupId5 := addPropertyItem(e, blockPropertyId5, "default")
+	_, r = updatePropertyValue(e, blockPropertyId5, "default", groupId5, "url", "http://samplelib.com/lib/preview/mp4/sample-5s.mp4", "URL")
+	r.Path("$.data.updatePropertyValue.propertyField.value").IsEqual("http://samplelib.com/lib/preview/mp4/sample-5s.mp4")
+
+	// showLayersStoryBlock
+	_, _, _, blockPropertyId6 := createBlock(e, sceneID, storyID, pageId, "reearth", "showLayersStoryBlock", lo.ToPtr(6))
+	_, _, _, groupId6 := addPropertyItem(e, blockPropertyId6, "default")
+	_, r = updatePropertyValue(e, blockPropertyId6, "default", groupId6, "showLayers", []string{nlsLayerId.String()}, "ARRAY")
+	r.Path("$.data.updatePropertyValue.propertyField.value").IsEqual([]string{nlsLayerId.String()})
+
+	// timelineStoryBlock
+	_, _, _, blockPropertyId7 := createBlock(e, sceneID, storyID, pageId, "reearth", "timelineStoryBlock", lo.ToPtr(7))
+	_, r = updatePropertyValue(e, blockPropertyId7, "default", "", "timelineSetting", map[string]any{
+		"currentTime": "2025-03-03T10:38:59+09:00",
+		"startTime":   "2025-02-23T10:38:43+09:00",
+		"endTime":     "2025-03-08T10:39:10+09:00",
+	}, "TIMELINE")
+	r.Path("$.data.updatePropertyValue.propertyField.value").IsEqual(map[string]any{
+		"currentTime": "2025-03-03T10:38:59+09:00",
+		"startTime":   "2025-02-23T10:38:43+09:00",
+		"endTime":     "2025-03-08T10:39:10+09:00",
+	})
+
 }

--- a/server/e2e/seeder.go
+++ b/server/e2e/seeder.go
@@ -45,9 +45,10 @@ var (
 	sID    = id.NewSceneID()
 	now    = time.Date(2022, time.January, 1, 0, 0, 0, 0, time.UTC)
 
-	storyID = id.NewStoryID()
-	pageID  = id.NewPageID()
-	blockID = id.NewBlockID()
+	nlsLayerId = id.NewNLSLayerID()
+	storyID    = id.NewStoryID()
+	pageID     = id.NewPageID()
+	blockID    = id.NewBlockID()
 )
 
 func baseSeeder(ctx context.Context, r *repo.Container, f gateway.File) error {
@@ -395,7 +396,7 @@ func addLayerSimple(ctx context.Context, r *repo.Container) error {
 	}
 
 	layerSimple, err := nlslayer.NewNLSLayerSimple().
-		NewID().
+		ID(nlsLayerId).
 		Scene(sID).
 		Config(gqlmodel.ToNLSConfig(config)).
 		LayerType(gqlmodel.ToNLSLayerType("simple")).

--- a/server/gql/newlayer.graphql
+++ b/server/gql/newlayer.graphql
@@ -8,6 +8,7 @@ interface NLSLayer {
   title: String!
   visible: Boolean!
   infobox: NLSInfobox
+  photoOverlay: NLSPhotoOverlay
   isSketch: Boolean!
   sketch: SketchInfo
 }
@@ -21,6 +22,7 @@ type NLSLayerSimple implements NLSLayer {
   title: String!
   visible: Boolean!
   infobox: NLSInfobox
+  photoOverlay: NLSPhotoOverlay
   scene: Scene
   isSketch: Boolean!
   sketch: SketchInfo
@@ -37,6 +39,7 @@ type NLSLayerGroup implements NLSLayer {
   title: String!
   visible: Boolean!
   infobox: NLSInfobox
+  photoOverlay: NLSPhotoOverlay
   scene: Scene
   isSketch: Boolean!
   sketch: SketchInfo
@@ -48,6 +51,15 @@ type NLSInfobox {
   layerId: ID!
   propertyId: ID!
   blocks: [InfoboxBlock!]!
+  property: Property
+  scene: Scene
+}
+
+type NLSPhotoOverlay {
+  id: ID!
+  sceneId: ID!
+  layerId: ID!
+  propertyId: ID!
   property: Property
   scene: Scene
 }
@@ -103,6 +115,14 @@ input CreateNLSInfoboxInput {
 }
 
 input RemoveNLSInfoboxInput {
+  layerId: ID!
+}
+
+input CreateNLSPhotoOverlayInput {
+  layerId: ID!
+}
+
+input RemoveNLSPhotoOverlayInput {
   layerId: ID!
 }
 
@@ -172,6 +192,14 @@ type RemoveNLSInfoboxPayload {
   layer: NLSLayer!
 }
 
+type CreateNLSPhotoOverlayPayload {
+  layer: NLSLayer!
+}
+
+type RemoveNLSPhotoOverlayPayload {
+  layer: NLSLayer!
+}
+
 type AddNLSInfoboxBlockPayload {
   infoboxBlock: InfoboxBlock!
   layer: NLSLayer!
@@ -200,6 +228,12 @@ extend type Mutation {
   createNLSInfobox(input: CreateNLSInfoboxInput!): CreateNLSInfoboxPayload
   removeNLSInfobox(input: RemoveNLSInfoboxInput!): RemoveNLSInfoboxPayload
   addNLSInfoboxBlock(input: AddNLSInfoboxBlockInput!): AddNLSInfoboxBlockPayload
+  createNLSPhotoOverlay(
+    input: CreateNLSPhotoOverlayInput!
+  ): CreateNLSPhotoOverlayPayload
+  removeNLSPhotoOverlay(
+    input: RemoveNLSPhotoOverlayInput!
+  ): RemoveNLSPhotoOverlayPayload
   moveNLSInfoboxBlock(
     input: MoveNLSInfoboxBlockInput!
   ): MoveNLSInfoboxBlockPayload

--- a/server/gql/plugin.graphql
+++ b/server/gql/plugin.graphql
@@ -23,6 +23,7 @@ enum PluginExtensionType {
   BLOCK
   VISUALIZER
   INFOBOX
+  PHOTOOVERLAY
   Story
   StoryPage
   StoryBlock

--- a/server/gqlgen.yml
+++ b/server/gqlgen.yml
@@ -323,6 +323,12 @@ models:
         resolver: true
       scene:
         resolver: true
+  NLSPhotoOverlay:
+    fields:
+      property:
+        resolver: true
+      scene:
+        resolver: true
   InfoboxBlock:
     fields:
       property:

--- a/server/internal/adapter/gql/generated.go
+++ b/server/internal/adapter/gql/generated.go
@@ -52,6 +52,7 @@ type ResolverRoot interface {
 	NLSInfobox() NLSInfoboxResolver
 	NLSLayerGroup() NLSLayerGroupResolver
 	NLSLayerSimple() NLSLayerSimpleResolver
+	NLSPhotoOverlay() NLSPhotoOverlayResolver
 	Plugin() PluginResolver
 	PluginExtension() PluginExtensionResolver
 	Project() ProjectResolver
@@ -141,6 +142,10 @@ type ComplexityRoot struct {
 	}
 
 	CreateNLSInfoboxPayload struct {
+		Layer func(childComplexity int) int
+	}
+
+	CreateNLSPhotoOverlayPayload struct {
 		Layer func(childComplexity int) int
 	}
 
@@ -341,6 +346,7 @@ type ComplexityRoot struct {
 		ChangeCustomPropertyTitle func(childComplexity int, input gqlmodel.ChangeCustomPropertyTitleInput) int
 		CreateAsset               func(childComplexity int, input gqlmodel.CreateAssetInput) int
 		CreateNLSInfobox          func(childComplexity int, input gqlmodel.CreateNLSInfoboxInput) int
+		CreateNLSPhotoOverlay     func(childComplexity int, input gqlmodel.CreateNLSPhotoOverlayInput) int
 		CreateProject             func(childComplexity int, input gqlmodel.CreateProjectInput) int
 		CreateScene               func(childComplexity int, input gqlmodel.CreateSceneInput) int
 		CreateStory               func(childComplexity int, input gqlmodel.CreateStoryInput) int
@@ -372,6 +378,7 @@ type ComplexityRoot struct {
 		RemoveNLSInfobox          func(childComplexity int, input gqlmodel.RemoveNLSInfoboxInput) int
 		RemoveNLSInfoboxBlock     func(childComplexity int, input gqlmodel.RemoveNLSInfoboxBlockInput) int
 		RemoveNLSLayer            func(childComplexity int, input gqlmodel.RemoveNLSLayerInput) int
+		RemoveNLSPhotoOverlay     func(childComplexity int, input gqlmodel.RemoveNLSPhotoOverlayInput) int
 		RemovePageLayer           func(childComplexity int, input gqlmodel.PageLayerInput) int
 		RemovePropertyField       func(childComplexity int, input gqlmodel.RemovePropertyFieldInput) int
 		RemovePropertyItem        func(childComplexity int, input gqlmodel.RemovePropertyItemInput) int
@@ -414,33 +421,44 @@ type ComplexityRoot struct {
 	}
 
 	NLSLayerGroup struct {
-		Children    func(childComplexity int) int
-		ChildrenIds func(childComplexity int) int
-		Config      func(childComplexity int) int
-		ID          func(childComplexity int) int
-		Index       func(childComplexity int) int
-		Infobox     func(childComplexity int) int
-		IsSketch    func(childComplexity int) int
-		LayerType   func(childComplexity int) int
-		Scene       func(childComplexity int) int
-		SceneID     func(childComplexity int) int
-		Sketch      func(childComplexity int) int
-		Title       func(childComplexity int) int
-		Visible     func(childComplexity int) int
+		Children     func(childComplexity int) int
+		ChildrenIds  func(childComplexity int) int
+		Config       func(childComplexity int) int
+		ID           func(childComplexity int) int
+		Index        func(childComplexity int) int
+		Infobox      func(childComplexity int) int
+		IsSketch     func(childComplexity int) int
+		LayerType    func(childComplexity int) int
+		PhotoOverlay func(childComplexity int) int
+		Scene        func(childComplexity int) int
+		SceneID      func(childComplexity int) int
+		Sketch       func(childComplexity int) int
+		Title        func(childComplexity int) int
+		Visible      func(childComplexity int) int
 	}
 
 	NLSLayerSimple struct {
-		Config    func(childComplexity int) int
-		ID        func(childComplexity int) int
-		Index     func(childComplexity int) int
-		Infobox   func(childComplexity int) int
-		IsSketch  func(childComplexity int) int
-		LayerType func(childComplexity int) int
-		Scene     func(childComplexity int) int
-		SceneID   func(childComplexity int) int
-		Sketch    func(childComplexity int) int
-		Title     func(childComplexity int) int
-		Visible   func(childComplexity int) int
+		Config       func(childComplexity int) int
+		ID           func(childComplexity int) int
+		Index        func(childComplexity int) int
+		Infobox      func(childComplexity int) int
+		IsSketch     func(childComplexity int) int
+		LayerType    func(childComplexity int) int
+		PhotoOverlay func(childComplexity int) int
+		Scene        func(childComplexity int) int
+		SceneID      func(childComplexity int) int
+		Sketch       func(childComplexity int) int
+		Title        func(childComplexity int) int
+		Visible      func(childComplexity int) int
+	}
+
+	NLSPhotoOverlay struct {
+		ID         func(childComplexity int) int
+		LayerID    func(childComplexity int) int
+		Property   func(childComplexity int) int
+		PropertyID func(childComplexity int) int
+		Scene      func(childComplexity int) int
+		SceneID    func(childComplexity int) int
 	}
 
 	PageInfo struct {
@@ -719,6 +737,10 @@ type ComplexityRoot struct {
 
 	RemoveNLSLayerPayload struct {
 		LayerID func(childComplexity int) int
+	}
+
+	RemoveNLSPhotoOverlayPayload struct {
+		Layer func(childComplexity int) int
 	}
 
 	RemoveStoryBlockPayload struct {
@@ -1049,6 +1071,8 @@ type MutationResolver interface {
 	CreateNLSInfobox(ctx context.Context, input gqlmodel.CreateNLSInfoboxInput) (*gqlmodel.CreateNLSInfoboxPayload, error)
 	RemoveNLSInfobox(ctx context.Context, input gqlmodel.RemoveNLSInfoboxInput) (*gqlmodel.RemoveNLSInfoboxPayload, error)
 	AddNLSInfoboxBlock(ctx context.Context, input gqlmodel.AddNLSInfoboxBlockInput) (*gqlmodel.AddNLSInfoboxBlockPayload, error)
+	CreateNLSPhotoOverlay(ctx context.Context, input gqlmodel.CreateNLSPhotoOverlayInput) (*gqlmodel.CreateNLSPhotoOverlayPayload, error)
+	RemoveNLSPhotoOverlay(ctx context.Context, input gqlmodel.RemoveNLSPhotoOverlayInput) (*gqlmodel.RemoveNLSPhotoOverlayPayload, error)
 	MoveNLSInfoboxBlock(ctx context.Context, input gqlmodel.MoveNLSInfoboxBlockInput) (*gqlmodel.MoveNLSInfoboxBlockPayload, error)
 	RemoveNLSInfoboxBlock(ctx context.Context, input gqlmodel.RemoveNLSInfoboxBlockInput) (*gqlmodel.RemoveNLSInfoboxBlockPayload, error)
 	DuplicateNLSLayer(ctx context.Context, input gqlmodel.DuplicateNLSLayerInput) (*gqlmodel.DuplicateNLSLayerPayload, error)
@@ -1117,6 +1141,10 @@ type NLSLayerGroupResolver interface {
 }
 type NLSLayerSimpleResolver interface {
 	Scene(ctx context.Context, obj *gqlmodel.NLSLayerSimple) (*gqlmodel.Scene, error)
+}
+type NLSPhotoOverlayResolver interface {
+	Property(ctx context.Context, obj *gqlmodel.NLSPhotoOverlay) (*gqlmodel.Property, error)
+	Scene(ctx context.Context, obj *gqlmodel.NLSPhotoOverlay) (*gqlmodel.Scene, error)
 }
 type PluginResolver interface {
 	Scene(ctx context.Context, obj *gqlmodel.Plugin) (*gqlmodel.Scene, error)
@@ -1471,6 +1499,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CreateNLSInfoboxPayload.Layer(childComplexity), true
+
+	case "CreateNLSPhotoOverlayPayload.layer":
+		if e.complexity.CreateNLSPhotoOverlayPayload.Layer == nil {
+			break
+		}
+
+		return e.complexity.CreateNLSPhotoOverlayPayload.Layer(childComplexity), true
 
 	case "CreateScenePayload.scene":
 		if e.complexity.CreateScenePayload.Scene == nil {
@@ -2269,6 +2304,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.CreateNLSInfobox(childComplexity, args["input"].(gqlmodel.CreateNLSInfoboxInput)), true
 
+	case "Mutation.createNLSPhotoOverlay":
+		if e.complexity.Mutation.CreateNLSPhotoOverlay == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createNLSPhotoOverlay_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateNLSPhotoOverlay(childComplexity, args["input"].(gqlmodel.CreateNLSPhotoOverlayInput)), true
+
 	case "Mutation.createProject":
 		if e.complexity.Mutation.CreateProject == nil {
 			break
@@ -2640,6 +2687,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.RemoveNLSLayer(childComplexity, args["input"].(gqlmodel.RemoveNLSLayerInput)), true
+
+	case "Mutation.removeNLSPhotoOverlay":
+		if e.complexity.Mutation.RemoveNLSPhotoOverlay == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_removeNLSPhotoOverlay_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RemoveNLSPhotoOverlay(childComplexity, args["input"].(gqlmodel.RemoveNLSPhotoOverlayInput)), true
 
 	case "Mutation.removePageLayer":
 		if e.complexity.Mutation.RemovePageLayer == nil {
@@ -3094,6 +3153,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.NLSLayerGroup.LayerType(childComplexity), true
 
+	case "NLSLayerGroup.photoOverlay":
+		if e.complexity.NLSLayerGroup.PhotoOverlay == nil {
+			break
+		}
+
+		return e.complexity.NLSLayerGroup.PhotoOverlay(childComplexity), true
+
 	case "NLSLayerGroup.scene":
 		if e.complexity.NLSLayerGroup.Scene == nil {
 			break
@@ -3171,6 +3237,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.NLSLayerSimple.LayerType(childComplexity), true
 
+	case "NLSLayerSimple.photoOverlay":
+		if e.complexity.NLSLayerSimple.PhotoOverlay == nil {
+			break
+		}
+
+		return e.complexity.NLSLayerSimple.PhotoOverlay(childComplexity), true
+
 	case "NLSLayerSimple.scene":
 		if e.complexity.NLSLayerSimple.Scene == nil {
 			break
@@ -3205,6 +3278,48 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.NLSLayerSimple.Visible(childComplexity), true
+
+	case "NLSPhotoOverlay.id":
+		if e.complexity.NLSPhotoOverlay.ID == nil {
+			break
+		}
+
+		return e.complexity.NLSPhotoOverlay.ID(childComplexity), true
+
+	case "NLSPhotoOverlay.layerId":
+		if e.complexity.NLSPhotoOverlay.LayerID == nil {
+			break
+		}
+
+		return e.complexity.NLSPhotoOverlay.LayerID(childComplexity), true
+
+	case "NLSPhotoOverlay.property":
+		if e.complexity.NLSPhotoOverlay.Property == nil {
+			break
+		}
+
+		return e.complexity.NLSPhotoOverlay.Property(childComplexity), true
+
+	case "NLSPhotoOverlay.propertyId":
+		if e.complexity.NLSPhotoOverlay.PropertyID == nil {
+			break
+		}
+
+		return e.complexity.NLSPhotoOverlay.PropertyID(childComplexity), true
+
+	case "NLSPhotoOverlay.scene":
+		if e.complexity.NLSPhotoOverlay.Scene == nil {
+			break
+		}
+
+		return e.complexity.NLSPhotoOverlay.Scene(childComplexity), true
+
+	case "NLSPhotoOverlay.sceneId":
+		if e.complexity.NLSPhotoOverlay.SceneID == nil {
+			break
+		}
+
+		return e.complexity.NLSPhotoOverlay.SceneID(childComplexity), true
 
 	case "PageInfo.endCursor":
 		if e.complexity.PageInfo.EndCursor == nil {
@@ -4642,6 +4757,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.RemoveNLSLayerPayload.LayerID(childComplexity), true
 
+	case "RemoveNLSPhotoOverlayPayload.layer":
+		if e.complexity.RemoveNLSPhotoOverlayPayload.Layer == nil {
+			break
+		}
+
+		return e.complexity.RemoveNLSPhotoOverlayPayload.Layer(childComplexity), true
+
 	case "RemoveStoryBlockPayload.blockId":
 		if e.complexity.RemoveStoryBlockPayload.BlockID == nil {
 			break
@@ -5805,6 +5927,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputChangeCustomPropertyTitleInput,
 		ec.unmarshalInputCreateAssetInput,
 		ec.unmarshalInputCreateNLSInfoboxInput,
+		ec.unmarshalInputCreateNLSPhotoOverlayInput,
 		ec.unmarshalInputCreateProjectInput,
 		ec.unmarshalInputCreateSceneInput,
 		ec.unmarshalInputCreateStoryBlockInput,
@@ -5840,6 +5963,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputRemoveNLSInfoboxBlockInput,
 		ec.unmarshalInputRemoveNLSInfoboxInput,
 		ec.unmarshalInputRemoveNLSLayerInput,
+		ec.unmarshalInputRemoveNLSPhotoOverlayInput,
 		ec.unmarshalInputRemovePropertyFieldInput,
 		ec.unmarshalInputRemovePropertyItemInput,
 		ec.unmarshalInputRemoveStoryBlockInput,
@@ -6258,6 +6382,7 @@ interface NLSLayer {
   title: String!
   visible: Boolean!
   infobox: NLSInfobox
+  photoOverlay: NLSPhotoOverlay
   isSketch: Boolean!
   sketch: SketchInfo
 }
@@ -6271,6 +6396,7 @@ type NLSLayerSimple implements NLSLayer {
   title: String!
   visible: Boolean!
   infobox: NLSInfobox
+  photoOverlay: NLSPhotoOverlay
   scene: Scene
   isSketch: Boolean!
   sketch: SketchInfo
@@ -6287,6 +6413,7 @@ type NLSLayerGroup implements NLSLayer {
   title: String!
   visible: Boolean!
   infobox: NLSInfobox
+  photoOverlay: NLSPhotoOverlay
   scene: Scene
   isSketch: Boolean!
   sketch: SketchInfo
@@ -6298,6 +6425,15 @@ type NLSInfobox {
   layerId: ID!
   propertyId: ID!
   blocks: [InfoboxBlock!]!
+  property: Property
+  scene: Scene
+}
+
+type NLSPhotoOverlay {
+  id: ID!
+  sceneId: ID!
+  layerId: ID!
+  propertyId: ID!
   property: Property
   scene: Scene
 }
@@ -6353,6 +6489,14 @@ input CreateNLSInfoboxInput {
 }
 
 input RemoveNLSInfoboxInput {
+  layerId: ID!
+}
+
+input CreateNLSPhotoOverlayInput {
+  layerId: ID!
+}
+
+input RemoveNLSPhotoOverlayInput {
   layerId: ID!
 }
 
@@ -6422,6 +6566,14 @@ type RemoveNLSInfoboxPayload {
   layer: NLSLayer!
 }
 
+type CreateNLSPhotoOverlayPayload {
+  layer: NLSLayer!
+}
+
+type RemoveNLSPhotoOverlayPayload {
+  layer: NLSLayer!
+}
+
 type AddNLSInfoboxBlockPayload {
   infoboxBlock: InfoboxBlock!
   layer: NLSLayer!
@@ -6450,6 +6602,12 @@ extend type Mutation {
   createNLSInfobox(input: CreateNLSInfoboxInput!): CreateNLSInfoboxPayload
   removeNLSInfobox(input: RemoveNLSInfoboxInput!): RemoveNLSInfoboxPayload
   addNLSInfoboxBlock(input: AddNLSInfoboxBlockInput!): AddNLSInfoboxBlockPayload
+  createNLSPhotoOverlay(
+    input: CreateNLSPhotoOverlayInput!
+  ): CreateNLSPhotoOverlayPayload
+  removeNLSPhotoOverlay(
+    input: RemoveNLSPhotoOverlayInput!
+  ): RemoveNLSPhotoOverlayPayload
   moveNLSInfoboxBlock(
     input: MoveNLSInfoboxBlockInput!
   ): MoveNLSInfoboxBlockPayload
@@ -6493,6 +6651,7 @@ enum PluginExtensionType {
   BLOCK
   VISUALIZER
   INFOBOX
+  PHOTOOVERLAY
   Story
   StoryPage
   StoryBlock
@@ -8048,6 +8207,34 @@ func (ec *executionContext) field_Mutation_createNLSInfobox_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_createNLSPhotoOverlay_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_createNLSPhotoOverlay_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_createNLSPhotoOverlay_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (gqlmodel.CreateNLSPhotoOverlayInput, error) {
+	if _, ok := rawArgs["input"]; !ok {
+		var zeroVal gqlmodel.CreateNLSPhotoOverlayInput
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNCreateNLSPhotoOverlayInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐCreateNLSPhotoOverlayInput(ctx, tmp)
+	}
+
+	var zeroVal gqlmodel.CreateNLSPhotoOverlayInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_createProject_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -8913,6 +9100,34 @@ func (ec *executionContext) field_Mutation_removeNLSLayer_argsInput(
 	}
 
 	var zeroVal gqlmodel.RemoveNLSLayerInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_removeNLSPhotoOverlay_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_removeNLSPhotoOverlay_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_removeNLSPhotoOverlay_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (gqlmodel.RemoveNLSPhotoOverlayInput, error) {
+	if _, ok := rawArgs["input"]; !ok {
+		var zeroVal gqlmodel.RemoveNLSPhotoOverlayInput
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNRemoveNLSPhotoOverlayInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐRemoveNLSPhotoOverlayInput(ctx, tmp)
+	}
+
+	var zeroVal gqlmodel.RemoveNLSPhotoOverlayInput
 	return zeroVal, nil
 }
 
@@ -11222,6 +11437,8 @@ func (ec *executionContext) fieldContext_AddNLSLayerSimplePayload_layers(_ conte
 				return ec.fieldContext_NLSLayerSimple_visible(ctx, field)
 			case "infobox":
 				return ec.fieldContext_NLSLayerSimple_infobox(ctx, field)
+			case "photoOverlay":
+				return ec.fieldContext_NLSLayerSimple_photoOverlay(ctx, field)
 			case "scene":
 				return ec.fieldContext_NLSLayerSimple_scene(ctx, field)
 			case "isSketch":
@@ -12612,6 +12829,50 @@ func (ec *executionContext) _CreateNLSInfoboxPayload_layer(ctx context.Context, 
 func (ec *executionContext) fieldContext_CreateNLSInfoboxPayload_layer(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "CreateNLSInfoboxPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("FieldContext.Child cannot be called on type INTERFACE")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreateNLSPhotoOverlayPayload_layer(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.CreateNLSPhotoOverlayPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreateNLSPhotoOverlayPayload_layer(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Layer, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gqlmodel.NLSLayer)
+	fc.Result = res
+	return ec.marshalNNLSLayer2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐNLSLayer(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreateNLSPhotoOverlayPayload_layer(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreateNLSPhotoOverlayPayload",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -18296,6 +18557,118 @@ func (ec *executionContext) fieldContext_Mutation_addNLSInfoboxBlock(ctx context
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_createNLSPhotoOverlay(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createNLSPhotoOverlay(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateNLSPhotoOverlay(rctx, fc.Args["input"].(gqlmodel.CreateNLSPhotoOverlayInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*gqlmodel.CreateNLSPhotoOverlayPayload)
+	fc.Result = res
+	return ec.marshalOCreateNLSPhotoOverlayPayload2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐCreateNLSPhotoOverlayPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createNLSPhotoOverlay(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "layer":
+				return ec.fieldContext_CreateNLSPhotoOverlayPayload_layer(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreateNLSPhotoOverlayPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createNLSPhotoOverlay_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_removeNLSPhotoOverlay(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_removeNLSPhotoOverlay(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RemoveNLSPhotoOverlay(rctx, fc.Args["input"].(gqlmodel.RemoveNLSPhotoOverlayInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*gqlmodel.RemoveNLSPhotoOverlayPayload)
+	fc.Result = res
+	return ec.marshalORemoveNLSPhotoOverlayPayload2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐRemoveNLSPhotoOverlayPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_removeNLSPhotoOverlay(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "layer":
+				return ec.fieldContext_RemoveNLSPhotoOverlayPayload_layer(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type RemoveNLSPhotoOverlayPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_removeNLSPhotoOverlay_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_moveNLSInfoboxBlock(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_moveNLSInfoboxBlock(ctx, field)
 	if err != nil {
@@ -22492,6 +22865,61 @@ func (ec *executionContext) fieldContext_NLSLayerGroup_infobox(_ context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _NLSLayerGroup_photoOverlay(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.NLSLayerGroup) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NLSLayerGroup_photoOverlay(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PhotoOverlay, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*gqlmodel.NLSPhotoOverlay)
+	fc.Result = res
+	return ec.marshalONLSPhotoOverlay2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐNLSPhotoOverlay(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NLSLayerGroup_photoOverlay(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NLSLayerGroup",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_NLSPhotoOverlay_id(ctx, field)
+			case "sceneId":
+				return ec.fieldContext_NLSPhotoOverlay_sceneId(ctx, field)
+			case "layerId":
+				return ec.fieldContext_NLSPhotoOverlay_layerId(ctx, field)
+			case "propertyId":
+				return ec.fieldContext_NLSPhotoOverlay_propertyId(ctx, field)
+			case "property":
+				return ec.fieldContext_NLSPhotoOverlay_property(ctx, field)
+			case "scene":
+				return ec.fieldContext_NLSPhotoOverlay_scene(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type NLSPhotoOverlay", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _NLSLayerGroup_scene(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.NLSLayerGroup) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_NLSLayerGroup_scene(ctx, field)
 	if err != nil {
@@ -23015,6 +23443,61 @@ func (ec *executionContext) fieldContext_NLSLayerSimple_infobox(_ context.Contex
 	return fc, nil
 }
 
+func (ec *executionContext) _NLSLayerSimple_photoOverlay(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.NLSLayerSimple) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NLSLayerSimple_photoOverlay(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PhotoOverlay, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*gqlmodel.NLSPhotoOverlay)
+	fc.Result = res
+	return ec.marshalONLSPhotoOverlay2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐNLSPhotoOverlay(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NLSLayerSimple_photoOverlay(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NLSLayerSimple",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_NLSPhotoOverlay_id(ctx, field)
+			case "sceneId":
+				return ec.fieldContext_NLSPhotoOverlay_sceneId(ctx, field)
+			case "layerId":
+				return ec.fieldContext_NLSPhotoOverlay_layerId(ctx, field)
+			case "propertyId":
+				return ec.fieldContext_NLSPhotoOverlay_propertyId(ctx, field)
+			case "property":
+				return ec.fieldContext_NLSPhotoOverlay_property(ctx, field)
+			case "scene":
+				return ec.fieldContext_NLSPhotoOverlay_scene(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type NLSPhotoOverlay", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _NLSLayerSimple_scene(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.NLSLayerSimple) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_NLSLayerSimple_scene(ctx, field)
 	if err != nil {
@@ -23174,6 +23657,308 @@ func (ec *executionContext) fieldContext_NLSLayerSimple_sketch(_ context.Context
 				return ec.fieldContext_SketchInfo_featureCollection(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SketchInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NLSPhotoOverlay_id(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.NLSPhotoOverlay) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NLSPhotoOverlay_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gqlmodel.ID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NLSPhotoOverlay_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NLSPhotoOverlay",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NLSPhotoOverlay_sceneId(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.NLSPhotoOverlay) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NLSPhotoOverlay_sceneId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SceneID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gqlmodel.ID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NLSPhotoOverlay_sceneId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NLSPhotoOverlay",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NLSPhotoOverlay_layerId(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.NLSPhotoOverlay) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NLSPhotoOverlay_layerId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LayerID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gqlmodel.ID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NLSPhotoOverlay_layerId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NLSPhotoOverlay",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NLSPhotoOverlay_propertyId(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.NLSPhotoOverlay) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NLSPhotoOverlay_propertyId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PropertyID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gqlmodel.ID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NLSPhotoOverlay_propertyId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NLSPhotoOverlay",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NLSPhotoOverlay_property(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.NLSPhotoOverlay) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NLSPhotoOverlay_property(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.NLSPhotoOverlay().Property(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*gqlmodel.Property)
+	fc.Result = res
+	return ec.marshalOProperty2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐProperty(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NLSPhotoOverlay_property(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NLSPhotoOverlay",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Property_id(ctx, field)
+			case "schemaId":
+				return ec.fieldContext_Property_schemaId(ctx, field)
+			case "items":
+				return ec.fieldContext_Property_items(ctx, field)
+			case "schema":
+				return ec.fieldContext_Property_schema(ctx, field)
+			case "merged":
+				return ec.fieldContext_Property_merged(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Property", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NLSPhotoOverlay_scene(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.NLSPhotoOverlay) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NLSPhotoOverlay_scene(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.NLSPhotoOverlay().Scene(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*gqlmodel.Scene)
+	fc.Result = res
+	return ec.marshalOScene2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐScene(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NLSPhotoOverlay_scene(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NLSPhotoOverlay",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Scene_id(ctx, field)
+			case "projectId":
+				return ec.fieldContext_Scene_projectId(ctx, field)
+			case "teamId":
+				return ec.fieldContext_Scene_teamId(ctx, field)
+			case "propertyId":
+				return ec.fieldContext_Scene_propertyId(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Scene_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Scene_updatedAt(ctx, field)
+			case "widgets":
+				return ec.fieldContext_Scene_widgets(ctx, field)
+			case "plugins":
+				return ec.fieldContext_Scene_plugins(ctx, field)
+			case "widgetAlignSystem":
+				return ec.fieldContext_Scene_widgetAlignSystem(ctx, field)
+			case "project":
+				return ec.fieldContext_Scene_project(ctx, field)
+			case "team":
+				return ec.fieldContext_Scene_team(ctx, field)
+			case "property":
+				return ec.fieldContext_Scene_property(ctx, field)
+			case "newLayers":
+				return ec.fieldContext_Scene_newLayers(ctx, field)
+			case "stories":
+				return ec.fieldContext_Scene_stories(ctx, field)
+			case "styles":
+				return ec.fieldContext_Scene_styles(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Scene", field.Name)
 		},
 	}
 	return fc, nil
@@ -32689,6 +33474,50 @@ func (ec *executionContext) fieldContext_RemoveNLSLayerPayload_layerId(_ context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RemoveNLSPhotoOverlayPayload_layer(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.RemoveNLSPhotoOverlayPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RemoveNLSPhotoOverlayPayload_layer(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Layer, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gqlmodel.NLSLayer)
+	fc.Result = res
+	return ec.marshalNNLSLayer2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐNLSLayer(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RemoveNLSPhotoOverlayPayload_layer(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RemoveNLSPhotoOverlayPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("FieldContext.Child cannot be called on type INTERFACE")
 		},
 	}
 	return fc, nil
@@ -43418,6 +44247,33 @@ func (ec *executionContext) unmarshalInputCreateNLSInfoboxInput(ctx context.Cont
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCreateNLSPhotoOverlayInput(ctx context.Context, obj any) (gqlmodel.CreateNLSPhotoOverlayInput, error) {
+	var it gqlmodel.CreateNLSPhotoOverlayInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"layerId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "layerId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("layerId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.LayerID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateProjectInput(ctx context.Context, obj any) (gqlmodel.CreateProjectInput, error) {
 	var it gqlmodel.CreateProjectInput
 	asMap := map[string]any{}
@@ -44723,6 +45579,33 @@ func (ec *executionContext) unmarshalInputRemoveNLSInfoboxInput(ctx context.Cont
 
 func (ec *executionContext) unmarshalInputRemoveNLSLayerInput(ctx context.Context, obj any) (gqlmodel.RemoveNLSLayerInput, error) {
 	var it gqlmodel.RemoveNLSLayerInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"layerId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "layerId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("layerId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.LayerID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputRemoveNLSPhotoOverlayInput(ctx context.Context, obj any) (gqlmodel.RemoveNLSPhotoOverlayInput, error) {
+	var it gqlmodel.RemoveNLSPhotoOverlayInput
 	asMap := map[string]any{}
 	for k, v := range obj.(map[string]any) {
 		asMap[k] = v
@@ -47068,6 +47951,45 @@ func (ec *executionContext) _CreateNLSInfoboxPayload(ctx context.Context, sel as
 	return out
 }
 
+var createNLSPhotoOverlayPayloadImplementors = []string{"CreateNLSPhotoOverlayPayload"}
+
+func (ec *executionContext) _CreateNLSPhotoOverlayPayload(ctx context.Context, sel ast.SelectionSet, obj *gqlmodel.CreateNLSPhotoOverlayPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createNLSPhotoOverlayPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreateNLSPhotoOverlayPayload")
+		case "layer":
+			out.Values[i] = ec._CreateNLSPhotoOverlayPayload_layer(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var createScenePayloadImplementors = []string{"CreateScenePayload"}
 
 func (ec *executionContext) _CreateScenePayload(ctx context.Context, sel ast.SelectionSet, obj *gqlmodel.CreateScenePayload) graphql.Marshaler {
@@ -49076,6 +49998,14 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_addNLSInfoboxBlock(ctx, field)
 			})
+		case "createNLSPhotoOverlay":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createNLSPhotoOverlay(ctx, field)
+			})
+		case "removeNLSPhotoOverlay":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_removeNLSPhotoOverlay(ctx, field)
+			})
 		case "moveNLSInfoboxBlock":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_moveNLSInfoboxBlock(ctx, field)
@@ -49565,6 +50495,8 @@ func (ec *executionContext) _NLSLayerGroup(ctx context.Context, sel ast.Selectio
 			}
 		case "infobox":
 			out.Values[i] = ec._NLSLayerGroup_infobox(ctx, field, obj)
+		case "photoOverlay":
+			out.Values[i] = ec._NLSLayerGroup_photoOverlay(ctx, field, obj)
 		case "scene":
 			field := field
 
@@ -49670,6 +50602,8 @@ func (ec *executionContext) _NLSLayerSimple(ctx context.Context, sel ast.Selecti
 			}
 		case "infobox":
 			out.Values[i] = ec._NLSLayerSimple_infobox(ctx, field, obj)
+		case "photoOverlay":
+			out.Values[i] = ec._NLSLayerSimple_photoOverlay(ctx, field, obj)
 		case "scene":
 			field := field
 
@@ -49710,6 +50644,126 @@ func (ec *executionContext) _NLSLayerSimple(ctx context.Context, sel ast.Selecti
 			}
 		case "sketch":
 			out.Values[i] = ec._NLSLayerSimple_sketch(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var nLSPhotoOverlayImplementors = []string{"NLSPhotoOverlay"}
+
+func (ec *executionContext) _NLSPhotoOverlay(ctx context.Context, sel ast.SelectionSet, obj *gqlmodel.NLSPhotoOverlay) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, nLSPhotoOverlayImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("NLSPhotoOverlay")
+		case "id":
+			out.Values[i] = ec._NLSPhotoOverlay_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "sceneId":
+			out.Values[i] = ec._NLSPhotoOverlay_sceneId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "layerId":
+			out.Values[i] = ec._NLSPhotoOverlay_layerId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "propertyId":
+			out.Values[i] = ec._NLSPhotoOverlay_propertyId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "property":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._NLSPhotoOverlay_property(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "scene":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._NLSPhotoOverlay_scene(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -52598,6 +53652,45 @@ func (ec *executionContext) _RemoveNLSLayerPayload(ctx context.Context, sel ast.
 			out.Values[i] = graphql.MarshalString("RemoveNLSLayerPayload")
 		case "layerId":
 			out.Values[i] = ec._RemoveNLSLayerPayload_layerId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var removeNLSPhotoOverlayPayloadImplementors = []string{"RemoveNLSPhotoOverlayPayload"}
+
+func (ec *executionContext) _RemoveNLSPhotoOverlayPayload(ctx context.Context, sel ast.SelectionSet, obj *gqlmodel.RemoveNLSPhotoOverlayPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, removeNLSPhotoOverlayPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("RemoveNLSPhotoOverlayPayload")
+		case "layer":
+			out.Values[i] = ec._RemoveNLSPhotoOverlayPayload_layer(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -55863,6 +56956,11 @@ func (ec *executionContext) unmarshalNCreateNLSInfoboxInput2githubᚗcomᚋreear
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNCreateNLSPhotoOverlayInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐCreateNLSPhotoOverlayInput(ctx context.Context, v any) (gqlmodel.CreateNLSPhotoOverlayInput, error) {
+	res, err := ec.unmarshalInputCreateNLSPhotoOverlayInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNCreateProjectInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐCreateProjectInput(ctx context.Context, v any) (gqlmodel.CreateProjectInput, error) {
 	res, err := ec.unmarshalInputCreateProjectInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -57527,6 +58625,11 @@ func (ec *executionContext) marshalNRemoveNLSLayerPayload2ᚖgithubᚗcomᚋreea
 	return ec._RemoveNLSLayerPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNRemoveNLSPhotoOverlayInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐRemoveNLSPhotoOverlayInput(ctx context.Context, v any) (gqlmodel.RemoveNLSPhotoOverlayInput, error) {
+	res, err := ec.unmarshalInputRemoveNLSPhotoOverlayInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNRemovePropertyFieldInput2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐRemovePropertyFieldInput(ctx context.Context, v any) (gqlmodel.RemovePropertyFieldInput, error) {
 	res, err := ec.unmarshalInputRemovePropertyFieldInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -58747,6 +59850,13 @@ func (ec *executionContext) marshalOCreateNLSInfoboxPayload2ᚖgithubᚗcomᚋre
 	return ec._CreateNLSInfoboxPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalOCreateNLSPhotoOverlayPayload2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐCreateNLSPhotoOverlayPayload(ctx context.Context, sel ast.SelectionSet, v *gqlmodel.CreateNLSPhotoOverlayPayload) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._CreateNLSPhotoOverlayPayload(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalOCreateScenePayload2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐCreateScenePayload(ctx context.Context, sel ast.SelectionSet, v *gqlmodel.CreateScenePayload) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -59019,6 +60129,13 @@ func (ec *executionContext) marshalONLSLayer2githubᚗcomᚋreearthᚋreearthᚋ
 	return ec._NLSLayer(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalONLSPhotoOverlay2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐNLSPhotoOverlay(ctx context.Context, sel ast.SelectionSet, v *gqlmodel.NLSPhotoOverlay) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._NLSPhotoOverlay(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalONode2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐNode(ctx context.Context, sel ast.SelectionSet, v gqlmodel.Node) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -59252,6 +60369,13 @@ func (ec *executionContext) marshalORemoveNLSInfoboxPayload2ᚖgithubᚗcomᚋre
 		return graphql.Null
 	}
 	return ec._RemoveNLSInfoboxPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalORemoveNLSPhotoOverlayPayload2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐRemoveNLSPhotoOverlayPayload(ctx context.Context, sel ast.SelectionSet, v *gqlmodel.RemoveNLSPhotoOverlayPayload) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._RemoveNLSPhotoOverlayPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalORemoveStylePayload2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐRemoveStylePayload(ctx context.Context, sel ast.SelectionSet, v *gqlmodel.RemoveStylePayload) graphql.Marshaler {

--- a/server/internal/adapter/gql/gqlmodel/convert_nlslayer.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_nlslayer.go
@@ -1,8 +1,6 @@
 package gqlmodel
 
 import (
-	"fmt"
-
 	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearth/server/pkg/nlslayer"
 	"github.com/reearth/reearthx/util"
@@ -50,7 +48,6 @@ func ToNLSLayerType(p string) nlslayer.LayerType {
 }
 
 func ToNLSLayerGroup(l *nlslayer.NLSLayerGroup, parent *id.NLSLayerID) *NLSLayerGroup {
-	fmt.Println("-------------- ToNLSLayerGroup()")
 	if l == nil {
 		return nil
 	}

--- a/server/internal/adapter/gql/gqlmodel/convert_nlslayer.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_nlslayer.go
@@ -1,6 +1,8 @@
 package gqlmodel
 
 import (
+	"fmt"
+
 	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearth/server/pkg/nlslayer"
 	"github.com/reearth/reearthx/util"
@@ -13,16 +15,17 @@ func ToNLSLayerSimple(l *nlslayer.NLSLayerSimple) *NLSLayerSimple {
 	}
 
 	return &NLSLayerSimple{
-		ID:        IDFrom(l.ID()),
-		Index:     l.Index(),
-		SceneID:   IDFrom(l.Scene()),
-		Title:     l.Title(),
-		Visible:   l.IsVisible(),
-		Infobox:   ToNLSInfobox(l.Infobox(), l.ID(), l.Scene()),
-		LayerType: string(l.LayerType()),
-		Config:    JSON(*l.Config()),
-		IsSketch:  l.IsSketch(),
-		Sketch:    ToNLSLayerSketchInfo(l.Sketch()),
+		ID:           IDFrom(l.ID()),
+		Index:        l.Index(),
+		SceneID:      IDFrom(l.Scene()),
+		Title:        l.Title(),
+		Visible:      l.IsVisible(),
+		Infobox:      ToNLSInfobox(l.Infobox(), l.ID(), l.Scene()),
+		PhotoOverlay: ToNLSPhotoOverlay(l.PhotoOverlay(), l.ID(), l.Scene()),
+		LayerType:    string(l.LayerType()),
+		Config:       JSON(*l.Config()),
+		IsSketch:     l.IsSketch(),
+		Sketch:       ToNLSLayerSketchInfo(l.Sketch()),
 	}
 }
 
@@ -47,19 +50,21 @@ func ToNLSLayerType(p string) nlslayer.LayerType {
 }
 
 func ToNLSLayerGroup(l *nlslayer.NLSLayerGroup, parent *id.NLSLayerID) *NLSLayerGroup {
+	fmt.Println("-------------- ToNLSLayerGroup()")
 	if l == nil {
 		return nil
 	}
 
 	return &NLSLayerGroup{
-		ID:          IDFrom(l.ID()),
-		Index:       l.Index(),
-		SceneID:     IDFrom(l.Scene()),
-		Title:       l.Title(),
-		Visible:     l.IsVisible(),
-		Config:      JSON(*l.Config()),
-		Infobox:     ToNLSInfobox(l.Infobox(), l.ID(), l.Scene()),
-		ChildrenIds: util.Map(l.Children().Layers(), IDFrom[id.NLSLayer]),
+		ID:           IDFrom(l.ID()),
+		Index:        l.Index(),
+		SceneID:      IDFrom(l.Scene()),
+		Title:        l.Title(),
+		Visible:      l.IsVisible(),
+		Config:       JSON(*l.Config()),
+		Infobox:      ToNLSInfobox(l.Infobox(), l.ID(), l.Scene()),
+		PhotoOverlay: ToNLSPhotoOverlay(l.PhotoOverlay(), l.ID(), l.Scene()),
+		ChildrenIds:  util.Map(l.Children().Layers(), IDFrom[id.NLSLayer]),
 	}
 }
 
@@ -118,6 +123,17 @@ func ToNLSInfobox(ib *nlslayer.Infobox, parent id.NLSLayerID, parentSceneID id.S
 		SceneID:    IDFrom(parentSceneID),
 		PropertyID: IDFrom(ib.Property()),
 		Blocks:     ToInfoboxBlocks(ib.Blocks(), parentSceneID),
+		LayerID:    IDFrom(parent),
+	}
+}
+
+func ToNLSPhotoOverlay(ib *nlslayer.PhotoOverlay, parent id.NLSLayerID, parentSceneID id.SceneID) *NLSPhotoOverlay {
+	if ib == nil {
+		return nil
+	}
+	return &NLSPhotoOverlay{
+		SceneID:    IDFrom(parentSceneID),
+		PropertyID: IDFrom(ib.Property()),
 		LayerID:    IDFrom(parent),
 	}
 }

--- a/server/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/server/internal/adapter/gql/gqlmodel/models_gen.go
@@ -28,6 +28,7 @@ type NLSLayer interface {
 	GetTitle() string
 	GetVisible() bool
 	GetInfobox() *NLSInfobox
+	GetPhotoOverlay() *NLSPhotoOverlay
 	GetIsSketch() bool
 	GetSketch() *SketchInfo
 }
@@ -179,6 +180,14 @@ type CreateNLSInfoboxInput struct {
 }
 
 type CreateNLSInfoboxPayload struct {
+	Layer NLSLayer `json:"layer"`
+}
+
+type CreateNLSPhotoOverlayInput struct {
+	LayerID ID `json:"layerId"`
+}
+
+type CreateNLSPhotoOverlayPayload struct {
 	Layer NLSLayer `json:"layer"`
 }
 
@@ -518,58 +527,71 @@ type NLSInfobox struct {
 }
 
 type NLSLayerGroup struct {
-	ID          ID          `json:"id"`
-	Index       *int        `json:"index,omitempty"`
-	LayerType   string      `json:"layerType"`
-	SceneID     ID          `json:"sceneId"`
-	Children    []NLSLayer  `json:"children"`
-	ChildrenIds []ID        `json:"childrenIds"`
-	Config      JSON        `json:"config,omitempty"`
-	Title       string      `json:"title"`
-	Visible     bool        `json:"visible"`
-	Infobox     *NLSInfobox `json:"infobox,omitempty"`
-	Scene       *Scene      `json:"scene,omitempty"`
-	IsSketch    bool        `json:"isSketch"`
-	Sketch      *SketchInfo `json:"sketch,omitempty"`
+	ID           ID               `json:"id"`
+	Index        *int             `json:"index,omitempty"`
+	LayerType    string           `json:"layerType"`
+	SceneID      ID               `json:"sceneId"`
+	Children     []NLSLayer       `json:"children"`
+	ChildrenIds  []ID             `json:"childrenIds"`
+	Config       JSON             `json:"config,omitempty"`
+	Title        string           `json:"title"`
+	Visible      bool             `json:"visible"`
+	Infobox      *NLSInfobox      `json:"infobox,omitempty"`
+	PhotoOverlay *NLSPhotoOverlay `json:"photoOverlay,omitempty"`
+	Scene        *Scene           `json:"scene,omitempty"`
+	IsSketch     bool             `json:"isSketch"`
+	Sketch       *SketchInfo      `json:"sketch,omitempty"`
 }
 
-func (NLSLayerGroup) IsNLSLayer()                  {}
-func (this NLSLayerGroup) GetID() ID               { return this.ID }
-func (this NLSLayerGroup) GetIndex() *int          { return this.Index }
-func (this NLSLayerGroup) GetLayerType() string    { return this.LayerType }
-func (this NLSLayerGroup) GetSceneID() ID          { return this.SceneID }
-func (this NLSLayerGroup) GetConfig() JSON         { return this.Config }
-func (this NLSLayerGroup) GetTitle() string        { return this.Title }
-func (this NLSLayerGroup) GetVisible() bool        { return this.Visible }
-func (this NLSLayerGroup) GetInfobox() *NLSInfobox { return this.Infobox }
-func (this NLSLayerGroup) GetIsSketch() bool       { return this.IsSketch }
-func (this NLSLayerGroup) GetSketch() *SketchInfo  { return this.Sketch }
+func (NLSLayerGroup) IsNLSLayer()                            {}
+func (this NLSLayerGroup) GetID() ID                         { return this.ID }
+func (this NLSLayerGroup) GetIndex() *int                    { return this.Index }
+func (this NLSLayerGroup) GetLayerType() string              { return this.LayerType }
+func (this NLSLayerGroup) GetSceneID() ID                    { return this.SceneID }
+func (this NLSLayerGroup) GetConfig() JSON                   { return this.Config }
+func (this NLSLayerGroup) GetTitle() string                  { return this.Title }
+func (this NLSLayerGroup) GetVisible() bool                  { return this.Visible }
+func (this NLSLayerGroup) GetInfobox() *NLSInfobox           { return this.Infobox }
+func (this NLSLayerGroup) GetPhotoOverlay() *NLSPhotoOverlay { return this.PhotoOverlay }
+func (this NLSLayerGroup) GetIsSketch() bool                 { return this.IsSketch }
+func (this NLSLayerGroup) GetSketch() *SketchInfo            { return this.Sketch }
 
 type NLSLayerSimple struct {
-	ID        ID          `json:"id"`
-	Index     *int        `json:"index,omitempty"`
-	LayerType string      `json:"layerType"`
-	SceneID   ID          `json:"sceneId"`
-	Config    JSON        `json:"config,omitempty"`
-	Title     string      `json:"title"`
-	Visible   bool        `json:"visible"`
-	Infobox   *NLSInfobox `json:"infobox,omitempty"`
-	Scene     *Scene      `json:"scene,omitempty"`
-	IsSketch  bool        `json:"isSketch"`
-	Sketch    *SketchInfo `json:"sketch,omitempty"`
+	ID           ID               `json:"id"`
+	Index        *int             `json:"index,omitempty"`
+	LayerType    string           `json:"layerType"`
+	SceneID      ID               `json:"sceneId"`
+	Config       JSON             `json:"config,omitempty"`
+	Title        string           `json:"title"`
+	Visible      bool             `json:"visible"`
+	Infobox      *NLSInfobox      `json:"infobox,omitempty"`
+	PhotoOverlay *NLSPhotoOverlay `json:"photoOverlay,omitempty"`
+	Scene        *Scene           `json:"scene,omitempty"`
+	IsSketch     bool             `json:"isSketch"`
+	Sketch       *SketchInfo      `json:"sketch,omitempty"`
 }
 
-func (NLSLayerSimple) IsNLSLayer()                  {}
-func (this NLSLayerSimple) GetID() ID               { return this.ID }
-func (this NLSLayerSimple) GetIndex() *int          { return this.Index }
-func (this NLSLayerSimple) GetLayerType() string    { return this.LayerType }
-func (this NLSLayerSimple) GetSceneID() ID          { return this.SceneID }
-func (this NLSLayerSimple) GetConfig() JSON         { return this.Config }
-func (this NLSLayerSimple) GetTitle() string        { return this.Title }
-func (this NLSLayerSimple) GetVisible() bool        { return this.Visible }
-func (this NLSLayerSimple) GetInfobox() *NLSInfobox { return this.Infobox }
-func (this NLSLayerSimple) GetIsSketch() bool       { return this.IsSketch }
-func (this NLSLayerSimple) GetSketch() *SketchInfo  { return this.Sketch }
+func (NLSLayerSimple) IsNLSLayer()                            {}
+func (this NLSLayerSimple) GetID() ID                         { return this.ID }
+func (this NLSLayerSimple) GetIndex() *int                    { return this.Index }
+func (this NLSLayerSimple) GetLayerType() string              { return this.LayerType }
+func (this NLSLayerSimple) GetSceneID() ID                    { return this.SceneID }
+func (this NLSLayerSimple) GetConfig() JSON                   { return this.Config }
+func (this NLSLayerSimple) GetTitle() string                  { return this.Title }
+func (this NLSLayerSimple) GetVisible() bool                  { return this.Visible }
+func (this NLSLayerSimple) GetInfobox() *NLSInfobox           { return this.Infobox }
+func (this NLSLayerSimple) GetPhotoOverlay() *NLSPhotoOverlay { return this.PhotoOverlay }
+func (this NLSLayerSimple) GetIsSketch() bool                 { return this.IsSketch }
+func (this NLSLayerSimple) GetSketch() *SketchInfo            { return this.Sketch }
+
+type NLSPhotoOverlay struct {
+	ID         ID        `json:"id"`
+	SceneID    ID        `json:"sceneId"`
+	LayerID    ID        `json:"layerId"`
+	PropertyID ID        `json:"propertyId"`
+	Property   *Property `json:"property,omitempty"`
+	Scene      *Scene    `json:"scene,omitempty"`
+}
 
 type PageInfo struct {
 	StartCursor     *usecasex.Cursor `json:"startCursor,omitempty"`
@@ -911,6 +933,14 @@ type RemoveNLSLayerInput struct {
 
 type RemoveNLSLayerPayload struct {
 	LayerID ID `json:"layerId"`
+}
+
+type RemoveNLSPhotoOverlayInput struct {
+	LayerID ID `json:"layerId"`
+}
+
+type RemoveNLSPhotoOverlayPayload struct {
+	Layer NLSLayer `json:"layer"`
 }
 
 type RemovePropertyFieldInput struct {
@@ -1596,6 +1626,7 @@ const (
 	PluginExtensionTypeBlock        PluginExtensionType = "BLOCK"
 	PluginExtensionTypeVisualizer   PluginExtensionType = "VISUALIZER"
 	PluginExtensionTypeInfobox      PluginExtensionType = "INFOBOX"
+	PluginExtensionTypePhotooverlay PluginExtensionType = "PHOTOOVERLAY"
 	PluginExtensionTypeStory        PluginExtensionType = "Story"
 	PluginExtensionTypeStoryPage    PluginExtensionType = "StoryPage"
 	PluginExtensionTypeStoryBlock   PluginExtensionType = "StoryBlock"
@@ -1608,6 +1639,7 @@ var AllPluginExtensionType = []PluginExtensionType{
 	PluginExtensionTypeBlock,
 	PluginExtensionTypeVisualizer,
 	PluginExtensionTypeInfobox,
+	PluginExtensionTypePhotooverlay,
 	PluginExtensionTypeStory,
 	PluginExtensionTypeStoryPage,
 	PluginExtensionTypeStoryBlock,
@@ -1616,7 +1648,7 @@ var AllPluginExtensionType = []PluginExtensionType{
 
 func (e PluginExtensionType) IsValid() bool {
 	switch e {
-	case PluginExtensionTypePrimitive, PluginExtensionTypeWidget, PluginExtensionTypeBlock, PluginExtensionTypeVisualizer, PluginExtensionTypeInfobox, PluginExtensionTypeStory, PluginExtensionTypeStoryPage, PluginExtensionTypeStoryBlock, PluginExtensionTypeInfoboxBlock:
+	case PluginExtensionTypePrimitive, PluginExtensionTypeWidget, PluginExtensionTypeBlock, PluginExtensionTypeVisualizer, PluginExtensionTypeInfobox, PluginExtensionTypePhotooverlay, PluginExtensionTypeStory, PluginExtensionTypeStoryPage, PluginExtensionTypeStoryBlock, PluginExtensionTypeInfoboxBlock:
 		return true
 	}
 	return false

--- a/server/internal/adapter/gql/resolver_mutation_nlslayer.go
+++ b/server/internal/adapter/gql/resolver_mutation_nlslayer.go
@@ -149,6 +149,38 @@ func (r *mutationResolver) RemoveNLSInfobox(ctx context.Context, input gqlmodel.
 	}, nil
 }
 
+func (r *mutationResolver) CreateNLSPhotoOverlay(ctx context.Context, input gqlmodel.CreateNLSPhotoOverlayInput) (*gqlmodel.CreateNLSPhotoOverlayPayload, error) {
+	lid, err := gqlmodel.ToID[id.NLSLayer](input.LayerID)
+	if err != nil {
+		return nil, err
+	}
+
+	layer, err := usecases(ctx).NLSLayer.CreateNLSPhotoOverlay(ctx, lid, getOperator(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	return &gqlmodel.CreateNLSPhotoOverlayPayload{
+		Layer: gqlmodel.ToNLSLayer(layer, nil),
+	}, nil
+}
+
+func (r *mutationResolver) RemoveNLSPhotoOverlay(ctx context.Context, input gqlmodel.RemoveNLSPhotoOverlayInput) (*gqlmodel.RemoveNLSPhotoOverlayPayload, error) {
+	lid, err := gqlmodel.ToID[id.NLSLayer](input.LayerID)
+	if err != nil {
+		return nil, err
+	}
+
+	layer, err := usecases(ctx).NLSLayer.RemoveNLSPhotoOverlay(ctx, lid, getOperator(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	return &gqlmodel.RemoveNLSPhotoOverlayPayload{
+		Layer: gqlmodel.ToNLSLayer(layer, nil),
+	}, nil
+}
+
 func (r *mutationResolver) AddNLSInfoboxBlock(ctx context.Context, input gqlmodel.AddNLSInfoboxBlockInput) (*gqlmodel.AddNLSInfoboxBlockPayload, error) {
 	lid, err := gqlmodel.ToID[id.NLSLayer](input.LayerID)
 	if err != nil {

--- a/server/internal/adapter/gql/resolver_nlslayer.go
+++ b/server/internal/adapter/gql/resolver_nlslayer.go
@@ -14,6 +14,10 @@ func (r *Resolver) NLSInfobox() NLSInfoboxResolver {
 	return &nlsInfoboxResolver{r}
 }
 
+func (r *Resolver) NLSPhotoOverlay() NLSPhotoOverlayResolver {
+	return &nlsPhotoOverlayResolver{r}
+}
+
 func (r *Resolver) InfoboxBlock() InfoboxBlockResolver {
 	return &infoboxBlockResolver{r}
 }
@@ -41,6 +45,16 @@ func (r *nlsInfoboxResolver) Scene(ctx context.Context, obj *gqlmodel.NLSInfobox
 }
 
 func (r *nlsInfoboxResolver) Property(ctx context.Context, obj *gqlmodel.NLSInfobox) (*gqlmodel.Property, error) {
+	return dataloaders(ctx).Property.Load(obj.PropertyID)
+}
+
+type nlsPhotoOverlayResolver struct{ *Resolver }
+
+func (r *nlsPhotoOverlayResolver) Scene(ctx context.Context, obj *gqlmodel.NLSPhotoOverlay) (*gqlmodel.Scene, error) {
+	return dataloaders(ctx).Scene.Load(obj.SceneID)
+}
+
+func (r *nlsPhotoOverlayResolver) Property(ctx context.Context, obj *gqlmodel.NLSPhotoOverlay) (*gqlmodel.Property, error) {
 	return dataloaders(ctx).Property.Load(obj.PropertyID)
 }
 

--- a/server/internal/adapter/gql/resolver_scene.go
+++ b/server/internal/adapter/gql/resolver_scene.go
@@ -39,12 +39,12 @@ func (r *sceneResolver) NewLayers(ctx context.Context, obj *gqlmodel.Scene) ([]g
 		return nil, err
 	}
 
-	nlslayer, err := usecases(ctx).NLSLayer.FetchByScene(ctx, sid, getOperator(ctx))
+	nlslayers, err := usecases(ctx).NLSLayer.FetchByScene(ctx, sid, getOperator(ctx))
 	if err != nil {
 		return nil, err
 	}
 
-	res := gqlmodel.ToNLSLayers(nlslayer, nil)
+	res := gqlmodel.ToNLSLayers(nlslayers, nil)
 	return res, nil
 }
 

--- a/server/internal/usecase/interactor/nlslayer.go
+++ b/server/internal/usecase/interactor/nlslayer.go
@@ -35,6 +35,8 @@ var (
 	ErrExtensionNotFound                    error = errors.New("extension not found")
 	ErrInfoboxNotFound                      error = errors.New("infobox not found")
 	ErrInfoboxAlreadyExists                 error = errors.New("infobox already exists")
+	ErrPhotoOverlayNotFound                 error = errors.New("photoOverlay not found")
+	ErrPhotoOverlayAlreadyExists            error = errors.New("photoOverlay already exists")
 	ErrCannotAddLayerToLinkedLayerGroup     error = errors.New("cannot add layer to linked layer group")
 	ErrCannotRemoveLayerToLinkedLayerGroup  error = errors.New("cannot remove layer to linked layer group")
 	ErrLinkedLayerItemCannotBeMoved         error = errors.New("linked layer item cannot be moved")
@@ -440,7 +442,7 @@ func (i *NLSLayer) CreateNLSPhotoOverlay(ctx context.Context, lid id.NLSLayerID,
 
 	photooverlay := l.PhotoOverlay()
 	if photooverlay != nil {
-		return nil, interfaces.ErrPhotoOverlayAlreadyExists
+		return nil, ErrPhotoOverlayAlreadyExists
 	}
 
 	schema := builtin.GetPropertySchema(builtin.PropertySchemaIDPhotoOverlay)
@@ -551,7 +553,7 @@ func (i *NLSLayer) RemoveNLSPhotoOverlay(ctx context.Context, layerID id.NLSLaye
 
 	photooverlay := layer.PhotoOverlay()
 	if photooverlay == nil {
-		return nil, interfaces.ErrPhotoOverlayNotFound
+		return nil, ErrPhotoOverlayNotFound
 	}
 
 	layer.SetPhotoOverlay(nil)

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -525,8 +525,9 @@ func SearchAssetURL(ctx context.Context, data any, assetRepo repo.Asset, file ga
 			}
 		}
 	case string:
-		if strings.HasPrefix(v, adapter.CurrentHost(ctx)) {
-			if err := AddZipAsset(ctx, assetRepo, file, zipWriter, v, assetNames); err != nil {
+		cleanedStr := strings.Trim(v, "'")
+		if strings.HasPrefix(cleanedStr, adapter.CurrentHost(ctx)) {
+			if err := AddZipAsset(ctx, assetRepo, file, zipWriter, cleanedStr, assetNames); err != nil {
 				return err
 			}
 		}

--- a/server/internal/usecase/interfaces/nlslayer.go
+++ b/server/internal/usecase/interfaces/nlslayer.go
@@ -80,6 +80,8 @@ type NLSLayer interface {
 	Update(context.Context, UpdateNLSLayerInput, *usecase.Operator) (nlslayer.NLSLayer, error)
 	CreateNLSInfobox(context.Context, id.NLSLayerID, *usecase.Operator) (nlslayer.NLSLayer, error)
 	RemoveNLSInfobox(context.Context, id.NLSLayerID, *usecase.Operator) (nlslayer.NLSLayer, error)
+	CreateNLSPhotoOverlay(context.Context, id.NLSLayerID, *usecase.Operator) (nlslayer.NLSLayer, error)
+	RemoveNLSPhotoOverlay(context.Context, id.NLSLayerID, *usecase.Operator) (nlslayer.NLSLayer, error)
 	AddNLSInfoboxBlock(context.Context, AddNLSInfoboxBlockParam, *usecase.Operator) (*nlslayer.InfoboxBlock, nlslayer.NLSLayer, error)
 	MoveNLSInfoboxBlock(context.Context, MoveNLSInfoboxBlockParam, *usecase.Operator) (id.InfoboxBlockID, nlslayer.NLSLayer, int, error)
 	RemoveNLSInfoboxBlock(context.Context, RemoveNLSInfoboxBlockParam, *usecase.Operator) (id.InfoboxBlockID, nlslayer.NLSLayer, error)

--- a/server/pkg/builtin/main.go
+++ b/server/pkg/builtin/main.go
@@ -27,6 +27,7 @@ var (
 	PropertySchemaIDVisualizerBetaCesium = id.MustPropertySchemaID("reearth/cesium-beta")
 	PropertySchemaIDInfobox              = id.MustPropertySchemaID("reearth/infobox")
 	PropertySchemaIDBetaInfobox          = id.MustPropertySchemaID("reearth/infobox-beta")
+	PropertySchemaIDPhotoOverlay         = id.MustPropertySchemaID("reearth/photo-overlay")
 	PropertySchemaIDInfoboxBlock         = id.MustPropertySchemaID("reearth/infoboxBlock")
 	PropertySchemaIDStory                = id.MustPropertySchemaID("reearth/story")
 	PropertySchemaIDStoryPage            = id.MustPropertySchemaID("reearth/storyPage")

--- a/server/pkg/builtin/manifest.yml
+++ b/server/pkg/builtin/manifest.yml
@@ -2838,3 +2838,25 @@ extensions:
               title: Content
               placeholder: ${your property key}
               ui: property_selector
+
+  - id: photo-overlay
+    name: Photo overlay
+    type: photoOverlay
+    description: Photo overlay
+    schema:
+      groups:
+        - id: default
+          title: Photo overlay
+          fields:
+            - id: enabled
+              type: bool
+              title: Enabled PhotoOverlay
+              # defaultValue: false
+              # description: xxxxxx
+            - id: cameraDuration
+              type: number
+              title: PhotoOverlay Camera Duration
+              # suffix: s
+              # min: 0
+              # defaultValue: 2
+              # description: xxxxxx

--- a/server/pkg/builtin/manifest_ja.yml
+++ b/server/pkg/builtin/manifest_ja.yml
@@ -1455,4 +1455,14 @@ extensions:
               ja: 日本語
               cn: 中国語
 
-  
+  photo-overlay:
+    name: フォトオーバーレイ
+    description: フォトオーバーレイ
+    propertySchema:
+      default:
+        title: デフォルト
+        fields:
+          enabled:
+            title: 有効
+          cameraDuration:
+            title: カメラ移動時間

--- a/server/pkg/id/id.go
+++ b/server/pkg/id/id.go
@@ -18,6 +18,7 @@ type User struct{}
 type Widget struct{}
 type Style struct{}
 type Infobox struct{}
+type PhotoOverlay struct{}
 type InfoboxBlock struct{}
 type Feature struct{}
 
@@ -37,6 +38,7 @@ func (User) Type() string                { return "user" }
 func (Widget) Type() string              { return "widget" }
 func (Style) Type() string               { return "style" }
 func (Infobox) Type() string             { return "infobox" }
+func (PhotoOverlay) Type() string        { return "photoOverlay" }
 func (InfoboxBlock) Type() string        { return "infoboxBlock" }
 func (Feature) Type() string             { return "feature" }
 
@@ -52,6 +54,7 @@ type UserID = idx.ID[User]
 type WidgetID = idx.ID[Widget]
 type StyleID = idx.ID[Style]
 type InfoboxID = idx.ID[Infobox]
+type PhotoOverlayID = idx.ID[PhotoOverlay]
 type InfoboxBlockID = idx.ID[InfoboxBlock]
 type FeatureID = idx.ID[Feature]
 
@@ -70,6 +73,7 @@ var NewSceneID = idx.New[Scene]
 var NewWidgetID = idx.New[Widget]
 var NewStyleID = idx.New[Style]
 var NewInfoboxID = idx.New[Infobox]
+var NewPhotoOverlayID = idx.New[PhotoOverlay]
 var NewInfoboxBlockID = idx.New[InfoboxBlock]
 var NewFeatureID = idx.New[Feature]
 
@@ -85,6 +89,7 @@ var MustUserID = idx.Must[User]
 var MustWidgetID = idx.Must[Widget]
 var MustStyleID = idx.Must[Style]
 var MustInfoboxID = idx.Must[Infobox]
+var MustPhotoOverlayID = idx.Must[PhotoOverlay]
 var MustInfoboxBlockID = idx.Must[InfoboxBlock]
 var MustFeatureID = idx.Must[Feature]
 
@@ -100,6 +105,7 @@ var UserIDFrom = idx.From[User]
 var WidgetIDFrom = idx.From[Widget]
 var StyleIDFrom = idx.From[Style]
 var InfoboxIDFrom = idx.From[Infobox]
+var PhotoOverlayIDFrom = idx.From[PhotoOverlay]
 var InfoboxBlockIDFrom = idx.From[InfoboxBlock]
 var FeatureIDFrom = idx.From[Feature]
 
@@ -115,6 +121,7 @@ var UserIDFromRef = idx.FromRef[User]
 var WidgetIDFromRef = idx.FromRef[Widget]
 var StyleIDFromRef = idx.FromRef[Style]
 var InfoboxIDFromRef = idx.FromRef[Infobox]
+var PhotoOverlayIDFromRef = idx.FromRef[PhotoOverlay]
 var InfoboxBlockIDFromRef = idx.FromRef[InfoboxBlock]
 var FeatureIDFromRef = idx.FromRef[Feature]
 
@@ -134,6 +141,7 @@ type UserIDList = idx.List[User]
 type WidgetIDList = idx.List[Widget]
 type StyleIDList = idx.List[Style]
 type InfoboxIDList = idx.List[Infobox]
+type PhotoOverlayIDList = idx.List[PhotoOverlay]
 type InfoboxBlockIDList = idx.List[InfoboxBlock]
 type FeatureIDList = idx.List[Feature]
 
@@ -149,6 +157,7 @@ var UserIDListFrom = idx.ListFrom[User]
 var WidgetIDListFrom = idx.ListFrom[Widget]
 var StyleIDListFrom = idx.ListFrom[Style]
 var InfoboxIDListFrom = idx.ListFrom[Infobox]
+var PhotoOverlayIDListFrom = idx.ListFrom[PhotoOverlay]
 var InfoboxBlockIDListFrom = idx.ListFrom[InfoboxBlock]
 var FeatureIDListFrom = idx.ListFrom[Feature]
 
@@ -164,6 +173,7 @@ type UserIDSet = idx.Set[User]
 type WidgetIDSet = idx.Set[Widget]
 type StyleIDSet = idx.Set[Style]
 type InfoboxIDSet = idx.Set[Infobox]
+type PhotoOverlayIDSet = idx.Set[PhotoOverlay]
 type InfoboxBlockIDSet = idx.Set[InfoboxBlock]
 type FeatureIDSet = idx.Set[Feature]
 
@@ -178,6 +188,7 @@ var NewSceneIDSet = idx.NewSet[Scene]
 var NewUserIDSet = idx.NewSet[User]
 var NewWidgetIDSet = idx.NewSet[Widget]
 var NewStyleIDSet = idx.NewSet[Style]
+var NewPhotoOverlayIDSet = idx.NewSet[PhotoOverlay]
 var NewInfoboxIDSet = idx.NewSet[InfoboxBlock]
 var NewInfoboxBlockIDSet = idx.NewSet[InfoboxBlock]
 var NewFeatureIDSet = idx.NewSet[Feature]

--- a/server/pkg/nlslayer/group.go
+++ b/server/pkg/nlslayer/group.go
@@ -52,6 +52,13 @@ func (l *NLSLayerGroup) Infobox() *Infobox {
 	return l.layerBase.infobox
 }
 
+func (l *NLSLayerGroup) PhotoOverlay() *PhotoOverlay {
+	if l == nil {
+		return nil
+	}
+	return l.layerBase.photoOverlay
+}
+
 func (l *NLSLayerGroup) SetVisible(visible bool) {
 	if l == nil {
 		return
@@ -64,6 +71,13 @@ func (l *NLSLayerGroup) SetInfobox(infobox *Infobox) {
 		return
 	}
 	l.layerBase.infobox = infobox
+}
+
+func (l *NLSLayerGroup) SetPhotoOverlay(photooverlay *PhotoOverlay) {
+	if l == nil {
+		return
+	}
+	l.layerBase.photoOverlay = photooverlay
 }
 
 func (l *NLSLayerGroup) Children() *IDList {

--- a/server/pkg/nlslayer/group_builder.go
+++ b/server/pkg/nlslayer/group_builder.go
@@ -104,6 +104,11 @@ func (b *NLSLayerGroupBuilder) Infobox(infobox *Infobox) *NLSLayerGroupBuilder {
 	return b
 }
 
+func (b *NLSLayerGroupBuilder) PhotoOverlay(photoOverlay *PhotoOverlay) *NLSLayerGroupBuilder {
+	b.l.photoOverlay = photoOverlay
+	return b
+}
+
 func (b *NLSLayerGroupBuilder) IsSketch(i bool) *NLSLayerGroupBuilder {
 	b.l.isSketch = i
 	return b

--- a/server/pkg/nlslayer/nlslayer.go
+++ b/server/pkg/nlslayer/nlslayer.go
@@ -15,6 +15,8 @@ type NLSLayer interface {
 	HasInfobox() bool
 	Infobox() *Infobox
 	SetInfobox(*Infobox)
+	PhotoOverlay() *PhotoOverlay
+	SetPhotoOverlay(*PhotoOverlay)
 	SetIndex(*int)
 	Rename(string)
 	UpdateConfig(*Config)
@@ -63,16 +65,17 @@ func ToLayerSimpleRef(l *NLSLayer) *NLSLayerSimple {
 }
 
 type layerBase struct {
-	id        id.NLSLayerID
-	index     *int
-	layerType LayerType
-	scene     id.SceneID
-	title     string
-	visible   bool
-	infobox   *Infobox
-	config    *Config
-	isSketch  bool
-	sketch    *SketchInfo
+	id           id.NLSLayerID
+	index        *int
+	layerType    LayerType
+	scene        id.SceneID
+	title        string
+	visible      bool
+	infobox      *Infobox
+	photoOverlay *PhotoOverlay
+	config       *Config
+	isSketch     bool
+	sketch       *SketchInfo
 }
 
 func (l *layerBase) ID() id.NLSLayerID {
@@ -136,6 +139,13 @@ func (l *layerBase) Infobox() *Infobox {
 	return l.infobox
 }
 
+func (l *layerBase) PhotoOverlay() *PhotoOverlay {
+	if l == nil {
+		return nil
+	}
+	return l.photoOverlay
+}
+
 func (l *layerBase) SetVisible(visible bool) {
 	if l == nil {
 		return
@@ -148,6 +158,13 @@ func (l *layerBase) SetInfobox(infobox *Infobox) {
 		return
 	}
 	l.infobox = infobox
+}
+
+func (l *layerBase) SetPhotoOverlay(photoOverlay *PhotoOverlay) {
+	if l == nil {
+		return
+	}
+	l.photoOverlay = photoOverlay
 }
 
 func (l *layerBase) SetIndex(index *int) {

--- a/server/pkg/nlslayer/photo_overlay.go
+++ b/server/pkg/nlslayer/photo_overlay.go
@@ -1,0 +1,34 @@
+package nlslayer
+
+import (
+	"github.com/reearth/reearth/server/pkg/id"
+)
+
+type PhotoOverlay struct {
+	id       id.PhotoOverlayID
+	property id.PropertyID
+}
+
+func NewPhotoOverlay(p PropertyID) *PhotoOverlay {
+	photooverlay := PhotoOverlay{
+		id:       id.NewPhotoOverlayID(),
+		property: p,
+	}
+	return &photooverlay
+}
+
+func (i *PhotoOverlay) Id() id.PhotoOverlayID {
+	return i.id
+}
+
+func (i *PhotoOverlay) Property() PropertyID {
+	return i.property
+}
+
+func (i *PhotoOverlay) PropertyRef() *PropertyID {
+	if i == nil {
+		return nil
+	}
+	pid := i.property
+	return &pid
+}

--- a/server/pkg/nlslayer/photo_overlay.go
+++ b/server/pkg/nlslayer/photo_overlay.go
@@ -9,7 +9,7 @@ type PhotoOverlay struct {
 	property id.PropertyID
 }
 
-func NewPhotoOverlay(p PropertyID) *PhotoOverlay {
+func NewPhotoOverlay(p id.PropertyID) *PhotoOverlay {
 	photooverlay := PhotoOverlay{
 		id:       id.NewPhotoOverlayID(),
 		property: p,
@@ -21,11 +21,11 @@ func (i *PhotoOverlay) Id() id.PhotoOverlayID {
 	return i.id
 }
 
-func (i *PhotoOverlay) Property() PropertyID {
+func (i *PhotoOverlay) Property() id.PropertyID {
 	return i.property
 }
 
-func (i *PhotoOverlay) PropertyRef() *PropertyID {
+func (i *PhotoOverlay) PropertyRef() *id.PropertyID {
 	if i == nil {
 		return nil
 	}

--- a/server/pkg/nlslayer/simple.go
+++ b/server/pkg/nlslayer/simple.go
@@ -54,6 +54,13 @@ func (l *NLSLayerSimple) Infobox() *Infobox {
 	return l.layerBase.infobox
 }
 
+func (l *NLSLayerSimple) PhotoOverlay() *PhotoOverlay {
+	if l == nil {
+		return nil
+	}
+	return l.layerBase.photoOverlay
+}
+
 func (l *NLSLayerSimple) SetVisible(visible bool) {
 	if l == nil {
 		return
@@ -66,6 +73,13 @@ func (l *NLSLayerSimple) SetInfobox(infobox *Infobox) {
 		return
 	}
 	l.layerBase.infobox = infobox
+}
+
+func (l *NLSLayerSimple) SetPhotoOverlay(photooverlay *PhotoOverlay) {
+	if l == nil {
+		return
+	}
+	l.layerBase.photoOverlay = photooverlay
 }
 
 func (l *NLSLayerSimple) LayerRef() *NLSLayer {

--- a/server/pkg/nlslayer/simple_builder.go
+++ b/server/pkg/nlslayer/simple_builder.go
@@ -89,6 +89,11 @@ func (b *NLSLayerSimpleBuilder) Infobox(infobox *Infobox) *NLSLayerSimpleBuilder
 	return b
 }
 
+func (b *NLSLayerSimpleBuilder) PhotoOverlay(photoOverlay *PhotoOverlay) *NLSLayerSimpleBuilder {
+	b.l.photoOverlay = photoOverlay
+	return b
+}
+
 func (b *NLSLayerSimpleBuilder) Config(c *Config) *NLSLayerSimpleBuilder {
 	b.l.config = c
 	return b

--- a/server/pkg/plugin/extension.go
+++ b/server/pkg/plugin/extension.go
@@ -23,6 +23,8 @@ var (
 	ExtensionTypeStory      ExtensionType = "story"
 	ExtensionTypeStoryPage  ExtensionType = "storyPage"
 	ExtensionTypeStoryBlock ExtensionType = "storyBlock"
+
+	ExtensionTypePhotoOverlay ExtensionType = "photoOverlay"
 )
 
 type Extension struct {

--- a/server/pkg/plugin/manifest/convert.go
+++ b/server/pkg/plugin/manifest/convert.go
@@ -133,6 +133,8 @@ func (i Extension) extension(pluginID id.PluginID, sys bool, te *TranslatedExten
 		typ = plugin.ExtensionTypeVisualizer
 	case "infobox":
 		typ = plugin.ExtensionTypeInfobox
+	case "photoOverlay":
+		typ = plugin.ExtensionTypePhotoOverlay
 	case "infoboxBlock":
 		typ = plugin.ExtensionTypeInfoboxBlock
 	case "cluster":

--- a/server/pkg/scene/builder/nlsLayer.go
+++ b/server/pkg/scene/builder/nlsLayer.go
@@ -8,16 +8,17 @@ import (
 )
 
 type nlsLayerJSON struct {
-	ID         string          `json:"id"`
-	Index      *int            `json:"index,omitempty"`
-	Title      string          `json:"title,omitempty"`
-	LayerType  string          `json:"layerType,omitempty"`
-	Config     *configJSON     `json:"config,omitempty"`
-	IsVisible  bool            `json:"isVisible"`
-	Infobox    *nlsInfoboxJSON `json:"nlsInfobox,omitempty"`
-	IsSketch   bool            `json:"isSketch"`
-	SketchInfo *sketchInfoJSON `json:"sketchInfo,omitempty"`
-	Children   []*nlsLayerJSON `json:"children,omitempty"`
+	ID           string               `json:"id"`
+	Index        *int                 `json:"index,omitempty"`
+	Title        string               `json:"title,omitempty"`
+	LayerType    string               `json:"layerType,omitempty"`
+	Config       *configJSON          `json:"config,omitempty"`
+	IsVisible    bool                 `json:"isVisible"`
+	Infobox      *nlsInfoboxJSON      `json:"nlsInfobox,omitempty"`
+	PhotoOverlay *nlsPhotoOverlayJSON `json:"nlsPhotoOverlay,omitempty"`
+	IsSketch     bool                 `json:"isSketch"`
+	SketchInfo   *sketchInfoJSON      `json:"sketchInfo,omitempty"`
+	Children     []*nlsLayerJSON      `json:"children,omitempty"`
 }
 
 type configJSON map[string]any
@@ -26,6 +27,11 @@ type nlsInfoboxJSON struct {
 	ID       string                `json:"id"`
 	Property propertyJSON          `json:"property"`
 	Blocks   []nlsInfoboxBlockJSON `json:"blocks"`
+}
+
+type nlsPhotoOverlayJSON struct {
+	ID       string       `json:"id"`
+	Property propertyJSON `json:"property"`
 }
 
 type nlsInfoboxBlockJSON struct {
@@ -113,16 +119,17 @@ func (b *Builder) getNLSLayerJSON(ctx context.Context, layer nlslayer.NLSLayer) 
 	}
 
 	return &nlsLayerJSON{
-		ID:         layer.ID().String(),
-		Index:      layer.Index(),
-		Title:      layer.Title(),
-		LayerType:  string(layer.LayerType()),
-		Config:     (*configJSON)(layer.Config()),
-		IsVisible:  layer.IsVisible(),
-		Infobox:    b.nlsInfoboxJSON(ctx, layer.Infobox()),
-		IsSketch:   layer.IsSketch(),
-		SketchInfo: b.sketchInfoJSON(ctx, layer.Sketch()),
-		Children:   children,
+		ID:           layer.ID().String(),
+		Index:        layer.Index(),
+		Title:        layer.Title(),
+		LayerType:    string(layer.LayerType()),
+		Config:       (*configJSON)(layer.Config()),
+		IsVisible:    layer.IsVisible(),
+		Infobox:      b.nlsInfoboxJSON(ctx, layer.Infobox()),
+		PhotoOverlay: b.nlsPhotoOverlayJSON(ctx, layer.PhotoOverlay()),
+		IsSketch:     layer.IsSketch(),
+		SketchInfo:   b.sketchInfoJSON(ctx, layer.Sketch()),
+		Children:     children,
 	}, nil
 }
 
@@ -142,6 +149,19 @@ func (b *Builder) nlsInfoboxJSON(ctx context.Context, infobox *nlslayer.Infobox)
 			}
 			return b.nlsInfoboxBlockJSON(ctx, *block), true
 		}),
+	}
+}
+
+func (b *Builder) nlsPhotoOverlayJSON(ctx context.Context, photooverlay *nlslayer.PhotoOverlay) *nlsPhotoOverlayJSON {
+	if photooverlay == nil {
+		return nil
+	}
+
+	p, _ := b.ploader(ctx, photooverlay.Property())
+
+	return &nlsPhotoOverlayJSON{
+		ID:       photooverlay.Id().String(),
+		Property: b.property(ctx, findProperty(p, photooverlay.Property())),
 	}
 }
 

--- a/server/schemas/plugin_manifest.json
+++ b/server/schemas/plugin_manifest.json
@@ -259,7 +259,8 @@
             "story",
             "storyPage",
             "storyBlock",
-            "infoboxBlock"
+            "infoboxBlock",
+            "photoOverlay"
           ]
         },
         "singleOnly": {


### PR DESCRIPTION
# Overview

I will add a PhotoOverlay based on the Layer.

## What I've done

### This is now treated at the same level as the infobox.
#### I copied the infobox and renamed it to PhotoOverlay, but I removed the blocks that were in the infobox.

### Just like the infobox, it needs to be created using createNLSPhotoOverlay.

### The PhotoOverlay will be added to the NLSLayer.

### The properties of PhotoOverlay currently support:
* enabled (BOOL)
* cameraDuration (NUMBER)

## 1.manifest.yml
```diff
+  - id: photo-overlay
+    name: Photo overlay
+    type: photoOverlay
+    description: Photo overlay
+    schema:
+      groups:
+        - id: default
+          title: Photo overlay
+          fields:
+            - id: enabled
+              type: bool
+              title: Enabled PhotoOverlay
+            - id: cameraDuration
+              type: number
+              title: PhotoOverlay Camera text
```

#### To add a new value, add it to the fields section of photo-overlay in manifest.yml.
```
- id: cameraText
  type: string
  title: PhotoOverlay Camera string
```
#### Localization needs to be added to manifest_ja.yml.

# 2.newlayer.graphql
#### The changes to GraphQL are as follows.
```diff
interface NLSLayer {
  id: ID!
  index: Int
  layerType: String!
  sceneId: ID!
  config: JSON
  title: String!
  visible: Boolean!
  infobox: NLSInfobox
+  photoOverlay: NLSPhotoOverlay
  isSketch: Boolean!
  sketch: SketchInfo
}

+ type NLSPhotoOverlay {
+  id: ID!
+  sceneId: ID!
+  layerId: ID!
+  propertyId: ID!
+  property: Property
+  scene: Scene
+ }

+ input CreateNLSPhotoOverlayInput {
+  layerId: ID!
+ }

+ input RemoveNLSPhotoOverlayInput {
+  layerId: ID!
+ }

+ type CreateNLSPhotoOverlayPayload {
+  layer: NLSLayer!
+ }

+ type RemoveNLSPhotoOverlayPayload {
+  layer: NLSLayer!
+ }

+ createNLSPhotoOverlay(input: CreateNLSPhotoOverlayInput!): CreateNLSPhotoOverlayPayload
+ removeNLSPhotoOverlay(input: RemoveNLSPhotoOverlayInput!): RemoveNLSPhotoOverlayPayload
````
## What I haven't done

## How I tested

* e2e test code
https://github.com/reearth/reearth-visualizer/pull/1508/files#diff-24ad6b984dd7d824485df99bc5f0afbad022e020e1f649feff78a5cdf2962af5R895

## Which point I want you to review particularly

## Memo

need to add photoOverlay to the Layer in the frontend code.
After that, all that's left is to generate GraphQL.
```diff
export const nlsLayerSimpleFragment = gql`
  fragment NLSLayerCommon on NLSLayer {
    id
    index
    layerType
    sceneId
    config
    title
    visible
    infobox {
      sceneId
      layerId
      propertyId
      property {
        id
        ...PropertyFragment
      }
      blocks {
        id
        pluginId
        extensionId
        propertyId
        property {
          id
          ...PropertyFragment
        }
      }
    }
+    photoOverlay {
+      sceneId
+      layerId
+      propertyId
+      property {
+        id
+        ...PropertyFragment
+      }
+    }
    isSketch
    sketch {
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a robust photo overlay functionality that enhances layer management. Users can now enable, create, and remove overlays via the updated GraphQL API. Configuration options have been expanded through improved manifest settings with localized support.
  
- **Tests**
  - Added comprehensive tests that validate overlay creation, updates, and removal, ensuring seamless integration and reliable operation of the new photo overlay feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->