### PR TITLE
refactor(web): update alias prefix in public settings for consistency

### DIFF
--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/AliasSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/AliasSettings/index.tsx
@@ -76,7 +76,7 @@ const AliasSetting: FC<AliasSettingProps> = ({
   );
 
   const handleCleanAlias = useCallback(async () => {
-    const alias = isStory ? `s-${settingsItem?.id}` : `p-${settingsItem?.id}`;
+    const alias = isStory ? `s-${settingsItem?.id}` : `c-${settingsItem?.id}`;
 
     const data = isStory
       ? await checkStoryAlias(alias, settingsItem?.id)
@@ -94,7 +94,7 @@ const AliasSetting: FC<AliasSettingProps> = ({
 
   const isDisabled = useMemo(
     () =>
-      settingsItem?.alias === `p-${settingsItem?.id}` ||
+      settingsItem?.alias === `c-${settingsItem?.id}` ||
       settingsItem?.alias === `s-${settingsItem?.id}`,
     [settingsItem?.alias, settingsItem?.id]
   );


### PR DESCRIPTION
# Overview

Change `p-` to `c-` for the default alias of project (scene)

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the prefix for project aliases from "p-" to "c-" in the alias settings interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->