### PR TITLE
ci(web): skip default labels for deploy-cloudrun

### DIFF
--- a/.github/workflows/deploy_web_nightly.yml
+++ b/.github/workflows/deploy_web_nightly.yml
@@ -56,6 +56,7 @@ jobs:
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: reearth-visualizer-web
+          skip_default_labels: true
           image: ${{ secrets.WEB_IMAGE_GC }}
           region: ${{ secrets.GC_REGION }}
           revision_traffic: 'LATEST=100'


### PR DESCRIPTION
# Overview
Because we don't use labels and it'll conflict with our in-house platform.

Ref: [user-content-skip_default_labels, google-github-actions/deploy-cloudrun: A GitHub Action for deploying services to Google Cloud Run.](https://github.com/google-github-actions/deploy-cloudrun#user-content-skip_default_labels)


## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
