### PR TITLE
ci: update go version gh action

### DIFF
--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -11,6 +11,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+      - name: Fetch base branch
+        run: git fetch origin main
       - name: set up
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
@@ -20,7 +25,7 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.1
-          args: --new-from-rev=HEAD --timeout=10m
+          args: --new-from-rev=origin/main --timeout=10m
           working-directory: server
       - name: Run go generate
         run: |

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -19,7 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: v1.63.4
           args: --timeout=10m
           working-directory: server
       - name: Run go generate

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -2,7 +2,7 @@ name: ci-server
 on:
   workflow_call:
 env:
-  GO_VERSION: "1.23.5"
+  GO_VERSION: "1.24"
 
 jobs:
   ci-server-lint:
@@ -17,9 +17,8 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@latest
         with:
-          version: v1.63.4
           args: --timeout=10m
           working-directory: server
       - name: Run go generate

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -17,7 +17,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@latest
+        uses: golangci/golangci-lint-action@v8
         with:
           args: --timeout=10m
           working-directory: server

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -20,7 +20,7 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.1
-          args: --timeout=10m
+          args: --new-from-rev=HEAD --timeout=10m
           working-directory: server
       - name: Run go generate
         run: |

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -19,7 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.63.4
+          version: v2.1
           args: --timeout=10m
           working-directory: server
       - name: Run go generate

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -19,6 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
+          version: v2.1
           args: --timeout=10m
           working-directory: server
       - name: Run go generate

--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -1,5 +1,4 @@
-version: "2.1"
-
+version: "2"
 linters:
   exclusions:
     presets:
@@ -8,7 +7,7 @@ linters:
       - legacy
       - std-error-handling
   settings:
-    goci: 'github.com/reearth/server'
+    gci: 'github.com/reearth/server'
 
 formatters:
   enable:

--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -1,11 +1,16 @@
-issues:
-  exclude-use-default: false
+version: "2.1"
 
 linters:
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+  settings:
+    goci: 'github.com/reearth/server'
+
+formatters:
   enable:
     - gofmt
     - goimports
-
-linters-settings:
-  goimports:
-    local-prefixes: github.com/reearth/server

--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -11,3 +11,7 @@ formatters:
   enable:
     - gofmt
     - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/reearth/server

--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -6,8 +6,6 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
-  settings:
-    gci: 'github.com/reearth/server'
 
 formatters:
   enable:


### PR DESCRIPTION
# Overview
This pull request updates the CI server workflow configuration to use the latest versions of Go and GolangCI-Lint, ensuring compatibility and access to the latest features and fixes.

Updates to CI server workflow:

* [`.github/workflows/ci_server.yml`](diffhunk://#diff-ab942a41ff0ff188166669aeaf44c1e61593934d3b4f69c6e1e839329c6c3eb7L5-R5): Updated `GO_VERSION` from `1.23.5` to `1.24` to use the latest version of Go.
* [`.github/workflows/ci_server.yml`](diffhunk://#diff-ab942a41ff0ff188166669aeaf44c1e61593934d3b4f69c6e1e839329c6c3eb7L20-L22): Changed the GolangCI-Lint action reference from a specific commit (`55c2c1448f86e01eaae002a5a3a9624417608d84`) to `@latest`, allowing automatic use of the latest version. Removed the explicit `version` parameter (`v1.63.4`).
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Go version and golangci-lint GitHub Action used in the CI workflow for improved compatibility and maintenance.
  - Refined linting configuration to align with the latest standards and added presets for issue exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->