### PR TITLE
feat(server): update alias validation[VIZ-1535] [VIZ-1558]

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -111,6 +111,9 @@ schematyper:
 deep-copy:
 	(cd pkg/property && deep-copy --type Initializer --pointer-receiver -o initializer_gen.go .)
 
+error-msg:
+	go generate ./pkg/i18n/...
+
 # =======================
 # Tools
 # =======================

--- a/server/e2e/gql_custom_property_test.go
+++ b/server/e2e/gql_custom_property_test.go
@@ -17,7 +17,7 @@ func TestUpdateCustomProperties(t *testing.T) {
 		"visualizer":  "CESIUM",
 		"coreSupport": true,
 	})
-	_, _, sId := createScene(e, pId)
+	sId := createScene(e, pId)
 	lId := addTestNLSLayerSimple(e, sId)
 
 	proId1 := RandomString(10)
@@ -114,7 +114,7 @@ func TestChangeCustomPropertyTitle(t *testing.T) {
 		"visualizer":  "CESIUM",
 		"coreSupport": true,
 	})
-	_, _, sId := createScene(e, pId)
+	sId := createScene(e, pId)
 	lId := addTestNLSLayerSimple(e, sId)
 
 	// change XXX -> ZZZ
@@ -241,7 +241,7 @@ func TestRemoveCustomProperty(t *testing.T) {
 		"visualizer":  "CESIUM",
 		"coreSupport": true,
 	})
-	_, _, sId := createScene(e, pId)
+	sId := createScene(e, pId)
 	lId := addTestNLSLayerSimple(e, sId)
 
 	// remove XXX

--- a/server/e2e/gql_featureCollection_test.go
+++ b/server/e2e/gql_featureCollection_test.go
@@ -183,7 +183,7 @@ func TestFeatureCollectionCRUD(t *testing.T) {
 		"visualizer":  "CESIUM",
 		"coreSupport": true,
 	})
-	_, _, sId := createScene(e, pId)
+	sId := createScene(e, pId)
 
 	_, res := fetchSceneForNewLayers(e, sId)
 	res.Object().

--- a/server/e2e/gql_nlslayer_test.go
+++ b/server/e2e/gql_nlslayer_test.go
@@ -399,7 +399,7 @@ func TestNLSLayerCRUD(t *testing.T) {
 		Value("node").Object().
 		Value("updatedAt").Raw().(string)
 
-	_, _, sId := createScene(e, pId)
+	sId := createScene(e, pId)
 
 	_, res := fetchSceneForNewLayers(e, sId)
 
@@ -792,7 +792,7 @@ func TestInfoboxBlocksCRUD(t *testing.T) {
 		Value("node").Object().
 		Value("updatedAt").Raw().(string)
 
-	_, _, sId := createScene(e, pId)
+	sId := createScene(e, pId)
 
 	// fetch scene
 	_, res := fetchSceneForNewLayers(e, sId)
@@ -863,7 +863,7 @@ func TestInfoboxProperty(t *testing.T) {
 		"visualizer":  "CESIUM",
 		"coreSupport": true,
 	})
-	_, _, sId := createScene(e, pId)
+	sId := createScene(e, pId)
 
 	// fetch scene
 	_, res := fetchSceneForNewLayers(e, sId)
@@ -921,7 +921,7 @@ func TestPhotoOverlayProperty(t *testing.T) {
 		"visualizer":  "CESIUM",
 		"coreSupport": true,
 	})
-	_, _, sId := createScene(e, pId)
+	sId := createScene(e, pId)
 
 	// fetch scene
 	_, res := fetchSceneForNewLayers(e, sId)
