### PR TITLE
chore(server, web): remove ArcGIS terrain [VIZ-1424]

### DIFF
--- a/server/pkg/builtin/manifest.yml
+++ b/server/pkg/builtin/manifest.yml
@@ -99,8 +99,6 @@ extensions:
               choices:
                 - key: cesium
                   label: Cesium World Terrain
-                - key: arcgis
-                  label: ArcGIS Terrain
                 - key: cesiumion
                   label: Cesium Ion
             - id: terrainCesiumIonAsset

--- a/server/pkg/builtin/manifest_ja.yml
+++ b/server/pkg/builtin/manifest_ja.yml
@@ -52,7 +52,6 @@ extensions:
             description: 地形の種類を指定します。
             choices:
               cesium: Cesium World Terrain
-              arcgis: ArcGIS Terrain
               cesiumion: Cesium Ion
           terrainCesiumIonAsset:
             title: Cesium Ion アセットID

--- a/web/src/beta/types/sceneProperty.ts
+++ b/web/src/beta/types/sceneProperty.ts
@@ -4,7 +4,7 @@
 
 type TerrainProperty = {
   terrain?: boolean;
-  terrainType?: "cesium" | "arcgis" | "cesiumion"; // default: cesium
+  terrainType?: "cesium" | "cesiumion"; // default: cesium
   terrainCesiumIonAsset?: string;
   terrainCesiumIonAccessToken?: string;
   terrainCesiumIonUrl?: string;
@@ -110,7 +110,7 @@ type LegacySceneProperty = {
   }[];
   terrain?: {
     terrain?: boolean;
-    terrainType?: "cesium" | "arcgis" | "cesiumion"; // default: cesium
+    terrainType?: "cesium" | "cesiumion"; // default: cesium
     terrainExaggeration?: number; // default: 1
     terrainExaggerationRelativeHeight?: number; // default: 0
     depthTestAgainstTerrain?: boolean;


### PR DESCRIPTION
# Overview
   Removed ArcGIS Terrain from Scene/Terrain Option because it requires license.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

These changes update terrain selection handling to provide a more streamlined user experience. Users will now see only two terrain options, ensuring clarity in selection.

- **Refactor**
  - Removed the ArcGIS Terrain option, leaving only Cesium World Terrain and Cesium Ion as selectable terrain types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->