### PR TITLE
feat(web): Add plugin api of getting current location

### DIFF
--- a/web/src/beta/features/Visualizer/Crust/Plugins/hooks/index.ts
+++ b/web/src/beta/features/Visualizer/Crust/Plugins/hooks/index.ts
@@ -58,6 +58,7 @@ export default function ({
     transformByOffsetOnScreen,
     isPositionVisibleOnGlobe,
     getGeoidHeight,
+    getCurrentLocationAsync,
     viewerEventsOn,
     viewerEventsOff,
     viewerEvents,
@@ -191,6 +192,7 @@ export default function ({
         transformByOffsetOnScreen,
         isPositionVisibleOnGlobe,
         getGeoidHeight,
+        getCurrentLocationAsync,
         // viewer events
         viewerEventsOn,
         viewerEventsOff,
@@ -285,6 +287,7 @@ export default function ({
       transformByOffsetOnScreen,
       isPositionVisibleOnGlobe,
       getGeoidHeight,
+      getCurrentLocationAsync,
       viewerEventsOn,
       viewerEventsOff,
       getCameraPosition,

--- a/web/src/beta/features/Visualizer/Crust/Plugins/hooks/useViewer.ts
+++ b/web/src/beta/features/Visualizer/Crust/Plugins/hooks/useViewer.ts
@@ -220,6 +220,42 @@ export default ({
     [geoidRef]
   );
 
+  const getCurrentLocationAsync = useCallback(
+    async (options?: {
+      enableHighAccuracy?: boolean;
+      timeout?: number;
+      maximumAge?: number;
+    }) => {
+      return new Promise<
+        { lat: number; lng: number; height: number } | undefined
+      >((resolve) => {
+        if (!navigator.geolocation) {
+          resolve(undefined);
+          return;
+        }
+
+        navigator.geolocation.getCurrentPosition(
+          (position) => {
+            resolve({
+              lat: position.coords.latitude,
+              lng: position.coords.longitude,
+              height: position.coords.altitude ?? 0
+            });
+          },
+          () => {
+            resolve(undefined);
+          },
+          {
+            enableHighAccuracy: options?.enableHighAccuracy ?? false,
+            timeout: options?.timeout ?? 10000,
+            maximumAge: options?.maximumAge ?? 0
+          }
+        );
+      });
+    },
+    []
+  );
+
   // events
   const [viewerEvents, emit] = useMemo(() => events<ViewerEventType>(), []);
 
@@ -315,6 +351,7 @@ export default ({
     transformByOffsetOnScreen,
     isPositionVisibleOnGlobe,
     getGeoidHeight,
+    getCurrentLocationAsync,
     viewerEventsOn,
     viewerEventsOff,
     viewerEvents,

--- a/web/src/beta/features/Visualizer/Crust/Plugins/pluginAPI/commonReearth.ts
+++ b/web/src/beta/features/Visualizer/Crust/Plugins/pluginAPI/commonReearth.ts
@@ -37,6 +37,7 @@ export function commonReearth({
   transformByOffsetOnScreen,
   isPositionVisibleOnGlobe,
   getGeoidHeight,
+  getCurrentLocationAsync,
   // viewer events
   viewerEventsOn,
   viewerEventsOff,
@@ -120,6 +121,7 @@ export function commonReearth({
   transformByOffsetOnScreen: GlobalThis["reearth"]["viewer"]["tools"]["transformByOffsetOnScreen"];
   isPositionVisibleOnGlobe: GlobalThis["reearth"]["viewer"]["tools"]["isPositionVisibleOnGlobe"];
   getGeoidHeight: GlobalThis["reearth"]["viewer"]["tools"]["getGeoidHeight"];
+  getCurrentLocationAsync: GlobalThis["reearth"]["viewer"]["tools"]["getCurrentLocationAsync"];
   // viewer events
   viewerEventsOn: GlobalThis["reearth"]["viewer"]["on"];
   viewerEventsOff: GlobalThis["reearth"]["viewer"]["off"];
@@ -221,7 +223,8 @@ export function commonReearth({
         cartesianToCartographic,
         transformByOffsetOnScreen,
         isPositionVisibleOnGlobe,
-        getGeoidHeight
+        getGeoidHeight,
+        getCurrentLocationAsync
       },
       on: viewerEventsOn,
       off: viewerEventsOff

--- a/web/src/beta/features/Visualizer/Crust/Plugins/pluginAPI/exposedReearth.ts
+++ b/web/src/beta/features/Visualizer/Crust/Plugins/pluginAPI/exposedReearth.ts
@@ -127,6 +127,20 @@ export function exposedReearth({
               startEventLoop?.();
               return result;
             };
+          },
+          get getCurrentLocationAsync() {
+            return async (options?: {
+              enableHighAccuracy?: boolean;
+              timeout?: number;
+              maximumAge?: number;
+            }) => {
+              const result =
+                await commonReearth?.viewer?.tools?.getCurrentLocationAsync?.(
+                  options
+                );
+              startEventLoop?.();
+              return result;
+            };
           }
         }),
         on: viewerEventsOn,

--- a/web/src/beta/features/Visualizer/Crust/Plugins/pluginAPI/types/viewer.ts
+++ b/web/src/beta/features/Visualizer/Crust/Plugins/pluginAPI/types/viewer.ts
@@ -83,6 +83,12 @@ export declare type Env = {
   readonly isBuilt: boolean;
 };
 
+export declare type GeolocationOptions = {
+  enableHighAccuracy?: boolean;
+  timeout?: number;
+  maximumAge?: number;
+};
+
 export declare type Tools = {
   readonly getLocationFromScreenCoordinate: (
     x: number,
@@ -125,6 +131,9 @@ export declare type Tools = {
     lng?: number,
     lat?: number
   ) => Promise<number | undefined>;
+  readonly getCurrentLocationAsync: (
+    options?: GeolocationOptions
+  ) => Promise<LatLngHeight | undefined>;
 };
 
 export declare type ViewerEventType = {

--- a/web/src/beta/features/Visualizer/Crust/Plugins/storybook.tsx
+++ b/web/src/beta/features/Visualizer/Crust/Plugins/storybook.tsx
@@ -117,6 +117,7 @@ export const context: Context = {
         getLocationFromScreenCoordinate: act("getLocationFromScreenCoordinate"),
         getScreenCoordinateFromPosition: act("getScreenCoordinateFromPosition"),
         getTerrainHeightAsync: act("getTerrainHeightAsync"),
+        getCurrentLocationAsync: act("getCurrentLocationAsync"),
         getGlobeHeight: act("getGlobeHeight"),
         getGlobeHeightByCamera: act("getGlobeHeightByCamera"),
         cartographicToCartesian: act("cartographicToCartesian"),


### PR DESCRIPTION
# Overview
Add plugin api of getting current location

## What I've done
- add type definitions
- add implementation in `web/src/beta/features/Visualizer/Crust/Plugins/hooks/useViewer.ts`
    - Added implementation using browser's Geolocation API
    - Include error handling and default options
- API integration
- test support in `web/src/beta/features/Visualizer/Crust/Plugins/storybook.tsx`.
    - Added mock implementation for Storybook

## What I haven't done

## How I tested

in console;
![Screenshot 2025-06-12 at 18 20 58](https://github.com/user-attachments/assets/7e2c6782-da02-4f3c-a788-1e9ddde40f8f)

If location is not allowed, undefined will return

![image](https://github.com/user-attachments/assets/56313c22-def6-4f83-b8c1-c48971d5e4ed)

in plugin playground (Location information is displayed in short for privacy reasons.)

![image](https://github.com/user-attachments/assets/25b9798e-bf91-4140-bc6d-590394cf442a)

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an asynchronous tool to retrieve the user's current geographic location, accessible within viewer tools and plugin APIs.
  - Introduced configurable options for geolocation requests, such as high accuracy, timeout, and maximum age.

- **Documentation**
  - Updated type definitions to document new geolocation options and the location retrieval method within viewer tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->