### PR TITLE
refactor(web): use scene.id when reset alias of published map [VIZ-1601]

### DIFF
--- a/web/src/beta/features/ProjectSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/index.tsx
@@ -167,6 +167,7 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({
           {tab === "public" && project && (
             <PublicSettings
               project={project}
+              sceneId={sceneId}
               isStory={!!subId}
               currentStory={currentStory}
               onUpdateStoryAlias={handleUpdateStoryAlias}

--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/AliasSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/AliasSettings/index.tsx
@@ -27,12 +27,14 @@ import EditPanel from "./EditPanel";
 export type AliasSettingProps = {
   isStory?: boolean;
   alias?: string;
+  sceneId?: string;
   settingsItem?: SettingsProjectWithTypename | StoryWithTypename;
   onUpdateAlias?: (settings: PublicAliasSettingsType) => void;
 };
 
 const AliasSetting: FC<AliasSettingProps> = ({
   isStory,
+  sceneId,
   settingsItem,
   onUpdateAlias
 }) => {
@@ -76,7 +78,12 @@ const AliasSetting: FC<AliasSettingProps> = ({
   );
 
   const handleCleanAlias = useCallback(async () => {
-    const alias = isStory ? `s-${settingsItem?.id}` : `c-${settingsItem?.id}`;
+    if ((isStory && !settingsItem?.id) || (!isStory && !sceneId)) return;
+
+    // Default alias
+    // `c-${scene.id}` for published map (scene)
+    // `s-${story.id}` for published story
+    const alias = isStory ? `s-${settingsItem?.id}` : `c-${sceneId}`;
 
     const data = isStory
       ? await checkStoryAlias(alias, settingsItem?.id)
@@ -89,14 +96,16 @@ const AliasSetting: FC<AliasSettingProps> = ({
     checkStoryAlias,
     handleSubmitAlias,
     isStory,
-    settingsItem?.id
+    settingsItem?.id,
+    sceneId
   ]);
 
   const isDisabled = useMemo(
     () =>
-      settingsItem?.alias === `c-${settingsItem?.id}` ||
+      (!isStory && !sceneId) ||
+      settingsItem?.alias === `c-${sceneId}` ||
       settingsItem?.alias === `s-${settingsItem?.id}`,
-    [settingsItem?.alias, settingsItem?.id]
+    [settingsItem?.alias, settingsItem?.id, sceneId, isStory]
   );
 
   return (

--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
@@ -40,6 +40,7 @@ export type StoryWithTypename = Story & WithTypename;
 
 type Props = {
   settingsItem: (SettingsProject | Story) & WithTypename;
+  sceneId?: string;
   isStory?: boolean;
   onUpdate: (settings: PublicSettingsType) => void;
   onUpdateBasicAuth: (settings: PublicBasicAuthSettingsType) => void;
@@ -56,6 +57,7 @@ type ExtensionComponentProps = (
 
 const PublicSettingsDetail: React.FC<Props> = ({
   settingsItem,
+  sceneId,
   isStory,
   onUpdate,
   onUpdateBasicAuth,
@@ -216,6 +218,7 @@ const PublicSettingsDetail: React.FC<Props> = ({
           <AliasSetting
             isStory={isStory}
             settingsItem={settingsItem}
+            sceneId={sceneId}
             onUpdateAlias={onUpdateAlias}
           />
         ) : (

--- a/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
+++ b/web/src/beta/features/ProjectSettings/innerPages/PublicSettings/index.tsx
@@ -49,6 +49,7 @@ export type SettingsProject = {
 
 type Props = {
   project: SettingsProject;
+  sceneId?: string;
   isStory: boolean;
   currentStory?: Story;
   onUpdateStory: (settings: PublicStorySettingsType) => void;
@@ -61,6 +62,7 @@ type Props = {
 
 const PublicSettings: FC<Props> = ({
   project,
+  sceneId,
   isStory,
   currentStory,
   onUpdateStory,
@@ -89,6 +91,7 @@ const PublicSettings: FC<Props> = ({
           <PublicSettingsDetail
             key="map"
             settingsItem={project}
+            sceneId={sceneId}
             onUpdate={onUpdateProject}
             onUpdateBasicAuth={onUpdateProjectBasicAuth}
             onUpdateAlias={onUpdateProjectAlias}


### PR DESCRIPTION
# Overview

We have changed to use scene.id instead of project.id when generate the default alias of published map (scene).
In most cases the generation is managed on BE, the only place FE need to do that is when reset. 
This PR updated the reset logic to use scene.id for reset, which will be `c-${scene.id}`.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved alias management in project settings to support both story and scene contexts, allowing for more accurate alias handling based on the selected context.

- **Bug Fixes**
  - Enhanced validation and disabling of alias actions to prevent errors when required identifiers are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->