### PR TITLE
refactor(web): add experimental icon to project settings dropdown export button

### DIFF
--- a/web/src/beta/features/Navbar/LeftSection/index.tsx
+++ b/web/src/beta/features/Navbar/LeftSection/index.tsx
@@ -4,6 +4,7 @@ import {
   PopupMenu,
   PopupMenuItem
 } from "@reearth/beta/lib/reearth-ui";
+import Tooltip from "@reearth/beta/lib/reearth-ui/components/Tooltip";
 import { useProjectFetcher } from "@reearth/services/api";
 import { useT } from "@reearth/services/i18n";
 import { styled } from "@reearth/services/theme";
@@ -73,6 +74,7 @@ const LeftSection: React.FC<Props> = ({
         icon: "downloadSimple",
         id: "export",
         title: t("Export"),
+        tileComponent: <Tooltip type="experimental" />,
         onClick: handleExportProject
       }
     ],


### PR DESCRIPTION
# Overview

Add experimental icon to project settings dropdown export button to keep the same appearance as the other export button on dashboard.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the Export menu option by adding an experimental tooltip to offer additional context to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->