### PR TITLE
feat(server): Add public projects support [VIZ-1482] [VIZ-1481] [VIZ-1480]

### DIFF
--- a/server/e2e/gql_asset_test.go
+++ b/server/e2e/gql_asset_test.go
@@ -126,11 +126,23 @@ func TestAssociateProjectGetAssets(t *testing.T) {
 	teamId := wID.String()
 
 	// Create projectA >>> test.png
-	pidA := createProject(e, "projectA")
+	pidA := createProject(e, uID, map[string]any{
+		"name":        "projectA",
+		"description": "abc",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
 	createAsset(t, e, "test.png", true, teamId, &pidA)
 
 	// Create projectB >>> test.csv
-	pidB := createProject(e, "projectB")
+	pidB := createProject(e, uID, map[string]any{
+		"name":        "projectB",
+		"description": "abc",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
 	createAsset(t, e, "test.csv", true, teamId, &pidB)
 
 	// Get projectA >>> test.png

--- a/server/e2e/gql_custom_property_test.go
+++ b/server/e2e/gql_custom_property_test.go
@@ -10,7 +10,13 @@ import (
 
 func TestUpdateCustomProperties(t *testing.T) {
 	e := Server(t, baseSeeder)
-	pId := createProject(e, "test")
+	pId := createProject(e, uID, map[string]any{
+		"name":        "test",
+		"description": "abc",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
 	_, _, sId := createScene(e, pId)
 	lId := addTestNLSLayerSimple(e, sId)
 
@@ -101,7 +107,13 @@ func TestUpdateCustomProperties(t *testing.T) {
 func TestChangeCustomPropertyTitle(t *testing.T) {
 	e := Server(t, baseSeeder)
 
-	pId := createProject(e, "test")
+	pId := createProject(e, uID, map[string]any{
+		"name":        "test",
+		"description": "abc",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
 	_, _, sId := createScene(e, pId)
 	lId := addTestNLSLayerSimple(e, sId)
 
@@ -222,7 +234,13 @@ func TestChangeCustomPropertyTitle(t *testing.T) {
 
 func TestRemoveCustomProperty(t *testing.T) {
 	e := Server(t, baseSeeder)
-	pId := createProject(e, "test")
+	pId := createProject(e, uID, map[string]any{
+		"name":        "test",
+		"description": "abc",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
 	_, _, sId := createScene(e, pId)
 	lId := addTestNLSLayerSimple(e, sId)
 

--- a/server/e2e/gql_featureCollection_test.go
+++ b/server/e2e/gql_featureCollection_test.go
@@ -176,7 +176,13 @@ func deleteGeoJSONFeature(
 func TestFeatureCollectionCRUD(t *testing.T) {
 	e := Server(t, baseSeeder)
 
-	pId := createProject(e, "test")
+	pId := createProject(e, uID, map[string]any{
+		"name":        "test",
+		"description": "abc",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
 	_, _, sId := createScene(e, pId)
 
 	_, res := fetchSceneForNewLayers(e, sId)

--- a/server/e2e/gql_nlslayer_test.go
+++ b/server/e2e/gql_nlslayer_test.go
@@ -385,7 +385,13 @@ func fetchSceneForNewLayers(e *httpexpect.Expect, sID string) (GraphQLRequest, *
 func TestNLSLayerCRUD(t *testing.T) {
 	e := Server(t, baseSeeder)
 
-	pId := createProject(e, "test")
+	pId := createProject(e, uID, map[string]any{
+		"name":        "test",
+		"description": "abc",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
 
 	_, notUpdatedProject := fetchProjectForNewLayers(e, pId)
 	notUpdatedProjectUpdatedAt := notUpdatedProject.Object().
@@ -772,7 +778,13 @@ func moveInfoboxBlock(e *httpexpect.Expect, layerId, infoboxBlockId string, inde
 func TestInfoboxBlocksCRUD(t *testing.T) {
 	e := Server(t, baseSeeder)
 
-	pId := createProject(e, "test")
+	pId := createProject(e, uID, map[string]any{
+		"name":        "test",
+		"description": "abc",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
 
 	_, notUpdatedProject := fetchProjectForNewLayers(e, pId)
 	notUpdatedProjectUpdatedAt := notUpdatedProject.Object().
@@ -844,7 +856,13 @@ func TestInfoboxBlocksCRUD(t *testing.T) {
 func TestInfoboxProperty(t *testing.T) {
 	e := Server(t, baseSeeder)
 
-	pId := createProject(e, "test")
+	pId := createProject(e, uID, map[string]any{
+		"name":        "test",
+		"description": "abc",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
 	_, _, sId := createScene(e, pId)
 
 	// fetch scene
@@ -896,7 +914,13 @@ func TestInfoboxProperty(t *testing.T) {
 func TestPhotoOverlayProperty(t *testing.T) {
 	e := Server(t, baseSeeder)
 
-	pId := createProject(e, "test")
+	pId := createProject(e, uID, map[string]any{
+		"name":        "test",
+		"description": "abc",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
 	_, _, sId := createScene(e, pId)
 
 	// fetch scene
@@ -964,7 +988,13 @@ func updateCustomProperties(
 func TestCustomProperties(t *testing.T) {
 	e := Server(t, baseSeeder)
 
-	pId := createProject(e, "test")
+	pId := createProject(e, uID, map[string]any{
+		"name":        "test",
+		"description": "abc",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
 
 	_, notUpdatedProject := fetchProjectForNewLayers(e, pId)
 	notUpdatedProjectUpdatedAt := notUpdatedProject.Object().

--- a/server/e2e/gql_scene_test.go
+++ b/server/e2e/gql_scene_test.go
@@ -63,7 +63,13 @@ func TestGetScenePlaceholderJapanese(t *testing.T) {
 
 func TestGetSceneNLSLayer(t *testing.T) {
 	e := Server(t, baseSeeder)
-	pId := createProject(e, "test")
+	pId := createProject(e, uID, map[string]any{
+		"name":        "test",
+		"description": "abc",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
 	_, _, sId := createScene(e, pId)
 	_, _, lId := addNLSLayerSimple(e, sId, "someTitle99", 99)
 
@@ -77,15 +83,7 @@ func TestGetSceneNLSLayer(t *testing.T) {
 func createProjectWithExternalImage(e *httpexpect.Expect, name string) string {
 	requestBody := GraphQLRequest{
 		OperationName: "CreateProject",
-		Query: `mutation CreateProject($teamId: ID!, $visualizer: Visualizer!, $name: String!, $description: String!, $coreSupport: Boolean) {
-			createProject( input: {teamId: $teamId, visualizer: $visualizer, name: $name, description: $description, coreSupport: $coreSupport} ) { 
-				project { 
-					id
-					__typename 
-				} 
-				__typename 
-			}
-		}`,
+		Query:         CreateProjectMutation,
 		Variables: map[string]any{
 			"name":        name,
 			"description": "abc",

--- a/server/e2e/gql_storytelling_test.go
+++ b/server/e2e/gql_storytelling_test.go
@@ -410,32 +410,6 @@ func TestStoryPublishing(t *testing.T) {
 
 }
 
-func createProject(e *httpexpect.Expect, name string) string {
-	requestBody := GraphQLRequest{
-		OperationName: "CreateProject",
-		Query: `mutation CreateProject($teamId: ID!, $visualizer: Visualizer!, $name: String!, $description: String!, $coreSupport: Boolean) {
-			createProject( input: {teamId: $teamId, visualizer: $visualizer, name: $name, description: $description, coreSupport: $coreSupport} ) { 
-				project { 
-					id
-					__typename 
-				} 
-				__typename 
-			}
-		}`,
-		Variables: map[string]any{
-			"name":        name,
-			"description": "abc",
-			"teamId":      wID.String(),
-			"visualizer":  "CESIUM",
-			"coreSupport": true,
-		},
-	}
-
-	res := Request(e, uID.String(), requestBody)
-
-	return res.Path("$.data.createProject.project.id").Raw().(string)
-}
-
 func createScene(e *httpexpect.Expect, pID string) (GraphQLRequest, *httpexpect.Value, string) {
 	requestBody := GraphQLRequest{
 		OperationName: "CreateScene",

--- a/server/e2e/gql_style_test.go
+++ b/server/e2e/gql_style_test.go
@@ -147,7 +147,13 @@ func fetchSceneForStyles(e *httpexpect.Expect, sID string) (GraphQLRequest, *htt
 func TestStyleCRUD(t *testing.T) {
 	e := Server(t, baseSeeder)
 
-	pId := createProject(e, "test")
+	pId := createProject(e, uID, map[string]any{
+		"name":        "test",
+		"description": "abc",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
 	_, _, sId := createScene(e, pId)
 
 	// fetch scene

--- a/server/e2e/gql_validate_geojson_test.go
+++ b/server/e2e/gql_validate_geojson_test.go
@@ -8,7 +8,13 @@ func TestValidateGeoJsonOfAssets(t *testing.T) {
 	e := Server(t, baseSeeder)
 
 	teamId := wID.String()
-	pId := createProject(e, "test")
+	pId := createProject(e, uID, map[string]any{
+		"name":        "test",
+		"description": "abc",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
 	_, _, sId := createScene(e, pId)
 
 	tests := []struct {
@@ -223,7 +229,14 @@ func TestValidateGeoJsonExternal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := Server(t, baseSeeder)
-			pId := createProject(e, "test")
+			pId := createProject(e, uID, map[string]any{
+				"name":        "test",
+				"description": "abc",
+				"teamId":      wID.String(),
+				"visualizer":  "CESIUM",
+				"coreSupport": true,
+			})
+
 			_, _, sId := createScene(e, pId)
 			res := addNLSLayerSimpleByGeojson(e, sId, tt.url, "test", 0)
 			if tt.hasError {
@@ -238,7 +251,13 @@ func TestValidateGeoJsonExternal(t *testing.T) {
 func TestValidateGeoFormData(t *testing.T) {
 	e := Server(t, baseSeeder)
 
-	pId := createProject(e, "test")
+	pId := createProject(e, uID, map[string]any{
+		"name":        "test",
+		"description": "abc",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
 	_, _, sId := createScene(e, pId)
 	tests := []struct {
 		name     string

--- a/server/gql/project.graphql
+++ b/server/gql/project.graphql
@@ -25,6 +25,7 @@ type Project implements Node {
   trackingId: String!
   starred: Boolean!
   isDeleted: Boolean!
+  visibility: String!
 }
 
 type ProjectAliasAvailability {
@@ -56,6 +57,7 @@ input CreateProjectInput {
   name: String
   description: String
   coreSupport: Boolean
+  visibility: String
 }
 
 input UpdateProjectInput {
@@ -79,6 +81,7 @@ input UpdateProjectInput {
   sceneId: ID
   starred: Boolean
   deleted: Boolean
+  visibility: String
 }
 
 input PublishProjectInput {
@@ -147,6 +150,7 @@ extend type Query {
   checkProjectAlias(alias: String!): ProjectAliasAvailability!
   starredProjects(teamId: ID!): ProjectConnection!
   deletedProjects(teamId: ID!): ProjectConnection!
+  visibilityProjects(teamId: ID!): ProjectConnection!
 }
 
 extend type Mutation {

--- a/server/internal/adapter/gql/gqlmodel/convert_project.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_project.go
@@ -67,6 +67,7 @@ func ToProject(p *project.Project) *Project {
 		TrackingID:        p.TrackingID(),
 		Starred:           p.Starred(),
 		IsDeleted:         p.IsDeleted(),
+		Visibility:        p.Visibility(),
 	}
 }
 

--- a/server/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/server/internal/adapter/gql/gqlmodel/models_gen.go
@@ -197,6 +197,7 @@ type CreateProjectInput struct {
 	Name        *string    `json:"name,omitempty"`
 	Description *string    `json:"description,omitempty"`
 	CoreSupport *bool      `json:"coreSupport,omitempty"`
+	Visibility  *string    `json:"visibility,omitempty"`
 }
 
 type CreateSceneInput struct {
@@ -705,6 +706,7 @@ type Project struct {
 	TrackingID        string            `json:"trackingId"`
 	Starred           bool              `json:"starred"`
 	IsDeleted         bool              `json:"isDeleted"`
+	Visibility        string            `json:"visibility"`
 }
 
 func (Project) IsNode()        {}
@@ -1264,6 +1266,7 @@ type UpdateProjectInput struct {
 	SceneID           *ID      `json:"sceneId,omitempty"`
 	Starred           *bool    `json:"starred,omitempty"`
 	Deleted           *bool    `json:"deleted,omitempty"`
+	Visibility        *string  `json:"visibility,omitempty"`
 }
 
 type UpdatePropertyItemInput struct {

--- a/server/internal/adapter/gql/loader_project.go
+++ b/server/internal/adapter/gql/loader_project.go
@@ -123,6 +123,28 @@ func (c *ProjectLoader) FindDeletedByWorkspace(ctx context.Context, wsID gqlmode
 	}, nil
 }
 
+func (c *ProjectLoader) VisibilityByWorkspace(ctx context.Context, wsID gqlmodel.ID) (*gqlmodel.ProjectConnection, error) {
+	tid, err := gqlmodel.ToID[accountdomain.Workspace](wsID)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.usecase.FindVisibilityByWorkspace(ctx, tid, getOperator(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	nodes := make([]*gqlmodel.Project, 0, len(res))
+	for _, p := range res {
+		nodes = append(nodes, gqlmodel.ToProject(p))
+	}
+
+	return &gqlmodel.ProjectConnection{
+		Nodes:      nodes,
+		TotalCount: len(nodes),
+	}, nil
+}
+
 // data loaders
 
 type ProjectDataLoader interface {

--- a/server/internal/adapter/gql/resolver_mutation_project.go
+++ b/server/internal/adapter/gql/resolver_mutation_project.go
@@ -34,6 +34,7 @@ func (r *mutationResolver) CreateProject(ctx context.Context, input gqlmodel.Cre
 		Name:        input.Name,
 		Description: input.Description,
 		CoreSupport: input.CoreSupport,
+		Visibility:  input.Visibility,
 	}, getOperator(ctx))
 	if err != nil {
 		return nil, err
@@ -79,6 +80,7 @@ func (r *mutationResolver) UpdateProject(ctx context.Context, input gqlmodel.Upd
 		Starred:           input.Starred,
 		Deleted:           input.Deleted,
 		SceneID:           gqlmodel.ToIDRef[id.Scene](input.SceneID),
+		Visibility:        input.Visibility,
 	}, getOperator(ctx))
 	if err != nil {
 		return nil, err

--- a/server/internal/adapter/gql/resolver_query.go
+++ b/server/internal/adapter/gql/resolver_query.go
@@ -182,3 +182,7 @@ func (r *queryResolver) StarredProjects(ctx context.Context, teamId gqlmodel.ID)
 func (r *queryResolver) DeletedProjects(ctx context.Context, teamId gqlmodel.ID) (*gqlmodel.ProjectConnection, error) {
 	return loaders(ctx).Project.FindDeletedByWorkspace(ctx, teamId)
 }
+
+func (r *queryResolver) VisibilityProjects(ctx context.Context, teamId gqlmodel.ID) (*gqlmodel.ProjectConnection, error) {
+	return loaders(ctx).Project.VisibilityByWorkspace(ctx, teamId)
+}

--- a/server/internal/infrastructure/memory/project.go
+++ b/server/internal/infrastructure/memory/project.go
@@ -127,6 +127,28 @@ func (r *Project) FindDeletedByWorkspace(ctx context.Context, id accountdomain.W
 	return result, nil
 }
 
+func (r *Project) FindVisibilityByWorkspace(ctx context.Context, id accountdomain.WorkspaceID) ([]*project.Project, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if !r.f.CanRead(id) {
+		return nil, nil
+	}
+
+	var result []*project.Project
+	for _, p := range r.data {
+		if p.Workspace() == id && !p.IsDeleted() && p.Visibility() == "public" {
+			result = append(result, p)
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].UpdatedAt().After(result[j].UpdatedAt())
+	})
+
+	return result, nil
+}
+
 func (r *Project) FindIDsByWorkspace(ctx context.Context, id accountdomain.WorkspaceID) (res []id.ProjectID, _ error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()

--- a/server/internal/infrastructure/mongo/mongodoc/project.go
+++ b/server/internal/infrastructure/mongo/mongodoc/project.go
@@ -33,9 +33,9 @@ type ProjectDocument struct {
 	CoreSupport       bool
 	EnableGA          bool
 	TrackingID        string
-	// Scene             string
-	Starred bool
-	Deleted bool
+	Starred           bool
+	Deleted           bool
+	Visibility        string
 }
 
 type ProjectConsumer = Consumer[*ProjectDocument, *project.Project]
@@ -76,9 +76,9 @@ func NewProject(project *project.Project) (*ProjectDocument, string) {
 		CoreSupport:       project.CoreSupport(),
 		EnableGA:          project.EnableGA(),
 		TrackingID:        project.TrackingID(),
-		// Scene:             project.Scene().String(),
-		Starred: project.Starred(),
-		Deleted: project.IsDeleted(),
+		Starred:           project.Starred(),
+		Deleted:           project.IsDeleted(),
+		Visibility:        project.Visibility(),
 	}, pid
 }
 
@@ -126,8 +126,8 @@ func (d *ProjectDocument) Model() (*project.Project, error) {
 		CoreSupport(d.CoreSupport).
 		EnableGA(d.EnableGA).
 		TrackingID(d.TrackingID).
-		// Scene(scene).
 		Starred(d.Starred).
 		Deleted(d.Deleted).
+		Visibility(d.Visibility).
 		Build()
 }

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -149,6 +149,20 @@ func (r *Project) FindDeletedByWorkspace(ctx context.Context, id accountdomain.W
 	return r.find(ctx, filter)
 }
 
+func (r *Project) FindVisibilityByWorkspace(ctx context.Context, id accountdomain.WorkspaceID) ([]*project.Project, error) {
+	if !r.f.CanRead(id) {
+		return nil, repo.ErrOperationDenied
+	}
+
+	filter := bson.M{
+		"team":       id.String(),
+		"deleted":    false,
+		"visibility": "public",
+	}
+
+	return r.find(ctx, filter)
+}
+
 func (r *Project) FindByPublicName(ctx context.Context, name string) (*project.Project, error) {
 	if name == "" {
 		return nil, rerror.ErrNotFound

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -91,6 +91,10 @@ func (i *Project) FindDeletedByWorkspace(ctx context.Context, id accountdomain.W
 	return i.projectRepo.FindDeletedByWorkspace(ctx, id)
 }
 
+func (i *Project) FindVisibilityByWorkspace(ctx context.Context, id accountdomain.WorkspaceID, operator *usecase.Operator) ([]*project.Project, error) {
+	return i.projectRepo.FindVisibilityByWorkspace(ctx, id)
+}
+
 func (i *Project) Create(ctx context.Context, input interfaces.CreateProjectParam, operator *usecase.Operator) (_ *project.Project, err error) {
 	return i.createProject(ctx, createProjectInput{
 		WorkspaceID: input.WorkspaceID,
@@ -98,6 +102,7 @@ func (i *Project) Create(ctx context.Context, input interfaces.CreateProjectPara
 		Name:        input.Name,
 		Description: input.Description,
 		CoreSupport: input.CoreSupport,
+		Visibility:  input.Visibility,
 	}, operator)
 }
 
@@ -211,6 +216,10 @@ func (i *Project) Update(ctx context.Context, p interfaces.UpdateProjectParam, o
 				return nil, err
 			}
 		}
+	}
+
+	if p.Visibility != nil {
+		prj.UpdateVisibility(*p.Visibility)
 	}
 
 	if len(graphql.GetErrors(ctx)) > 0 {
@@ -663,6 +672,7 @@ type createProjectInput struct {
 	Alias       *string
 	Archived    *bool
 	CoreSupport *bool
+	Visibility  *string
 }
 
 func (i *Project) createProject(ctx context.Context, input createProjectInput, operator *usecase.Operator) (_ *project.Project, err error) {
@@ -733,6 +743,12 @@ func (i *Project) createProject(ctx context.Context, input createProjectInput, o
 
 	if input.Name != nil {
 		prj = prj.Name(*input.Name)
+	}
+
+	if input.Visibility != nil {
+		prj = prj.Visibility(*input.Visibility)
+	} else {
+		prj = prj.Visibility("private")
 	}
 
 	proj, err := prj.Build()

--- a/server/internal/usecase/interfaces/project.go
+++ b/server/internal/usecase/interfaces/project.go
@@ -24,6 +24,7 @@ type CreateProjectParam struct {
 	Name        *string
 	Description *string
 	CoreSupport *bool
+	Visibility  *string
 }
 
 type UpdateProjectParam struct {
@@ -47,6 +48,7 @@ type UpdateProjectParam struct {
 	SceneID           *id.SceneID
 	Starred           *bool
 	Deleted           *bool
+	Visibility        *string
 }
 
 type PublishProjectParam struct {
@@ -70,6 +72,7 @@ type Project interface {
 	FindByWorkspace(context.Context, accountdomain.WorkspaceID, *string, *project.SortType, *usecasex.Pagination, *usecase.Operator) ([]*project.Project, *usecasex.PageInfo, error)
 	FindStarredByWorkspace(context.Context, accountdomain.WorkspaceID, *usecase.Operator) ([]*project.Project, error)
 	FindDeletedByWorkspace(context.Context, accountdomain.WorkspaceID, *usecase.Operator) ([]*project.Project, error)
+	FindVisibilityByWorkspace(context.Context, accountdomain.WorkspaceID, *usecase.Operator) ([]*project.Project, error)
 	Create(context.Context, CreateProjectParam, *usecase.Operator) (*project.Project, error)
 	Update(context.Context, UpdateProjectParam, *usecase.Operator) (*project.Project, error)
 	Publish(context.Context, PublishProjectParam, *usecase.Operator) (*project.Project, error)

--- a/server/internal/usecase/repo/project.go
+++ b/server/internal/usecase/repo/project.go
@@ -24,6 +24,7 @@ type Project interface {
 	FindByWorkspace(context.Context, accountdomain.WorkspaceID, ProjectFilter) ([]*project.Project, *usecasex.PageInfo, error)
 	FindStarredByWorkspace(context.Context, accountdomain.WorkspaceID) ([]*project.Project, error)
 	FindDeletedByWorkspace(context.Context, accountdomain.WorkspaceID) ([]*project.Project, error)
+	FindVisibilityByWorkspace(context.Context, accountdomain.WorkspaceID) ([]*project.Project, error)
 	FindByPublicName(context.Context, string) (*project.Project, error)
 	CountByWorkspace(context.Context, accountdomain.WorkspaceID) (int, error)
 	CountPublicByWorkspace(context.Context, accountdomain.WorkspaceID) (int, error)

--- a/server/pkg/project/builder.go
+++ b/server/pkg/project/builder.go
@@ -83,6 +83,11 @@ func (b *Builder) Name(name string) *Builder {
 	return b
 }
 
+func (b *Builder) Visibility(visibility string) *Builder {
+	b.p.visibility = visibility
+	return b
+}
+
 func (b *Builder) Description(description string) *Builder {
 	b.p.description = description
 	return b

--- a/server/pkg/project/project.go
+++ b/server/pkg/project/project.go
@@ -54,6 +54,7 @@ type Project struct {
 	sceneId           id.SceneID
 	starred           bool
 	isDeleted         bool
+	visibility        string
 }
 
 func (p *Project) ID() id.ProjectID {
@@ -86,6 +87,10 @@ func (p *Project) PublishedAt() time.Time {
 
 func (p *Project) Name() string {
 	return p.name
+}
+
+func (p *Project) Visibility() string {
+	return p.visibility
 }
 
 func (p *Project) Description() string {
@@ -205,6 +210,10 @@ func (p *Project) SetDeleted(isDeleted bool) {
 
 func (p *Project) UpdateName(name string) {
 	p.name = name
+}
+
+func (p *Project) UpdateVisibility(visibility string) {
+	p.visibility = visibility
 }
 
 func (p *Project) UpdateDescription(description string) {


### PR DESCRIPTION
# Overview
##  added a visibility parameter to projects.

## What I've done

### 1. visibility (string) will be added to the project.
```diff
type Project implements Node {
  ...
  trackingId: String!
  starred: Boolean!
  isDeleted: Boolean!
+  visibility: String!
}
```

### 2. The visibility can be set to either "public" or "private" (as strings).
If not specified during createProject, it will default to "private".
```diff
input CreateProjectInput {
  teamId: ID!
  visualizer: Visualizer!
  name: String
  description: String
  coreSupport: Boolean
+  visibility: String
}
```
### 3. The visibility can be updated using updateProject.
```diff
input UpdateProjectInput {
  ....
  sceneId: ID
  starred: Boolean
  deleted: Boolean
+  visibility: String
}
```

### 4. Similar to starredProjects and deletedProjects, we added visibilityProjects,
which retrieves only projects where visibility is "public" and deleted is false.
```diff
extend type Query {
  projects(
    teamId: ID!
    pagination: Pagination
    keyword: String
    sort: ProjectSort
  ): ProjectConnection! # not included deleted projects
  checkProjectAlias(alias: String!): ProjectAliasAvailability!
  starredProjects(teamId: ID!): ProjectConnection!
  deletedProjects(teamId: ID!): ProjectConnection!
+  visibilityProjects(teamId: ID!): ProjectConnection!
}
```

### 5. In the project's e2e tests, queries and mutations that were defined individually have been refactored and consolidated into a single place.
```
const ProjectFragment = `
fragment ProjectFragment on Project {
    ...

const CreateProjectMutation = `
mutation CreateProject(
    ...

const GetProjectsQuery = `
query GetProjects(
    ...

const UpdateProjectMutation = `
mutation UpdateProject($input: UpdateProjectInput!) {
    ...
```
## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Please add visibility to the projectFragment in the frontend.
```diff
export const projectFragment = gql`
  fragment ProjectFragment on Project {
    id
    name
    description
    imageUrl
    isArchived
    isBasicAuthActive
    basicAuthUsername
    basicAuthPassword
    publicTitle
    publicDescription
    publicImage
    alias
    enableGa
    trackingId
    publishmentStatus
    updatedAt
    createdAt
    coreSupport
    starred
    isDeleted
+    visibility
  }
`;
```

## Also, please add the visibilityProjects query.
```
export const GET_VISIBILITY_PROJECTS = gql(`
	query GetVisibilityProjects($teamId: ID!) {
		visibilityProjects(teamId: $teamId) {
			nodes {
				id
				name
				visibility
				isDeleted
			}
			totalCount
		}
	}
`);
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Projects now support additional attributes (description, team assignment, visualizer options, and core support) during creation for a richer setup experience.
	- A visibility setting has been introduced, enabling users to designate and filter projects based on their public or private status, enhancing project organization and access control.
	- New queries and mutations for managing project visibility have been added, improving the GraphQL API functionality.
  
- **Bug Fixes**
	- Improved handling of project visibility in various test cases to ensure accurate project initialization and management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->