### PR TITLE
chore(web): enable Corepack and set Yarn version in license checker workflow

### DIFF
--- a/.github/workflows/license_checker.yml
+++ b/.github/workflows/license_checker.yml
@@ -61,8 +61,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: yarn
-          cache-dependency-path: '**/yarn.lock'
+      - name: Enable Corepack and set correct Yarn version
+        run: |
+          corepack enable
+          corepack prepare yarn@4.6.0 --activate
       - name: Install
         run: yarn install
       - uses: reearth/actions/license-checker/npm@e445d10332411e14f53e6abc73c966ecb49d3e57


### PR DESCRIPTION
# Overview

Web project's package.json specifies the yarn version to v.4.6.0 while ci uses the global v1.22.22, this PR sets the yarn version for it.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
