### PR TITLE
ci(server): changed golang version on dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.5-alpine AS build
+FROM golang:1.24-alpine AS build
 ARG TAG=release
 ARG VERSION
 


### PR DESCRIPTION
# Overview
This pull request updates the `server/Dockerfile` to use a newer version of the Go programming language for the build process.

* [`server/Dockerfile`](diffhunk://#diff-7dcfbc368ef61cdb87ff87938d3901a82097fe398633f995dc4ab1cbee761a40L1-R1): Updated the base image from `golang:1.23.5-alpine` to `golang:1.24-alpine` to ensure compatibility with the latest Go features and improvements.
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
