### PR TITLE
test(web): add unit tests to components [VIZ-1465]

### DIFF
--- a/web/src/beta/lib/reearth-ui/components/Panel/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Panel/index.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from "@reearth/test/utils";
+import { describe, test, expect, vi } from "vitest";
+
+import { Panel } from "./index";
+
+describe("Panel Component", () => {
+  test("renders with default props", () => {
+    render(<Panel>Test Content</Panel>);
+
+    expect(screen.getByText("Test Content")).toBeInTheDocument();
+  });
+
+  test("renders with custom title", () => {
+    render(<Panel title="Custom Title">Test Content</Panel>);
+
+    expect(screen.getByText("Custom Title")).toBeInTheDocument();
+    expect(screen.getByText("Test Content")).toBeInTheDocument();
+  });
+
+  test("renders with custom width", () => {
+    const customWidth = 400;
+    const { container } = render(
+      <Panel width={customWidth}>Test Content</Panel>
+    );
+
+    expect(container.firstChild).toHaveStyle(`width: ${customWidth}px`);
+  });
+
+  test("renders with actions", () => {
+    render(
+      <Panel actions={<button>Action Button</button>}>Test Content</Panel>
+    );
+
+    expect(screen.getByText("Action Button")).toBeInTheDocument();
+    expect(screen.getByText("Test Content")).toBeInTheDocument();
+  });
+
+  test("calls onCancel when close button is clicked", () => {
+    const handleCancel = vi.fn();
+    render(
+      <Panel title="Test Title" onCancel={handleCancel}>
+        Test Content
+      </Panel>
+    );
+
+    const closeButton = screen.getByRole("button");
+    fireEvent.click(closeButton);
+
+    expect(handleCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not render header when title is not provided", () => {
+    render(<Panel>Test Content</Panel>);
+
+    const closeButton = screen.queryByRole("button");
+    expect(closeButton).not.toBeInTheDocument();
+  });
+
+  test("does not render actions section when actions are not provided", () => {
+    const { container } = render(<Panel>Test Content</Panel>);
+
+    const actionWrappers = container.querySelectorAll(
+      "[class*='ActionWrapper']"
+    );
+    expect(actionWrappers.length).toBe(0);
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/Popup/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Popup/index.test.tsx
@@ -20,22 +20,6 @@ describe("Popup Component", () => {
     expect(screen.getByText("Popup content")).toBeInTheDocument();
   });
 
-  test("hides content when clicking outside", () => {
-    render(
-      <div>
-        <Popup trigger="Click me">Popup content</Popup>
-        <div data-testid="outside">Outside</div>
-      </div>
-    );
-
-    const trigger = screen.getByText("Click me");
-    fireEvent.click(trigger);
-
-    expect(screen.getByText("Popup content")).toBeInTheDocument();
-
-    expect(screen.queryByText("outside")).not.toBeInTheDocument();
-  });
-
   test("renders as controlled component", () => {
     const handleOpenChange = vi.fn();
 

--- a/web/src/beta/lib/reearth-ui/components/Popup/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Popup/index.test.tsx
@@ -1,0 +1,97 @@
+import { screen, fireEvent, render } from "@reearth/test/utils";
+import { describe, test, expect, vi } from "vitest";
+
+import { Popup } from "./index";
+
+describe("Popup Component", () => {
+  test("renders with trigger", () => {
+    render(<Popup trigger="Click me">Popup content</Popup>);
+
+    expect(screen.getByText("Click me")).toBeInTheDocument();
+    expect(screen.queryByText("Popup content")).not.toBeInTheDocument();
+  });
+
+  test("shows content when trigger is clicked", () => {
+    render(<Popup trigger="Click me">Popup content</Popup>);
+
+    const trigger = screen.getByText("Click me");
+    fireEvent.click(trigger);
+
+    expect(screen.getByText("Popup content")).toBeInTheDocument();
+  });
+
+  test("hides content when clicking outside", () => {
+    render(
+      <div>
+        <Popup trigger="Click me">Popup content</Popup>
+        <div data-testid="outside">Outside</div>
+      </div>
+    );
+
+    const trigger = screen.getByText("Click me");
+    fireEvent.click(trigger);
+
+    expect(screen.getByText("Popup content")).toBeInTheDocument();
+
+    expect(screen.queryByText("outside")).not.toBeInTheDocument();
+  });
+
+  test("renders as controlled component", () => {
+    const handleOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <Popup trigger="Click me" open={false} onOpenChange={handleOpenChange}>
+        Popup content
+      </Popup>
+    );
+
+    expect(screen.queryByText("Popup content")).not.toBeInTheDocument();
+
+    const trigger = screen.getByText("Click me");
+    fireEvent.click(trigger);
+
+    expect(handleOpenChange).toHaveBeenCalledWith(true);
+
+    rerender(
+      <Popup trigger="Click me" open={true} onOpenChange={handleOpenChange}>
+        Popup content
+      </Popup>
+    );
+
+    expect(screen.getByText("Popup content")).toBeInTheDocument();
+  });
+
+  test("auto closes when autoClose is enabled", () => {
+    render(
+      <Popup trigger="Click me" autoClose>
+        <button>Action</button>
+      </Popup>
+    );
+
+    const trigger = screen.getByText("Click me");
+    fireEvent.click(trigger);
+
+    expect(screen.getByText("Action")).toBeInTheDocument();
+
+    const action = screen.getByText("Action");
+    fireEvent.click(action);
+
+    expect(screen.queryByText("Action")).not.toBeInTheDocument();
+  });
+
+  test("doesn't close when clicking content without autoClose", () => {
+    render(
+      <Popup trigger="Click me">
+        <button>Action</button>
+      </Popup>
+    );
+
+    const trigger = screen.getByText("Click me");
+    fireEvent.click(trigger);
+
+    const action = screen.getByText("Action");
+    fireEvent.click(action);
+
+    expect(screen.getByText("Action")).toBeInTheDocument();
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/PopupMenu/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/PopupMenu/index.test.tsx
@@ -1,0 +1,196 @@
+import { screen, fireEvent, render } from "@reearth/test/utils";
+import { MemoryRouter } from "react-router-dom";
+import { describe, test, expect, vi } from "vitest";
+
+import { PopupMenu } from "./index";
+
+const mockMenuItems = [
+  {
+    id: "item1",
+    title: "Menu Item 1",
+    icon: "check" as const
+  },
+  {
+    id: "item2",
+    title: "Menu Item 2",
+    icon: "close" as const
+  },
+  {
+    id: "item3",
+    title: "Menu Item 3",
+    onClick: vi.fn()
+  }
+];
+
+const mockCustomSubMenuItems = [
+  {
+    id: "item1",
+    title: "Group 1 Item 1",
+    hasCustomSubMenu: true,
+    customSubMenuLabel: "Group 1",
+    customSubMenuOrder: 1
+  },
+  {
+    id: "item2",
+    title: "Group 1 Item 2",
+    hasCustomSubMenu: true,
+    customSubMenuLabel: "Group 1",
+    customSubMenuOrder: 2
+  },
+  {
+    id: "item3",
+    title: "Group 2 Item 1",
+    hasCustomSubMenu: true,
+    customSubMenuLabel: "Group 2",
+    customSubMenuOrder: 1
+  }
+];
+
+const renderWithRouter = (ui: React.ReactElement) => {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+};
+
+describe("PopupMenu Component", () => {
+  test("renders with label", () => {
+    renderWithRouter(<PopupMenu label="Menu" menu={mockMenuItems} />);
+
+    expect(screen.getByText("Menu")).toBeInTheDocument();
+  });
+
+  test("shows menu when trigger is clicked", () => {
+    renderWithRouter(<PopupMenu label="Menu" menu={mockMenuItems} />);
+
+    const trigger = screen.getByText("Menu");
+    fireEvent.click(trigger);
+
+    expect(screen.getByText("Menu Item 1")).toBeInTheDocument();
+    expect(screen.getByText("Menu Item 2")).toBeInTheDocument();
+    expect(screen.getByText("Menu Item 3")).toBeInTheDocument();
+  });
+
+  test("calls item onClick when menu item is clicked", () => {
+    const onClickMock = vi.fn();
+    const menuItems = [
+      {
+        id: "item1",
+        title: "Clickable Item",
+        onClick: onClickMock
+      }
+    ];
+
+    renderWithRouter(<PopupMenu label="Menu" menu={menuItems} />);
+
+    const trigger = screen.getByText("Menu");
+    fireEvent.click(trigger);
+
+    const menuItem = screen.getByText("Clickable Item");
+    fireEvent.click(menuItem);
+
+    expect(onClickMock).toHaveBeenCalledWith("item1");
+  });
+
+  test("renders with icon as trigger", () => {
+    renderWithRouter(<PopupMenu icon="setting" menu={mockMenuItems} />);
+
+    const iconElement = document.querySelector("svg");
+    expect(iconElement).toBeInTheDocument();
+  });
+
+  test("renders with path items as links", () => {
+    const menuItems = [
+      {
+        id: "item1",
+        title: "Link Item",
+        path: "/some-path"
+      }
+    ];
+
+    renderWithRouter(<PopupMenu label="Menu" menu={menuItems} />);
+
+    const trigger = screen.getByText("Menu");
+    fireEvent.click(trigger);
+
+    const linkElement = screen.getByText("Link Item").closest("a");
+    expect(linkElement).toHaveAttribute("href", "/some-path");
+  });
+
+  test("renders disabled item", () => {
+    const onClickMock = vi.fn();
+    const menuItems = [
+      {
+        id: "item1",
+        title: "Disabled Item",
+        disabled: true,
+        onClick: onClickMock
+      }
+    ];
+
+    renderWithRouter(<PopupMenu label="Menu" menu={menuItems} />);
+
+    const trigger = screen.getByText("Menu");
+    fireEvent.click(trigger);
+
+    const menuItem = screen.getByText("Disabled Item");
+    fireEvent.click(menuItem);
+
+    expect(onClickMock).not.toHaveBeenCalled();
+  });
+
+  test("calls onOpenChange when menu opens and closes", () => {
+    const onOpenChangeMock = vi.fn();
+    renderWithRouter(
+      <PopupMenu
+        label="Menu"
+        menu={mockMenuItems}
+        onOpenChange={onOpenChangeMock}
+      />
+    );
+
+    const trigger = screen.getByText("Menu");
+    fireEvent.click(trigger);
+
+    expect(onOpenChangeMock).toHaveBeenCalledWith(true);
+
+    fireEvent.click(trigger);
+
+    expect(onOpenChangeMock).toHaveBeenCalledWith(false);
+  });
+
+  test("renders with controlled open state", () => {
+    const { rerender } = renderWithRouter(
+      <PopupMenu label="Menu" menu={mockMenuItems} openMenu={false} />
+    );
+
+    expect(screen.queryByText("Menu Item 1")).not.toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter>
+        <PopupMenu label="Menu" menu={mockMenuItems} openMenu={true} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Menu Item 1")).toBeInTheDocument();
+  });
+
+  test("renders with custom submenu groups", () => {
+    renderWithRouter(
+      <PopupMenu label="Menu" menu={mockCustomSubMenuItems} nested />
+    );
+
+    const trigger = screen.getByText("Menu");
+    fireEvent.click(trigger);
+
+    expect(screen.getByText("Group 1")).toBeInTheDocument();
+    expect(screen.getByText("Group 2")).toBeInTheDocument();
+    expect(screen.getByText("Group 1 Item 1")).toBeInTheDocument();
+    expect(screen.getByText("Group 1 Item 2")).toBeInTheDocument();
+    expect(screen.getByText("Group 2 Item 1")).toBeInTheDocument();
+  });
+
+  test("renders with React Node as label", () => {
+    const customLabel = <div data-testid="custom-label">Custom Label</div>;
+    renderWithRouter(<PopupMenu label={customLabel} menu={mockMenuItems} />);
+
+    expect(screen.getByTestId("custom-label")).toBeInTheDocument();
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/PopupPanel/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/PopupPanel/index.test.tsx
@@ -1,0 +1,86 @@
+import { screen, fireEvent, render } from "@reearth/test/utils";
+import { describe, test, expect, vi } from "vitest";
+
+import { PopupPanel } from "./index";
+
+describe("PopupPanel Component", () => {
+  test("renders with default props", () => {
+    render(<PopupPanel>Test Content</PopupPanel>);
+
+    expect(screen.getByText("Test Content")).toBeInTheDocument();
+  });
+
+  test("renders with custom title", () => {
+    render(<PopupPanel title="Custom Panel">Test Content</PopupPanel>);
+
+    expect(screen.getByText("Custom Panel")).toBeInTheDocument();
+    expect(screen.getByText("Test Content")).toBeInTheDocument();
+  });
+
+  test("renders with custom width", () => {
+    const customWidth = 400;
+    const { container } = render(
+      <PopupPanel width={customWidth}>Test Content</PopupPanel>
+    );
+
+    const wrapperDiv = container.firstChild?.firstChild;
+    expect(wrapperDiv).toHaveStyle(`width: ${customWidth}px`);
+  });
+
+  test("renders with actions", () => {
+    render(
+      <PopupPanel actions={<button>Action Button</button>}>
+        Test Content
+      </PopupPanel>
+    );
+
+    expect(screen.getByText("Action Button")).toBeInTheDocument();
+    expect(screen.getByText("Test Content")).toBeInTheDocument();
+  });
+
+  test("calls onCancel when close button is clicked", () => {
+    const handleCancel = vi.fn();
+    render(
+      <PopupPanel title="Test Panel" onCancel={handleCancel}>
+        Test Content
+      </PopupPanel>
+    );
+
+    const closeButton = screen.getByRole("button");
+    fireEvent.click(closeButton);
+
+    expect(handleCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("calls onCancel when clicking outside the panel", () => {
+    const handleCancel = vi.fn();
+
+    render(
+      <div>
+        <div data-testid="outside-element">Outside</div>
+        <PopupPanel onCancel={handleCancel}>Test Content</PopupPanel>
+      </div>
+    );
+
+    const outsideElement = screen.getByTestId("outside-element");
+    fireEvent.mouseDown(outsideElement);
+
+    expect(handleCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not render header when title is not provided", () => {
+    render(<PopupPanel>Test Content</PopupPanel>);
+
+    const closeButton = screen.queryByRole("button");
+    expect(closeButton).not.toBeInTheDocument();
+  });
+
+  test("does not render actions section when actions are not provided", () => {
+    const { container } = render(<PopupPanel>Test Content</PopupPanel>);
+
+    const actionWrappers = container.querySelectorAll(
+      "[class*='ActionWrapper']"
+    );
+    expect(actionWrappers.length).toBe(0);
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/Radio/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Radio/index.test.tsx
@@ -1,0 +1,55 @@
+import { screen, fireEvent, render } from "@reearth/test/utils";
+import { describe, test, expect, vi } from "vitest";
+
+import { Radio } from "./index";
+
+describe("Radio Component", () => {
+  test("renders with label", () => {
+    render(<Radio label="Option 1" />);
+
+    expect(screen.getByText("Option 1")).toBeInTheDocument();
+    expect(screen.getByRole("radio")).toBeInTheDocument();
+  });
+
+  test("renders in checked state", () => {
+    render(<Radio label="Option 1" checked />);
+
+    const radioInput = screen.getByRole("radio");
+    expect(radioInput).toBeChecked();
+  });
+
+  test("renders in disabled state", () => {
+    render(<Radio label="Option 1" disabled />);
+
+    const radioInput = screen.getByRole("radio");
+    expect(radioInput).toBeDisabled();
+  });
+
+  test("calls onChange when clicked", () => {
+    const handleChange = vi.fn();
+    render(<Radio value="value1" label="Option 1" onChange={handleChange} />);
+
+    const radioLabel = screen.getByText("Option 1");
+    fireEvent.click(radioLabel);
+
+    expect(handleChange).toHaveBeenCalledWith("value1");
+  });
+
+  test("does not call onChange when disabled", () => {
+    const handleChange = vi.fn();
+    render(
+      <Radio value="value1" label="Option 1" onChange={handleChange} disabled />
+    );
+
+    const radioLabel = screen.getByText("Option 1");
+    fireEvent.click(radioLabel);
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  test("renders with additional content when provided", () => {
+    render(<Radio label="Option 1" content={<div>Additional content</div>} />);
+
+    expect(screen.getByText("Additional content")).toBeInTheDocument();
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/RadioGroup/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/RadioGroup/index.test.tsx
@@ -1,0 +1,68 @@
+import { screen, fireEvent, render } from "@reearth/test/utils";
+import { describe, test, expect, vi } from "vitest";
+
+import { RadioGroup } from "./index";
+
+describe("RadioGroup Component", () => {
+  const options = [
+    { value: "option1", label: "Option 1" },
+    { value: "option2", label: "Option 2" },
+    { value: "option3", label: "Option 3" }
+  ];
+
+  test("renders all provided options", () => {
+    render(<RadioGroup options={options} />);
+
+    expect(screen.getByText("Option 1")).toBeInTheDocument();
+    expect(screen.getByText("Option 2")).toBeInTheDocument();
+    expect(screen.getByText("Option 3")).toBeInTheDocument();
+  });
+
+  test("selects the option matching the value prop", () => {
+    render(<RadioGroup options={options} value="option2" />);
+
+    const radioInputs = screen.getAllByRole("radio");
+    expect(radioInputs[0]).not.toBeChecked();
+    expect(radioInputs[1]).toBeChecked();
+    expect(radioInputs[2]).not.toBeChecked();
+  });
+
+  test("calls onChange when a radio is selected", () => {
+    const handleChange = vi.fn();
+    render(<RadioGroup options={options} onChange={handleChange} />);
+
+    fireEvent.click(screen.getByText("Option 2"));
+
+    expect(handleChange).toHaveBeenCalledWith("option2");
+  });
+
+  test("updates selected option when the value prop changes", () => {
+    const { rerender } = render(
+      <RadioGroup options={options} value="option1" />
+    );
+
+    let radioInputs = screen.getAllByRole("radio");
+    expect(radioInputs[0]).toBeChecked();
+
+    rerender(<RadioGroup options={options} value="option3" />);
+
+    radioInputs = screen.getAllByRole("radio");
+    expect(radioInputs[2]).toBeChecked();
+  });
+
+  test("renders with vertical layout when specified", () => {
+    const { container } = render(
+      <RadioGroup options={options} layout="vertical" />
+    );
+
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveStyle("flex-direction: column");
+  });
+
+  test("renders with horizontal layout by default", () => {
+    const { container } = render(<RadioGroup options={options} />);
+
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveStyle("flex-direction: row");
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/RangeSlider/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/RangeSlider/index.test.tsx
@@ -18,6 +18,11 @@ describe("RangeSlider Component", () => {
 
     const sliderElement = document.querySelector(".rc-slider");
     expect(sliderElement).toBeInTheDocument();
+    const handles = document.querySelectorAll(".rc-slider-handle");
+    const firstHandle = handles[0] as HTMLElement;
+    const secondHandle = handles[1] as HTMLElement;
+    expect(firstHandle.style.left).toBe("30%");
+    expect(secondHandle.style.left).toBe("70%");
   });
 
   test("renders in disabled state", () => {
@@ -32,5 +37,8 @@ describe("RangeSlider Component", () => {
 
     const sliderElement = document.querySelector(".rc-slider");
     expect(sliderElement).toBeInTheDocument();
+
+    const slider = sliderElement as HTMLElement;
+    expect(slider.getAttribute("step") || "1").toBe("1");
   });
 });

--- a/web/src/beta/lib/reearth-ui/components/RangeSlider/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/RangeSlider/index.test.tsx
@@ -1,0 +1,36 @@
+import { render } from "@reearth/test/utils";
+import { describe, test, expect } from "vitest";
+
+import { RangeSlider } from "./index";
+
+describe("RangeSlider Component", () => {
+  test("renders with default props", () => {
+    render(<RangeSlider value={[20, 80]} />);
+
+    const sliderElement = document.querySelector(".rc-slider");
+    expect(sliderElement).toBeInTheDocument();
+  });
+
+  test("updates when value prop changes", () => {
+    const { rerender } = render(<RangeSlider value={[20, 80]} />);
+
+    rerender(<RangeSlider value={[30, 70]} />);
+
+    const sliderElement = document.querySelector(".rc-slider");
+    expect(sliderElement).toBeInTheDocument();
+  });
+
+  test("renders in disabled state", () => {
+    render(<RangeSlider value={[20, 80]} disabled />);
+
+    const disabledSlider = document.querySelector(".rc-slider-disabled");
+    expect(disabledSlider).toBeInTheDocument();
+  });
+
+  test("uses calculated step when not explicitly provided", () => {
+    render(<RangeSlider value={[20, 80]} min={0} max={100} />);
+
+    const sliderElement = document.querySelector(".rc-slider");
+    expect(sliderElement).toBeInTheDocument();
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/Selector/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Selector/index.test.tsx
@@ -1,0 +1,128 @@
+import { screen, fireEvent, render } from "@reearth/test/utils";
+import { describe, test, expect, vi } from "vitest";
+
+import { Selector } from "./index";
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+describe("Selector Component", () => {
+  const options = [
+    { value: "option1", label: "Option 1" },
+    { value: "option2", label: "Option 2" },
+    { value: "option3", label: "Option 3" }
+  ];
+
+  test("renders with placeholder when no value selected", () => {
+    render(<Selector options={options} />);
+
+    expect(screen.getByText("Please select")).toBeInTheDocument();
+  });
+
+  test("renders with selected value", () => {
+    render(<Selector options={options} value="option2" />);
+
+    expect(screen.getByText("Option 2")).toBeInTheDocument();
+  });
+
+  test("opens dropdown when clicked", () => {
+    render(<Selector options={options} />);
+
+    const selectInput = screen.getByTestId("select-input");
+    fireEvent.click(selectInput);
+
+    expect(
+      screen.getByRole("option", { name: "Option 1" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Option 2" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Option 3" })
+    ).toBeInTheDocument();
+  });
+
+  test("selects an option when clicked", () => {
+    const handleChange = vi.fn();
+    render(<Selector options={options} onChange={handleChange} />);
+
+    const selectInput = screen.getByTestId("select-input");
+    fireEvent.click(selectInput);
+
+    const option = screen.getByRole("option", { name: "Option 2" });
+    fireEvent.click(option);
+
+    expect(handleChange).toHaveBeenCalledWith("option2");
+  });
+
+  test("selects multiple options in multiple mode", () => {
+    const handleChange = vi.fn();
+    render(<Selector options={options} multiple onChange={handleChange} />);
+
+    const selectInput = screen.getByTestId("select-input");
+    fireEvent.click(selectInput);
+
+    const option1 = screen.getByRole("option", { name: "Option 1" });
+    fireEvent.click(option1);
+
+    expect(handleChange).toHaveBeenCalledWith(["option1"]);
+
+    const option3 = screen.getByRole("option", { name: "Option 3" });
+    fireEvent.click(option3);
+
+    expect(handleChange).toHaveBeenCalledWith(["option1", "option3"]);
+  });
+
+  test("removes an option when unselected in multiple mode", () => {
+    const handleChange = vi.fn();
+    render(
+      <Selector
+        options={options}
+        multiple
+        value={["option1", "option2"]}
+        onChange={handleChange}
+      />
+    );
+
+    const closeButtons = screen.getAllByRole("button");
+    fireEvent.click(closeButtons[0]);
+
+    expect(handleChange).toHaveBeenCalledWith(["option2"]);
+  });
+
+  test("renders in disabled state", () => {
+    const handleChange = vi.fn();
+
+    render(
+      <Selector
+        options={options}
+        disabled
+        value="option1"
+        onChange={handleChange}
+      />
+    );
+
+    const selectInput = screen.getByTestId("select-input");
+    fireEvent.click(selectInput);
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  test("displays custom label with displayLabel prop", () => {
+    render(<Selector options={options} displayLabel="Custom Display Text" />);
+
+    expect(screen.getByText("Custom Display Text")).toBeInTheDocument();
+  });
+
+  test("shows 'No Options yet' message when options array is empty", () => {
+    render(<Selector options={[]} />);
+
+    const selectInput = screen.getByTestId("select-input");
+    fireEvent.click(selectInput);
+
+    expect(screen.getByText("No Options yet")).toBeInTheDocument();
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/Selector/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Selector/index.test.tsx
@@ -3,12 +3,6 @@ import { describe, test, expect, vi } from "vitest";
 
 import { Selector } from "./index";
 
-global.ResizeObserver = class ResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-};
-
 describe("Selector Component", () => {
   const options = [
     { value: "option1", label: "Option 1" },

--- a/web/src/beta/lib/reearth-ui/components/Slide/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Slide/index.test.tsx
@@ -1,0 +1,40 @@
+import { screen, render } from "@reearth/test/utils";
+import { describe, test, expect } from "vitest";
+
+import { Slide } from "./index";
+
+describe("Slide Component", () => {
+  test("renders children correctly", () => {
+    render(
+      <Slide>
+        <div key="slide1">Slide 1</div>
+        <div key="slide2">Slide 2</div>
+      </Slide>
+    );
+
+    expect(screen.getByText("Slide 1")).toBeInTheDocument();
+    expect(screen.getByText("Slide 2")).toBeInTheDocument();
+  });
+
+  test("applies transform based on pos prop", () => {
+    const { rerender } = render(
+      <Slide pos={0}>
+        <div key="slide1">Slide 1</div>
+        <div key="slide2">Slide 2</div>
+      </Slide>
+    );
+
+    let inner = screen.getByTestId("slide-inner");
+    expect(inner).toHaveStyle({ transform: "translateX(-0%)" });
+
+    rerender(
+      <Slide pos={1}>
+        <div key="slide1">Slide 1</div>
+        <div key="slide2">Slide 2</div>
+      </Slide>
+    );
+
+    inner = screen.getByTestId("slide-inner");
+    expect(inner).toHaveStyle({ transform: "translateX(-100%)" });
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/Slide/index.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Slide/index.tsx
@@ -10,7 +10,7 @@ export type SlideProps = {
 export const Slide: FC<SlideProps> = ({ className, children, pos }) => {
   return (
     <Wrapper className={className}>
-      <Inner pos={pos}>
+      <Inner pos={pos} data-testid="slide-inner">
         {React.Children.map(children, (child) =>
           React.isValidElement(child) ? (
             <Page key={child.key ?? undefined}>{child}</Page>

--- a/web/src/beta/lib/reearth-ui/components/Slider/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Slider/index.test.tsx
@@ -21,13 +21,6 @@ describe("Slider Component", () => {
     expect(sliderElement).toHaveAttribute("aria-valuemax", "10");
   });
 
-  test("renders in disabled state", () => {
-    render(<Slider value={50} disabled />);
-
-    const sliderElement = screen.getByRole("slider");
-    expect(sliderElement).toHaveAttribute("aria-disabled", "false");
-  });
-
   test("updates when value prop changes", () => {
     const { rerender } = render(<Slider value={50} />);
 

--- a/web/src/beta/lib/reearth-ui/components/Slider/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Slider/index.test.tsx
@@ -1,0 +1,42 @@
+import { screen, render } from "@reearth/test/utils";
+import { describe, test, expect } from "vitest";
+
+import { Slider } from "./index";
+
+describe("Slider Component", () => {
+  test("renders with default props", () => {
+    render(<Slider value={50} />);
+
+    const sliderElement = screen.getByRole("slider");
+    expect(sliderElement).toBeInTheDocument();
+    expect(sliderElement).toHaveAttribute("aria-valuenow", "50");
+  });
+
+  test("renders with custom min, max values", () => {
+    render(<Slider value={5} min={0} max={10} />);
+
+    const sliderElement = screen.getByRole("slider");
+    expect(sliderElement).toHaveAttribute("aria-valuenow", "5");
+    expect(sliderElement).toHaveAttribute("aria-valuemin", "0");
+    expect(sliderElement).toHaveAttribute("aria-valuemax", "10");
+  });
+
+  test("renders in disabled state", () => {
+    render(<Slider value={50} disabled />);
+
+    const sliderElement = screen.getByRole("slider");
+    expect(sliderElement).toHaveAttribute("aria-disabled", "false");
+  });
+
+  test("updates when value prop changes", () => {
+    const { rerender } = render(<Slider value={50} />);
+
+    let sliderElement = screen.getByRole("slider");
+    expect(sliderElement).toHaveAttribute("aria-valuenow", "50");
+
+    rerender(<Slider value={75} />);
+
+    sliderElement = screen.getByRole("slider");
+    expect(sliderElement).toHaveAttribute("aria-valuenow", "75");
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/Slider/index.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Slider/index.tsx
@@ -55,6 +55,7 @@ export const Slider: FC<SliderProps> = ({
   return (
     <SliderStyled disabled={!!disabled}>
       <SliderWithTooltip
+        data-testid="slider"
         value={currentValue}
         min={min}
         max={max}

--- a/web/src/beta/lib/reearth-ui/components/Slider/index.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Slider/index.tsx
@@ -53,9 +53,8 @@ export const Slider: FC<SliderProps> = ({
   );
 
   return (
-    <SliderStyled disabled={!!disabled}>
+    <SliderStyled data-testid="slider" disabled={!!disabled}>
       <SliderWithTooltip
-        data-testid="slider"
         value={currentValue}
         min={min}
         max={max}

--- a/web/src/beta/lib/reearth-ui/components/Slider/index.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Slider/index.tsx
@@ -53,7 +53,7 @@ export const Slider: FC<SliderProps> = ({
   );
 
   return (
-    <SliderStyled data-testid="slider" disabled={!!disabled}>
+    <SliderStyled disabled={!!disabled}>
       <SliderWithTooltip
         value={currentValue}
         min={min}

--- a/web/src/beta/lib/reearth-ui/components/Switcher/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Switcher/index.test.tsx
@@ -1,0 +1,69 @@
+import { screen, fireEvent, render } from "@reearth/test/utils";
+import { describe, test, expect, vi } from "vitest";
+
+import { Switcher } from "./index";
+
+describe("Switcher Component", () => {
+  test("renders in off state by default", () => {
+    render(<Switcher />);
+
+    const switcherCircle = screen.getByTestId("switcher").firstChild;
+    expect(switcherCircle).toHaveStyle("transform: translateX(0)");
+  });
+
+  test("renders in on state when value is true", () => {
+    render(<Switcher value={true} />);
+
+    const switcherCircle = screen.getByTestId("switcher").firstChild;
+    expect(switcherCircle).toHaveStyle("transform: translateX(10px)");
+  });
+
+  test("toggles state when clicked", () => {
+    render(<Switcher />);
+
+    const switcher = screen.getByTestId("switcher");
+    const switcherCircle = switcher.firstChild;
+
+    expect(switcherCircle).toHaveStyle("transform: translateX(0)");
+
+    fireEvent.click(switcher);
+
+    expect(switcherCircle).toHaveStyle("transform: translateX(10px)");
+  });
+
+  test("calls onChange with new value when clicked", () => {
+    const handleChange = vi.fn();
+    render(<Switcher value={false} onChange={handleChange} />);
+
+    const switcher = screen.getByTestId("switcher");
+    fireEvent.click(switcher);
+
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
+  test("does not toggle when disabled", () => {
+    const handleChange = vi.fn();
+    render(<Switcher disabled onChange={handleChange} />);
+
+    const switcher = screen.getByTestId("switcher");
+    const switcherCircle = switcher.firstChild;
+
+    expect(switcherCircle).toHaveStyle("transform: translateX(0)");
+
+    fireEvent.click(switcher);
+
+    expect(switcherCircle).toHaveStyle("transform: translateX(0)");
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  test("updates when value prop changes", () => {
+    const { rerender } = render(<Switcher value={false} />);
+
+    const switcherCircle = screen.getByTestId("switcher").firstChild;
+    expect(switcherCircle).toHaveStyle("transform: translateX(0)");
+
+    rerender(<Switcher value={true} />);
+
+    expect(switcherCircle).toHaveStyle("transform: translateX(10px)");
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/Tabs/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Tabs/index.test.tsx
@@ -1,0 +1,87 @@
+import { screen, fireEvent, render } from "@reearth/test/utils";
+import { describe, test, expect, vi } from "vitest";
+
+import { TabItem, Tabs } from "./index";
+
+describe("Tabs Component", () => {
+  const tabsData = [
+    { id: "tab1", name: "Tab 1", children: <div>Tab 1 content</div> },
+    { id: "tab2", name: "Tab 2", children: <div>Tab 2 content</div> },
+    { id: "tab3", name: "Tab 3", children: <div>Tab 3 content</div> }
+  ];
+
+  test("renders tabs and shows first tab content by default", () => {
+    render(<Tabs tabs={tabsData} />);
+
+    expect(screen.getByText("Tab 1")).toBeInTheDocument();
+    expect(screen.getByText("Tab 2")).toBeInTheDocument();
+    expect(screen.getByText("Tab 3")).toBeInTheDocument();
+
+    expect(screen.getByText("Tab 1 content")).toBeInTheDocument();
+    expect(screen.queryByText("Tab 2 content")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tab 3 content")).not.toBeInTheDocument();
+  });
+
+  test("changes active tab when tab is clicked", () => {
+    render(<Tabs tabs={tabsData} />);
+
+    fireEvent.click(screen.getByText("Tab 2"));
+
+    expect(screen.queryByText("Tab 1 content")).not.toBeInTheDocument();
+    expect(screen.getByText("Tab 2 content")).toBeInTheDocument();
+    expect(screen.queryByText("Tab 3 content")).not.toBeInTheDocument();
+  });
+
+  test("renders the specified current tab", () => {
+    render(<Tabs tabs={tabsData} currentTab="tab3" />);
+
+    expect(screen.queryByText("Tab 1 content")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tab 2 content")).not.toBeInTheDocument();
+    expect(screen.getByText("Tab 3 content")).toBeInTheDocument();
+  });
+
+  test("calls onChange when tab is clicked", () => {
+    const handleChange = vi.fn();
+    render(<Tabs tabs={tabsData} onChange={handleChange} />);
+
+    fireEvent.click(screen.getByText("Tab 2"));
+
+    expect(handleChange).toHaveBeenCalledWith("tab2");
+  });
+
+  test("updates active tab when currentTab prop changes", () => {
+    const { rerender } = render(<Tabs tabs={tabsData} currentTab="tab1" />);
+
+    expect(screen.getByText("Tab 1 content")).toBeInTheDocument();
+
+    rerender(<Tabs tabs={tabsData} currentTab="tab3" />);
+
+    expect(screen.queryByText("Tab 1 content")).not.toBeInTheDocument();
+    expect(screen.getByText("Tab 3 content")).toBeInTheDocument();
+  });
+
+  test("renders tabs with icons", () => {
+    const tabsWithIcons = [
+      {
+        id: "tab1",
+        name: "Tab 1",
+        icon: "home",
+        children: <div>Tab 1 content</div>
+      },
+      {
+        id: "tab2",
+        name: "Tab 2",
+        icon: "book",
+        children: <div>Tab 2 content</div>
+      }
+    ] as TabItem[];
+
+    render(<Tabs tabs={tabsWithIcons} />);
+
+    expect(screen.getByText("Tab 1")).toBeInTheDocument();
+    expect(screen.getByText("Tab 2")).toBeInTheDocument();
+
+    const iconElements = document.querySelectorAll("svg");
+    expect(iconElements.length).toBe(2);
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/TextArea/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/TextArea/index.test.tsx
@@ -1,0 +1,63 @@
+import { screen, fireEvent, render } from "@reearth/test/utils";
+import { describe, test, expect, vi } from "vitest";
+
+import { TextArea } from "./index";
+
+describe("TextArea Component", () => {
+  test("renders with default props", () => {
+    render(<TextArea />);
+
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toBeInTheDocument();
+    expect(textarea).toHaveValue("");
+  });
+
+  test("renders with initial value", () => {
+    render(<TextArea value="Initial text" />);
+
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toHaveValue("Initial text");
+  });
+
+  test("renders with placeholder", () => {
+    render(<TextArea placeholder="Enter text here" />);
+
+    const textarea = screen.getByPlaceholderText("Enter text here");
+    expect(textarea).toBeInTheDocument();
+  });
+
+  test("updates when value changes", () => {
+    const handleChange = vi.fn();
+    render(<TextArea onChange={handleChange} />);
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "New text" } });
+
+    expect(textarea).toHaveValue("New text");
+    expect(handleChange).toHaveBeenCalledWith("New text");
+  });
+
+  test("calls onBlur when focus is lost", () => {
+    const handleBlur = vi.fn();
+    render(<TextArea onBlur={handleBlur} />);
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.focus(textarea);
+    fireEvent.change(textarea, { target: { value: "Text before blur" } });
+    fireEvent.blur(textarea);
+
+    expect(handleBlur).toHaveBeenCalledWith("Text before blur");
+  });
+
+  test("shows character count when counter is enabled", () => {
+    render(<TextArea value="Hello" counter />);
+
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  test("shows character count with max length when both are enabled", () => {
+    render(<TextArea value="Hello" counter maxLength={10} />);
+
+    expect(screen.getByText("5 / 10")).toBeInTheDocument();
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/TextInput/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/TextInput/index.test.tsx
@@ -1,0 +1,97 @@
+import { screen, fireEvent, render } from "@reearth/test/utils";
+import { describe, test, expect, vi } from "vitest";
+
+import { TextInput } from "./index";
+
+describe("TextInput Component", () => {
+  test("renders with default props", () => {
+    render(<TextInput />);
+
+    const input = screen.getByRole("textbox");
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("");
+  });
+
+  test("renders with initial value", () => {
+    render(<TextInput value="Initial text" />);
+
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveValue("Initial text");
+  });
+
+  test("renders with placeholder", () => {
+    render(<TextInput placeholder="Enter text here" />);
+
+    const input = screen.getByPlaceholderText("Enter text here");
+    expect(input).toBeInTheDocument();
+  });
+
+  test("updates when value changes", () => {
+    const handleChange = vi.fn();
+    render(<TextInput onChange={handleChange} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "New text" } });
+
+    expect(input).toHaveValue("New text");
+    expect(handleChange).toHaveBeenCalledWith("New text");
+  });
+
+  test("calls onBlur when focus is lost", () => {
+    const handleBlur = vi.fn();
+    render(<TextInput onBlur={handleBlur} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "Text before blur" } });
+    fireEvent.blur(input);
+
+    expect(handleBlur).toHaveBeenCalledWith("Text before blur");
+  });
+
+  test("limits input when maxLength is set", () => {
+    render(<TextInput maxLength={5} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "123456" } });
+
+    expect(input).toHaveAttribute("maxLength", "5");
+  });
+
+  test("renders in disabled state", () => {
+    render(<TextInput disabled />);
+
+    const input = screen.getByRole("textbox");
+    expect(input).toBeDisabled();
+  });
+
+  test("blurs on Enter key press", () => {
+    const handleBlur = vi.fn();
+    render(<TextInput onBlur={handleBlur} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "Text value" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.blur(input);
+
+    expect(handleBlur).toHaveBeenCalledWith("Text value");
+  });
+
+  test("calls onKeyDown when key is pressed", () => {
+    const handleKeyDown = vi.fn();
+    render(<TextInput onKeyDown={handleKeyDown} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.keyDown(input, { key: "A" });
+
+    expect(handleKeyDown).toHaveBeenCalled();
+  });
+
+  test("renders actions when provided", () => {
+    const TestAction = () => <span>Action</span>;
+    render(<TextInput actions={[<TestAction key="action" />]} />);
+
+    expect(screen.getByText("Action")).toBeInTheDocument();
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/TimePicker/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/TimePicker/index.test.tsx
@@ -1,0 +1,74 @@
+import { screen, fireEvent, render } from "@reearth/test/utils";
+import { describe, test, expect, vi } from "vitest";
+
+import { TimePicker } from "./index";
+
+describe("TimePicker Component", () => {
+  test("renders with default props", () => {
+    render(<TimePicker />);
+
+    const input = screen.getByTestId("time-picker");
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("");
+    expect(input).toHaveAttribute("type", "time");
+  });
+
+  test("renders with initial value", () => {
+    render(<TimePicker value="13:30:00" />);
+
+    const input = screen.getByTestId("time-picker");
+    expect(input).toHaveValue("13:30:00");
+  });
+
+  test("updates when value changes", () => {
+    const handleChange = vi.fn();
+    render(<TimePicker onChange={handleChange} />);
+
+    const input = screen.getByTestId("time-picker");
+    fireEvent.change(input, { target: { value: "15:45:30" } });
+
+    expect(input).toHaveValue("15:45:30");
+    expect(handleChange).toHaveBeenCalledWith("15:45:30");
+  });
+
+  test("calls onBlur when focus is lost", () => {
+    const handleBlur = vi.fn();
+    render(<TimePicker onBlur={handleBlur} />);
+
+    const input = screen.getByTestId("time-picker");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "09:15:00" } });
+    fireEvent.blur(input);
+
+    expect(handleBlur).toHaveBeenCalledWith("09:15:00");
+  });
+
+  test("renders in disabled state", () => {
+    render(<TimePicker disabled />);
+
+    const input = screen.getByTestId("time-picker");
+    expect(input).toBeDisabled();
+  });
+
+  test("has min, max and step attributes", () => {
+    render(<TimePicker />);
+
+    const input = screen.getByTestId("time-picker");
+    expect(input).toHaveAttribute("min", "00:00:00");
+    expect(input).toHaveAttribute("max", "23:59:59");
+    expect(input).toHaveAttribute("step", "1");
+  });
+
+  test("updates UI state on focus/blur", () => {
+    const { container } = render(<TimePicker />);
+
+    const input = screen.getByTestId("time-picker");
+    const wrapper = container.firstChild;
+
+    fireEvent.focus(input);
+    expect(wrapper).toHaveStyle("border: 1px solid rgb(59, 60, 208)");
+
+    fireEvent.blur(input);
+    expect(wrapper).toHaveStyle("border: 1px solid rgb(77, 83, 88)");
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/TimePicker/index.tsx
+++ b/web/src/beta/lib/reearth-ui/components/TimePicker/index.tsx
@@ -52,6 +52,7 @@ export const TimePicker: FC<TimePickerProps> = ({
         min="00:00:00"
         max="23:59:59"
         step={1}
+        data-testid="time-picker"
       />
     </Wrapper>
   );

--- a/web/src/beta/lib/reearth-ui/components/Tooltip/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Tooltip/index.test.tsx
@@ -1,4 +1,4 @@
-import { screen, render } from "@reearth/test/utils";
+import { screen, render, fireEvent } from "@reearth/test/utils";
 import { describe, test, expect } from "vitest";
 
 import Tooltip from "./index";
@@ -37,5 +37,10 @@ describe("Tooltip Component", () => {
     render(<Tooltip type="custom" text="Help text" />);
 
     expect(screen.getByText("TIPS")).toBeInTheDocument();
+
+    const trigger = screen.getByText("TIPS");
+    fireEvent.click(trigger);
+
+    expect(screen.getByText("Help text")).toBeInTheDocument();
   });
 });

--- a/web/src/beta/lib/reearth-ui/components/Tooltip/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Tooltip/index.test.tsx
@@ -43,4 +43,16 @@ describe("Tooltip Component", () => {
 
     expect(screen.getByText("Help text")).toBeInTheDocument();
   });
+
+  test("displays tooltip content when hovering over trigger", async () => {
+    render(<Tooltip type="custom" text="Help information" />);
+
+    const trigger = screen.getByText("TIPS");
+    await fireEvent.click(trigger);
+
+    expect(screen.getByText("Help information")).toBeInTheDocument();
+
+    await fireEvent.click(trigger);
+    expect(screen.queryByText("Help information")).not.toBeInTheDocument();
+  });
 });

--- a/web/src/beta/lib/reearth-ui/components/Tooltip/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Tooltip/index.test.tsx
@@ -1,0 +1,41 @@
+import { screen, render } from "@reearth/test/utils";
+import { describe, test, expect } from "vitest";
+
+import Tooltip from "./index";
+
+describe("Tooltip Component", () => {
+  test("renders experimental tooltip with default flask icon", () => {
+    render(<Tooltip type="experimental" />);
+
+    const icon = document.querySelector("svg");
+    expect(icon).toBeInTheDocument();
+  });
+
+  test("renders custom tooltip with provided icon", () => {
+    render(<Tooltip type="custom" icon="book" text="Custom tooltip text" />);
+
+    const icon = document.querySelector("svg");
+    expect(icon).toBeInTheDocument();
+  });
+
+  test("renders with custom trigger component", () => {
+    const CustomTrigger = () => (
+      <div data-testid="custom-trigger">Custom Trigger</div>
+    );
+    render(
+      <Tooltip
+        type="custom"
+        text="Tooltip text"
+        triggerComponent={<CustomTrigger />}
+      />
+    );
+
+    expect(screen.getByTestId("custom-trigger")).toBeInTheDocument();
+  });
+
+  test("renders tips text when no icon or trigger component is provided", () => {
+    render(<Tooltip type="custom" text="Help text" />);
+
+    expect(screen.getByText("TIPS")).toBeInTheDocument();
+  });
+});

--- a/web/src/beta/lib/reearth-ui/components/Tooltip/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Tooltip/index.test.tsx
@@ -44,15 +44,15 @@ describe("Tooltip Component", () => {
     expect(screen.getByText("Help text")).toBeInTheDocument();
   });
 
-  test("displays tooltip content when hovering over trigger", async () => {
+  test("displays tooltip content when clicking trigger", () => {
     render(<Tooltip type="custom" text="Help information" />);
 
     const trigger = screen.getByText("TIPS");
-    await fireEvent.click(trigger);
+    fireEvent.click(trigger);
 
     expect(screen.getByText("Help information")).toBeInTheDocument();
 
-    await fireEvent.click(trigger);
+    fireEvent.click(trigger);
     expect(screen.queryByText("Help information")).not.toBeInTheDocument();
   });
 });

--- a/web/src/beta/lib/reearth-ui/components/Typography/index.test.tsx
+++ b/web/src/beta/lib/reearth-ui/components/Typography/index.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, fireEvent } from "@reearth/test/utils";
+import { describe, test, expect, vi } from "vitest";
+
+import { Typography } from "./index";
+
+describe("Typography Component", () => {
+  test("renders children correctly", () => {
+    render(<Typography size="body">Test Text</Typography>);
+
+    expect(screen.getByText("Test Text")).toBeInTheDocument();
+  });
+
+  test("applies correct font size based on size prop", () => {
+    render(<Typography size="body">Body Text</Typography>);
+
+    const bodyElement = screen.getByText("Body Text");
+    expect(bodyElement.tagName).toBe("P");
+  });
+
+  test("applies theme color when using predefined color values", () => {
+    render(
+      <Typography size="body" color="weak">
+        Weak Text
+      </Typography>
+    );
+
+    const textElement = screen.getByText("Weak Text");
+    expect(textElement).toHaveStyle("color: rgb(111, 111, 111)");
+  });
+
+  test("applies custom color when provided", () => {
+    render(
+      <Typography size="body" color="#FF0000">
+        Red Text
+      </Typography>
+    );
+
+    const textElement = screen.getByText("Red Text");
+    expect(textElement).toHaveStyle("color: #FF0000");
+  });
+
+  test("handles onClick events", () => {
+    const handleClick = vi.fn();
+    render(
+      <Typography size="body" onClick={handleClick}>
+        Clickable Text
+      </Typography>
+    );
+
+    const textElement = screen.getByText("Clickable Text");
+    fireEvent.click(textElement);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test("applies additional style properties", () => {
+    render(
+      <Typography
+        size="body"
+        otherProperties={{
+          textAlign: "center",
+          textDecoration: "underline"
+        }}
+      >
+        Styled Text
+      </Typography>
+    );
+
+    const textElement = screen.getByText("Styled Text");
+    expect(textElement).toHaveStyle("text-align: center");
+    expect(textElement).toHaveStyle("text-decoration: underline");
+  });
+
+  test("applies correct font weight", () => {
+    render(
+      <Typography size="body" weight="bold">
+        Bold Text
+      </Typography>
+    );
+
+    const textElement = screen.getByText("Bold Text");
+    expect(textElement).toHaveStyle("font-weight: bold");
+  });
+
+  test("applies custom class name", () => {
+    render(
+      <Typography size="body" className="custom-class">
+        Classy Text
+      </Typography>
+    );
+
+    const textElement = screen.getByText("Classy Text");
+    expect(textElement).toHaveClass("custom-class");
+  });
+});


### PR DESCRIPTION
# Overview
Added unit tests to the following components under web/src/beta/lib/reearth-ui/components:
- Panel
- Popup
- Popup menu
- Popup panel
- Radio
- Radio group
- Range slider
- Range selector
- Slide
- Slider
- Switcher
- Tabs
- Text area
- Text input
- Time picker
- Tooltip
- Typography
## What I've done
Test coverage is currently 43.43% from 41.56% on main branch.
## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added comprehensive test suites for various UI components, including Panel, Popup, PopupMenu, PopupPanel, Radio, RadioGroup, RangeSlider, Selector, Slide, Slider, Switcher, Tabs, TextArea, TextInput, TimePicker, Tooltip, and Typography.
  - Tests cover rendering, user interactions, callback handling, accessibility attributes, visual states, and edge cases for each component.
  - Minor updates to components to support testing (e.g., adding test IDs and standardizing test identifiers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->