### PR TITLE
feat(server): add topics for metadata [VIZ-1758]

### DIFF
--- a/server/e2e/gql_project_metadata_test.go
+++ b/server/e2e/gql_project_metadata_test.go
@@ -16,6 +16,7 @@ mutation UpdateProjectMetadata($input: UpdateProjectMetadataInput!) {
       workspace
       readme
       license
+	  topics
       importStatus
       createdAt
       updatedAt
@@ -58,6 +59,7 @@ func TestCreateAndGetProjectMetadata(t *testing.T) {
 			"project": projectID,
 			"readme":  "readme test",
 			"license": "license test",
+			"topics":  "topics test",
 		},
 	})
 
@@ -82,5 +84,5 @@ func TestCreateAndGetProjectMetadata(t *testing.T) {
 
 	res.Value("readme").String().IsEqual("readme test")
 	res.Value("license").String().IsEqual("license test")
-
+	res.Value("topics").String().IsEqual("topics test")
 }

--- a/server/e2e/gql_project_test.go
+++ b/server/e2e/gql_project_test.go
@@ -56,6 +56,7 @@ fragment ProjectMetadataFragment on ProjectMetadata {
   workspace
   readme
   license
+  topics
   importStatus
   createdAt
   updatedAt

--- a/server/e2e/proto_project_metadata_test.go
+++ b/server/e2e/proto_project_metadata_test.go
@@ -39,10 +39,12 @@ func TestInternalAPI_metadata_update(t *testing.T) {
 				ProjectId: projectID.String(),
 				Readme:    lo.ToPtr("test readme"),
 				License:   lo.ToPtr("test license"),
+				Topics:    lo.ToPtr("test topics"),
 			},
 		)
 		assert.Equal(t, "test readme", *res.Readme)
 		assert.Equal(t, "test license", *res.License)
+		assert.Equal(t, "test topics", *res.Topics)
 	})
 }
 

