### PR TITLE
fix(server): use scene.id when id is checked in project.Publish

### DIFF
--- a/server/e2e/gql_publish_test.go
+++ b/server/e2e/gql_publish_test.go
@@ -543,7 +543,7 @@ func TestCheckProjectAlias(t *testing.T) {
 			want: want{"test-xxxxxx", true},
 		},
 		{
-			name: "alias equals projectId",
+			name: "alias equals sceneID",
 			args: args{sceneID, projectId},
 			want: want{sceneID, true},
 		},

--- a/server/e2e/gql_publish_test.go
+++ b/server/e2e/gql_publish_test.go
@@ -194,39 +194,6 @@ func TestPublishProjectUniqueAlias(t *testing.T) {
 			tc.expect(res, err)
 		})
 	}
-
-	// // publish projectId2 => 'project-id2'
-	// publishProject(e, uID, map[string]any{
-	// 	"projectId": projectId2,
-	// 	"alias":     "project-id2",
-	// 	"status":    "LIMITED",
-	// })
-	// // publish storyId1 => 'story-id1'
-	// publishStory(e, uID, map[string]any{
-	// 	"storyId": storyId1,
-	// 	"alias":   "story-id1",
-	// 	"status":  "LIMITED",
-	// })
-	// // publish storyId2 => 'story-id2'
-	// publishStory(e, uID, map[string]any{
-	// 	"storyId": storyId2,
-	// 	"alias":   "story-id2",
-	// 	"status":  "LIMITED",
-	// })
-
-	// // used aliases
-	// aliases := []string{"project-id2", "story-id1", "story-id2"}
-
-	// for _, alias := range aliases {
-	// 	t.Run("alias conflict: "+alias, func(t *testing.T) {
-	// 		res, err := publishProjectErrors(e, uID, map[string]any{
-	// 			"projectId": projectId1,
-	// 			"alias":     alias,
-	// 			"status":    "LIMITED",
-	// 		})
-	// 		checkProjectAliasAlreadyExists(res, err)
-	// 	})
-	// }
 }
 
 func checkProjectAliasAlreadyExists(res *httpexpect.Value, err *httpexpect.Value) {
@@ -248,7 +215,7 @@ func checkProjectAliasAlreadyExists(res *httpexpect.Value, err *httpexpect.Value
 func TestReservedReearthPrefixProject(t *testing.T) {
 	e := Server(t, baseSeeder)
 
-	projectId, _, _ := createProjectSet(e)
+	projectId, sceneId, _ := createProjectSet(e)
 
 	// prefix 'c-'
 	res, err := publishProjectErrors(e, uID, map[string]any{
@@ -269,12 +236,12 @@ func TestReservedReearthPrefixProject(t *testing.T) {
 	// prefix + self id
 	res = publishProject(e, uID, map[string]any{
 		"projectId": projectId,
-		"alias":     alias.ReservedReearthPrefixProject + projectId,
+		"alias":     alias.ReservedReearthPrefixProject + sceneId,
 		"status":    "LIMITED",
 	})
 	res.Object().IsEqual(map[string]any{
 		"id":                projectId,
-		"alias":             alias.ReservedReearthPrefixProject + projectId, // ok
+		"alias":             alias.ReservedReearthPrefixProject + sceneId, // ok
 		"publishmentStatus": "LIMITED",
 	})
 
@@ -481,39 +448,6 @@ func TestPublishStoryUniqueAlias(t *testing.T) {
 			tc.expect(res, err)
 		})
 	}
-
-	// // publish projectId1 => 'project-id1'
-	// publishProject(e, uID, map[string]any{
-	// 	"projectId": projectId1,
-	// 	"alias":     "project-id1",
-	// 	"status":    "LIMITED",
-	// })
-	// // publish projectId2 => 'project-id2'
-	// publishProject(e, uID, map[string]any{
-	// 	"projectId": projectId2,
-	// 	"alias":     "project-id2",
-	// 	"status":    "LIMITED",
-	// })
-	// // publish storyId2 => 'story-id2'
-	// publishStory(e, uID, map[string]any{
-	// 	"storyId": storyId2,
-	// 	"alias":   "story-id2",
-	// 	"status":  "LIMITED",
-	// })
-
-	// // used aliases
-	// aliases := []string{"project-id1", "project-id2", "story-id2"}
-
-	// for _, alias := range aliases {
-	// 	t.Run("alias conflict: "+alias, func(t *testing.T) {
-	// 		res, err := publishStoryErrors(e, uID, map[string]any{
-	// 			"storyId": storyId1,
-	// 			"alias":   alias,
-	// 			"status":  "LIMITED",
-	// 		})
-	// 		checkStoryAliasAlreadyExists(res, err)
-	// 	})
-	// }
 }
 
 func checkStoryAliasAlreadyExists(res *httpexpect.Value, err *httpexpect.Value) {
@@ -588,7 +522,7 @@ func checkReservedReearthPrefixStory(alias string, res *httpexpect.Value, err *h
 
 func TestCheckProjectAlias(t *testing.T) {
 	e := Server(t, baseSeeder)
-	projectId, _, _ := createProjectSet(e)
+	projectId, sceneID, _ := createProjectSet(e)
 
 	type args struct {
 		alias     string
@@ -610,13 +544,13 @@ func TestCheckProjectAlias(t *testing.T) {
 		},
 		{
 			name: "alias equals projectId",
-			args: args{projectId, projectId},
-			want: want{projectId, true},
+			args: args{sceneID, projectId},
+			want: want{sceneID, true},
 		},
 		{
 			name: "reserved prefix ok for self project",
-			args: args{alias.ReservedReearthPrefixProject + projectId, projectId},
-			want: want{alias.ReservedReearthPrefixProject + projectId, true},
+			args: args{alias.ReservedReearthPrefixProject + sceneID, projectId},
+			want: want{alias.ReservedReearthPrefixProject + sceneID, true},
 		},
 	}
 

--- a/server/internal/testutil/factory/scene.go
+++ b/server/internal/testutil/factory/scene.go
@@ -1,0 +1,16 @@
+package factory
+
+import (
+	"github.com/reearth/reearth/server/pkg/scene"
+)
+
+type SceneOption func(*scene.Builder)
+
+func NewScene(opts ...SceneOption) *scene.Scene {
+	p := scene.New().
+		NewID()
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p.MustBuild()
+}

--- a/server/internal/usecase/interactor/project_test.go
+++ b/server/internal/usecase/interactor/project_test.go
@@ -12,7 +12,11 @@ import (
 	"github.com/reearth/reearth/server/internal/usecase"
 	"github.com/reearth/reearth/server/internal/usecase/interfaces"
 	"github.com/reearth/reearth/server/pkg/alias"
+	"github.com/reearth/reearth/server/pkg/builtin"
+	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearth/server/pkg/project"
+	"github.com/reearth/reearth/server/pkg/property"
+	"github.com/reearth/reearth/server/pkg/scene"
 	"github.com/reearth/reearth/server/pkg/visualizer"
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
@@ -195,6 +199,25 @@ func TestProject_CheckAlias(t *testing.T) {
 	_ = uc.projectRepo.Save(ctx, pj)
 	pid := pj.ID()
 
+	sid := id.NewSceneID()
+	schema := builtin.GetPropertySchemaByVisualizer(visualizer.VisualizerCesiumBeta)
+	prop, err := property.New().NewID().Schema(schema.ID()).Scene(sid).Build()
+	if err != nil {
+		panic(err)
+	}
+	ps := scene.NewPlugins([]*scene.Plugin{
+		scene.NewPlugin(id.OfficialPluginID, nil),
+	})
+	sc := factory.NewScene(func(p *scene.Builder) {
+		p.ID(sid)
+		p.Project(pid)
+		p.Workspace(pj.Workspace())
+		p.Property(prop.ID())
+		p.Plugins(ps)
+	})
+
+	err = uc.sceneRepo.Save(ctx, sc)
+	assert.NoError(t, err)
 	t.Run("when alias is valid", func(t *testing.T) {
 
 		t.Run("when alias length is valid max length", func(t *testing.T) {

--- a/server/pkg/project/builder.go
+++ b/server/pkg/project/builder.go
@@ -21,9 +21,6 @@ func (b *Builder) Build() (*Project, error) {
 	if b.p.id.IsNil() {
 		return nil, id.ErrInvalidID
 	}
-	// if b.p.alias == "" {
-	// 	b.p.alias = alias.ReservedReearthPrefixProject + b.p.id.String()
-	// }
 	if b.p.updatedAt.IsZero() {
 		b.p.updatedAt = b.p.CreatedAt()
 	}

--- a/server/pkg/scene/scene.go
+++ b/server/pkg/scene/scene.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/reearth/reearth/server/pkg/alias"
 	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearthx/account/accountdomain"
 )
@@ -110,4 +111,8 @@ func (s *Scene) Properties() []id.PropertyID {
 	ids = append(ids, s.plugins.Properties()...)
 	ids = append(ids, s.widgets.Properties()...)
 	return ids
+}
+
+func (s *Scene) DefaultAlias() string {
+	return alias.ReservedReearthPrefixProject + s.ID().String()
 }

--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/AliasSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/AliasSettings/index.tsx
@@ -76,7 +76,7 @@ const AliasSetting: FC<AliasSettingProps> = ({
   );
 
   const handleCleanAlias = useCallback(async () => {
-    const alias = isStory ? `s-${settingsItem?.id}` : `p-${settingsItem?.id}`;
+    const alias = isStory ? `s-${settingsItem?.id}` : `c-${settingsItem?.id}`;
 
     const data = isStory
       ? await checkStoryAlias(alias, settingsItem?.id)
@@ -94,7 +94,7 @@ const AliasSetting: FC<AliasSettingProps> = ({
 
   const isDisabled = useMemo(
     () =>
-      settingsItem?.alias === `p-${settingsItem?.id}` ||
+      settingsItem?.alias === `c-${settingsItem?.id}` ||
       settingsItem?.alias === `s-${settingsItem?.id}`,
     [settingsItem?.alias, settingsItem?.id]
   );


### PR DESCRIPTION
# Overview
https://eukarya-inc.slack.com/archives/CDEF20ZDX/p1747103964148959?thread_ts=1747031540.860849&cid=CDEF20ZDX

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a utility for creating scene objects in tests.
  - Introduced a method to retrieve the default alias for a scene.

- **Bug Fixes**
  - Improved alias validation and assignment to consistently use scene IDs and default aliases instead of project IDs.

- **Tests**
  - Enhanced test setup to include scene creation and association.
  - Cleaned up unused and commented-out test code.

- **Refactor**
  - Removed outdated alias assignment logic tied to project IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->