@@ -1002,7 +1002,7 @@ func TestCustomProperties(t *testing.T) {
 		Value("node").Object().
 		Value("updatedAt").Raw().(string)
 
-	_, _, sId := createScene(e, pId)
+	sId := createScene(e, pId)
 
 	_, res := fetchSceneForNewLayers(e, sId)
 	res.Object().

--- a/server/e2e/gql_project_export_import_test.go
+++ b/server/e2e/gql_project_export_import_test.go
@@ -91,6 +91,7 @@ func compareValue(t *testing.T, key string, e, a *httpexpect.Value) {
 			if isIgnore(`"id":`, expectedLine, actualLine) ||
 				isIgnore(`"propertyId":`, expectedLine, actualLine) ||
 				isIgnore(`"sceneId":`, expectedLine, actualLine) ||
+				isIgnore(`"alias":`, expectedLine, actualLine) ||
 				(isID(expectedLine) && isID(actualLine)) {
 				continue
 			}

--- a/server/e2e/gql_property_schema_test.go
+++ b/server/e2e/gql_property_schema_test.go
@@ -16,7 +16,7 @@ func TestPropertySchemaOrder(t *testing.T) {
 		"visualizer":  "CESIUM",
 		"coreSupport": true,
 	})
-	_, _, sId := createScene(e, pId)
+	sId := createScene(e, pId)
 	res := getScene(e, sId, language.Und.String())
 
 	propID := res.Path("$.property.id").Raw().(string)

--- a/server/e2e/gql_publish_test.go
+++ b/server/e2e/gql_publish_test.go
@@ -1,0 +1,572 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gavv/httpexpect/v2"
+	"github.com/reearth/reearthx/account/accountdomain"
+)
+
+/////// TestPublish Project ///////
+
+func TestPublishProject(t *testing.T) {
+	e := Server(t, baseSeeder)
+
+	projectId, _, _ := createProjectSet(e)
+
+	// default
+	res := publishProject(e, uID, map[string]any{
+		"projectId": projectId,
+		"alias":     "",
+		"status":    "LIMITED",
+	})
+	res.Object().IsEqual(map[string]any{
+		"id":                projectId,
+		"alias":             projectId, // default self id
+		"publishmentStatus": "LIMITED",
+	})
+
+	projectId, _, _ = createProjectSet(e)
+
+	// self project id
+	res = publishProject(e, uID, map[string]any{
+		"projectId": projectId,
+		"alias":     projectId,
+		"status":    "LIMITED",
+	})
+	res.Object().IsEqual(map[string]any{
+		"id":                projectId,
+		"alias":             projectId, // ok
+		"publishmentStatus": "LIMITED",
+	})
+
+	// publish
+	res = publishProject(e, uID, map[string]any{
+		"projectId": projectId,
+		"alias":     "xxxxxxxx", // update
+		"status":    "LIMITED",
+	})
+	res.Object().IsEqual(map[string]any{
+		"id":                projectId,
+		"alias":             "xxxxxxxx", // update
+		"publishmentStatus": "LIMITED",
+	})
+
+	// unpublish
+	res = publishProject(e, uID, map[string]any{
+		"projectId": projectId,
+		"alias":     "", // empty
+		"status":    "PRIVATE",
+	})
+	res.Object().IsEqual(map[string]any{
+		"id":                projectId,
+		"alias":             "xxxxxxxx", // keep
+		"publishmentStatus": "PRIVATE",
+	})
+
+	// publish
+	res = publishProject(e, uID, map[string]any{
+		"projectId": projectId,
+		"alias":     "", // empty
+		"status":    "LIMITED",
+	})
+	res.Object().IsEqual(map[string]any{
+		"id":                projectId,
+		"alias":             "xxxxxxxx", // keep
+		"publishmentStatus": "LIMITED",
+	})
+
+}
+
+func TestPublishProjectAliasPattern(t *testing.T) {
+	e := Server(t, baseSeeder)
+
+	projectId, _, _ := createProjectSet(e)
+
+	tests := []struct {
+		name  string
+		alias string
+	}{
+		{name: "Illegal characters1", alias: "a!aaaaa"},
+		{name: "Illegal characters2", alias: "aあaaaaa"},
+		{name: "Illegal characters3", alias: "-xxxxxxxxxx"}, // first hyphen
+		{name: "Illegal characters4", alias: "xxxxxxxxxx-"}, // last hyphen
+		{name: "Too short", alias: strings.Repeat("x", 4)},
+		{name: "Too long", alias: strings.Repeat("x", 33)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := publishProjectErrors(e, uID, map[string]any{
+				"projectId": projectId,
+				"alias":     tt.alias,
+				"status":    "LIMITED",
+			})
+			checkProjectInvalidAlias(tt.alias, res, err)
+		})
+	}
+}
+
+func checkProjectInvalidAlias(alias string, res *httpexpect.Value, err *httpexpect.Value) {
+	message := fmt.Sprintf("Invalid alias name: %s", alias)
+	description := fmt.Sprintf("The alias '%s' must be 5-32 characters long and can only contain alphanumeric, hyphen (a-z, 0-9, -).", alias)
+	res.IsNull()
+	err.Array().IsEqual([]map[string]any{
+		{
+			"message": message,
+			"path":    []any{"publishProject"},
+			"extensions": map[string]any{
+				"code":         "invalid_alias",
+				"description":  description,
+				"message":      message,
+				"system_error": "",
+			},
+		},
+	})
+}
+
+func TestPublishProjectAliasReserved(t *testing.T) {
+	e := Server(t, baseSeeder)
+	projectId, _, _ := createProjectSet(e)
+
+	tests := []struct {
+		name  string
+		alias string
+	}{
+		{name: "Reserved 'visualizer'", alias: "visualizer"},
+		{name: "Reserved 'authentication'", alias: "authentication"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := publishProjectErrors(e, uID, map[string]any{
+				"projectId": projectId,
+				"alias":     tt.alias,
+				"status":    "LIMITED",
+			})
+			checkProjectInvalidReservedAlias(tt.alias, res, err)
+		})
+	}
+}
+
+func checkProjectInvalidReservedAlias(alias string, res *httpexpect.Value, err *httpexpect.Value) {
+	message := fmt.Sprintf("The alias '%s' is reserved and cannot be used.", alias)
+	res.IsNull()
+	err.Array().IsEqual([]map[string]any{
+		{
+			"message": message,
+			"path":    []any{"publishProject"},
+			"extensions": map[string]any{
+				"code":         "invalid_reserved_alias",
+				"description":  "The following aliases are reserved and cannot be used: administrator,development",
+				"message":      message,
+				"system_error": "",
+			},
+		},
+	})
+}
+
+func TestPublishProjectUniqueAlias(t *testing.T) {
+	e := Server(t, baseSeeder)
+	projectId1, _, storyId1 := createProjectSet(e)
+	projectId2, _, storyId2 := createProjectSet(e)
+
+	testCases := []struct {
+		name   string
+		alias  string
+		expect func(res *httpexpect.Value, err *httpexpect.Value)
+	}{
+		{"self storyId", storyId1, checkProjectAliasAlreadyExists},
+		{"other projectId", projectId2, checkProjectAliasAlreadyExists},
+		{"other storyId", storyId2, checkProjectAliasAlreadyExists},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := publishProjectErrors(e, uID, map[string]any{
+				"projectId": projectId1,
+				"alias":     tc.alias,
+				"status":    "LIMITED",
+			})
+			tc.expect(res, err)
+		})
+	}
+
+	// publish projectId2 => 'project-id2'
+	publishProject(e, uID, map[string]any{
+		"projectId": projectId2,
+		"alias":     "project-id2",
+		"status":    "LIMITED",
+	})
+	// publish storyId1 => 'story-id1'
+	publishStory(e, uID, map[string]any{
+		"storyId": storyId1,
+		"alias":   "story-id1",
+		"status":  "LIMITED",
+	})
+	// publish storyId2 => 'story-id2'
+	publishStory(e, uID, map[string]any{
+		"storyId": storyId2,
+		"alias":   "story-id2",
+		"status":  "LIMITED",
+	})
+
+	// used aliases
+	aliases := []string{"project-id2", "story-id1", "story-id2"}
+
+	for _, alias := range aliases {
+		t.Run("alias conflict: "+alias, func(t *testing.T) {
+			res, err := publishProjectErrors(e, uID, map[string]any{
+				"projectId": projectId1,
+				"alias":     alias,
+				"status":    "LIMITED",
+			})
+			checkProjectAliasAlreadyExists(res, err)
+		})
+	}
+}
+
+func checkProjectAliasAlreadyExists(res *httpexpect.Value, err *httpexpect.Value) {
+	res.IsNull()
+	err.Array().IsEqual([]map[string]any{
+		{
+			"message": "This alias is already in use. Please try another one.",
+			"path":    []any{"publishProject"},
+			"extensions": map[string]any{
+				"code":         "alias_already_exists",
+				"description":  "Each alias must be unique across projects and stories.",
+				"message":      "This alias is already in use. Please try another one.",
+				"system_error": "",
+			},
+		},
+	})
+}
+
+/////// TestPublishStory ///////
+
+func TestPublishStory(t *testing.T) {
+	e := Server(t, baseSeeder)
+
+	_, _, storyId := createProjectSet(e)
+
+	// default
+	res := publishStory(e, uID, map[string]any{
+		"storyId": storyId,
+		"alias":   "",
+		"status":  "LIMITED",
+	})
+	res.Object().IsEqual(map[string]any{
+		"id":                storyId,
+		"alias":             storyId, // default self id
+		"publishmentStatus": "LIMITED",
+	})
+
+	_, _, storyId = createProjectSet(e)
+
+	// self story id
+	res = publishStory(e, uID, map[string]any{
+		"storyId": storyId,
+		"alias":   storyId,
+		"status":  "LIMITED",
+	})
+	res.Object().IsEqual(map[string]any{
+		"id":                storyId,
+		"alias":             storyId, // ok
+		"publishmentStatus": "LIMITED",
+	})
+
+	// publish
+	res = publishStory(e, uID, map[string]any{
+		"storyId": storyId,
+		"alias":   "xxxxxxxx", // update
+		"status":  "LIMITED",
+	})
+	res.Object().IsEqual(map[string]any{
+		"id":                storyId,
+		"alias":             "xxxxxxxx", // update
+		"publishmentStatus": "LIMITED",
+	})
+
+	// unpublish
+	res = publishStory(e, uID, map[string]any{
+		"storyId": storyId,
+		"alias":   "", // empty
+		"status":  "PRIVATE",
+	})
+	res.Object().IsEqual(map[string]any{
+		"id":                storyId,
+		"alias":             "xxxxxxxx", // keep
+		"publishmentStatus": "PRIVATE",
+	})
+
+	// publish
+	res = publishStory(e, uID, map[string]any{
+		"storyId": storyId,
+		"alias":   "", // empty
+		"status":  "LIMITED",
+	})
+	res.Object().IsEqual(map[string]any{
+		"id":                storyId,
+		"alias":             "xxxxxxxx", // keep
+		"publishmentStatus": "LIMITED",
+	})
+
+}
+
+func TestPublishStoryAliasPattern(t *testing.T) {
+	e := Server(t, baseSeeder)
+
+	_, _, storyId := createProjectSet(e)
+
+	tests := []struct {
+		name  string
+		alias string
+	}{
+		{name: "Illegal characters1", alias: "a!aaaaa"},
+		{name: "Illegal characters2", alias: "aあaaaaa"},
+		{name: "Illegal characters3", alias: "-xxxxxxxxxx"}, // first hyphen
+		{name: "Illegal characters4", alias: "xxxxxxxxxx-"}, // last hyphen
+		{name: "Too short", alias: strings.Repeat("x", 4)},
+		{name: "Too long", alias: strings.Repeat("x", 33)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := publishStoryErrors(e, uID, map[string]any{
+				"storyId": storyId,
+				"alias":   tt.alias,
+				"status":  "LIMITED",
+			})
+			checkStoryInvalidAlias(tt.alias, res, err)
+		})
+	}
+}
+
+func checkStoryInvalidAlias(alias string, res *httpexpect.Value, err *httpexpect.Value) {
+	message := fmt.Sprintf("Invalid alias name: %s", alias)
+	description := fmt.Sprintf("The alias '%s' must be 5-32 characters long and can only contain alphanumeric, hyphen (a-z, 0-9, -).", alias)
+	res.IsNull()
+	err.Array().IsEqual([]map[string]any{
+		{
+			"message": message,
+			"path":    []any{"publishStory"},
+			"extensions": map[string]any{
+				"code":         "invalid_alias",
+				"description":  description,
+				"message":      message,
+				"system_error": "",
+			},
+		},
+	})
+}
+
+func TestPublishStoryAliasReserved(t *testing.T) {
+	e := Server(t, baseSeeder)
+	_, _, storyId := createProjectSet(e)
+
+	tests := []struct {
+		name  string
+		alias string
+	}{
+		{name: "Reserved 'visualizer'", alias: "visualizer"},
+		{name: "Reserved 'authentication'", alias: "authentication"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := publishStoryErrors(e, uID, map[string]any{
+				"storyId": storyId,
+				"alias":   tt.alias,
+				"status":  "LIMITED",
+			})
+			checkStoryInvalidReservedAlias(tt.alias, res, err)
+		})
+	}
+}
+
+func checkStoryInvalidReservedAlias(alias string, res *httpexpect.Value, err *httpexpect.Value) {
+	message := fmt.Sprintf("The alias '%s' is reserved and cannot be used.", alias)
+	res.IsNull()
+	err.Array().IsEqual([]map[string]any{
+		{
+			"message": message,
+			"path":    []any{"publishStory"},
+			"extensions": map[string]any{
+				"code":         "invalid_reserved_alias",
+				"description":  "The following aliases are reserved and cannot be used: administrator,development",
+				"message":      message,
+				"system_error": "",
+			},
+		},
+	})
+}
+
+func TestPublishStoryUniqueAlias(t *testing.T) {
+	e := Server(t, baseSeeder)
+	projectId1, _, storyId1 := createProjectSet(e)
+	projectId2, _, storyId2 := createProjectSet(e)
+
+	testCases := []struct {
+		name   string
+		alias  string
+		expect func(res *httpexpect.Value, err *httpexpect.Value)
+	}{
+		{"self projectId", projectId1, checkStoryAliasAlreadyExists},
+		{"other projectId", projectId2, checkStoryAliasAlreadyExists},
+		{"other storyId", storyId2, checkStoryAliasAlreadyExists},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := publishStoryErrors(e, uID, map[string]any{
+				"storyId": storyId1,
+				"alias":   tc.alias,
+				"status":  "LIMITED",
+			})
+			tc.expect(res, err)
+		})
+	}
+
+	// publish projectId1 => 'project-id1'
+	publishProject(e, uID, map[string]any{
+		"projectId": projectId1,
+		"alias":     "project-id1",
+		"status":    "LIMITED",
+	})
+	// publish projectId2 => 'project-id2'
+	publishProject(e, uID, map[string]any{
+		"projectId": projectId2,
+		"alias":     "project-id2",
+		"status":    "LIMITED",
+	})
+	// publish storyId2 => 'story-id2'
+	publishStory(e, uID, map[string]any{
+		"storyId": storyId2,
+		"alias":   "story-id2",
+		"status":  "LIMITED",
+	})
+
+	// used aliases
+	aliases := []string{"project-id1", "project-id2", "story-id2"}
+
+	for _, alias := range aliases {
+		t.Run("alias conflict: "+alias, func(t *testing.T) {
+			res, err := publishStoryErrors(e, uID, map[string]any{
+				"storyId": storyId1,
+				"alias":   alias,
+				"status":  "LIMITED",
+			})
+			checkStoryAliasAlreadyExists(res, err)
+		})
+	}
+}
+
+func checkStoryAliasAlreadyExists(res *httpexpect.Value, err *httpexpect.Value) {
+	res.IsNull()
+	err.Array().IsEqual([]map[string]any{
+		{
+			"message": "This alias is already in use. Please try another one.",
+			"path":    []any{"publishStory"},
+			"extensions": map[string]any{
+				"code":         "alias_already_exists",
+				"description":  "Each alias must be unique across projects and stories.",
+				"message":      "This alias is already in use. Please try another one.",
+				"system_error": "",
+			},
+		},
+	})
+}
+
+/////// Common ///////
+
+const PublishProjectMutation = `
+mutation PublishProject(
+  $projectId: ID!
+  $alias: String
+  $status: PublishmentStatus!
+) {
+  publishProject(
+    input: { projectId: $projectId, alias: $alias, status: $status }
+  ) {
+    project {
+      id
+      alias
+      publishmentStatus
+    }
+  }
+}`
+
+const PublishStoryMutation = `
+mutation PublishStory(
+  $storyId: ID!
+  $alias: String
+  $status: PublishmentStatus!
+) {
+  publishStory(input: { storyId: $storyId, alias: $alias, status: $status }) {
+    story {
+      id
+      alias
+      publishmentStatus
+    }
+  }
+}`
+
+func createProjectSet(e *httpexpect.Expect) (string, string, string) {
+	projectId := createProject(e, uID, map[string]any{
+		"name":        "test project",
+		"description": "test description",
+		"teamId":      wID.String(),
+		"visualizer":  "CESIUM",
+		"coreSupport": true,
+	})
+	sceneId := createScene(e, projectId)
+	storyId := createStory(e, map[string]any{
+		"sceneId": sceneId,
+		"title":   "test title",
+		"index":   1,
+	})
+
+	return projectId, sceneId, storyId
+}
+
+func publishProject(e *httpexpect.Expect, u accountdomain.UserID, variables map[string]any) *httpexpect.Value {
+	requestBody := GraphQLRequest{
+		OperationName: "PublishProject",
+		Query:         PublishProjectMutation,
+		Variables:     variables,
+	}
+	res := Request(e, u.String(), requestBody)
+	return res.Path("$.data.publishProject.project")
+}
+
+func publishProjectErrors(e *httpexpect.Expect, u accountdomain.UserID, variables map[string]any) (*httpexpect.Value, *httpexpect.Value) {
+	requestBody := GraphQLRequest{
+		OperationName: "PublishProject",
+		Query:         PublishProjectMutation,
+		Variables:     variables,
+	}
+	res := Request(e, u.String(), requestBody)
+	return res.Path("$.data.publishProject"), res.Path("$.errors")
+}
+
+func publishStory(e *httpexpect.Expect, u accountdomain.UserID, variables map[string]any) *httpexpect.Value {
+	requestBody := GraphQLRequest{
+		OperationName: "PublishStory",
+		Query:         PublishStoryMutation,
+		Variables:     variables,
+	}
+	res := Request(e, u.String(), requestBody)
+	return res.Path("$.data.publishStory.story")
+}
+
+func publishStoryErrors(e *httpexpect.Expect, u accountdomain.UserID, variables map[string]any) (*httpexpect.Value, *httpexpect.Value) {
+	requestBody := GraphQLRequest{
+		OperationName: "PublishStory",
+		Query:         PublishStoryMutation,
+		Variables:     variables,
+	}
+	res := Request(e, u.String(), requestBody)
+	return res.Path("$.data"), res.Path("$.errors")
+}

