### PR TITLE
fix(web): member page permissions for modify role and remove member

### DIFF
--- a/web/src/beta/features/Dashboard/ContentsContainer/Members/ListItem.tsx
+++ b/web/src/beta/features/Dashboard/ContentsContainer/Members/ListItem.tsx
@@ -73,7 +73,7 @@ const ListItem: FC<{
                 icon: "arrowLeftRight",
                 id: "changeRole",
                 title: t("Change Role"),
-                disabled: PermissionService.canModify(
+                disabled: !PermissionService.canModify(
                   meRole,
                   member.role,
                   isLastOwner
@@ -84,7 +84,7 @@ const ListItem: FC<{
                 icon: "close",
                 id: "remove",
                 title: t("Remove"),
-                disabled: PermissionService.canRemove(
+                disabled: !PermissionService.canRemove(
                   meRole,
                   member.role,
                   isLastOwner


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the settings for the "Change Role" and "Remove" buttons in the dashboard members view so these options now display their enabled/disabled state correctly based on user permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->