### PR TITLE
ci: skip default labels for preview Cloud Run

### DIFF
--- a/.github/workflows/deploy_web_nightly.yml
+++ b/.github/workflows/deploy_web_nightly.yml
@@ -65,6 +65,7 @@ jobs:
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: reearth-visualizer-web
+          skip_default_labels: true
           image: ${{ env.DEPLOY_IMAGE }}
           region: ${{ secrets.GC_REGION }}
           tag: pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
# Overview

Because we don't use `labels` and it'll conflict with our in-house platform.

Ref: [user-content-skip_default_labels, google-github-actions/deploy-cloudrun: A GitHub Action for deploying services to Google Cloud Run.](https://github.com/google-github-actions/deploy-cloudrun#user-content-skip_default_labels)

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

We always skip it: https://github.com/reearth/actions/blob/ecb4231198dc0992c3f69c333ee9748ec50ee8a4/deploy-cloud-run/action.yml#L109


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment process for pull request previews to adjust label handling during Cloud Run deployments. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->