### PR TITLE
fix(server): save status from project to project metadata

### DIFF
--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -309,26 +309,23 @@ func (i *Project) UpdateVisibility(ctx context.Context, pid id.ProjectID, visibi
 
 }
 
-func (i *Project) UpdateImportStatus(ctx context.Context, pid id.ProjectID, importStatus project.ProjectImportStatus, operator *usecase.Operator) (*project.Project, error) {
+func (i *Project) UpdateImportStatus(ctx context.Context, pid id.ProjectID, importStatus project.ProjectImportStatus, operator *usecase.Operator) (*project.ProjectMetadata, error) {
 
-	prj, err := i.projectRepo.FindByID(ctx, pid)
+	meta, err := i.projectMetadataRepo.FindByProjectID(ctx, pid)
 	if err != nil {
 		return nil, err
 	}
 
-	currentTime := time.Now().UTC()
-
-	metadata := prj.Metadata()
-	if metadata != nil {
-		metadata.SetImportStatus(&importStatus)
-		metadata.SetUpdatedAt(&currentTime)
+	if meta != nil {
+		currentTime := time.Now().UTC()
+		meta.SetImportStatus(&importStatus)
+		meta.SetUpdatedAt(&currentTime)
 	}
-	prj.SetMetadata(metadata)
 
-	if err := i.projectRepo.Save(ctx, prj); err != nil {
+	if err := i.projectMetadataRepo.Save(ctx, meta); err != nil {
 		return nil, err
 	}
-	return prj, nil
+	return meta, nil
 
 }
 

--- a/server/internal/usecase/interfaces/project.go
+++ b/server/internal/usecase/interfaces/project.go
@@ -95,6 +95,6 @@ type Project interface {
 
 	ExportProjectData(context.Context, id.ProjectID, *zip.Writer, *usecase.Operator) (*project.Project, error)
 	ImportProjectData(context.Context, string, *string, *[]byte, *usecase.Operator) (*project.Project, error)
-	UpdateImportStatus(context.Context, id.ProjectID, project.ProjectImportStatus, *usecase.Operator) (*project.Project, error)
+	UpdateImportStatus(context.Context, id.ProjectID, project.ProjectImportStatus, *usecase.Operator) (*project.ProjectMetadata, error)
 	UploadExportProjectZip(context.Context, *zip.Writer, afero.File, map[string]any, *project.Project) error
 }


### PR DESCRIPTION
# Overview

## ImportStatus is stored in the metadata.

## What I've done

### When importing via the REST endpoint /split-import, it used to be stored in the project.
### This was the old specification; now it is stored in the metadata.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved efficiency of updating project import status by operating directly on project metadata instead of the full project entity.
  - The update import status operation now returns project metadata rather than the entire project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->