### PR TITLE
feat(server): set project visibility [VIZ-1517]

### DIFF
--- a/server/internal/infrastructure/mongo/migration/250417160823_set_project_visibility.go
+++ b/server/internal/infrastructure/mongo/migration/250417160823_set_project_visibility.go
@@ -1,0 +1,28 @@
+package migration
+
+import (
+	"context"
+	"log"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func SetProjectVisibility(ctx context.Context, c DBClient) error {
+
+	filter := bson.M{}
+
+	update := bson.M{
+		"$set": bson.M{
+			"visibility": "private",
+		},
+	}
+
+	result, err := c.WithCollection("project").Client().UpdateMany(ctx, filter, update)
+	if err != nil {
+		log.Fatalf("Update error: %v", err)
+	}
+
+	log.Printf("Matched %d documents and updated %d documents.\n", result.MatchedCount, result.ModifiedCount)
+
+	return err
+}

--- a/server/internal/infrastructure/mongo/migration/250417160823_set_project_visibility_test.go
+++ b/server/internal/infrastructure/mongo/migration/250417160823_set_project_visibility_test.go
@@ -1,0 +1,54 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearthx/mongox"
+	"github.com/reearth/reearthx/mongox/mongotest"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestSetProjectVisibility(t *testing.T) {
+	db := mongotest.Connect(t)(t)
+	client := mongox.NewClientWithDatabase(db)
+	ctx := context.Background()
+
+	t.Run("updates all project documents with visibility=private", func(t *testing.T) {
+
+		_, err := db.Collection("project").InsertMany(ctx, []interface{}{
+			bson.M{"_id": "p1", "id": "item1", "name": "Project 1"},
+			bson.M{"_id": "p2", "id": "item2", "name": "Project 2", "visibility": "public"},
+			bson.M{"_id": "p3", "id": "item3", "name": "Project 3"},
+		})
+		assert.NoError(t, err)
+
+		err = SetProjectVisibility(ctx, client)
+		assert.NoError(t, err)
+
+		cursor, err := db.Collection("project").Find(ctx, bson.M{})
+		assert.NoError(t, err)
+
+		var results []bson.M
+		err = cursor.All(ctx, &results)
+		assert.NoError(t, err)
+		assert.Len(t, results, 3)
+
+		for _, doc := range results {
+			assert.Equal(t, "private", doc["visibility"])
+		}
+	})
+
+	t.Run("no documents in collection", func(t *testing.T) {
+		err := db.Collection("project").Drop(ctx)
+		assert.NoError(t, err)
+
+		err = SetProjectVisibility(ctx, client)
+		assert.NoError(t, err)
+
+		count, err := db.Collection("project").CountDocuments(ctx, bson.M{})
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), count)
+	})
+}

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -19,4 +19,5 @@ var migrations = migration.Migrations[DBClient]{
   221028204300: MoveTerrainProperties,
   250305230545: AssetProjectAssociation,
   250317115957: AddIndex,
+  250417160823: SetProjectVisibility,
 }


### PR DESCRIPTION
# Overview

### Set the visibility of the project to private

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a database migration to set all project visibility fields to "private".
- **Tests**
  - Introduced tests to verify the migration updates project visibility and handles empty collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->