### PR TITLE
fix(web): fix TS error in vite.config.ts file [VIZ-1559]

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -8,11 +8,10 @@ import { resolve } from "path";
 import yaml from "@rollup/plugin-yaml";
 import react from "@vitejs/plugin-react-swc";
 import { readEnv } from "read-env";
-import { defineConfig, loadEnv, type Plugin } from "vite";
+import { defineConfig, loadEnv, PluginOption, type Plugin } from "vite";
 import cesium from "vite-plugin-cesium";
 import svgr from "vite-plugin-svgr";
 import tsconfigPaths from "vite-tsconfig-paths";
-import { configDefaults } from "vitest/config";
 
 import pkg from "./package.json";
 
@@ -44,7 +43,7 @@ export default defineConfig({
   plugins: [
     svgr(),
     react(),
-    yaml(),
+    yaml() as PluginOption,
     cesium({
       cesiumBaseUrl: cesiumVersion ? `cesium-${cesiumVersion}/` : undefined
     }),
@@ -79,29 +78,6 @@ export default defineConfig({
   resolve: {
     alias: [
       { find: "crypto", replacement: "crypto-js" } // quickjs-emscripten
-    ]
-  },
-  test: {
-    environment: "jsdom",
-    setupFiles: "src/test/setup.ts",
-    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
-    exclude: [...configDefaults.exclude, "e2e/*"],
-    coverage: {
-      provider: "v8",
-      include: ["src/**/*.{ts,tsx}"],
-      exclude: [
-        "src/**/*.d.ts",
-        "src/**/*.cy.tsx",
-        "src/**/*.stories.tsx",
-        "src/beta/services/gql/__gen__/**/*",
-        "src/test/**/*",
-        "src/**/*.test.{ts,tsx}"
-      ],
-      reporter: ["text", "json", "lcov"]
-    },
-    alias: [
-      { find: "crypto", replacement: "crypto" }, // reset setting for quickjs-emscripten
-      { find: "csv-parse", replacement: "csv-parse" }
     ]
   }
 });

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,6 +1,40 @@
-import { defineConfig, mergeConfig } from "vitest/config";
+import yaml from "@rollup/plugin-yaml";
+import { PluginOption } from "vite";
+import svgr from "vite-plugin-svgr";
+import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig, mergeConfig, configDefaults } from "vitest/config";
 
-import viteConfig from "./vite.config.ts";
-
-// This file is required by VSCode's Vitest extension.
-export default mergeConfig(viteConfig, defineConfig({}));
+export default mergeConfig(
+  {
+    plugins: [svgr(), tsconfigPaths(), yaml() as PluginOption],
+    test: {
+      environment: "jsdom",
+      setupFiles: "src/test/setup.ts",
+      include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+      exclude: [...configDefaults.exclude, "e2e/*"],
+      coverage: {
+        provider: "v8",
+        include: ["src/**/*.{ts,tsx}"],
+        exclude: [
+          "src/**/*.d.ts",
+          "src/**/*.cy.tsx",
+          "src/**/*.stories.tsx",
+          "src/beta/services/gql/__gen__/**/*",
+          "src/test/**/*",
+          "src/**/*.test.{ts,tsx}"
+        ],
+        reporter: ["text", "json", "lcov"]
+      },
+      alias: [
+        { find: "crypto", replacement: "crypto" }, // reset setting for quickjs-emscripten
+        { find: "csv-parse", replacement: "csv-parse" },
+        { find: "@reearth/test/utils", replacement: "src/test/utils" },
+        {
+          find: "@reearth/services/theme/reearthTheme/common/spacing",
+          replacement: "src/services/theme/reearthTheme/common/spacing"
+        }
+      ]
+    }
+  },
+  defineConfig({})
+);

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, configDefaults } from "vitest/config";
 
 import viteConfig from "./vite.config";
 
+// This file is required by VSCode's Vitest extension.
 export default mergeConfig(
   viteConfig,
   defineConfig({

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,12 +1,11 @@
-import yaml from "@rollup/plugin-yaml";
-import { PluginOption } from "vite";
-import svgr from "vite-plugin-svgr";
-import tsconfigPaths from "vite-tsconfig-paths";
-import { defineConfig, mergeConfig, configDefaults } from "vitest/config";
+import { mergeConfig } from "vite";
+import { defineConfig, configDefaults } from "vitest/config";
+
+import viteConfig from "./vite.config";
 
 export default mergeConfig(
-  {
-    plugins: [svgr(), tsconfigPaths(), yaml() as PluginOption],
+  viteConfig,
+  defineConfig({
     test: {
       environment: "jsdom",
       setupFiles: "src/test/setup.ts",
@@ -24,17 +23,7 @@ export default mergeConfig(
           "src/**/*.test.{ts,tsx}"
         ],
         reporter: ["text", "json", "lcov"]
-      },
-      alias: [
-        { find: "crypto", replacement: "crypto" }, // reset setting for quickjs-emscripten
-        { find: "csv-parse", replacement: "csv-parse" },
-        { find: "@reearth/test/utils", replacement: "src/test/utils" },
-        {
-          find: "@reearth/services/theme/reearthTheme/common/spacing",
-          replacement: "src/services/theme/reearthTheme/common/spacing"
-        }
-      ]
+      }
     }
-  },
-  defineConfig({})
+  })
 );

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,5 +1,4 @@
-import { mergeConfig } from "vite";
-import { defineConfig, configDefaults } from "vitest/config";
+import { configDefaults, defineConfig, mergeConfig } from "vitest/config";
 
 import viteConfig from "./vite.config";
 


### PR DESCRIPTION
# Overview
- Fixes TypeScript warning regarding rollup plugin, yaml, which had no matching type with that for vite plugins. Solution was to add a cast. 
- Moves test configuration logic to `vitest.config.ts`  
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated test configuration to separate testing setup from the main configuration.
	- Adjusted plugin usage and test environment settings for improved test management.
	- Refined coverage reporting and module aliasing for tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->