--- a/server/gql/project.graphql
+++ b/server/gql/project.graphql
@@ -38,6 +38,7 @@ type ProjectMetadata {
   workspace: ID!
   readme: String
   license: String
+  topics: String
   importStatus: ProjectImportStatus
   createdAt: DateTime
   updatedAt: DateTime
@@ -106,6 +107,7 @@ input UpdateProjectMetadataInput {
   project: ID!
   readme: String
   license: String
+  topics: String
 }
 
 input PublishProjectInput {

--- a/server/internal/adapter/gql/generated.go
+++ b/server/internal/adapter/gql/generated.go
@@ -581,6 +581,7 @@ type ComplexityRoot struct {
 		License      func(childComplexity int) int
 		Project      func(childComplexity int) int
 		Readme       func(childComplexity int) int
+		Topics       func(childComplexity int) int
 		UpdatedAt    func(childComplexity int) int
 		Workspace    func(childComplexity int) int
 	}
@@ -4015,6 +4016,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.ProjectMetadata.Readme(childComplexity), true
 
+	case "ProjectMetadata.topics":
+		if e.complexity.ProjectMetadata.Topics == nil {
+			break
+		}
+
+		return e.complexity.ProjectMetadata.Topics(childComplexity), true
+
 	case "ProjectMetadata.updatedAt":
 		if e.complexity.ProjectMetadata.UpdatedAt == nil {
 			break
@@ -6893,6 +6901,7 @@ type ProjectMetadata {
   workspace: ID!
   readme: String
   license: String
+  topics: String
   importStatus: ProjectImportStatus
   createdAt: DateTime
   updatedAt: DateTime
@@ -6961,6 +6970,7 @@ input UpdateProjectMetadataInput {
   project: ID!
   readme: String
   license: String
+  topics: String
 }
 
 input PublishProjectInput {
@@ -27286,6 +27296,8 @@ func (ec *executionContext) fieldContext_Project_metadata(_ context.Context, fie
 				return ec.fieldContext_ProjectMetadata_readme(ctx, field)
 			case "license":
 				return ec.fieldContext_ProjectMetadata_license(ctx, field)
+			case "topics":
+				return ec.fieldContext_ProjectMetadata_topics(ctx, field)
 			case "importStatus":
 				return ec.fieldContext_ProjectMetadata_importStatus(ctx, field)
 			case "createdAt":
@@ -28519,6 +28531,47 @@ func (ec *executionContext) fieldContext_ProjectMetadata_license(_ context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _ProjectMetadata_topics(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.ProjectMetadata) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ProjectMetadata_topics(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Topics, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ProjectMetadata_topics(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProjectMetadata",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ProjectMetadata_importStatus(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.ProjectMetadata) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ProjectMetadata_importStatus(ctx, field)
 	if err != nil {
@@ -28691,6 +28744,8 @@ func (ec *executionContext) fieldContext_ProjectMetadataPayload_metadata(_ conte
 				return ec.fieldContext_ProjectMetadata_readme(ctx, field)
 			case "license":
 				return ec.fieldContext_ProjectMetadata_license(ctx, field)
+			case "topics":
+				return ec.fieldContext_ProjectMetadata_topics(ctx, field)
 			case "importStatus":
 				return ec.fieldContext_ProjectMetadata_importStatus(ctx, field)
 			case "createdAt":
@@ -47228,7 +47283,7 @@ func (ec *executionContext) unmarshalInputUpdateProjectMetadataInput(ctx context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"project", "readme", "license"}
+	fieldsInOrder := [...]string{"project", "readme", "license", "topics"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -47256,6 +47311,13 @@ func (ec *executionContext) unmarshalInputUpdateProjectMetadataInput(ctx context
 				return it, err
 			}
 			it.License = data
+		case "topics":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("topics"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Topics = data
 		}
 	}
 
@@ -52636,6 +52698,8 @@ func (ec *executionContext) _ProjectMetadata(ctx context.Context, sel ast.Select
 			out.Values[i] = ec._ProjectMetadata_readme(ctx, field, obj)
 		case "license":
 			out.Values[i] = ec._ProjectMetadata_license(ctx, field, obj)
+		case "topics":
+			out.Values[i] = ec._ProjectMetadata_topics(ctx, field, obj)
 		case "importStatus":
 			out.Values[i] = ec._ProjectMetadata_importStatus(ctx, field, obj)
 		case "createdAt":

--- a/server/internal/adapter/gql/gqlmodel/convert_project.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_project.go
@@ -68,6 +68,7 @@ func ToProjectMetadata(pm *project.ProjectMetadata) *ProjectMetadata {
 		Project:      IDFrom(pm.Project()),
 		Readme:       pm.Readme(),
 		License:      pm.License(),
+		Topics:       pm.Topics(),
 		ImportStatus: &importStatus,
 		CreatedAt:    pm.CreatedAt(),
 		UpdatedAt:    pm.UpdatedAt(),

--- a/server/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/server/internal/adapter/gql/gqlmodel/models_gen.go
@@ -728,6 +728,7 @@ type ProjectMetadata struct {
 	Workspace    ID                   `json:"workspace"`
 	Readme       *string              `json:"readme,omitempty"`
 	License      *string              `json:"license,omitempty"`
+	Topics       *string              `json:"topics,omitempty"`
 	ImportStatus *ProjectImportStatus `json:"importStatus,omitempty"`
 	CreatedAt    *time.Time           `json:"createdAt,omitempty"`
 	UpdatedAt    *time.Time           `json:"updatedAt,omitempty"`
@@ -1285,6 +1286,7 @@ type UpdateProjectMetadataInput struct {
 	Project ID      `json:"project"`
 	Readme  *string `json:"readme,omitempty"`
 	License *string `json:"license,omitempty"`
+	Topics  *string `json:"topics,omitempty"`
 }
 
 type UpdatePropertyItemInput struct {

--- a/server/internal/adapter/gql/resolver_mutation_project.go
+++ b/server/internal/adapter/gql/resolver_mutation_project.go
@@ -99,6 +99,7 @@ func (r *mutationResolver) UpdateProjectMetadata(ctx context.Context, input gqlm
 		ID:      pid,
 		Readme:  input.Readme,
 		License: input.License,
+		Topics:  input.Topics,
 	}, getOperator(ctx))
 	if err != nil {
 		return nil, err

--- a/server/internal/adapter/internalapi/internalapimodel/project.go
+++ b/server/internal/adapter/internalapi/internalapimodel/project.go
@@ -80,6 +80,7 @@ func ToProjectMetadata(p *project.ProjectMetadata) *pb.ProjectMetadata {
 		WorkspaceId:  p.Workspace().String(),
 		Readme:       p.Readme(),
 		License:      p.License(),
+		Topics:       p.Topics(),
 		ImportStatus: importStatus,
 		CreatedAt:    createdAt,
 		UpdatedAt:    updatedAt,

--- a/server/internal/adapter/internalapi/schemas/internalapi/v1/schema.pb.go
+++ b/server/internal/adapter/internalapi/schemas/internalapi/v1/schema.pb.go
@@ -470,12 +470,14 @@ type ProjectMetadata struct {
 	Readme *string `protobuf:"bytes,4,opt,name=readme,proto3,oneof" json:"readme,omitempty"`
 	// Project license
 	License *string `protobuf:"bytes,5,opt,name=license,proto3,oneof" json:"license,omitempty"`
+	// Project topics
+	Topics *string `protobuf:"bytes,6,opt,name=topics,proto3,oneof" json:"topics,omitempty"`
 	// Project import status — if PROCESSING, data should not be retrieved
-	ImportStatus ProjectImportStatus `protobuf:"varint,6,opt,name=import_status,json=importStatus,proto3,enum=reearth.visualizer.v1.ProjectImportStatus" json:"import_status,omitempty"`
+	ImportStatus ProjectImportStatus `protobuf:"varint,7,opt,name=import_status,json=importStatus,proto3,enum=reearth.visualizer.v1.ProjectImportStatus" json:"import_status,omitempty"`
 	// ProjectMetadata created date
-	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	// ProjectMetadata updated date
-	UpdatedAt     *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	UpdatedAt     *timestamppb.Timestamp `protobuf:"bytes,9,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -541,6 +543,13 @@ func (x *ProjectMetadata) GetReadme() string {
 func (x *ProjectMetadata) GetLicense() string {
 	if x != nil && x.License != nil {
 		return *x.License
+	}
+	return ""
+}
+
+func (x *ProjectMetadata) GetTopics() string {
+	if x != nil && x.Topics != nil {
+		return *x.Topics
 	}
 	return ""
 }
@@ -969,9 +978,11 @@ type UpdateProjectMetadataRequest struct {
 	// Project ID
 	ProjectId string `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
 	// Project readme
-	Readme *string `protobuf:"bytes,4,opt,name=readme,proto3,oneof" json:"readme,omitempty"`
+	Readme *string `protobuf:"bytes,2,opt,name=readme,proto3,oneof" json:"readme,omitempty"`
 	// Project license
-	License       *string `protobuf:"bytes,5,opt,name=license,proto3,oneof" json:"license,omitempty"`
+	License *string `protobuf:"bytes,3,opt,name=license,proto3,oneof" json:"license,omitempty"`
+	// Project topics
+	Topics        *string `protobuf:"bytes,4,opt,name=topics,proto3,oneof" json:"topics,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1023,6 +1034,13 @@ func (x *UpdateProjectMetadataRequest) GetReadme() string {
 func (x *UpdateProjectMetadataRequest) GetLicense() string {
 	if x != nil && x.License != nil {
 		return *x.License
+	}
+	return ""
+}
+
+func (x *UpdateProjectMetadataRequest) GetTopics() string {
+	if x != nil && x.Topics != nil {
+		return *x.Topics
 	}
 	return ""
 }
@@ -1397,22 +1415,24 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\n" +
 	"_image_urlB\v\n" +
 	"\t_metadataB\x0f\n" +
-	"\r_published_at\"\xfd\x02\n" +
+	"\r_published_at\"\xa5\x03\n" +
 	"\x0fProjectMetadata\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x02 \x01(\tR\tprojectId\x12!\n" +
 	"\fworkspace_id\x18\x03 \x01(\tR\vworkspaceId\x12\x1b\n" +
 	"\x06readme\x18\x04 \x01(\tH\x00R\x06readme\x88\x01\x01\x12\x1d\n" +
-	"\alicense\x18\x05 \x01(\tH\x01R\alicense\x88\x01\x01\x12O\n" +
-	"\rimport_status\x18\x06 \x01(\x0e2*.reearth.visualizer.v1.ProjectImportStatusR\fimportStatus\x129\n" +
+	"\alicense\x18\x05 \x01(\tH\x01R\alicense\x88\x01\x01\x12\x1b\n" +
+	"\x06topics\x18\x06 \x01(\tH\x02R\x06topics\x88\x01\x01\x12O\n" +
+	"\rimport_status\x18\a \x01(\x0e2*.reearth.visualizer.v1.ProjectImportStatusR\fimportStatus\x129\n" +
 	"\n" +
-	"created_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
+	"created_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
 	"\n" +
-	"updated_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAtB\t\n" +
+	"updated_at\x18\t \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAtB\t\n" +
 	"\a_readmeB\n" +
 	"\n" +
-	"\b_license\"`\n" +
+	"\b_licenseB\t\n" +
+	"\a_topics\"`\n" +
 	"\x15GetProjectListRequest\x12!\n" +
 	"\fworkspace_id\x18\x01 \x01(\tR\vworkspaceId\x12$\n" +
 	"\rauthenticated\x18\x02 \x01(\bR\rauthenticated\"2\n" +
@@ -1483,15 +1503,17 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\x14_basic_auth_passwordB\f\n" +
 	"\n" +
 	"_enable_gaB\x0e\n" +
-	"\f_tracking_id\"\x90\x01\n" +
+	"\f_tracking_id\"\xb8\x01\n" +
 	"\x1cUpdateProjectMetadataRequest\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x1b\n" +
-	"\x06readme\x18\x04 \x01(\tH\x00R\x06readme\x88\x01\x01\x12\x1d\n" +
-	"\alicense\x18\x05 \x01(\tH\x01R\alicense\x88\x01\x01B\t\n" +
+	"\x06readme\x18\x02 \x01(\tH\x00R\x06readme\x88\x01\x01\x12\x1d\n" +
+	"\alicense\x18\x03 \x01(\tH\x01R\alicense\x88\x01\x01\x12\x1b\n" +
+	"\x06topics\x18\x04 \x01(\tH\x02R\x06topics\x88\x01\x01B\t\n" +
 	"\a_readmeB\n" +
 	"\n" +
-	"\b_license\"5\n" +
+	"\b_licenseB\t\n" +
+	"\a_topics\"5\n" +
 	"\x14DeleteProjectRequest\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\"N\n" +

--- a/server/internal/adapter/internalapi/server.go
+++ b/server/internal/adapter/internalapi/server.go
@@ -139,6 +139,7 @@ func (s server) UpdateProjectMetadata(ctx context.Context, req *pb.UpdateProject
 		ID:      pid,
 		Readme:  req.Readme,
 		License: req.License,
+		Topics:  req.Topics,
 	}, op)
 	if err != nil {
 		return nil, err

--- a/server/internal/infrastructure/mongo/mongodoc/project_metadata.go
+++ b/server/internal/infrastructure/mongo/mongodoc/project_metadata.go
@@ -16,6 +16,7 @@ type ProjectMetadataDocument struct {
 	ImportStatus *string
 	Readme       *string
 	License      *string
+	Topics       *string
 	CreatedAt    *time.Time
 	UpdatedAt    *time.Time
 }
@@ -44,6 +45,7 @@ func NewProjectMetadata(r *project.ProjectMetadata) (*ProjectMetadataDocument, s
 		ImportStatus: importStatus,
 		Readme:       r.Readme(),
 		License:      r.License(),
+		Topics:       r.Topics(),
 		CreatedAt:    r.CreatedAt(),
 		UpdatedAt:    r.UpdatedAt(),
 	}, rid
@@ -79,6 +81,7 @@ func (d *ProjectMetadataDocument) Model() (*project.ProjectMetadata, error) {
 		ImportStatus(importStatus).
 		Readme(d.Readme).
 		License(d.License).
+		Topics(d.Topics).
 		UpdatedAt(d.UpdatedAt).
 		CreatedAt(d.CreatedAt).
 		Build()

--- a/server/internal/usecase/interactor/project_metadata.go
+++ b/server/internal/usecase/interactor/project_metadata.go
@@ -64,6 +64,10 @@ func (i *ProjectMetadata) Update(ctx context.Context, p interfaces.UpdateProject
 		meta.SetLicense(p.License)
 	}
 
+	if p.Topics != nil {
+		meta.SetTopics(p.Topics)
+	}
+
 	currentTime := time.Now().UTC()
 	meta.SetUpdatedAt(&currentTime)
 	if err := i.projectMetadataRepo.Save(ctx, meta); err != nil {

--- a/server/internal/usecase/interfaces/project.go
+++ b/server/internal/usecase/interfaces/project.go
@@ -58,6 +58,7 @@ type UpdateProjectMetadataParam struct {
 	ID      id.ProjectID
 	Readme  *string
 	License *string
+	Topics  *string
 }
 
 type PublishProjectParam struct {

--- a/server/pkg/project/builder_metadata.go
+++ b/server/pkg/project/builder_metadata.go
@@ -56,18 +56,23 @@ func (b *MetadataBuilder) Project(project id.ProjectID) *MetadataBuilder {
 	return b
 }
 
-func (b *MetadataBuilder) Readme(readme *string) *MetadataBuilder {
-	b.r.readme = readme
-	return b
-}
-
 func (b *MetadataBuilder) ImportStatus(importStatus *ProjectImportStatus) *MetadataBuilder {
 	b.r.importStatus = importStatus
 	return b
 }
 
+func (b *MetadataBuilder) Readme(readme *string) *MetadataBuilder {
+	b.r.readme = readme
+	return b
+}
+
 func (b *MetadataBuilder) License(license *string) *MetadataBuilder {
 	b.r.license = license
+	return b
+}
+
+func (b *MetadataBuilder) Topics(topics *string) *MetadataBuilder {
+	b.r.topics = topics
 	return b
 }
 

--- a/server/pkg/project/project_metadata.go
+++ b/server/pkg/project/project_metadata.go
@@ -21,6 +21,7 @@ type ProjectMetadata struct {
 	importStatus *ProjectImportStatus
 	readme       *string
 	license      *string
+	topics       *string
 	createdAt    *time.Time
 	updatedAt    *time.Time
 }
@@ -50,6 +51,10 @@ func (r *ProjectMetadata) ImportStatus() *ProjectImportStatus {
 
 func (r *ProjectMetadata) License() *string {
 	return r.license
+}
+
+func (r *ProjectMetadata) Topics() *string {
+	return r.topics
 }
 
 func (r *ProjectMetadata) CreatedAt() *time.Time {
@@ -87,6 +92,13 @@ func (r *ProjectMetadata) SetLicense(license *string) {
 		return
 	}
 	r.license = license
+}
+
+func (r *ProjectMetadata) SetTopics(topics *string) {
+	if r == nil {
+		return
+	}
+	r.topics = topics
 }
 
 func (r *ProjectMetadata) SetCreatedAt(createdAt *time.Time) {

--- a/server/schemas/internalapi/docs/schema.md
+++ b/server/schemas/internalapi/docs/schema.md
@@ -16,8 +16,8 @@
     - [ProjectMetadata](#reearth-visualizer-v1-ProjectMetadata)
     - [UpdateProjectMetadataRequest](#reearth-visualizer-v1-UpdateProjectMetadataRequest)
     - [UpdateProjectMetadataResponse](#reearth-visualizer-v1-UpdateProjectMetadataResponse)
-    - [UpdateProjectVisibilityRequest](#reearth-visualizer-v1-UpdateProjectVisibilityRequest)
-    - [UpdateProjectVisibilityResponse](#reearth-visualizer-v1-UpdateProjectVisibilityResponse)
+    - [UpdateProjectRequest](#reearth-visualizer-v1-UpdateProjectRequest)
+    - [UpdateProjectResponse](#reearth-visualizer-v1-UpdateProjectResponse)
   
     - [ProjectImportStatus](#reearth-visualizer-v1-ProjectImportStatus)
     - [PublishmentStatus](#reearth-visualizer-v1-PublishmentStatus)
@@ -221,6 +221,7 @@ Core Project messages
 | workspace_id | [string](#string) |  | Workspace id |
 | readme | [string](#string) | optional | Project readme |
 | license | [string](#string) | optional | Project license |
+| topics | [string](#string) | optional | Project topics |
 | import_status | [ProjectImportStatus](#reearth-visualizer-v1-ProjectImportStatus) |  | Project import status — if PROCESSING, data should not be retrieved |
 | created_at | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | ProjectMetadata created date |
 | updated_at | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | ProjectMetadata updated date |
@@ -242,6 +243,7 @@ Cannot be updated under a team the user does not belong to.
 | project_id | [string](#string) |  | Project ID |
 | readme | [string](#string) | optional | Project readme |
 | license | [string](#string) | optional | Project license |
+| topics | [string](#string) | optional | Project topics |
 
 
 
@@ -263,26 +265,44 @@ Response messages
 
 
 
-<a name="reearth-visualizer-v1-UpdateProjectVisibilityRequest"></a>
+<a name="reearth-visualizer-v1-UpdateProjectRequest"></a>
 
-### UpdateProjectVisibilityRequest
-Update project visibility.
+### UpdateProjectRequest
+Update project fields.
 Only the project owner can operate this
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| project_id | [string](#string) |  | Project ID |
-| visibility | [string](#string) | optional | Visibility of the project (e.g., &#34;public&#34;, &#34;private&#34;) |
+| project_id | [string](#string) |  | Project ID (required) |
+| name | [string](#string) | optional | Project basic info (optional) |
+| description | [string](#string) | optional |  |
+| archived | [bool](#bool) | optional |  |
+| image_url | [string](#string) | optional |  |
+| delete_image_url | [bool](#bool) | optional |  |
+| scene_id | [string](#string) | optional |  |
+| starred | [bool](#bool) | optional |  |
+| deleted | [bool](#bool) | optional |  |
+| visibility | [string](#string) | optional |  |
+| public_title | [string](#string) | optional | Publishment settings (optional) |
+| public_description | [string](#string) | optional |  |
+| public_image | [string](#string) | optional |  |
+| public_no_index | [bool](#bool) | optional |  |
+| delete_public_image | [bool](#bool) | optional |  |
+| is_basic_auth_active | [bool](#bool) | optional |  |
+| basic_auth_username | [string](#string) | optional |  |
+| basic_auth_password | [string](#string) | optional |  |
+| enable_ga | [bool](#bool) | optional |  |
+| tracking_id | [string](#string) | optional |  |
 
 
 
 
 
 
-<a name="reearth-visualizer-v1-UpdateProjectVisibilityResponse"></a>
+<a name="reearth-visualizer-v1-UpdateProjectResponse"></a>
 
-### UpdateProjectVisibilityResponse
+### UpdateProjectResponse
 Response messages
 
 
@@ -352,8 +372,8 @@ Response messages
 | GetProjectList | [GetProjectListRequest](#reearth-visualizer-v1-GetProjectListRequest) | [GetProjectListResponse](#reearth-visualizer-v1-GetProjectListResponse) | Retrieves the list of projects the user can access. Request headers: user-id: &lt;User ID&gt; |
 | GetProject | [GetProjectRequest](#reearth-visualizer-v1-GetProjectRequest) | [GetProjectResponse](#reearth-visualizer-v1-GetProjectResponse) | Retrieves a specific project regardless of authentication. Request headers: user-id: &lt;User ID&gt; |
 | CreateProject | [CreateProjectRequest](#reearth-visualizer-v1-CreateProjectRequest) | [CreateProjectResponse](#reearth-visualizer-v1-CreateProjectResponse) | Creates a new project in the specified team. Request headers: user-id: &lt;User ID&gt; |
+| UpdateProject | [UpdateProjectRequest](#reearth-visualizer-v1-UpdateProjectRequest) | [UpdateProjectResponse](#reearth-visualizer-v1-UpdateProjectResponse) | Update a project. Request headers: user-id: &lt;User ID&gt; |
 | UpdateProjectMetadata | [UpdateProjectMetadataRequest](#reearth-visualizer-v1-UpdateProjectMetadataRequest) | [UpdateProjectMetadataResponse](#reearth-visualizer-v1-UpdateProjectMetadataResponse) | Updates a new project metadata in the specified team. Request headers: user-id: &lt;User ID&gt; |
-| UpdateProjectVisibility | [UpdateProjectVisibilityRequest](#reearth-visualizer-v1-UpdateProjectVisibilityRequest) | [UpdateProjectVisibilityResponse](#reearth-visualizer-v1-UpdateProjectVisibilityResponse) | Update the visibility a project. Request headers: user-id: &lt;User ID&gt; |
 | DeleteProject | [DeleteProjectRequest](#reearth-visualizer-v1-DeleteProjectRequest) | [DeleteProjectResponse](#reearth-visualizer-v1-DeleteProjectResponse) | Deletes a project. Request headers: user-id: &lt;User ID&gt; |
 
  

--- a/server/schemas/internalapi/v1/schema.proto
+++ b/server/schemas/internalapi/v1/schema.proto
@@ -117,12 +117,15 @@ message ProjectMetadata {
   optional string readme = 4;
   // Project license
   optional string license = 5;
+  // Project topics
+  optional string topics = 6;
+
   // Project import status — if PROCESSING, data should not be retrieved
-  ProjectImportStatus import_status = 6;
+  ProjectImportStatus import_status = 7;
   // ProjectMetadata created date
-  google.protobuf.Timestamp created_at = 7;
+  google.protobuf.Timestamp created_at = 8;
   // ProjectMetadata updated date
-  google.protobuf.Timestamp updated_at = 8;
+  google.protobuf.Timestamp updated_at = 9;
 }
 
 enum Visualizer {
@@ -225,9 +228,11 @@ message UpdateProjectMetadataRequest {
   // Project ID
   string project_id = 1;
   // Project readme
-  optional string readme = 4;
+  optional string readme = 2;
   // Project license
-  optional string license = 5;
+  optional string license = 3;
+  // Project topics
+  optional string topics = 4;
 }
 
 // Deletes a project.


### PR DESCRIPTION
# Overview

### Add topics to project metadata

## What I've done

```diff
type ProjectMetadata {
  id: ID!
  project: ID!
  workspace: ID!
  readme: String
  license: String
+  topics: String
  importStatus: ProjectImportStatus
  createdAt: DateTime
  updatedAt: DateTime
}

input UpdateProjectMetadataInput {
  project: ID!
  readme: String
  license: String
+  topics: String
}
```

#### The following parts have been updated:
* MongDoc
* ProjectMetadata
* Builder
* GraphQL API
* Internal API

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for a new "topics" field in project metadata, allowing users to view and update topics associated with a project.
  - Expanded project update functionality to edit multiple attributes (name, description, visibility, image, publishing settings, and more) in a single operation.

- **Bug Fixes**
  - Corrected internal logic for setting and retrieving project metadata fields.

- **Tests**
  - Enhanced tests to cover the new "topics" field and comprehensive project updates.

- **API Changes**
  - Updated GraphQL and internal API schemas to include the "topics" field and consolidated project update methods with expanded fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->