--- a/server/e2e/gql_scene_test.go
+++ b/server/e2e/gql_scene_test.go
@@ -10,7 +10,7 @@ import (
 func TestGetScenePlaceholderEnglish(t *testing.T) {
 	e := ServerLanguage(t, language.English)
 	pID := createProjectWithExternalImage(e, "test")
-	_, _, sID := createScene(e, pID)
+	sID := createScene(e, pID)
 	r := getScene(e, sID, language.English.String())
 
 	for _, group := range r.Object().Value("property").Object().Value("schema").Object().Value("groups").Array().Iter() {
@@ -36,7 +36,7 @@ func TestGetScenePlaceholderEnglish(t *testing.T) {
 func TestGetScenePlaceholderJapanese(t *testing.T) {
 	e := ServerLanguage(t, language.Japanese)
 	pID := createProjectWithExternalImage(e, "test")
-	_, _, sID := createScene(e, pID)
+	sID := createScene(e, pID)
 	r := getScene(e, sID, language.Japanese.String())
 
 	for _, group := range r.Object().Value("property").Object().Value("schema").Object().Value("groups").Array().Iter() {
@@ -70,7 +70,7 @@ func TestGetSceneNLSLayer(t *testing.T) {
 		"visualizer":  "CESIUM",
 		"coreSupport": true,
 	})
-	_, _, sId := createScene(e, pId)
+	sId := createScene(e, pId)
 	_, _, lId := addNLSLayerSimple(e, sId, "someTitle99", 99)
 
 	r := getScene(e, sId, language.Und.String())
@@ -94,4 +94,23 @@ func createProjectWithExternalImage(e *httpexpect.Expect, name string) string {
 	}
 	res := Request(e, uID.String(), requestBody)
 	return res.Path("$.data.createProject.project.id").Raw().(string)
+}
+
+func createScene(e *httpexpect.Expect, pID string) string {
+	requestBody := GraphQLRequest{
+		OperationName: "CreateScene",
+		Query: `mutation CreateScene($projectId: ID!) {
+			createScene( input: {projectId: $projectId} ) { 
+				scene { 
+					id
+				} 
+			}
+		}`,
+		Variables: map[string]any{
+			"projectId": pID,
+		},
+	}
+
+	res := Request(e, uID.String(), requestBody)
+	return res.Path("$.data.createScene.scene.id").Raw().(string)
 }

--- a/server/e2e/gql_style_test.go
+++ b/server/e2e/gql_style_test.go
@@ -154,7 +154,7 @@ func TestStyleCRUD(t *testing.T) {
 		"visualizer":  "CESIUM",
 		"coreSupport": true,
 	})
-	_, _, sId := createScene(e, pId)
+	sId := createScene(e, pId)
 
 	// fetch scene
 	_, res := fetchSceneForStyles(e, sId)

--- a/server/e2e/gql_validate_geojson_test.go
+++ b/server/e2e/gql_validate_geojson_test.go
@@ -15,7 +15,7 @@ func TestValidateGeoJsonOfAssets(t *testing.T) {
 		"visualizer":  "CESIUM",
 		"coreSupport": true,
 	})
-	_, _, sId := createScene(e, pId)
+	sId := createScene(e, pId)
 
 	tests := []struct {
 		name     string
@@ -237,7 +237,7 @@ func TestValidateGeoJsonExternal(t *testing.T) {
 				"coreSupport": true,
 			})
 
-			_, _, sId := createScene(e, pId)
+			sId := createScene(e, pId)
 			res := addNLSLayerSimpleByGeojson(e, sId, tt.url, "test", 0)
 			if tt.hasError {
 				res.Object().Value("errors").Array().NotEmpty()
@@ -258,7 +258,7 @@ func TestValidateGeoFormData(t *testing.T) {
 		"visualizer":  "CESIUM",
 		"coreSupport": true,
 	})
-	_, _, sId := createScene(e, pId)
+	sId := createScene(e, pId)
 	tests := []struct {
 		name     string
 		geometry map[string]any

--- a/server/gql/project.graphql
+++ b/server/gql/project.graphql
@@ -68,7 +68,6 @@ input UpdateProjectInput {
   isBasicAuthActive: Boolean
   basicAuthUsername: String
   basicAuthPassword: String
-  alias: String
   imageUrl: URL
   publicTitle: String
   publicDescription: String

--- a/server/gql/storytelling.graphql
+++ b/server/gql/storytelling.graphql
@@ -73,7 +73,6 @@ input UpdateStoryInput {
   isBasicAuthActive: Boolean
   basicAuthUsername: String
   basicAuthPassword: String
-  alias: String
   publicTitle: String
   publicDescription: String
   publicImage: String

--- a/server/internal/adapter/gql/generated.go
+++ b/server/internal/adapter/gql/generated.go
@@ -6815,7 +6815,6 @@ input UpdateProjectInput {
   isBasicAuthActive: Boolean
   basicAuthUsername: String
   basicAuthPassword: String
-  alias: String
   imageUrl: URL
   publicTitle: String
   publicDescription: String
@@ -7322,7 +7321,6 @@ input UpdateStoryInput {
   isBasicAuthActive: Boolean
   basicAuthUsername: String
   basicAuthPassword: String
-  alias: String
   publicTitle: String
   publicDescription: String
   publicImage: String
@@ -46313,7 +46311,7 @@ func (ec *executionContext) unmarshalInputUpdateProjectInput(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"projectId", "name", "description", "archived", "isBasicAuthActive", "basicAuthUsername", "basicAuthPassword", "alias", "imageUrl", "publicTitle", "publicDescription", "publicImage", "publicNoIndex", "deleteImageUrl", "deletePublicImage", "enableGa", "trackingId", "sceneId", "starred", "deleted", "visibility"}
+	fieldsInOrder := [...]string{"projectId", "name", "description", "archived", "isBasicAuthActive", "basicAuthUsername", "basicAuthPassword", "imageUrl", "publicTitle", "publicDescription", "publicImage", "publicNoIndex", "deleteImageUrl", "deletePublicImage", "enableGa", "trackingId", "sceneId", "starred", "deleted", "visibility"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -46369,13 +46367,6 @@ func (ec *executionContext) unmarshalInputUpdateProjectInput(ctx context.Context
 				return it, err
 			}
 			it.BasicAuthPassword = data
-		case "alias":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("alias"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Alias = data
 		case "imageUrl":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("imageUrl"))
 			data, err := ec.unmarshalOURL2ᚖnetᚋurlᚐURL(ctx, v)
@@ -46638,7 +46629,7 @@ func (ec *executionContext) unmarshalInputUpdateStoryInput(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"sceneId", "storyId", "title", "index", "panelPosition", "bgColor", "isBasicAuthActive", "basicAuthUsername", "basicAuthPassword", "alias", "publicTitle", "publicDescription", "publicImage", "publicNoIndex", "deletePublicImage", "enableGa", "trackingId"}
+	fieldsInOrder := [...]string{"sceneId", "storyId", "title", "index", "panelPosition", "bgColor", "isBasicAuthActive", "basicAuthUsername", "basicAuthPassword", "publicTitle", "publicDescription", "publicImage", "publicNoIndex", "deletePublicImage", "enableGa", "trackingId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -46708,13 +46699,6 @@ func (ec *executionContext) unmarshalInputUpdateStoryInput(ctx context.Context, 
 				return it, err
 			}
 			it.BasicAuthPassword = data
-		case "alias":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("alias"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Alias = data
 		case "publicTitle":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("publicTitle"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)

--- a/server/internal/adapter/gql/gqlmodel/convert_storytelling.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_storytelling.go
@@ -16,7 +16,7 @@ func ToStory(s *storytelling.Story) *Story {
 		PropertyID:        IDFrom(s.Property()),
 		Property:          nil,
 		Pages:             ToPages(s.Pages()),
-		PublishmentStatus: ToStoryPublishmentStatus(s.Status()),
+		PublishmentStatus: ToStoryPublishmentStatus(s.PublishmentStatus()),
 		CreatedAt:         s.Id().Timestamp(),
 		UpdatedAt:         s.UpdatedAt(),
 		PublishedAt:       s.PublishedAt(),

--- a/server/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/server/internal/adapter/gql/gqlmodel/models_gen.go
@@ -1253,7 +1253,6 @@ type UpdateProjectInput struct {
 	IsBasicAuthActive *bool    `json:"isBasicAuthActive,omitempty"`
 	BasicAuthUsername *string  `json:"basicAuthUsername,omitempty"`
 	BasicAuthPassword *string  `json:"basicAuthPassword,omitempty"`
-	Alias             *string  `json:"alias,omitempty"`
 	ImageURL          *url.URL `json:"imageUrl,omitempty"`
 	PublicTitle       *string  `json:"publicTitle,omitempty"`
 	PublicDescription *string  `json:"publicDescription,omitempty"`
@@ -1302,7 +1301,6 @@ type UpdateStoryInput struct {
 	IsBasicAuthActive *bool     `json:"isBasicAuthActive,omitempty"`
 	BasicAuthUsername *string   `json:"basicAuthUsername,omitempty"`
 	BasicAuthPassword *string   `json:"basicAuthPassword,omitempty"`
-	Alias             *string   `json:"alias,omitempty"`
 	PublicTitle       *string   `json:"publicTitle,omitempty"`
 	PublicDescription *string   `json:"publicDescription,omitempty"`
 	PublicImage       *string   `json:"publicImage,omitempty"`

--- a/server/internal/adapter/gql/resolver_mutation_project.go
+++ b/server/internal/adapter/gql/resolver_mutation_project.go
@@ -63,7 +63,6 @@ func (r *mutationResolver) UpdateProject(ctx context.Context, input gqlmodel.Upd
 		ID:                pid,
 		Name:              input.Name,
 		Description:       input.Description,
-		Alias:             input.Alias,
 		ImageURL:          input.ImageURL,
 		Archived:          input.Archived,
 		IsBasicAuthActive: input.IsBasicAuthActive,

--- a/server/internal/adapter/gql/resolver_mutation_storytelling.go
+++ b/server/internal/adapter/gql/resolver_mutation_storytelling.go
@@ -49,7 +49,6 @@ func (r *mutationResolver) UpdateStory(ctx context.Context, input gqlmodel.Updat
 		IsBasicAuthActive: input.IsBasicAuthActive,
 		BasicAuthUsername: input.BasicAuthUsername,
 		BasicAuthPassword: input.BasicAuthPassword,
-		Alias:             input.Alias,
 		PublicTitle:       input.PublicTitle,
 		PublicDescription: input.PublicDescription,
 		PublicImage:       input.PublicImage,

--- a/server/internal/infrastructure/memory/project.go
+++ b/server/internal/infrastructure/memory/project.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/reearth/reearth/server/internal/usecase/repo"
+	"github.com/reearth/reearth/server/pkg/alias"
 	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearth/server/pkg/project"
 	"github.com/reearth/reearthx/account/accountdomain"
@@ -193,6 +194,19 @@ func (r *Project) FindByPublicName(ctx context.Context, name string) (*project.P
 		}
 	}
 	return nil, rerror.ErrNotFound
+}
+
+func (r *Project) CheckAliasUnique(ctx context.Context, name string) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for _, p := range r.data {
+		if p.ID().String() == name || p.Alias() == name {
+			return alias.ErrExistsStorytellingAlias
+		}
+	}
+
+	return nil
 }
 
 func (r *Project) CountByWorkspace(_ context.Context, ws accountdomain.WorkspaceID) (n int, _ error) {

--- a/server/internal/infrastructure/memory/storytelling.go
+++ b/server/internal/infrastructure/memory/storytelling.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/reearth/reearth/server/internal/usecase/repo"
+	"github.com/reearth/reearth/server/pkg/alias"
 	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearth/server/pkg/storytelling"
 	"github.com/reearth/reearthx/rerror"
@@ -88,6 +89,19 @@ func (r *Storytelling) FindByPublicName(ctx context.Context, name string) (*stor
 		}
 	}
 	return nil, rerror.ErrNotFound
+}
+
+func (r *Storytelling) CheckAliasUnique(ctx context.Context, name string) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for _, s := range r.data {
+		if s.Id().String() == name || s.Alias() == name {
+			return alias.ErrExistsStorytellingAlias
+		}
+	}
+
+	return nil
 }
 
 func (r *Storytelling) Save(_ context.Context, p storytelling.Story) error {

--- a/server/internal/infrastructure/mongo/mongodoc/storytelling.go
+++ b/server/internal/infrastructure/mongo/mongodoc/storytelling.go
@@ -70,7 +70,7 @@ func NewStorytelling(s *storytelling.Story) (*StorytellingDocument, string) {
 		Title:         s.Title(),
 		Alias:         s.Alias(),
 		Pages:         newPages(s.Pages()),
-		Status:        string(s.Status()),
+		Status:        string(s.PublishmentStatus()),
 		PublishedAt:   s.PublishedAt(),
 		UpdatedAt:     s.UpdatedAt(),
 		Index:         1,

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -19,6 +19,7 @@ import (
 	"github.com/reearth/reearth/server/internal/usecase/gateway"
 	"github.com/reearth/reearth/server/internal/usecase/interfaces"
 	"github.com/reearth/reearth/server/internal/usecase/repo"
+	"github.com/reearth/reearth/server/pkg/alias"
 	"github.com/reearth/reearth/server/pkg/file"
 	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearth/server/pkg/project"
@@ -123,22 +124,12 @@ func (i *Project) Update(ctx context.Context, p interfaces.UpdateProjectParam, o
 		return nil, err
 	}
 
-	oldAlias := prj.Alias()
-
 	if p.Name != nil {
 		prj.UpdateName(*p.Name)
 	}
 
 	if p.Description != nil {
 		prj.UpdateDescription(*p.Description)
-	}
-
-	if p.Alias != nil {
-		if _, err := i.checkAlias(ctx, prj.ID(), *p.Alias); err != nil {
-			graphql.AddError(ctx, err)
-		} else {
-			prj.UpdateAlias(*p.Alias)
-		}
 	}
 
 	if p.DeleteImageURL {
@@ -205,15 +196,6 @@ func (i *Project) Update(ctx context.Context, p interfaces.UpdateProjectParam, o
 		prj.UpdatePublicDescription(*p.PublicDescription)
 	}
 
-	if prj.PublishmentStatus() != project.PublishmentStatusPrivate && p.Alias != nil && *p.Alias != oldAlias {
-		if err := i.file.MoveBuiltScene(ctx, oldAlias, *p.Alias); err != nil {
-			// ignore ErrNotFound
-			if !errors.Is(err, rerror.ErrNotFound) {
-				return nil, err
-			}
-		}
-	}
-
 	if p.Visibility != nil {
 		if err := prj.UpdateVisibility(*p.Visibility); err != nil {
 			return nil, err
@@ -245,7 +227,7 @@ func (i *Project) CheckAlias(ctx context.Context, alias string) (bool, error) {
 	return i.checkAlias(ctx, id.NewProjectID(), alias)
 }
 
-func (i *Project) Publish(ctx context.Context, params interfaces.PublishProjectParam, operator *usecase.Operator) (_ *project.Project, err error) {
+func (i *Project) Publish(ctx context.Context, params interfaces.PublishProjectParam, op *usecase.Operator) (_ *project.Project, err error) {
 	tx, err := i.transaction.Begin(ctx)
 	if err != nil {
 		return
@@ -262,130 +244,55 @@ func (i *Project) Publish(ctx context.Context, params interfaces.PublishProjectP
 	if err != nil {
 		return nil, err
 	}
-	coreSupport := prj.CoreSupport()
-	enableGa := prj.EnableGA()
-	trackingId := prj.TrackingID()
-	if err := i.CanWriteWorkspace(prj.Workspace(), operator); err != nil {
+
+	if err := i.CanWriteWorkspace(prj.Workspace(), op); err != nil {
 		return nil, err
 	}
-
-	ws, err := i.workspaceRepo.FindByID(ctx, prj.Workspace())
-	if err != nil {
-		return nil, err
-	}
-
-	// enforce policy
-	if params.Status != project.PublishmentStatusPrivate {
-		if policyID := operator.Policy(ws.Policy()); policyID != nil {
-			p, err := i.policyRepo.FindByID(ctx, *policyID)
-			if err != nil {
-				return nil, err
-			}
-
-			projectCount, err := i.projectRepo.CountPublicByWorkspace(ctx, ws.ID())
-			if err != nil {
-				return nil, err
-			}
-
-			// newrly published
-			if prj.PublishmentStatus() == project.PublishmentStatusPrivate {
-				projectCount += 1
-			}
-
-			if err := p.EnforcePublishedProjectCount(projectCount); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	s, err := i.sceneRepo.FindByProject(ctx, params.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := i.CheckSceneLock(ctx, s.ID()); err != nil {
-		return nil, err
-	}
-
-	sceneID := s.ID()
 
 	prevAlias := prj.Alias()
-	if params.Alias == nil && prevAlias == "" && params.Status != project.PublishmentStatusPrivate {
-		return nil, interfaces.ErrProjectAliasIsNotSet
-	}
 
-	var prevPublishedAlias string
-	if prj.PublishmentStatus() != project.PublishmentStatusPrivate {
-		prevPublishedAlias = prevAlias
-	}
-
-	newAlias := prevAlias
-	if params.Alias != nil {
-		if _, err := i.checkAlias(ctx, prj.ID(), *params.Alias); err != nil {
-			graphql.AddError(ctx, err)
+	// if ProjectID is not specified
+	if params.Alias == nil || *params.Alias == "" {
+		// if you don't have an alias, set it to ProjectID
+		if prj.Alias() == "" {
+			prj.UpdateAlias(prj.ID().String()) // default ID
 		}
-		newAlias = *params.Alias
-	}
-
-	newPublishedAlias := newAlias
-
-	nlsLayers, err := i.nlsLayerRepo.FindByScene(ctx, sceneID)
-	if err != nil {
-		return nil, err
-	}
-
-	layerStyles, err := i.layerStyles.FindByScene(ctx, sceneID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Lock
-	if err := i.UpdateSceneLock(ctx, sceneID, scene.LockModeFree, scene.LockModePublishing); err != nil {
-		return nil, err
-	}
-
-	defer i.ReleaseSceneLock(ctx, sceneID)
-
-	if params.Status == project.PublishmentStatusPrivate {
-		// unpublish
-		if err = i.file.RemoveBuiltScene(ctx, prevPublishedAlias); err != nil {
-			return prj, err
-		}
+		// if anything is set, do nothing
 	} else {
-		// publish
-		r, w := io.Pipe()
+		prj.UpdateAlias(*params.Alias)
+	}
 
-		// Build
-		go func() {
-			var err error
-
-			defer func() {
-				_ = w.CloseWithError(err)
-			}()
-
-			err = builder.New(
-				repo.PropertyLoaderFrom(i.propertyRepo),
-				repo.NLSLayerLoaderFrom(i.nlsLayerRepo),
-				false,
-			).ForScene(s).WithNLSLayers(&nlsLayers).WithLayerStyle(layerStyles).Build(ctx, w, time.Now(), coreSupport, enableGa, trackingId)
-		}()
-
-		// Save
-		if err := i.file.UploadBuiltScene(ctx, r, newPublishedAlias); err != nil {
+	if prevAlias == prj.Alias() || prj.ID().String() == prj.Alias() {
+		// if do not change alias or self ProjectID, do nothing
+	} else {
+		if err := alias.CheckProjectAliasPattern(prj.Alias()); err != nil {
 			return nil, err
 		}
-
-		// If project has been published before and alias is changed,
-		// remove old published data.
-		if prevPublishedAlias != "" && newPublishedAlias != prevPublishedAlias {
-			if err := i.file.RemoveBuiltScene(ctx, prevPublishedAlias); err != nil {
-				return nil, err
-			}
+		if err := i.projectRepo.CheckAliasUnique(ctx, prj.Alias()); err != nil {
+			return nil, err
+		}
+		if err = i.storytellingRepo.CheckAliasUnique(ctx, prj.Alias()); err != nil {
+			return nil, err
 		}
 	}
 
 	prj.UpdatePublishmentStatus(params.Status)
-	prj.SetPublishedAt(time.Now())
+
+	// publish
+	if prj.PublishmentStatus() != project.PublishmentStatusPrivate {
+		if err := i.uploadPublishScene(ctx, prj, op); err != nil {
+			return nil, err
+		}
+		prj.SetPublishedAt(time.Now())
+	}
+
+	// unpublish
+	if prj.PublishmentStatus() == project.PublishmentStatusPrivate || prevAlias != prj.Alias() {
+		// always delete previous aliase
+		if err = i.file.RemoveBuiltScene(ctx, prevAlias); err != nil {
+			return prj, err
+		}
+	}
 
 	if err := i.projectRepo.Save(ctx, prj); err != nil {
 		return nil, err
@@ -393,6 +300,96 @@ func (i *Project) Publish(ctx context.Context, params interfaces.PublishProjectP
 
 	tx.Commit()
 	return prj, nil
+}
+
+func (i *Project) checkPublishPolicy(ctx context.Context, prj *project.Project, op *usecase.Operator) (*scene.Scene, error) {
+
+	ws, err := i.workspaceRepo.FindByID(ctx, prj.Workspace())
+	if err != nil {
+		return nil, err
+	}
+
+	if policyID := op.Policy(ws.Policy()); policyID != nil {
+
+		p, err := i.policyRepo.FindByID(ctx, *policyID)
+		if err != nil {
+			return nil, err
+		}
+
+		projectCount, err := i.projectRepo.CountPublicByWorkspace(ctx, ws.ID())
+		if err != nil {
+			return nil, err
+		}
+
+		// newrly published
+		if prj.PublishmentStatus() != project.PublishmentStatusPrivate {
+			projectCount += 1
+		}
+
+		if err := p.EnforcePublishedProjectCount(projectCount); err != nil {
+			return nil, err
+		}
+	}
+
+	return i.sceneRepo.FindByProject(ctx, prj.ID())
+}
+
+func (i *Project) uploadPublishScene(ctx context.Context, p *project.Project, op *usecase.Operator) error {
+
+	// enforce policy
+	s, err := i.checkPublishPolicy(ctx, p, op)
+	if err != nil {
+		return err
+	}
+
+	// Lock
+	if err := i.CheckSceneLock(ctx, s.ID()); err != nil {
+		return err
+	}
+
+	if err := i.UpdateSceneLock(ctx, s.ID(), scene.LockModeFree, scene.LockModePublishing); err != nil {
+		return err
+	}
+
+	defer i.ReleaseSceneLock(ctx, s.ID())
+
+	nlsLayers, err := i.nlsLayerRepo.FindByScene(ctx, s.ID())
+	if err != nil {
+		return err
+	}
+
+	layerStyles, err := i.layerStyles.FindByScene(ctx, s.ID())
+	if err != nil {
+		return err
+	}
+
+	// publish
+	r, w := io.Pipe()
+
+	// Build
+	go func() {
+		var err error
+
+		defer func() {
+			_ = w.CloseWithError(err)
+		}()
+
+		err = builder.New(
+			repo.PropertyLoaderFrom(i.propertyRepo),
+			repo.NLSLayerLoaderFrom(i.nlsLayerRepo),
+			false,
+		).ForScene(s).
+			WithNLSLayers(&nlsLayers).
+			WithLayerStyle(layerStyles).
+			Build(ctx, w, time.Now(), p.CoreSupport(), p.EnableGA(), p.TrackingID())
+	}()
+
+	// Save
+	if err := i.file.UploadBuiltScene(ctx, r, p.Alias()); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (i *Project) Delete(ctx context.Context, projectID id.ProjectID, operator *usecase.Operator) (err error) {
@@ -644,8 +641,8 @@ func updateProjectUpdatedAtByScene(ctx context.Context, sceneID id.SceneID, r re
 }
 
 func (i *Project) checkAlias(ctx context.Context, updatedProjectID id.ProjectID, newAlias string) (bool, error) {
-	if !project.CheckAliasPattern(newAlias) {
-		return false, project.ErrInvalidProjectAlias.AddTemplateData("aliasName", newAlias)
+	if err := alias.CheckProjectAliasPattern(newAlias); err != nil {
+		return false, err
 	}
 
 	prj, err := i.projectRepo.FindByPublicName(ctx, newAlias)

--- a/server/internal/usecase/interactor/project_test.go
+++ b/server/internal/usecase/interactor/project_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/reearth/reearth/server/internal/testutil/factory"
 	"github.com/reearth/reearth/server/internal/usecase"
 	"github.com/reearth/reearth/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth/server/pkg/alias"
 	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearth/server/pkg/project"
 	"github.com/reearth/reearth/server/pkg/visualizer"
@@ -225,18 +226,18 @@ func TestProject_CheckAlias(t *testing.T) {
 		t.Run("when alias include not allowed characters", func(t *testing.T) {
 			for _, c := range []string{"!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "+", "=", "|", "~", "`", ".", ",", ":", ";", "'", "\"", "/", "\\", "?"} {
 				ok, err := uc.checkAlias(ctx, pj.ID(), "alias2"+c)
-				assert.EqualError(t, err, project.ErrInvalidProjectAlias.Error())
+				assert.EqualError(t, err, alias.ErrInvalidProjectAlias.Error())
 				assert.False(t, ok)
 			}
 		})
 		t.Run("when alias is too short", func(t *testing.T) {
 			ok, err := uc.checkAlias(ctx, pj.ID(), "aaaa")
-			assert.EqualError(t, err, project.ErrInvalidProjectAlias.Error())
+			assert.EqualError(t, err, alias.ErrInvalidProjectAlias.Error())
 			assert.False(t, ok)
 		})
 		t.Run("when alias is too long", func(t *testing.T) {
 			ok, err := uc.checkAlias(ctx, pj.ID(), strings.Repeat("a", 33))
-			assert.EqualError(t, err, project.ErrInvalidProjectAlias.Error())
+			assert.EqualError(t, err, alias.ErrInvalidProjectAlias.Error())
 			assert.False(t, ok)
 		})
 	})

--- a/server/internal/usecase/interactor/project_test.go
+++ b/server/internal/usecase/interactor/project_test.go
@@ -77,7 +77,6 @@ func TestProject_createProject(t *testing.T) {
 				Visualizer:  visualizer.VisualizerCesium,
 				Name:        lo.ToPtr("aaa"),
 				Description: lo.ToPtr("bbb"),
-				Alias:       lo.ToPtr("alias"),
 				ImageURL:    lo.Must(url.Parse("https://example.com/hoge")),
 				CoreSupport: lo.ToPtr(true),
 				Archived:    lo.ToPtr(true),
@@ -93,7 +92,6 @@ func TestProject_createProject(t *testing.T) {
 			assert.Equal(t, input.Visualizer, got.Visualizer())
 			assert.Equal(t, *input.Name, got.Name())
 			assert.Equal(t, *input.Description, got.Description())
-			assert.Equal(t, *input.Alias, got.Alias())
 			assert.Equal(t, input.ImageURL, got.ImageURL())
 			assert.Equal(t, *input.CoreSupport, got.CoreSupport())
 			assert.Equal(t, *input.Archived, got.IsArchived())
@@ -114,7 +112,6 @@ func TestProject_createProject(t *testing.T) {
 			assert.Equal(t, visualizer.Visualizer(""), got.Visualizer())
 			assert.Equal(t, "", got.Name())                  // name default value is empty string
 			assert.Equal(t, "", got.Description())           // description default value is empty string
-			assert.Equal(t, got.ID().String(), got.Alias())  // alias default value is project-{projectID}
 			assert.Equal(t, (*url.URL)(nil), got.ImageURL()) // image url default value is nil
 			assert.Equal(t, false, got.CoreSupport())        // core support default value is false
 			assert.Equal(t, false, got.IsArchived())         // archived default value is false

--- a/server/internal/usecase/interactor/storytelling.go
+++ b/server/internal/usecase/interactor/storytelling.go
@@ -11,11 +11,12 @@ import (
 	"github.com/reearth/reearth/server/internal/usecase/gateway"
 	"github.com/reearth/reearth/server/internal/usecase/interfaces"
 	"github.com/reearth/reearth/server/internal/usecase/repo"
+	"github.com/reearth/reearth/server/pkg/alias"
 	"github.com/reearth/reearth/server/pkg/builtin"
 	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearth/server/pkg/plugin"
 	"github.com/reearth/reearth/server/pkg/property"
-	scene2 "github.com/reearth/reearth/server/pkg/scene"
+	"github.com/reearth/reearth/server/pkg/scene"
 	"github.com/reearth/reearth/server/pkg/scene/builder"
 	"github.com/reearth/reearth/server/pkg/storytelling"
 	"github.com/reearth/reearthx/account/accountusecase/accountrepo"
@@ -181,27 +182,11 @@ func (i *Storytelling) Update(ctx context.Context, inp interfaces.UpdateStoryInp
 		story.SetTrackingID(*inp.TrackingID)
 	}
 
-	oldAlias := story.Alias()
-	if inp.Alias != nil && *inp.Alias != oldAlias {
-		if err := story.UpdateAlias(*inp.Alias); err != nil {
-			return nil, err
-		}
-	}
-
 	// TODO: Handel ordering
 
 	err = i.storytellingRepo.Save(ctx, *story)
 	if err != nil {
 		return nil, err
-	}
-
-	if story.PublishmentStatus() != storytelling.PublishmentStatusPrivate && inp.Alias != nil && story.Alias() != oldAlias {
-		if err := i.file.MoveStory(ctx, oldAlias, story.Alias()); err != nil {
-			// ignore ErrNotFound
-			if !errors.Is(err, rerror.ErrNotFound) {
-				return nil, err
-			}
-		}
 	}
 
 	err = updateProjectUpdatedAtByScene(ctx, story.Scene(), i.projectRepo, i.sceneRepo)
@@ -265,121 +250,55 @@ func (i *Storytelling) Publish(ctx context.Context, inp interfaces.PublishStoryI
 	if err != nil {
 		return nil, err
 	}
+
 	if err := i.CanWriteScene(story.Scene(), op); err != nil {
-		return nil, err
-	}
-	if err := i.CheckSceneLock(ctx, story.Scene()); err != nil {
-		return nil, err
-	}
-
-	scene, err := i.sceneRepo.FindByID(ctx, story.Scene())
-	if err != nil {
-		return nil, err
-	}
-
-	ws, err := i.workspaceRepo.FindByID(ctx, scene.Workspace())
-	if err != nil {
-		return nil, err
-	}
-
-	if story.PublishmentStatus() == storytelling.PublishmentStatusPrivate {
-		// enforce policy
-		if policyID := op.Policy(ws.Policy()); policyID != nil {
-			p, err := i.policyRepo.FindByID(ctx, *policyID)
-			if err != nil {
-				return nil, err
-			}
-			s, err := i.projectRepo.CountPublicByWorkspace(ctx, ws.ID())
-			if err != nil {
-				return nil, err
-			}
-			if err := p.EnforcePublishedProjectCount(s + 1); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	nlsLayers, err := i.nlsLayerRepo.FindByScene(ctx, story.Scene())
-	if err != nil {
-		return nil, err
-	}
-
-	layerStyles, err := i.layerStyles.FindByScene(ctx, story.Scene())
-	if err != nil {
 		return nil, err
 	}
 
 	prevAlias := story.Alias()
-	if inp.Alias == nil && prevAlias == "" && inp.Status != storytelling.PublishmentStatusPrivate {
-		return nil, interfaces.ErrProjectAliasIsNotSet
-	}
 
-	var prevPublishedAlias string
-	if story.PublishmentStatus() != storytelling.PublishmentStatusPrivate {
-		prevPublishedAlias = prevAlias
-	}
-
-	newAlias := prevAlias
-	if inp.Alias != nil && *inp.Alias != prevAlias {
-		if publishedStory, err := i.storytellingRepo.FindByPublicName(ctx, *inp.Alias); err != nil && !errors.Is(err, rerror.ErrNotFound) {
-			return nil, err
-		} else if publishedStory != nil && story.Id() != publishedStory.Id() {
-			return nil, interfaces.ErrProjectAliasAlreadyUsed
+	// if StoryID is not specified
+	if inp.Alias == nil || *inp.Alias == "" {
+		// if you don't have an alias, set it to StoryID
+		if story.Alias() == "" {
+			story.UpdateAlias(story.Id().String()) // default ID
 		}
-
-		if err := story.UpdateAlias(*inp.Alias); err != nil {
-			return nil, err
-		}
-		newAlias = *inp.Alias
-	}
-
-	// Lock
-	if err := i.UpdateSceneLock(ctx, scene.ID(), scene2.LockModeFree, scene2.LockModePublishing); err != nil {
-		return nil, err
-	}
-
-	defer i.ReleaseSceneLock(ctx, scene.ID())
-
-	if inp.Status == storytelling.PublishmentStatusPrivate {
-		// unpublish
-		if err = i.file.RemoveStory(ctx, prevPublishedAlias); err != nil {
-			return story, err
-		}
+		// if anything is set, do nothing
 	} else {
-		// publish
-		r, w := io.Pipe()
+		story.UpdateAlias(*inp.Alias)
+	}
 
-		// Build
-		go func() {
-			var err error
-
-			defer func() {
-				_ = w.CloseWithError(err)
-			}()
-
-			err = builder.New(
-				repo.PropertyLoaderFrom(i.propertyRepo),
-				repo.NLSLayerLoaderFrom(i.nlsLayerRepo),
-				false,
-			).ForScene(scene).WithNLSLayers(&nlsLayers).WithLayerStyle(layerStyles).WithStory(story).Build(ctx, w, time.Now(), true, story.EnableGa(), story.TrackingID())
-		}()
-
-		// Save
-		if err := i.file.UploadStory(ctx, r, newAlias); err != nil {
+	if prevAlias == story.Alias() || story.Id().String() == story.Alias() {
+		// if do not change alias or self StoryID, do nothing
+	} else {
+		if err := alias.CheckAliasPatternStorytelling(story.Alias()); err != nil {
 			return nil, err
 		}
-
-		// If project has been published before and alias is changed,
-		// remove old published data.
-		if prevPublishedAlias != "" && newAlias != prevPublishedAlias {
-			if err := i.file.RemoveStory(ctx, prevPublishedAlias); err != nil {
-				return nil, err
-			}
+		if err := i.projectRepo.CheckAliasUnique(ctx, story.Alias()); err != nil {
+			return nil, err
+		}
+		if err = i.storytellingRepo.CheckAliasUnique(ctx, story.Alias()); err != nil {
+			return nil, err
 		}
 	}
 
 	story.UpdatePublishmentStatus(inp.Status)
-	story.SetPublishedAt(time.Now())
+
+	// publish
+	if story.PublishmentStatus() != storytelling.PublishmentStatusPrivate {
+		if err := i.uploadPublishStory(ctx, story, op); err != nil {
+			return nil, err
+		}
+		story.SetPublishedAt(time.Now())
+	}
+
+	// unpublish
+	if story.PublishmentStatus() == storytelling.PublishmentStatusPrivate || prevAlias != story.Alias() {
+		// always delete previous aliase
+		if err = i.file.RemoveBuiltScene(ctx, prevAlias); err != nil {
+			return story, err
+		}
+	}
 
 	if err := i.storytellingRepo.Save(ctx, *story); err != nil {
 		return nil, err
@@ -392,6 +311,91 @@ func (i *Storytelling) Publish(ctx context.Context, inp interfaces.PublishStoryI
 
 	tx.Commit()
 	return story, nil
+}
+
+func (i *Storytelling) checkPublishPolicy(ctx context.Context, story *storytelling.Story, op *usecase.Operator) (*scene.Scene, error) {
+	s, err := i.sceneRepo.FindByID(ctx, story.Scene())
+	if err != nil {
+		return nil, err
+	}
+
+	ws, err := i.workspaceRepo.FindByID(ctx, s.Workspace())
+	if err != nil {
+		return nil, err
+	}
+	if policyID := op.Policy(ws.Policy()); policyID != nil {
+		p, err := i.policyRepo.FindByID(ctx, *policyID)
+		if err != nil {
+			return nil, err
+		}
+		s, err := i.projectRepo.CountPublicByWorkspace(ctx, ws.ID())
+		if err != nil {
+			return nil, err
+		}
+		if err := p.EnforcePublishedProjectCount(s + 1); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
+func (i *Storytelling) uploadPublishStory(ctx context.Context, story *storytelling.Story, op *usecase.Operator) error {
+
+	// enforce policy
+	s, err := i.checkPublishPolicy(ctx, story, op)
+	if err != nil {
+		return err
+	}
+
+	// Lock
+	if err := i.CheckSceneLock(ctx, story.Scene()); err != nil {
+		return err
+	}
+
+	if err := i.UpdateSceneLock(ctx, story.Scene(), scene.LockModeFree, scene.LockModePublishing); err != nil {
+		return err
+	}
+
+	defer i.ReleaseSceneLock(ctx, story.Scene())
+
+	nlsLayers, err := i.nlsLayerRepo.FindByScene(ctx, story.Scene())
+	if err != nil {
+		return err
+	}
+
+	layerStyles, err := i.layerStyles.FindByScene(ctx, story.Scene())
+	if err != nil {
+		return err
+	}
+
+	// publish
+	r, w := io.Pipe()
+
+	// Build
+	go func() {
+		var err error
+
+		defer func() {
+			_ = w.CloseWithError(err)
+		}()
+
+		err = builder.New(
+			repo.PropertyLoaderFrom(i.propertyRepo),
+			repo.NLSLayerLoaderFrom(i.nlsLayerRepo),
+			false,
+		).ForScene(s).
+			WithNLSLayers(&nlsLayers).
+			WithLayerStyle(layerStyles).
+			WithStory(story).
+			Build(ctx, w, time.Now(), true, story.EnableGa(), story.TrackingID())
+	}()
+
+	// Save
+	if err := i.file.UploadStory(ctx, r, story.Alias()); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (i *Storytelling) Move(_ context.Context, _ interfaces.MoveStoryInput, _ *usecase.Operator) (*id.StoryID, int, error) {

--- a/server/internal/usecase/interfaces/project.go
+++ b/server/internal/usecase/interfaces/project.go
@@ -31,7 +31,6 @@ type UpdateProjectParam struct {
 	ID                id.ProjectID
 	Name              *string
 	Description       *string
-	Alias             *string
 	Archived          *bool
 	IsBasicAuthActive *bool
 	BasicAuthUsername *string

--- a/server/internal/usecase/interfaces/story.go
+++ b/server/internal/usecase/interfaces/story.go
@@ -28,7 +28,6 @@ type UpdateStoryInput struct {
 	IsBasicAuthActive *bool
 	BasicAuthUsername *string
 	BasicAuthPassword *string
-	Alias             *string
 	PublicTitle       *string
 	PublicDescription *string
 	PublicImage       *string

--- a/server/internal/usecase/repo/project.go
+++ b/server/internal/usecase/repo/project.go
@@ -25,6 +25,7 @@ type Project interface {
 	FindStarredByWorkspace(context.Context, accountdomain.WorkspaceID) ([]*project.Project, error)
 	FindDeletedByWorkspace(context.Context, accountdomain.WorkspaceID) ([]*project.Project, error)
 	FindByPublicName(context.Context, string) (*project.Project, error)
+	CheckAliasUnique(context.Context, string) error
 	CountByWorkspace(context.Context, accountdomain.WorkspaceID) (int, error)
 	CountPublicByWorkspace(context.Context, accountdomain.WorkspaceID) (int, error)
 	Save(context.Context, *project.Project) error

--- a/server/internal/usecase/repo/storytelling.go
+++ b/server/internal/usecase/repo/storytelling.go
@@ -12,7 +12,8 @@ type Storytelling interface {
 	FindByID(context.Context, id.StoryID) (*storytelling.Story, error)
 	FindByIDs(context.Context, id.StoryIDList) (*storytelling.StoryList, error)
 	FindByScene(context.Context, id.SceneID) (*storytelling.StoryList, error)
-	FindByPublicName(ctx context.Context, alias string) (*storytelling.Story, error)
+	FindByPublicName(context.Context, string) (*storytelling.Story, error)
+	CheckAliasUnique(context.Context, string) error
 	Save(context.Context, storytelling.Story) error
 	SaveAll(context.Context, storytelling.StoryList) error
 	Remove(context.Context, id.StoryID) error

--- a/server/pkg/alias/check.go
+++ b/server/pkg/alias/check.go
@@ -12,6 +12,10 @@ import (
 )
 
 var (
+	ReservedReearthPrefixProject = "p-"
+
+	ReservedReearthPrefixStory = "s-"
+
 	reservedSubdomains = map[string]struct{}{
 		"admin":          {},
 		"administrator":  {},
@@ -96,6 +100,13 @@ var (
 		nil,
 	)
 
+	ErrInvalidProjectInvalidPrefixAlias = verror.NewVError(
+		errmsg.ErrKeyPkgProjectInvalidPrefixAlias,
+		errmsg.ErrorMessages[errmsg.ErrKeyPkgProjectInvalidPrefixAlias],
+		nil,
+		nil,
+	)
+
 	ErrInvalidStorytellingAlias = verror.NewVError(
 		errmsg.ErrKeyPkgStorytellingInvalidAlias,
 		errmsg.ErrorMessages[errmsg.ErrKeyPkgStorytellingInvalidAlias],
@@ -119,6 +130,13 @@ var (
 	ErrInvalidReservedStorytellingAlias = verror.NewVError(
 		errmsg.ErrKeyPkgStorytellingInvalidReservedAlias,
 		errmsg.ErrorMessages[errmsg.ErrKeyPkgStorytellingInvalidReservedAlias],
+		nil,
+		nil,
+	)
+
+	ErrInvalidStorytellingInvalidPrefixAlias = verror.NewVError(
+		errmsg.ErrKeyPkgStorytellingInvalidPrefixAlias,
+		errmsg.ErrorMessages[errmsg.ErrKeyPkgStorytellingInvalidPrefixAlias],
 		nil,
 		nil,
 	)

--- a/server/pkg/alias/check.go
+++ b/server/pkg/alias/check.go
@@ -1,0 +1,145 @@
+package alias
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/reearth/reearth/server/pkg/i18n/message"
+	"github.com/reearth/reearth/server/pkg/i18n/message/entitymsg"
+	"github.com/reearth/reearth/server/pkg/i18n/message/errmsg"
+	"github.com/reearth/reearth/server/pkg/verror"
+	"golang.org/x/text/language"
+)
+
+var (
+	reservedSubdomains = map[string]struct{}{
+		"admin":          {},
+		"administrator":  {},
+		"root":           {},
+		"superuser":      {},
+		"www":            {},
+		"web":            {},
+		"api":            {},
+		"rest":           {},
+		"graphql":        {},
+		"localhost":      {},
+		"host":           {},
+		"system":         {},
+		"server":         {},
+		"dev":            {},
+		"development":    {},
+		"test":           {},
+		"testing":        {},
+		"qa":             {},
+		"stg":            {},
+		"staging":        {},
+		"prd":            {},
+		"prod":           {},
+		"production":     {},
+		"demo":           {},
+		"beta":           {},
+		"app":            {},
+		"application":    {},
+		"backend":        {},
+		"frontend":       {},
+		"dashboard":      {},
+		"console":        {},
+		"portal":         {},
+		"auth":           {},
+		"authentication": {},
+		"account":        {},
+		"user":           {},
+		"login":          {},
+		"ftp":            {},
+		"sftp":           {},
+		"ssh":            {},
+		"http":           {},
+		"https":          {},
+		"smtp":           {},
+		"mail":           {},
+		"email":          {},
+		"reearth":        {},
+		"visualizer":     {},
+		"oss":            {},
+		"security":       {},
+		"access":         {},
+		"password":       {},
+		"pwd":            {},
+	}
+
+	subdomainRegex = regexp.MustCompile(`^[a-zA-Z0-9](?:[a-zA-Z0-9-]{3,30})[a-zA-Z0-9]$`)
+
+	ErrInvalidProjectAlias = verror.NewVError(
+		errmsg.ErrKeyPkgProjectInvalidAlias,
+		errmsg.ErrorMessages[errmsg.ErrKeyPkgProjectInvalidAlias],
+		message.MultiLocaleTemplateData(map[string]interface{}{
+			"minLength": 5,
+			"maxLength": 32,
+			"allowedChars": func(locale language.Tag) string {
+				return entitymsg.GetLocalizedEntityMessage(entitymsg.EntityKeyPkgProjectAliasAllowedChars, locale)
+			},
+		}),
+		nil,
+	)
+
+	ErrExistsProjectAlias = verror.NewVError(
+		errmsg.ErrKeyPkgProjectAliasAlreadyExists,
+		errmsg.ErrorMessages[errmsg.ErrKeyPkgProjectAliasAlreadyExists],
+		nil,
+		nil,
+	)
+
+	ErrInvalidReservedProjectAlias = verror.NewVError(
+		errmsg.ErrKeyPkgProjectInvalidReservedAlias,
+		errmsg.ErrorMessages[errmsg.ErrKeyPkgProjectInvalidReservedAlias],
+		nil,
+		nil,
+	)
+
+	ErrInvalidStorytellingAlias = verror.NewVError(
+		errmsg.ErrKeyPkgStorytellingInvalidAlias,
+		errmsg.ErrorMessages[errmsg.ErrKeyPkgStorytellingInvalidAlias],
+		message.MultiLocaleTemplateData(map[string]interface{}{
+			"minLength": 5,
+			"maxLength": 32,
+			"allowedChars": func(locale language.Tag) string {
+				return entitymsg.GetLocalizedEntityMessage(entitymsg.EntityKeyPkgStorytellingAliasAllowedChars, locale)
+			},
+		}),
+		nil,
+	)
+
+	ErrExistsStorytellingAlias = verror.NewVError(
+		errmsg.ErrKeyPkgStorytellingAliasAlreadyExists,
+		errmsg.ErrorMessages[errmsg.ErrKeyPkgStorytellingAliasAlreadyExists],
+		nil,
+		nil,
+	)
+
+	ErrInvalidReservedStorytellingAlias = verror.NewVError(
+		errmsg.ErrKeyPkgStorytellingInvalidReservedAlias,
+		errmsg.ErrorMessages[errmsg.ErrKeyPkgStorytellingInvalidReservedAlias],
+		nil,
+		nil,
+	)
+)
+
+func CheckProjectAliasPattern(alias string) error {
+	if alias != "" && !subdomainRegex.Match([]byte(alias)) {
+		return ErrInvalidProjectAlias.AddTemplateData("aliasName", alias)
+	}
+	if _, found := reservedSubdomains[strings.ToLower(alias)]; found {
+		return ErrInvalidReservedProjectAlias.AddTemplateData("aliasName", alias)
+	}
+	return nil
+}
+
+func CheckAliasPatternStorytelling(alias string) error {
+	if alias != "" && !subdomainRegex.Match([]byte(alias)) {
+		return ErrInvalidStorytellingAlias.AddTemplateData("aliasName", alias)
+	}
+	if _, found := reservedSubdomains[strings.ToLower(alias)]; found {
+		return ErrInvalidReservedStorytellingAlias.AddTemplateData("aliasName", alias)
+	}
+	return nil
+}

--- a/server/pkg/i18n/locales/entitymsg/en.json
+++ b/server/pkg/i18n/locales/entitymsg/en.json
@@ -2,8 +2,13 @@
   "pkg": {
     "project": {
       "alias": {
-        "allowed_chars": "alphanumeric, underscore, hyphen"
-      }      
+        "allowed_chars": "alphanumeric, hyphen (a-z, 0-9, -)"
+      }
+    },
+    "storytelling": {
+      "alias": {
+        "allowed_chars": "alphanumeric, hyphen (a-z, 0-9, -)"
+      }
     }
   }
 }

--- a/server/pkg/i18n/locales/entitymsg/ja.json
+++ b/server/pkg/i18n/locales/entitymsg/ja.json
@@ -2,7 +2,12 @@
   "pkg": {
     "project": {
       "alias": {
-        "allowed_chars": "英数字、アンダースコア、ハイフン"
+        "allowed_chars": "英数字、ハイフン（a-z、0-9、-）"
+      }
+    },
+    "storytelling": {
+      "alias": {
+        "allowed_chars": "英数字、ハイフン（a-z、0-9、-）"
       }
     }
   }

--- a/server/pkg/i18n/locales/errmsg/en.json
+++ b/server/pkg/i18n/locales/errmsg/en.json
@@ -1,10 +1,32 @@
 {
-    "pkg": {
-      "project": {
-        "invalid_alias": {
-          "message": "Invalid alias name: {{.aliasName}}",
-          "description": "The alias '{{.aliasName}}' must be {{.minLength}}-{{.maxLength}} characters long and can only contain {{.allowedChars}}."
-        }
+  "pkg": {
+    "project": {
+      "invalid_alias": {
+        "message": "Invalid alias name: {{.aliasName}}",
+        "description": "The alias '{{.aliasName}}' must be {{.minLength}}-{{.maxLength}} characters long and can only contain {{.allowedChars}}."
+      },
+      "alias_already_exists": {
+        "message": "This alias is already in use. Please try another one.",
+        "description": "Each alias must be unique across projects and stories."
+      },
+      "invalid_reserved_alias": {
+        "message": "The alias '{{.aliasName}}' is reserved and cannot be used.",
+        "description": "The following aliases are reserved and cannot be used: administrator,development"
+      }
+    },
+    "storytelling": {
+      "invalid_alias": {
+        "message": "Invalid alias name: {{.aliasName}}",
+        "description": "The alias '{{.aliasName}}' must be {{.minLength}}-{{.maxLength}} characters long and can only contain {{.allowedChars}}."
+      },
+      "alias_already_exists": {
+        "message": "This alias is already in use. Please try another one.",
+        "description": "Each alias must be unique across projects and stories."
+      },
+      "invalid_reserved_alias": {
+        "message": "The alias '{{.aliasName}}' is reserved and cannot be used.",
+        "description": "The following aliases are reserved and cannot be used: administrator,development"
       }
     }
+  }
 }

--- a/server/pkg/i18n/locales/errmsg/en.json
+++ b/server/pkg/i18n/locales/errmsg/en.json
@@ -12,6 +12,10 @@
       "invalid_reserved_alias": {
         "message": "The alias '{{.aliasName}}' is reserved and cannot be used.",
         "description": "The following aliases are reserved and cannot be used: administrator,development"
+      },
+      "invalid_prefix_alias": {
+        "message": "Aliases starting with 'p-' or 's-' are not allowed: {{.aliasName}}",
+        "description": "Aliases that start with 'p-' or 's-' are reserved and cannot be used."
       }
     },
     "storytelling": {
@@ -26,6 +30,10 @@
       "invalid_reserved_alias": {
         "message": "The alias '{{.aliasName}}' is reserved and cannot be used.",
         "description": "The following aliases are reserved and cannot be used: administrator,development"
+      },
+      "invalid_prefix_alias": {
+        "message": "Aliases starting with 'p-' or 's-' are not allowed: {{.aliasName}}",
+        "description": "Aliases that start with 'p-' or 's-' are reserved and cannot be used."
       }
     }
   }

--- a/server/pkg/i18n/locales/errmsg/ja.json
+++ b/server/pkg/i18n/locales/errmsg/ja.json
@@ -1,10 +1,32 @@
 {
-    "pkg": {
-      "project": {
-        "invalid_alias": {
-          "message": "不正なエイリアス名です: {{.aliasName}}",
-          "description": "エイリアス名は{{.minLength}}-{{.maxLength}}文字で、{{.allowedChars}}のみ使用できます。"
-        }
+  "pkg": {
+    "project": {
+      "invalid_alias": {
+        "message": "不正なエイリアス名です: {{.aliasName}}",
+        "description": "エイリアス名は{{.minLength}}-{{.maxLength}}文字で、{{.allowedChars}}のみ使用できます。"
+      },
+      "alias_already_exists": {
+        "message": "そのエイリアスは既に使用されています。別の値を試してください",
+        "description": "プロジェクトやストーリーのエイリアスは一意である必要があります。"
+      },
+      "invalid_reserved_alias": {
+        "message": "予約済みのエイリアス名は使用できません: {{.aliasName}}",
+        "description": "次のようなエイリアス名は予約されており、使用できません: administrator,development"
+      }
+    },
+    "storytelling": {
+      "invalid_alias": {
+        "message": "不正なエイリアス名です: {{.aliasName}}",
+        "description": "エイリアス名は{{.minLength}}-{{.maxLength}}文字で、{{.allowedChars}}のみ使用できます。"
+      },
+      "alias_already_exists": {
+        "message": "そのエイリアスは既に使用されています。別の値を試してください",
+        "description": "プロジェクトやストーリーのエイリアスは一意である必要があります。"
+      },
+      "invalid_reserved_alias": {
+        "message": "予約済みのエイリアス名は使用できません: {{.aliasName}}",
+        "description": "次のようなエイリアス名は予約されており、使用できません: administrator,development"
       }
     }
   }
+}

--- a/server/pkg/i18n/locales/errmsg/ja.json
+++ b/server/pkg/i18n/locales/errmsg/ja.json
@@ -12,6 +12,10 @@
       "invalid_reserved_alias": {
         "message": "予約済みのエイリアス名は使用できません: {{.aliasName}}",
         "description": "次のようなエイリアス名は予約されており、使用できません: administrator,development"
+      },
+      "invalid_prefix_alias": {
+        "message": "'p-'や's-'から始まるエイリアス名は使用できません: {{.aliasName}}",
+        "description": "エイリアス名の先頭が 'p-' または 's-' で始まるものは予約されており、使用できません。"
       }
     },
     "storytelling": {
@@ -26,6 +30,10 @@
       "invalid_reserved_alias": {
         "message": "予約済みのエイリアス名は使用できません: {{.aliasName}}",
         "description": "次のようなエイリアス名は予約されており、使用できません: administrator,development"
+      },
+      "invalid_prefix_alias": {
+        "message": "'p-'や's-'から始まるエイリアス名は使用できません: {{.aliasName}}",
+        "description": "エイリアス名の先頭が 'p-' または 's-' で始まるものは予約されており、使用できません。"
       }
     }
   }

--- a/server/pkg/i18n/message/entitymsg/entitymsg_generated.go
+++ b/server/pkg/i18n/message/entitymsg/entitymsg_generated.go
@@ -8,12 +8,17 @@ import (
 
 const (
 	EntityKeyPkgProjectAliasAllowedChars message.EntityKey = "pkg.project.alias.allowed_chars"
+	EntityKeyPkgStorytellingAliasAllowedChars message.EntityKey = "pkg.storytelling.alias.allowed_chars"
 )
 
 var EntityMessages = map[message.EntityKey]map[language.Tag]string{
 	EntityKeyPkgProjectAliasAllowedChars: {
-		language.English: "alphanumeric, underscore, hyphen",
-		language.Japanese: "英数字、アンダースコア、ハイフン",
+		language.English: "alphanumeric, hyphen (a-z, 0-9, -)",
+		language.Japanese: "英数字、ハイフン（a-z、0-9、-）",
+	},
+	EntityKeyPkgStorytellingAliasAllowedChars: {
+		language.English: "alphanumeric, hyphen (a-z, 0-9, -)",
+		language.Japanese: "英数字、ハイフン（a-z、0-9、-）",
 	},
 }
 

--- a/server/pkg/i18n/message/errmsg/errmsg_generated.go
+++ b/server/pkg/i18n/message/errmsg/errmsg_generated.go
@@ -9,9 +9,11 @@ import (
 const (
 	ErrKeyPkgProjectAliasAlreadyExists message.ErrKey = "pkg.project.alias_already_exists"
 	ErrKeyPkgProjectInvalidAlias message.ErrKey = "pkg.project.invalid_alias"
+	ErrKeyPkgProjectInvalidPrefixAlias message.ErrKey = "pkg.project.invalid_prefix_alias"
 	ErrKeyPkgProjectInvalidReservedAlias message.ErrKey = "pkg.project.invalid_reserved_alias"
 	ErrKeyPkgStorytellingAliasAlreadyExists message.ErrKey = "pkg.storytelling.alias_already_exists"
 	ErrKeyPkgStorytellingInvalidAlias message.ErrKey = "pkg.storytelling.invalid_alias"
+	ErrKeyPkgStorytellingInvalidPrefixAlias message.ErrKey = "pkg.storytelling.invalid_prefix_alias"
 	ErrKeyPkgStorytellingInvalidReservedAlias message.ErrKey = "pkg.storytelling.invalid_reserved_alias"
 )
 
@@ -34,6 +36,16 @@ var ErrorMessages = map[message.ErrKey]map[language.Tag]message.ErrorMessage{
 		language.Japanese: {
 			Message:     "不正なエイリアス名です: {{.aliasName}}",
 			Description: "エイリアス名は{{.minLength}}-{{.maxLength}}文字で、{{.allowedChars}}のみ使用できます。",
+		},
+	},
+	ErrKeyPkgProjectInvalidPrefixAlias: {
+		language.English: {
+			Message:     "Aliases starting with 'p-' or 's-' are not allowed: {{.aliasName}}",
+			Description: "Aliases that start with 'p-' or 's-' are reserved and cannot be used.",
+		},
+		language.Japanese: {
+			Message:     "'p-'や's-'から始まるエイリアス名は使用できません: {{.aliasName}}",
+			Description: "エイリアス名の先頭が 'p-' または 's-' で始まるものは予約されており、使用できません。",
 		},
 	},
 	ErrKeyPkgProjectInvalidReservedAlias: {
@@ -64,6 +76,16 @@ var ErrorMessages = map[message.ErrKey]map[language.Tag]message.ErrorMessage{
 		language.Japanese: {
 			Message:     "不正なエイリアス名です: {{.aliasName}}",
 			Description: "エイリアス名は{{.minLength}}-{{.maxLength}}文字で、{{.allowedChars}}のみ使用できます。",
+		},
+	},
+	ErrKeyPkgStorytellingInvalidPrefixAlias: {
+		language.English: {
+			Message:     "Aliases starting with 'p-' or 's-' are not allowed: {{.aliasName}}",
+			Description: "Aliases that start with 'p-' or 's-' are reserved and cannot be used.",
+		},
+		language.Japanese: {
+			Message:     "'p-'や's-'から始まるエイリアス名は使用できません: {{.aliasName}}",
+			Description: "エイリアス名の先頭が 'p-' または 's-' で始まるものは予約されており、使用できません。",
 		},
 	},
 	ErrKeyPkgStorytellingInvalidReservedAlias: {

--- a/server/pkg/i18n/message/errmsg/errmsg_generated.go
+++ b/server/pkg/i18n/message/errmsg/errmsg_generated.go
@@ -7,10 +7,25 @@ import (
 )
 
 const (
+	ErrKeyPkgProjectAliasAlreadyExists message.ErrKey = "pkg.project.alias_already_exists"
 	ErrKeyPkgProjectInvalidAlias message.ErrKey = "pkg.project.invalid_alias"
+	ErrKeyPkgProjectInvalidReservedAlias message.ErrKey = "pkg.project.invalid_reserved_alias"
+	ErrKeyPkgStorytellingAliasAlreadyExists message.ErrKey = "pkg.storytelling.alias_already_exists"
+	ErrKeyPkgStorytellingInvalidAlias message.ErrKey = "pkg.storytelling.invalid_alias"
+	ErrKeyPkgStorytellingInvalidReservedAlias message.ErrKey = "pkg.storytelling.invalid_reserved_alias"
 )
 
 var ErrorMessages = map[message.ErrKey]map[language.Tag]message.ErrorMessage{
+	ErrKeyPkgProjectAliasAlreadyExists: {
+		language.English: {
+			Message:     "This alias is already in use. Please try another one.",
+			Description: "Each alias must be unique across projects and stories.",
+		},
+		language.Japanese: {
+			Message:     "そのエイリアスは既に使用されています。別の値を試してください",
+			Description: "プロジェクトやストーリーのエイリアスは一意である必要があります。",
+		},
+	},
 	ErrKeyPkgProjectInvalidAlias: {
 		language.English: {
 			Message:     "Invalid alias name: {{.aliasName}}",
@@ -19,6 +34,46 @@ var ErrorMessages = map[message.ErrKey]map[language.Tag]message.ErrorMessage{
 		language.Japanese: {
 			Message:     "不正なエイリアス名です: {{.aliasName}}",
 			Description: "エイリアス名は{{.minLength}}-{{.maxLength}}文字で、{{.allowedChars}}のみ使用できます。",
+		},
+	},
+	ErrKeyPkgProjectInvalidReservedAlias: {
+		language.English: {
+			Message:     "The alias '{{.aliasName}}' is reserved and cannot be used.",
+			Description: "The following aliases are reserved and cannot be used: administrator,development",
+		},
+		language.Japanese: {
+			Message:     "予約済みのエイリアス名は使用できません: {{.aliasName}}",
+			Description: "次のようなエイリアス名は予約されており、使用できません: administrator,development",
+		},
+	},
+	ErrKeyPkgStorytellingAliasAlreadyExists: {
+		language.English: {
+			Message:     "This alias is already in use. Please try another one.",
+			Description: "Each alias must be unique across projects and stories.",
+		},
+		language.Japanese: {
+			Message:     "そのエイリアスは既に使用されています。別の値を試してください",
+			Description: "プロジェクトやストーリーのエイリアスは一意である必要があります。",
+		},
+	},
+	ErrKeyPkgStorytellingInvalidAlias: {
+		language.English: {
+			Message:     "Invalid alias name: {{.aliasName}}",
+			Description: "The alias '{{.aliasName}}' must be {{.minLength}}-{{.maxLength}} characters long and can only contain {{.allowedChars}}.",
+		},
+		language.Japanese: {
+			Message:     "不正なエイリアス名です: {{.aliasName}}",
+			Description: "エイリアス名は{{.minLength}}-{{.maxLength}}文字で、{{.allowedChars}}のみ使用できます。",
+		},
+	},
+	ErrKeyPkgStorytellingInvalidReservedAlias: {
+		language.English: {
+			Message:     "The alias '{{.aliasName}}' is reserved and cannot be used.",
+			Description: "The following aliases are reserved and cannot be used: administrator,development",
+		},
+		language.Japanese: {
+			Message:     "予約済みのエイリアス名は使用できません: {{.aliasName}}",
+			Description: "次のようなエイリアス名は予約されており、使用できません: administrator,development",
 		},
 	},
 }

--- a/server/pkg/project/builder.go
+++ b/server/pkg/project/builder.go
@@ -21,9 +21,6 @@ func (b *Builder) Build() (*Project, error) {
 	if b.p.id.IsNil() {
 		return nil, id.ErrInvalidID
 	}
-	if b.p.alias != "" && !CheckAliasPattern(b.p.alias) {
-		return nil, ErrInvalidProjectAlias
-	}
 	if b.p.updatedAt.IsZero() {
 		b.p.updatedAt = b.p.CreatedAt()
 	}

--- a/server/pkg/project/builder.go
+++ b/server/pkg/project/builder.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/reearth/reearth/server/pkg/alias"
 	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearth/server/pkg/visualizer"
 	"github.com/reearth/reearthx/account/accountdomain"
@@ -20,6 +21,9 @@ func New() *Builder {
 func (b *Builder) Build() (*Project, error) {
 	if b.p.id.IsNil() {
 		return nil, id.ErrInvalidID
+	}
+	if b.p.alias == "" {
+		b.p.alias = alias.ReservedReearthPrefixProject + b.p.id.String()
 	}
 	if b.p.updatedAt.IsZero() {
 		b.p.updatedAt = b.p.CreatedAt()

--- a/server/pkg/project/builder_test.go
+++ b/server/pkg/project/builder_test.go
@@ -239,15 +239,6 @@ func TestBuilder_Build(t *testing.T) {
 			name: "failed invalid id",
 			err:  id.ErrInvalidID,
 		},
-		{
-			name: "failed invalid alias",
-			args: args{
-				id:    id.NewProjectID(),
-				alias: "xxx.aaa",
-			},
-			expected: nil,
-			err:      ErrInvalidProjectAlias,
-		},
 	}
 
 	for _, tt := range tests {
@@ -368,14 +359,6 @@ func TestBuilder_MustBuild(t *testing.T) {
 		{
 			name: "failed invalid id",
 			err:  id.ErrInvalidID,
-		},
-		{
-			name: "failed invalid alias",
-			args: args{
-				id:    id.NewProjectID(),
-				alias: "xxx.aaa",
-			},
-			err: ErrInvalidProjectAlias,
 		},
 	}
 

--- a/server/pkg/project/builder_test.go
+++ b/server/pkg/project/builder_test.go
@@ -193,7 +193,7 @@ func TestBuilder_Build(t *testing.T) {
 			args: args{
 				name:              "xxx.aaa",
 				description:       "ddd",
-				alias:             "aaaaa",
+				alias:             "p-" + pid.String(),
 				publicTitle:       "ttt",
 				publicDescription: "dddd",
 				publicImage:       "iii",
@@ -211,7 +211,7 @@ func TestBuilder_Build(t *testing.T) {
 				id:                pid,
 				description:       "ddd",
 				name:              "xxx.aaa",
-				alias:             "aaaaa",
+				alias:             "p-" + pid.String(),
 				publicTitle:       "ttt",
 				publicDescription: "dddd",
 				publicImage:       "iii",
@@ -232,6 +232,7 @@ func TestBuilder_Build(t *testing.T) {
 			},
 			expected: &Project{
 				id:        pid,
+				alias:     "p-" + pid.String(),
 				updatedAt: pid.Timestamp(),
 			},
 		},

--- a/server/pkg/project/builder_test.go
+++ b/server/pkg/project/builder_test.go
@@ -354,6 +354,7 @@ func TestBuilder_MustBuild(t *testing.T) {
 			},
 			expected: &Project{
 				id:        pid,
+				alias:     "p-" + pid.String(),
 				updatedAt: pid.Timestamp(),
 			},
 		},

--- a/server/pkg/project/project.go
+++ b/server/pkg/project/project.go
@@ -3,31 +3,11 @@ package project
 import (
 	"errors"
 	"net/url"
-	"regexp"
 	"time"
 
-	"github.com/reearth/reearth/server/pkg/i18n/message"
-	"github.com/reearth/reearth/server/pkg/i18n/message/entitymsg"
-	"github.com/reearth/reearth/server/pkg/i18n/message/errmsg"
 	"github.com/reearth/reearth/server/pkg/id"
-	"github.com/reearth/reearth/server/pkg/verror"
 	"github.com/reearth/reearth/server/pkg/visualizer"
 	"github.com/reearth/reearthx/account/accountdomain"
-	"golang.org/x/text/language"
-)
-
-var (
-	ErrInvalidProjectAlias = verror.NewVError(
-		errmsg.ErrKeyPkgProjectInvalidAlias,
-		errmsg.ErrorMessages[errmsg.ErrKeyPkgProjectInvalidAlias],
-		message.MultiLocaleTemplateData(map[string]interface{}{
-			"minLength": 5,
-			"maxLength": 32,
-			"allowedChars": func(locale language.Tag) string {
-				return entitymsg.GetLocalizedEntityMessage(entitymsg.EntityKeyPkgProjectAliasAllowedChars, locale)
-			},
-		}), nil)
-	aliasRegexp = regexp.MustCompile("^[a-zA-Z0-9_-]{5,32}$")
 )
 
 type Project struct {
@@ -284,8 +264,4 @@ func (p *Project) MatchWithPublicName(name string) bool {
 		return true
 	}
 	return false
-}
-
-func CheckAliasPattern(alias string) bool {
-	return alias != "" && aliasRegexp.Match([]byte(alias))
 }

--- a/server/pkg/project/project_errkey_test.go
+++ b/server/pkg/project/project_errkey_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/reearth/reearth/server/pkg/alias"
 	"github.com/reearth/reearth/server/pkg/i18n"
 	"github.com/reearth/reearth/server/pkg/i18n/message"
 	"github.com/stretchr/testify/assert"
@@ -11,7 +12,7 @@ import (
 
 func TestErrInvalidAlias(t *testing.T) {
 	ctx := context.Background()
-	vErr := ErrInvalidProjectAlias.AddTemplateData("aliasName", "test")
+	vErr := alias.ErrInvalidProjectAlias.AddTemplateData("aliasName", "test")
 	for _, locale := range i18n.LocaleTypes() {
 		assert.NotEqual(t, "", message.ApplyTemplate(ctx, vErr.ErrMsg[locale].Message, vErr.TemplateData, locale))
 		assert.NotEqual(t, "", message.ApplyTemplate(ctx, vErr.ErrMsg[locale].Description, vErr.TemplateData, locale))

--- a/server/pkg/project/project_test.go
+++ b/server/pkg/project/project_test.go
@@ -5,33 +5,41 @@ import (
 	"testing"
 	"time"
 
+	"github.com/reearth/reearth/server/pkg/alias"
 	"github.com/reearth/reearth/server/pkg/visualizer"
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCheckAliasPattern(t *testing.T) {
-	testCase := []struct {
-		name, alias string
-		expexted    bool
+	testCases := []struct {
+		name     string
+		alias    string
+		expected bool
 	}{
 		{
 			name:     "accepted regex",
 			alias:    "xxxxx",
-			expexted: true,
+			expected: true,
 		},
 		{
 			name:     "refused regex",
 			alias:    "xxx",
-			expexted: false,
+			expected: false,
 		},
 	}
 
-	for _, tt := range testCase {
+	for _, tt := range testCases {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expexted, CheckAliasPattern(tt.alias))
+
+			err := alias.CheckProjectAliasPattern(tt.alias)
+			if tt.expected {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
 		})
 	}
 }

--- a/server/pkg/storytelling/story.go
+++ b/server/pkg/storytelling/story.go
@@ -2,7 +2,6 @@ package storytelling
 
 import (
 	"fmt"
-	"regexp"
 	"time"
 
 	"github.com/pkg/errors"
@@ -15,7 +14,6 @@ import (
 var (
 	ErrBasicAuthUserNamePasswordEmpty       = errors.New("basic auth username or password is empty")
 	ErrInvalidAlias                   error = errors.New("invalid alias")
-	aliasRegexp                             = regexp.MustCompile("^[a-zA-Z0-9_-]{5,32}$")
 )
 
 type Story struct {
@@ -68,10 +66,6 @@ func (s *Story) Title() string {
 
 func (s *Story) Alias() string {
 	return s.alias
-}
-
-func (s *Story) Status() PublishmentStatus {
-	return s.status
 }
 
 func (s *Story) PublishedAt() *time.Time {
@@ -240,13 +234,8 @@ func (s *Story) SetPublishedAt(now time.Time) {
 	s.publishedAt = &now
 }
 
-func (s *Story) UpdateAlias(alias string) error {
-	if CheckAliasPattern(alias) {
-		s.alias = alias
-	} else {
-		return ErrInvalidAlias
-	}
-	return nil
+func (s *Story) UpdateAlias(newAlias string) {
+	s.alias = newAlias
 }
 
 func (s *Story) MatchWithPublicName(name string) bool {
@@ -254,8 +243,4 @@ func (s *Story) MatchWithPublicName(name string) bool {
 		return false
 	}
 	return s.alias == name
-}
-
-func CheckAliasPattern(alias string) bool {
-	return alias != "" && aliasRegexp.Match([]byte(alias))
 }

--- a/server/pkg/storytelling/story_bulider.go
+++ b/server/pkg/storytelling/story_bulider.go
@@ -3,6 +3,7 @@ package storytelling
 import (
 	"time"
 
+	"github.com/reearth/reearth/server/pkg/alias"
 	"github.com/reearth/reearth/server/pkg/id"
 )
 
@@ -17,6 +18,9 @@ func NewStory() *StoryBuilder {
 func (b *StoryBuilder) Build() (*Story, error) {
 	if b.s.id.IsNil() {
 		return nil, id.ErrInvalidID
+	}
+	if b.s.alias == "" {
+		b.s.alias = alias.ReservedReearthPrefixStory + b.s.id.String()
 	}
 	if b.s.updatedAt.IsZero() {
 		b.s.updatedAt = b.s.CreatedAt()

--- a/server/pkg/storytelling/story_test.go
+++ b/server/pkg/storytelling/story_test.go
@@ -42,7 +42,7 @@ func TestStory_SettersGetters(t *testing.T) {
 	assert.Equal(t, sceneID, s.Scene())
 	assert.Equal(t, "test", s.Title())
 	assert.Equal(t, "abc", s.Alias())
-	assert.Equal(t, PublishmentStatusPrivate, s.Status())
+	assert.Equal(t, PublishmentStatusPrivate, s.PublishmentStatus())
 	assert.Equal(t, now, s.UpdatedAt())
 	assert.Nil(t, s.Pages())
 	assert.Nil(t, s.PublishedAt())


### PR DESCRIPTION
# Overview

# Alias Update API Changes in Publish Settings

## What I've done
## 1. Disallow updating alias via UpdateProject / UpdateStory

```diff
input UpdateProjectInput {
...
  basicAuthPassword: String
-  alias: String
  imageUrl: URL
...
}

input UpdateStoryInput {
...
  basicAuthPassword: String
-  alias: String
  publicTitle: String
...
}
```

## 2. Alias management is now handled exclusively through publish mutations.
```
input PublishProjectInput {
  projectId: ID!
  alias: String
  status: PublishmentStatus!
}
input PublishStoryInput {
  storyId: ID!
  alias: String
  status: PublishmentStatus!
}
```
### * The alias field in PublishProject and PublishStory accepts either a subdomain or an empty string ("").
### * If an empty string is passed:
### If no alias has been set yet (initial state)
### → The alias will be set to the p-{projectId} or s-{storyId} (self).

### If an alias is already set
### → It will not be updated. In other words, the alias cannot be reset to "" from the frontend.
#### Even if the content is unpublished, the public page will be removed, but the alias itself will be retained.

3. By default, aliases are set with a prefix:
p-{projectId}
s-{storyId}

Aliases starting with ‘p-’ or ‘s-’ are generally prohibited:
p-{???????} => NG
s-{???????} => NG

However, if the alias matches its own ID, it is allowed:
p-{self ProjectId} => OK
s-{self StoryId} => OK

“Self” here refers to the individual project or story.
  
p-{self StoryId} => NG I can't set StoryID even though it's 'p-'
s-{self ProjectId} => NG

## What I haven't done

## How I tested

* Testing by E2E

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive end-to-end tests for publishing projects and stories, including alias validation, reserved alias checks, and uniqueness enforcement.
  - Added localization for alias-related error messages and allowed character descriptions in English and Japanese.
  - Added Makefile target for generating internationalization messages.

- **Bug Fixes**
  - Enhanced alias validation to prevent use of invalid, reserved, or duplicate aliases across projects and stories.

- **Refactor**
  - Centralized alias validation into a dedicated alias package, removing previous validation from project and storytelling modules.
  - Modularized publishing workflows with explicit policy enforcement, alias checks, scene locking, building, and upload steps.
  - Simplified test code by updating helper functions and streamlining scene and story creation calls.
  - Removed alias updates from project and story update operations, consolidating alias management within publishing.
  - Removed alias field from update inputs and internal structures to reflect new alias management approach.
  - Updated project and storytelling builders to assign default aliases automatically when none provided.
  - Removed alias validation logic from project and storytelling domain models.
  - Improved alias uniqueness checks in in-memory and MongoDB repositories.

- **Chores**
  - Updated localization files and error message mappings to align with new alias validation and error reporting rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->