### PR TITLE
fix(web): remove margin from paragraph tag and refactor plugin styles

### DIFF
--- a/web/src/beta/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
@@ -26,9 +26,10 @@ const widgetFile: FileType = {
 
 reearth.ui.show(\`
 ${PRESET_PLUGIN_COMMON_STYLE}
-<div class="primary-background text-center p-16 rounded-sm">
+<div class="primary-background flex-column gap-8 text-center align-center p-16 rounded-sm">
   <p class="text-3xl font-bold">Rotate Camera Angle</p>
-      <button class="btn-neutral w-14 h-4" id="rotateBtn">Click here</button>
+  <p class="text-md text-secondary">Click the button to rotate the camera angle</p>
+  <button class="btn-neutral w-14 h-4" id="rotateBtn">Click here</button>
 </div>
 <script>
 let rotating = false;

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
@@ -28,8 +28,9 @@ const widgetFile: FileType = {
 // ================================
 reearth.ui.show(\`
 ${PRESET_PLUGIN_COMMON_STYLE}
-  <div class="primary-background text-center justify-center p-16 rounded-sm">
+  <div class="primary-background flex-column gap-8 text-center justify-center p-16 rounded-sm">
     <p class="text-3xl font-bold">Zoom Level</p>
+    <p class="text-md text-secondary text-center">Click the buttons to change zoom level</p>
     <div class="flex-center gap-8">
       <button class="display-flex align-center justify-center btn btn-neutral w-10 h-5" id="zoomIn">
         <img src="https://reearth.github.io/visualizer-plugin-sample-data/public/image/plus.svg" alt="Zoom In" />

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/common.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/common.ts
@@ -15,6 +15,10 @@ html {
   padding: 0;
 }
 
+ p {
+  margin: 0;
+ }
+
 /* Buttons */
 button {
   border: none;

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/data/extensionProperty.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/data/extensionProperty.ts
@@ -64,7 +64,7 @@ const widgetFile: FileType = {
   title: "extension-property-widget.js",
   sourceCode: `reearth.ui.show(\`
   ${PRESET_PLUGIN_COMMON_STYLE}
-  <div class="primary-background p-16 rounded-sm">
+  <div class="primary-background p-16 rounded-sm flex-column gap-8">
     <p class="text-3xl font-bold text-center">Extension Property</p>
     <p class="text-md text-secondary text-center">Input on Extension Settings and execute code again.</p>
     <p class="text-md text-center" id="text"></p>

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/data/messengerBetweenExtensions.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/data/messengerBetweenExtensions.ts
@@ -26,7 +26,7 @@ extensions:
 const extension1SourceCode = `
 reearth.ui.show(\`
   ${PRESET_PLUGIN_COMMON_STYLE}
-  <div class="primary-background p-16 rounded-sm">
+  <div class="primary-background p-16 rounded-sm flex-column gap-8">
     <p class="text-3xl font-bold">Extension 1</p>
     <div class="flex-center">
       <input id="messageInput" type="text" placeholder="Enter message"/>
@@ -90,7 +90,7 @@ reearth.extension.on("extensionMessage", msg => {
 const extension2SourceCode = `
 reearth.ui.show(\`
   ${PRESET_PLUGIN_COMMON_STYLE}
-  <div class="primary-background p-16 rounded-sm">
+  <div class="primary-background p-16 rounded-sm flex-column gap-8">
     <p class="text-3xl font-bold">Extension 2</p>
     <div class="flex-center">
       <input id="messageInput" type="text" placeholder="Enter message"/>

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/layerStyles/filterFeaturebyStyle.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/layerStyles/filterFeaturebyStyle.ts
@@ -27,7 +27,7 @@ const widgetFile: FileType = {
 // Define the plug-in UI //
 reearth.ui.show(\`
 ${PRESET_PLUGIN_COMMON_STYLE}
-  <div class="primary-background p-16 rounded-sm">
+  <div class="primary-background flex-column gap-8 p-16 rounded-sm">
     <p class="text-lg font-bold">Filter Cities based on Population:</p>
     <div class="flex-column justify-center gap-8">
       <button class="btn-neutral btn-success p-8" id="allBtn">Show all</button>

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/layerStyles/overrideStyle.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/layerStyles/overrideStyle.ts
@@ -27,7 +27,7 @@ const widgetFile: FileType = {
 // Define the plug-in UI //
 reearth.ui.show(\`
 ${PRESET_PLUGIN_COMMON_STYLE}
-  <div class="primary-background p-16 rounded-sm">
+  <div class="primary-background flex-column gap-8 p-16 rounded-sm">
     <p class="text-3xl font-bold text-center">Color by Height</p>
     <p class="text-md text-secondary text-center">Choose your preferred color scheme<p>
     <div class="display-flex justify-center gap-8">

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/layers/overrideLayerData.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/layers/overrideLayerData.ts
@@ -25,8 +25,9 @@ const widgetFile: FileType = {
 // The following describes the style and functionality of the UI //
 reearth.ui.show(\`
  ${PRESET_PLUGIN_COMMON_STYLE}
-  <div class="primary-background flex-column align-center p-16 rounded-sm">
-    <p class="text-3xl font-bold text-center">Click the button below to enlarge the polygon.</p>
+  <div class="primary-background flex-column gap-8 align-center p-16 rounded-sm">
+    <p class="text-3xl font-bold text-center">Override Layer Data</p>
+    <p class="text-md text-secondary text-center">Click the button below to enlarge the polygon.</p>
     <button class="btn-neutral w-10 h-4" id="scaleBtn">Enlarge</button>
   </div>
 <script>

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
@@ -23,8 +23,9 @@ const widgetFile: FileType = {
   sourceCode: `// Configure the UI side of the Plug-in
   reearth.ui.show(\`
   ${PRESET_PLUGIN_COMMON_STYLE}
-    <div class="primary-background flex-column p-16 rounded-sm">
-      <p class="text-3xl font-bold text-center">Click a building to view it's properties</p>
+    <div class="primary-background flex-column gap-8 p-16 rounded-sm">
+      <p class="text-3xl font-bold text-center">Show Selected Features Information</p>
+      <p class="text-md text-secondary text-center">Click a building to view it's properties</p>
     <div>
       <p class="text-sm">Building ID</p>
       <span id="gml_id" class="secondary-background h-5 p-8 rounded-sm text-sm display-flex align-center"></span>

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/viewer/mouseEvent.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/viewer/mouseEvent.ts
@@ -49,7 +49,7 @@ const widgetFile: FileType = {
     }
   </style>
 
-  <div class="primary-background rounded-sm p-16">
+  <div class="primary-background flex-column gap-8 rounded-sm p-16">
     <p class="text-3xl font-bold text-center">Click Coordinates</p>
     <div class="secondary-background p-16 gap-4">
       <div>

--- a/web/src/beta/features/PluginPlayground/Plugins/presets/viewer/takeScreenshot.ts
+++ b/web/src/beta/features/PluginPlayground/Plugins/presets/viewer/takeScreenshot.ts
@@ -25,7 +25,7 @@ const widgetFile: FileType = {
   ${PRESET_PLUGIN_COMMON_STYLE}
   <div class="primary-background flex-column align-center p-16 rounded-sm gap-16">
     <p class="text-3xl font-bold m-0">Image Capture</p>
-    <p class="text-md text-secondary m-0">Adjust your view as needed, then capture the screenshot</p>
+    <p class="text-md text-secondary text-center m-0">Adjust your view as needed, then capture the screenshot</p>
     <div class="flex-center">
       <button class="btn-primary p-8" id="captureButton">Capture View</button>
     </div>


### PR DESCRIPTION
# Overview
Removed the default margin no the paragraph tag so that margin or spacing can be set through styles
Refactored plugins that used the paragraph tag and were affected by this margin
Added short descriptions to plugins that required them
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
