### PR TITLE
fix(web): input's action key missing

### DIFF
--- a/web/src/beta/features/Editor/Map/InspectorPanel/LayerInspector/DataSource/ResourceUrl/index.tsx
+++ b/web/src/beta/features/Editor/Map/InspectorPanel/LayerInspector/DataSource/ResourceUrl/index.tsx
@@ -48,6 +48,7 @@ const ResourceUrl: FC<ResourceUrlProp> = ({ value, title, onSubmit }) => {
               icon="copy"
               size="small"
               appearance="simple"
+              key="copy"
               iconColor={theme.content.weak}
               onClick={handleIconClick}
             />


### PR DESCRIPTION
# Overview

## What I've done
- add missing key in IconButton for the TextInput actions

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved stability of the copy button in the resource URL inspector to enhance rendering reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->