### PR TITLE
feat(server): phrase matching during project import

### DIFF
--- a/server/pkg/plugin/plugin.go
+++ b/server/pkg/plugin/plugin.go
@@ -1,6 +1,8 @@
 package plugin
 
 import (
+	"strings"
+
 	"github.com/blang/semver"
 	"github.com/reearth/reearth/server/pkg/i18n"
 	"github.com/reearth/reearth/server/pkg/id"
@@ -87,6 +89,15 @@ func (p *Plugin) Extension(id id.PluginExtensionID) *Extension {
 	if ok {
 		return e
 	}
+
+	// If the phrase matches (case-insensitively), treat it as a valid match.
+	input := strings.ToLower(id.String())
+	for key, val := range p.extensions {
+		if strings.ToLower(key.String()) == input {
+			return val
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
# Overview

### Error importing project

## What I've done

#### If the phrase is the same except for capitalization, it should still be considered a valid match.
#### With this fix, even past data will be corrected and imported properly.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved extension lookup to support case-insensitive matching, making it easier to find extensions regardless of letter casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->