### PR TITLE
ci(migration): update gcloud auth to use GC_WORKLOAD_IDENTITY_PROVIDER

### DIFF
--- a/.github/workflows/run_migration.yml
+++ b/.github/workflows/run_migration.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GC_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.GC_WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: Update Migration Job
         run: |


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated authentication secret names used in the migration workflow for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->