### PR TITLE
refactor(web): improve error handling [VIZ-1485]

### DIFF
--- a/web/src/services/gql/index.ts
+++ b/web/src/services/gql/index.ts
@@ -1,2 +1,5 @@
 export * from "./__gen__/graphql";
 export { default as Provider } from "./provider";
+
+//'x-' prefix as a custom header to prevent naming conflicts with official HTTP headers.
+export const SKIP_GLOBAL_ERROR = "x-skip-global-error";

--- a/web/src/services/gql/index.ts
+++ b/web/src/services/gql/index.ts
@@ -2,4 +2,4 @@ export * from "./__gen__/graphql";
 export { default as Provider } from "./provider";
 
 //'x-' prefix as a custom header to prevent naming conflicts with official HTTP headers.
-export const SKIP_GLOBAL_ERROR = "x-skip-global-error";
+export const HEADER_KEY_SKIP_GLOBAL_ERROR_NOTIFICATION = "x-skip-global-error";

--- a/web/src/services/gql/provider/links/errorLink.ts
+++ b/web/src/services/gql/provider/links/errorLink.ts
@@ -3,14 +3,14 @@ import { reportError } from "@reearth/sentry";
 import { useSetError } from "@reearth/services/state";
 import { GQLError } from "@reearth/services/state/gqlErrorHandling";
 
-import { SKIP_GLOBAL_ERROR } from "../..";
+import { HEADER_KEY_SKIP_GLOBAL_ERROR_NOTIFICATION } from "../..";
 
 export default () => {
   const { setErrors } = useSetError();
 
   return onError(({ graphQLErrors, networkError, operation }) => {
     const skipGlobalError =
-      operation.getContext()?.headers?.[SKIP_GLOBAL_ERROR];
+      operation.getContext()?.headers?.[HEADER_KEY_SKIP_GLOBAL_ERROR_NOTIFICATION];
 
     if (!networkError && !graphQLErrors) return;
 

--- a/web/src/services/gql/provider/links/errorLink.ts
+++ b/web/src/services/gql/provider/links/errorLink.ts
@@ -10,7 +10,9 @@ export default () => {
 
   return onError(({ graphQLErrors, networkError, operation }) => {
     const skipGlobalError =
-      operation.getContext()?.headers?.[HEADER_KEY_SKIP_GLOBAL_ERROR_NOTIFICATION];
+      operation.getContext()?.headers?.[
+        HEADER_KEY_SKIP_GLOBAL_ERROR_NOTIFICATION
+      ];
 
     if (!networkError && !graphQLErrors) return;
 
@@ -32,8 +34,7 @@ export default () => {
 
     if (errors.length > 0) {
       reportError(errors);
-      if (skipGlobalError) return;
-      setErrors(errors);
+      if (!skipGlobalError) setErrors(errors);
     }
   });
 };

--- a/web/src/services/gql/provider/links/errorLink.ts
+++ b/web/src/services/gql/provider/links/errorLink.ts
@@ -3,17 +3,16 @@ import { reportError } from "@reearth/sentry";
 import { useSetError } from "@reearth/services/state";
 import { GQLError } from "@reearth/services/state/gqlErrorHandling";
 
+import { SKIP_GLOBAL_ERROR } from "../..";
+
 export default () => {
   const { setErrors } = useSetError();
 
   return onError(({ graphQLErrors, networkError, operation }) => {
-
-  // 'x-' prefix marks this as a custom (non-standard) header to prevent naming conflicts with official HTTP headers.
     const skipGlobalError =
-      operation.getContext()?.headers?.["x-skip-global-error"];
+      operation.getContext()?.headers?.[SKIP_GLOBAL_ERROR];
 
     if (!networkError && !graphQLErrors) return;
-    if (skipGlobalError) return;
 
     let errors: GQLError[] = [];
 
@@ -32,8 +31,9 @@ export default () => {
     }
 
     if (errors.length > 0) {
-      setErrors(errors);
       reportError(errors);
+      if (skipGlobalError) return;
+      setErrors(errors);
     }
   });
 };

--- a/web/src/services/gql/provider/links/errorLink.ts
+++ b/web/src/services/gql/provider/links/errorLink.ts
@@ -6,25 +6,31 @@ import { GQLError } from "@reearth/services/state/gqlErrorHandling";
 export default () => {
   const { setErrors } = useSetError();
 
-  return onError(({ graphQLErrors, networkError }) => {
+  return onError(({ graphQLErrors, networkError, operation }) => {
+
+  // 'x-' prefix marks this as a custom (non-standard) header to prevent naming conflicts with official HTTP headers.
+    const skipGlobalError =
+      operation.getContext()?.headers?.["x-skip-global-error"];
+
     if (!networkError && !graphQLErrors) return;
+    if (skipGlobalError) return;
+
     let errors: GQLError[] = [];
 
     if (networkError?.message) {
       errors = [
-        { message: networkError?.message, description: networkError.message }
+        { message: networkError.message, description: networkError.message }
       ];
     } else {
       errors =
-        graphQLErrors?.map((gqlError) => {
-          return {
-            type: gqlError.path?.[0].toString(),
-            message: gqlError.message,
-            code: gqlError.extensions?.code as string,
-            description: gqlError.extensions?.description as string
-          };
-        }) ?? [];
+        graphQLErrors?.map((gqlError) => ({
+          type: gqlError.path?.[0]?.toString(),
+          message: gqlError.message,
+          code: gqlError.extensions?.code as string,
+          description: gqlError.extensions?.description as string
+        })) ?? [];
     }
+
     if (errors.length > 0) {
       setErrors(errors);
       reportError(errors);


### PR DESCRIPTION
# Overview

The current implementation for displaying error messages is handled through a global state and shown using a global notification, which is generally fine. However, there are cases where the error from an API hook needs to be displayed within the component that consumes the hook. This PR addresses that by allowing the global notification to be hidden when the error is displayed inside the component.

## What I've done

## What I haven't done

## How I tested
current try any mutation/query example of how I tested

```
const useUpdateProjectRemove = useCallback(
  async (input: { projectId: string; deleted: boolean }) => {
    if (!input.projectId) return { status: "error" };

    const { data, errors } = await updateProjectRemoveMutation({
      variables: { ...input },
      errorPolicy: 'all',
      context: {
        headers: {
          "x-skip-global-error": "true" 
        }
      }
    });

    if (errors || !data?.updateProject) {
      console.log("GraphQL: Failed to move project to Recycle bin", errors);
      setNotification({
        type: "error",
        text: input.deleted
          ? t("Failed to move to the Recycle bin.")
          : t("Failed to recover the project!")
      });

      return { status: "error" };
    }

    setNotification({
      type: "success",
      text: input.deleted
        ? t("Successfully moved to Recycle bin!")
        : t("Successfully recovered the project!")
    });

    return { data: data?.updateProject?.project, status: "success" };
  },
  [updateProjectRemoveMutation, setNotification, t]
);

```



## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for skipping global error notifications on specific GraphQL requests using a custom header.

- **Style**
  - Simplified and improved error handling logic for clearer and more maintainable code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->