### PR TITLE
ci: cleanup pr-revision tags on PR closure

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,5 +18,6 @@ reviews:
     - '!**/*.md'
     - '!**/*.txt'
     - '!**/*.lock'
+    - '!**/*.conf'
 chat:
   auto_reply: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,3 +139,11 @@ jobs:
     with:
       url: ${{ needs.deploy-web-pr.outputs.preview_url }}
     secrets: inherit
+
+  cleanup-web-pr-revision:
+    if: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' && github.event.action == 'closed' }}
+    uses: ./.github/workflows/cleanup_feature_revision.yml
+    with:
+      service: reearth-visualizer-web
+      tag: pr-${{ github.event.pull_request.number }}
+    secrets: inherit

--- a/.github/workflows/cleanup_feature_revision.yml
+++ b/.github/workflows/cleanup_feature_revision.yml
@@ -43,4 +43,4 @@ jobs:
       run: |
         gcloud run services update-traffic ${{ inputs.service }} \
           --region ${{ secrets.GC_REGION }} \
-          --remove-tags=${{ inputs.tag }}
+          --remove-tags=${{ inputs.tag }} || echo "Warning: Failed to remove tag ${{ inputs.tag }} - it may not exist"

--- a/.github/workflows/cleanup_feature_revision.yml
+++ b/.github/workflows/cleanup_feature_revision.yml
@@ -1,0 +1,46 @@
+name: Remove PR Cloud Run Revision Tags
+
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        description: 'Service name to remove revision tags.'
+        type: string
+        required: true
+      tag:
+        description: 'Revision tag to remove.'
+        type: string
+        required: true
+  workflow_call:
+    inputs:
+      service:
+        description: 'Service name to remove revision tags.'
+        type: string
+        required: true
+      tag:
+        description: 'Revision tag to remove.'
+        type: string
+        required: true
+
+jobs:
+  remove-revision-tags:
+    runs-on: ubuntu-latest
+    if: github.event.repository.full_name == 'reearth/reearth-visualizer'
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        service_account: ${{ secrets.GC_SA_EMAIL }}
+        workload_identity_provider: ${{ secrets.GC_WORKLOAD_IDENTITY_PROVIDER }}
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
+
+    - name: Remove revision tags
+      run: |
+        gcloud run services update-traffic ${{ inputs.service }} \
+          --region ${{ secrets.GC_REGION }} \
+          --remove-tags=${{ inputs.tag }}

--- a/.github/workflows/deploy_web_nightly.yml
+++ b/.github/workflows/deploy_web_nightly.yml
@@ -65,6 +65,7 @@ jobs:
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: reearth-visualizer-web
+          skip_default_labels: true
           image: ${{ env.DEPLOY_IMAGE }}
           region: ${{ secrets.GC_REGION }}
           tag: pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/deploy_web_nightly.yml
+++ b/.github/workflows/deploy_web_nightly.yml
@@ -53,12 +53,12 @@ jobs:
           docker push ${{ env.DEPLOY_IMAGE }}
       - name: Deploy to Cloud Run
         if: ${{ github.event_name == 'push' && (github.ref_name == 'release' || !startsWith(github.event.head_commit.message, 'v')) }}
-        run: |
-          gcloud run deploy reearth-visualizer-web \
-            --image ${{ secrets.WEB_IMAGE_GC }} \
-            --region ${{ secrets.GC_REGION }} \
-            --platform managed \
-            --quiet
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: reearth-visualizer-web
+          image: ${{ secrets.WEB_IMAGE_GC }}
+          region: ${{ secrets.GC_REGION }}
+          revision_traffic: 'LATEST=100'
       - name: Deploy to Cloud Run (PR)
         id: deploy-pr
         if: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' && (github.event.action == 'opened' || github.event.action == 'synchronize') }}


### PR DESCRIPTION
# Overview

- Cleanup PR services when the pull-request has been merged

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Added automated cleanup for web pull request revisions when a PR is closed, ensuring that outdated Cloud Run revision tags are removed. This helps maintain a cleaner deployment environment.
	- Updated auto-review configuration to exclude `.conf` files from the review process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->