### PR TITLE
fix(web): add supportedLangs to i18n initializer [VIZ-1412]

### DIFF
--- a/web/src/services/i18n/i18n.ts
+++ b/web/src/services/i18n/i18n.ts
@@ -23,6 +23,7 @@ export const SUPPORTED_LANGUAGES = {
 } as const;
 
 i18n.use(LanguageDetector).use(initReactI18next).init({
+  supportedLngs: availableLanguages,
   resources,
   fallbackLng: "en",
   // allow keys to be phrases having `:`, `.`


### PR DESCRIPTION
# Overview
The cause for the language dropdown in the settings panel on the plugin playground to not have a default option is due to the il8n language detector using the language detected from the browser which might not match with the available options which are `en` and `ja`. For example, my browser will detect the default language as `en-GB` but the options available are `en` and `ja`. 

Adding the `suppportedLngs` props and setting it to the array of languages we support will tell the i18n language detector to match based on the languages in that array. So if the detected browser language is `en-GB` or `en-US`, the language it will use will be `en`.

Other possible solution is doing the following below to set the language used by the dropdown to `en` if the detected browser language is not one of the available languages but I thought the first solution might be better.
```
 const detectedLang = useLang();
 const lang = !availableLanguages.includes(detectedLang) ? "en" : detectedLang;
```
## What I've done

## What I haven't done

## How I tested
Manually
## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the internationalization setup to dynamically detect and support available languages based on current translations. This update enables the application to automatically recognize all supported language options, ensuring a more flexible and up-to-date multilingual experience for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->