### PR TITLE
chore(server): test internal api call [VIZ-1604]

### DIFF
--- a/server/internal/app/server.go
+++ b/server/internal/app/server.go
@@ -101,7 +101,7 @@ func (w *WebServer) Run(ctx context.Context) {
 			err := w.appServer.StartH2CServer(w.address, &http2.Server{})
 			log.Fatalc(ctx, err.Error())
 		}()
-		log.Infof("server: started%s at http://%s", debugLog, w.address)
+		log.Infof("server: started%s echo server at http://%s", debugLog, w.address)
 	}
 
 	quit := make(chan os.Signal, 1)

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/url"
 	"path"
 	"strings"
@@ -15,6 +16,8 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/reearth/reearth/server/internal/adapter"
 	jsonmodel "github.com/reearth/reearth/server/internal/adapter/gql/gqlmodel"
+	"github.com/reearth/reearth/server/internal/adapter/internalapi"
+	pb "github.com/reearth/reearth/server/internal/adapter/internalapi/schemas/internalapi/v1"
 	"github.com/reearth/reearth/server/internal/usecase"
 	"github.com/reearth/reearth/server/internal/usecase/gateway"
 	"github.com/reearth/reearth/server/internal/usecase/interfaces"
@@ -140,6 +143,25 @@ func (i *Project) Update(ctx context.Context, p interfaces.UpdateProjectParam, o
 
 	if p.Name != nil {
 		prj.UpdateName(*p.Name)
+
+		// ------- InvokeApi Test
+		err := internalapi.InvokeApi(
+			ctx,
+			operator.AcOperator.User.String(),
+			"reearth-visualizer-internal-ajr67subya-an.a.run.app",
+			func(client pb.ReEarthVisualizerClient, ctx context.Context) error {
+				res, err := client.GetProject(ctx, &pb.GetProjectRequest{
+					ProjectId: prj.ID().String(),
+				})
+				if err != nil {
+					log.Printf("!!! gRPC GetProject Error : %v", err)
+					return err
+				}
+				log.Printf("OK!! gRPC GetProject : %v", res)
+				return err
+			},
+		)
+		log.Printf("!!! internalapi.InvokeApi Error : %v", err)
 
 	}
 


### PR DESCRIPTION
# Overview

### This is a check to ensure the internal API is being called correctly.

### When the project name is updated, the internal API will call GetProjectRequest.

### This code will be reverted later.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved server startup log messages to clearly indicate when the Echo server has started.
  - Enhanced project update process to trigger an internal API call and log results whenever a project name is updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->