### PR TITLE
feat(server): update project api alias [VIZ-1849]

### DIFF
--- a/server/e2e/gql_publish_test.go
+++ b/server/e2e/gql_publish_test.go
@@ -25,7 +25,7 @@ func TestPublishProject(t *testing.T) {
 	})
 	res.Object().IsEqual(map[string]any{
 		"id":                projectId,
-		"alias":             alias.ReservedReearthPrefixProject + sceneId, // default prefix + self id
+		"alias":             alias.ReservedReearthPrefixScene + sceneId, // default prefix + self id
 		"publishmentStatus": "LIMITED",
 	})
 
@@ -212,7 +212,7 @@ func checkProjectAliasAlreadyExists(res *httpexpect.Value, err *httpexpect.Value
 	})
 }
 
-func TestReservedReearthPrefixProject(t *testing.T) {
+func TestReservedReearthPrefixScene(t *testing.T) {
 	e := Server(t, baseSeeder)
 
 	projectId, sceneId, _ := createProjectSet(e)
@@ -223,7 +223,7 @@ func TestReservedReearthPrefixProject(t *testing.T) {
 		"alias":     "c-test",
 		"status":    "LIMITED",
 	})
-	checkReservedReearthPrefixProject("c-test", res, err)
+	checkReservedReearthPrefixScene("c-test", res, err)
 
 	// prefix 's-'
 	res, err = publishProjectErrors(e, uID, map[string]any{
@@ -231,23 +231,23 @@ func TestReservedReearthPrefixProject(t *testing.T) {
 		"alias":     "s-test",
 		"status":    "LIMITED",
 	})
-	checkReservedReearthPrefixProject("s-test", res, err)
+	checkReservedReearthPrefixScene("s-test", res, err)
 
 	// prefix + self id
 	res = publishProject(e, uID, map[string]any{
 		"projectId": projectId,
-		"alias":     alias.ReservedReearthPrefixProject + sceneId,
+		"alias":     alias.ReservedReearthPrefixScene + sceneId,
 		"status":    "LIMITED",
 	})
 	res.Object().IsEqual(map[string]any{
 		"id":                projectId,
-		"alias":             alias.ReservedReearthPrefixProject + sceneId, // ok
+		"alias":             alias.ReservedReearthPrefixScene + sceneId, // ok
 		"publishmentStatus": "LIMITED",
 	})
 
 }
 
-func checkReservedReearthPrefixProject(alias string, res *httpexpect.Value, err *httpexpect.Value) {
+func checkReservedReearthPrefixScene(alias string, res *httpexpect.Value, err *httpexpect.Value) {
 	message := fmt.Sprintf("Aliases starting with 'c-' or 's-' are not allowed: %s", alias)
 	res.IsNull()
 	err.Array().IsEqual([]map[string]any{
@@ -549,8 +549,8 @@ func TestCheckProjectAlias(t *testing.T) {
 		},
 		{
 			name: "reserved prefix ok for self project",
-			args: args{alias.ReservedReearthPrefixProject + sceneID, projectId},
-			want: want{alias.ReservedReearthPrefixProject + sceneID, true},
+			args: args{alias.ReservedReearthPrefixScene + sceneID, projectId},
+			want: want{alias.ReservedReearthPrefixScene + sceneID, true},
 		},
 	}
 
@@ -614,11 +614,11 @@ func TestCheckProjectAliasError(t *testing.T) {
 		},
 		{
 			name: "reserved prefix + storyId as alias with project id",
-			args: args{alias.ReservedReearthPrefixProject + storyId, projectId},
+			args: args{alias.ReservedReearthPrefixScene + storyId, projectId},
 			want: want{
 				fmt.Sprintf(
 					"Aliases starting with 'c-' or 's-' are not allowed: %s",
-					alias.ReservedReearthPrefixProject+storyId,
+					alias.ReservedReearthPrefixScene+storyId,
 				),
 			},
 		},

--- a/server/e2e/proto_project_alias_test.go
+++ b/server/e2e/proto_project_alias_test.go
@@ -1,0 +1,146 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/reearth/reearth/server/internal/adapter/internalapi/schemas/internalapi/v1"
+	"github.com/reearth/reearth/server/pkg/id"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+)
+
+// export REEARTH_DB=mongodb://localhost
+// go test -v -run TestInternalAPI_alias ./e2e/...
+
+func TestInternalAPI_alias(t *testing.T) {
+	_, r, _ := GRPCServer(t, baseSeeder)
+
+	// create public Project
+	runTestWithUser(t, uID.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
+
+		//-------------------------------------
+		// create public Project1
+		//-------------------------------------
+		res1, err := client.CreateProject(ctx, &pb.CreateProjectRequest{
+			WorkspaceId: wID.String(),
+			Visualizer:  pb.Visualizer_VISUALIZER_CESIUM,
+			Name:        lo.ToPtr("Test Project1"),
+			Description: lo.ToPtr("Test Description1"),
+			CoreSupport: lo.ToPtr(true),
+			Visibility:  lo.ToPtr("public"),
+		})
+		require.Nil(t, err)
+
+		pj1 := res1.GetProject()
+
+		// allow case
+		//----------------------------
+		allowRes, err := client.ValidateProjectAlias(ctx, &pb.ValidateProjectAliasRequest{
+			ProjectId: &pj1.Id,
+			Alias:     pj1.SceneId, // self SceneId => OK
+		})
+		require.Nil(t, err)
+		require.Equal(t, allowRes.Available, true)
+
+		allowRes, err = client.ValidateProjectAlias(ctx, &pb.ValidateProjectAliasRequest{
+			ProjectId: &pj1.Id,
+			Alias:     res1.Project.Alias, // self Alias => OK
+		})
+		require.Nil(t, err)
+		require.Equal(t, allowRes.Available, true)
+
+		allowRes, err = client.ValidateProjectAlias(ctx, &pb.ValidateProjectAliasRequest{
+			ProjectId: &pj1.Id,
+			Alias:     "xxxxxxxxxx", // uniq Alias => OK
+		})
+		require.Nil(t, err)
+		require.Equal(t, allowRes.Available, true)
+
+		// forbidden case
+		//----------------------------
+		forbiddenRes, err := client.ValidateProjectAlias(ctx, &pb.ValidateProjectAliasRequest{
+			ProjectId: &pj1.Id,
+			Alias:     "c-xxxxxxx", // NG
+		})
+		require.Nil(t, err)
+		require.Equal(t, forbiddenRes.Available, false)
+
+		forbiddenRes, err = client.ValidateProjectAlias(ctx, &pb.ValidateProjectAliasRequest{
+			ProjectId: &pj1.Id,
+			Alias:     "s-xxxxxxx", // NG
+		})
+		require.Nil(t, err)
+		require.Equal(t, forbiddenRes.Available, false)
+
+		// forbidden case (anonymous)
+		//----------------------------
+		forbiddenRes, err = client.ValidateProjectAlias(ctx, &pb.ValidateProjectAliasRequest{
+			ProjectId: nil,
+			Alias:     pj1.SceneId, // NG
+		})
+		require.Nil(t, err)
+		require.Equal(t, forbiddenRes.Available, false)
+
+		//-------------------------------------
+		// create public Project2
+		//-------------------------------------
+		res2, err := client.CreateProject(ctx, &pb.CreateProjectRequest{
+			WorkspaceId: wID.String(),
+			Visualizer:  pb.Visualizer_VISUALIZER_CESIUM,
+			Name:        lo.ToPtr("Test Project1"),
+			Description: lo.ToPtr("Test Description1"),
+			CoreSupport: lo.ToPtr(true),
+			Visibility:  lo.ToPtr("public"),
+		})
+
+		require.Nil(t, err)
+
+		pj2 := res2.GetProject()
+
+		// forbidden case
+		//----------------------------
+		forbiddenRes, err = client.ValidateProjectAlias(ctx, &pb.ValidateProjectAliasRequest{
+			ProjectId: &pj2.Id,
+			Alias:     pj1.SceneId, // NG
+		})
+		require.Nil(t, err)
+		require.Equal(t, forbiddenRes.Available, false)
+
+		forbiddenRes, err = client.ValidateProjectAlias(ctx, &pb.ValidateProjectAliasRequest{
+			ProjectId: &pj2.Id,
+			Alias:     res1.Project.Alias, // NG
+		})
+		require.Nil(t, err)
+		require.Equal(t, forbiddenRes.Available, false)
+
+		//-------------------------------------
+		// update project1 Alias
+		//-------------------------------------
+		pid1, err := id.ProjectIDFrom(pj1.Id)
+		require.Nil(t, err)
+		pj, err := r.Project.FindByID(ctx, pid1)
+		require.Nil(t, err)
+		pj.UpdateAlias("xxxxxxxxxx")
+		err = r.Project.Save(ctx, pj)
+		require.Nil(t, err)
+		pj, err = r.Project.FindByID(ctx, pid1)
+		require.Nil(t, err)
+		require.Equal(t, "xxxxxxxxxx", pj.Alias())
+
+		allowRes, err = client.ValidateProjectAlias(ctx, &pb.ValidateProjectAliasRequest{
+			ProjectId: &pj1.Id,
+			Alias:     "xxxxxxxxxx", // project1 xxxxxxxxxx => OK
+		})
+		require.Nil(t, err)
+		require.Equal(t, allowRes.Available, true)
+
+		forbiddenRes, err = client.ValidateProjectAlias(ctx, &pb.ValidateProjectAliasRequest{
+			ProjectId: &pj2.Id,
+			Alias:     "xxxxxxxxxx", // project2 xxxxxxxxxx => NG
+		})
+		require.Nil(t, err)
+		require.Equal(t, forbiddenRes.Available, false)
+
+	})
+}

--- a/server/e2e/proto_project_metadata_test.go
+++ b/server/e2e/proto_project_metadata_test.go
@@ -20,7 +20,7 @@ func TestInternalAPI_metadata_update(t *testing.T) {
 	// call api
 	runTestWithUser(t, uID.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
 		// create public Project
-		projectID := CreateProjectInternal(
+		projectID := createProjectInternal(
 			t, ctx, r, client, "public",
 			&pb.CreateProjectRequest{
 				WorkspaceId: wID.String(),

--- a/server/e2e/proto_project_test.go
+++ b/server/e2e/proto_project_test.go
@@ -193,7 +193,6 @@ func checkProjectFields(t *testing.T, project *pb.Project) {
 	assert.Contains(t, m, "id")
 	assert.Contains(t, m, "workspaceId")
 	assert.Contains(t, m, "sceneId")
-	assert.Contains(t, m, "storyId")
 	assert.Contains(t, m, "name")
 	assert.Contains(t, m, "description")
 	assert.Contains(t, m, "visualizer")
@@ -226,10 +225,17 @@ func checkProjectFields(t *testing.T, project *pb.Project) {
 	assert.Contains(t, m, "publishedUrl")
 
 	// Story publishment fields
-	assert.Contains(t, m, "storyAlias")
-	assert.Contains(t, m, "storyPublishmentStatus")
-	assert.Contains(t, m, "storyPublishedUrl")
+	assert.Contains(t, m, "stories")
+	stories, ok := m["stories"].([]any)
+	assert.True(t, ok, "stories should be an array")
 
+	if len(stories) > 0 {
+		story, ok := stories[0].(map[string]any)
+		assert.True(t, ok, "story should be a map")
+		assert.Contains(t, story, "storyAlias")
+		assert.Contains(t, story, "storyPublishmentStatus")
+		assert.Contains(t, story, "storyPublishedUrl")
+	}
 }
 
 func PbDump(m proto.Message) {

--- a/server/e2e/proto_project_test.go
+++ b/server/e2e/proto_project_test.go
@@ -33,7 +33,7 @@ func TestInternalAPI(t *testing.T) {
 	runTestWithUser(t, uID.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
 
 		// create public Project
-		pid1 := CreateProjectInternal(
+		pid1 := createProjectInternal(
 			t, ctx, r, client, "public",
 			&pb.CreateProjectRequest{
 				WorkspaceId: wID.String(),
@@ -45,7 +45,7 @@ func TestInternalAPI(t *testing.T) {
 			})
 
 		// create private Project
-		pid2 := CreateProjectInternal(
+		pid2 := createProjectInternal(
 			t, ctx, r, client, "private",
 			&pb.CreateProjectRequest{
 				WorkspaceId: wID.String(),
@@ -57,7 +57,7 @@ func TestInternalAPI(t *testing.T) {
 			})
 
 		// create public Project2
-		CreateProjectInternal(
+		createProjectInternal(
 			t, ctx, r, client, "public",
 			&pb.CreateProjectRequest{
 				WorkspaceId: wID.String(),
@@ -68,7 +68,7 @@ func TestInternalAPI(t *testing.T) {
 				Visibility:  lo.ToPtr("public"),
 			})
 
-		CreateProjectInternal(
+		createProjectInternal(
 			t, ctx, r, client, "private",
 			&pb.CreateProjectRequest{
 				WorkspaceId: wID.String(),
@@ -79,8 +79,8 @@ func TestInternalAPI(t *testing.T) {
 				Visibility:  lo.ToPtr("private"),
 			})
 
-		LogicalDeleteProject(t, ctx, r, pid1)
-		LogicalDeleteProject(t, ctx, r, pid2)
+		logicalDeleteProject(t, ctx, r, pid1)
+		logicalDeleteProject(t, ctx, r, pid2)
 
 		// 0: creante public  => public   delete => true !!
 		// 1: creante private => private  delete => true !!
@@ -138,7 +138,7 @@ func TestInternalAPI_unit(t *testing.T) {
 
 	runTestWithUser(t, uID.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
 		// Create Project
-		pid := CreateProjectInternal(
+		pid := createProjectInternal(
 			t, ctx, r, client, "public",
 			&pb.CreateProjectRequest{
 				WorkspaceId: wID.String(),
@@ -193,7 +193,7 @@ func checkProjectFields(t *testing.T, project *pb.Project) {
 	assert.Contains(t, m, "id")
 	assert.Contains(t, m, "workspaceId")
 	assert.Contains(t, m, "sceneId")
-	assert.Contains(t, m, "stories")
+	assert.Contains(t, m, "storyId")
 	assert.Contains(t, m, "name")
 	assert.Contains(t, m, "description")
 	assert.Contains(t, m, "visualizer")
@@ -204,6 +204,7 @@ func checkProjectFields(t *testing.T, project *pb.Project) {
 	assert.Contains(t, m, "starred")
 	assert.Contains(t, m, "isDeleted")
 	assert.Contains(t, m, "visibility")
+
 	assert.Contains(t, m, "editorUrl")
 
 	// metadata
@@ -219,23 +220,16 @@ func checkProjectFields(t *testing.T, project *pb.Project) {
 	assert.Contains(t, meta, "createdAt")
 	assert.Contains(t, meta, "updatedAt")
 
-	// Scene publishment fields
+	// Scene publishment field
 	assert.Contains(t, m, "alias")
 	assert.Contains(t, m, "publishmentStatus")
 	assert.Contains(t, m, "publishedUrl")
 
-	// Stories array
-	stories, ok := m["stories"].([]any)
-	assert.True(t, ok, "stories should be an array")
-	assert.Greater(t, len(stories), 0, "stories array should not be empty")
+	// Story publishment fields
+	assert.Contains(t, m, "storyAlias")
+	assert.Contains(t, m, "storyPublishmentStatus")
+	assert.Contains(t, m, "storyPublishedUrl")
 
-	// Check first story fields
-	story, ok := stories[0].(map[string]any)
-	assert.True(t, ok, "first story should be a map")
-	assert.Contains(t, story, "id")
-	assert.Contains(t, story, "storyAlias")
-	assert.Contains(t, story, "storyPublishmentStatus")
-	assert.Contains(t, story, "storyPublishedUrl")
 }
 
 func PbDump(m proto.Message) {
@@ -267,7 +261,7 @@ func runTestWithUser(t *testing.T, userID string, testFunc func(client pb.ReEart
 	testFunc(client, ctx)
 }
 
-func CreateProjectInternal(t *testing.T, ctx context.Context, r *repo.Container, client pb.ReEarthVisualizerClient, visibility string, req *pb.CreateProjectRequest) id.ProjectID {
+func createProjectInternal(t *testing.T, ctx context.Context, r *repo.Container, client pb.ReEarthVisualizerClient, visibility string, req *pb.CreateProjectRequest) id.ProjectID {
 	// test CreateProject
 	res, err := client.CreateProject(ctx, req)
 	require.Nil(t, err)
@@ -283,16 +277,25 @@ func CreateProjectInternal(t *testing.T, ctx context.Context, r *repo.Container,
 	s, err := r.Storytelling.FindByScene(ctx, c.ID())
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(*s))
+
 	// test GetProject
 	res2, err := client.GetProject(ctx, &pb.GetProjectRequest{
 		ProjectId: res.Project.Id,
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, visibility, res2.Project.Visibility)
+
+	// test GetProjectByAlias
+	res3, err := client.GetProjectByAlias(ctx, &pb.GetProjectByAliasRequest{
+		Alias: res2.Project.Alias,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, res2.Project.Alias, res3.Project.Alias)
+
 	return pid
 }
 
-func LogicalDeleteProject(t *testing.T, ctx context.Context, r *repo.Container, pid id.ProjectID) {
+func logicalDeleteProject(t *testing.T, ctx context.Context, r *repo.Container, pid id.ProjectID) {
 	prj, err := r.Project.FindByID(ctx, pid)
 	assert.Nil(t, err)
 	prj.SetDeleted(true)

--- a/server/e2e/proto_project_update_test.go
+++ b/server/e2e/proto_project_update_test.go
@@ -20,7 +20,7 @@ func TestInternalAPI_update(t *testing.T) {
 	runTestWithUser(t, uID.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
 
 		// create public Project
-		pid1 = CreateProjectInternal(
+		pid1 = createProjectInternal(
 			t, ctx, r, client, "public",
 			&pb.CreateProjectRequest{
 				WorkspaceId: wID.String(),

--- a/server/e2e/proto_project_user_test.go
+++ b/server/e2e/proto_project_user_test.go
@@ -19,7 +19,7 @@ func TestInternalAPI_private(t *testing.T) {
 	runTestWithUser(t, uID.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
 
 		// create default Project -> private
-		CreateProjectInternal(
+		createProjectInternal(
 			t, ctx, r, client, "private",
 			&pb.CreateProjectRequest{
 				WorkspaceId: wID.String(),
@@ -31,7 +31,7 @@ func TestInternalAPI_private(t *testing.T) {
 			})
 
 		// create private Project
-		CreateProjectInternal(
+		createProjectInternal(
 			t, ctx, r, client, "private",
 			&pb.CreateProjectRequest{
 				WorkspaceId: wID.String(),
@@ -77,7 +77,7 @@ func TestInternalAPI_public(t *testing.T) {
 	runTestWithUser(t, uID.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
 
 		// create public Project
-		CreateProjectInternal(
+		createProjectInternal(
 			t, ctx, r, client, "public",
 			&pb.CreateProjectRequest{
 				WorkspaceId: wID.String(),
@@ -89,7 +89,7 @@ func TestInternalAPI_public(t *testing.T) {
 			})
 
 		// create private Project
-		CreateProjectInternal(
+		createProjectInternal(
 			t, ctx, r, client, "private",
 			&pb.CreateProjectRequest{
 				WorkspaceId: wID.String(),

--- a/server/internal/adapter/internalapi/schemas/internalapi/v1/schema.pb.go
+++ b/server/internal/adapter/internalapi/schemas/internalapi/v1/schema.pb.go
@@ -687,6 +687,107 @@ func (x *GetProjectRequest) GetProjectId() string {
 	return ""
 }
 
+// Find a project by alias.
+type GetProjectByAliasRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Scene alias
+	Alias         string `protobuf:"bytes,1,opt,name=alias,proto3" json:"alias,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetProjectByAliasRequest) Reset() {
+	*x = GetProjectByAliasRequest{}
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetProjectByAliasRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetProjectByAliasRequest) ProtoMessage() {}
+
+func (x *GetProjectByAliasRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetProjectByAliasRequest.ProtoReflect.Descriptor instead.
+func (*GetProjectByAliasRequest) Descriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *GetProjectByAliasRequest) GetAlias() string {
+	if x != nil {
+		return x.Alias
+	}
+	return ""
+}
+
+// Determines if an alias is valid.
+type ValidateProjectAliasRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Project ID
+	ProjectId *string `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3,oneof" json:"project_id,omitempty"`
+	// Scene alias
+	Alias         string `protobuf:"bytes,2,opt,name=alias,proto3" json:"alias,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ValidateProjectAliasRequest) Reset() {
+	*x = ValidateProjectAliasRequest{}
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ValidateProjectAliasRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ValidateProjectAliasRequest) ProtoMessage() {}
+
+func (x *ValidateProjectAliasRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ValidateProjectAliasRequest.ProtoReflect.Descriptor instead.
+func (*ValidateProjectAliasRequest) Descriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ValidateProjectAliasRequest) GetProjectId() string {
+	if x != nil && x.ProjectId != nil {
+		return *x.ProjectId
+	}
+	return ""
+}
+
+func (x *ValidateProjectAliasRequest) GetAlias() string {
+	if x != nil {
+		return x.Alias
+	}
+	return ""
+}
+
 // Creates a new project.
 // Cannot be created under a team the user does not belong to.
 type CreateProjectRequest struct {
@@ -709,7 +810,7 @@ type CreateProjectRequest struct {
 
 func (x *CreateProjectRequest) Reset() {
 	*x = CreateProjectRequest{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[5]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -721,7 +822,7 @@ func (x *CreateProjectRequest) String() string {
 func (*CreateProjectRequest) ProtoMessage() {}
 
 func (x *CreateProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[5]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -734,7 +835,7 @@ func (x *CreateProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateProjectRequest.ProtoReflect.Descriptor instead.
 func (*CreateProjectRequest) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{5}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *CreateProjectRequest) GetWorkspaceId() string {
@@ -812,7 +913,7 @@ type UpdateProjectRequest struct {
 
 func (x *UpdateProjectRequest) Reset() {
 	*x = UpdateProjectRequest{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[6]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -824,7 +925,7 @@ func (x *UpdateProjectRequest) String() string {
 func (*UpdateProjectRequest) ProtoMessage() {}
 
 func (x *UpdateProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[6]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -837,7 +938,7 @@ func (x *UpdateProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProjectRequest.ProtoReflect.Descriptor instead.
 func (*UpdateProjectRequest) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{6}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *UpdateProjectRequest) GetProjectId() string {
@@ -998,7 +1099,7 @@ type UpdateProjectMetadataRequest struct {
 
 func (x *UpdateProjectMetadataRequest) Reset() {
 	*x = UpdateProjectMetadataRequest{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[7]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1010,7 +1111,7 @@ func (x *UpdateProjectMetadataRequest) String() string {
 func (*UpdateProjectMetadataRequest) ProtoMessage() {}
 
 func (x *UpdateProjectMetadataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[7]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1023,7 +1124,7 @@ func (x *UpdateProjectMetadataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProjectMetadataRequest.ProtoReflect.Descriptor instead.
 func (*UpdateProjectMetadataRequest) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{7}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *UpdateProjectMetadataRequest) GetProjectId() string {
@@ -1067,7 +1168,7 @@ type DeleteProjectRequest struct {
 
 func (x *DeleteProjectRequest) Reset() {
 	*x = DeleteProjectRequest{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[8]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1079,7 +1180,7 @@ func (x *DeleteProjectRequest) String() string {
 func (*DeleteProjectRequest) ProtoMessage() {}
 
 func (x *DeleteProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[8]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1092,7 +1193,7 @@ func (x *DeleteProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProjectRequest.ProtoReflect.Descriptor instead.
 func (*DeleteProjectRequest) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{8}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *DeleteProjectRequest) GetProjectId() string {
@@ -1113,7 +1214,7 @@ type ExportProjectRequest struct {
 
 func (x *ExportProjectRequest) Reset() {
 	*x = ExportProjectRequest{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[9]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1125,7 +1226,7 @@ func (x *ExportProjectRequest) String() string {
 func (*ExportProjectRequest) ProtoMessage() {}
 
 func (x *ExportProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[9]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1138,7 +1239,7 @@ func (x *ExportProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportProjectRequest.ProtoReflect.Descriptor instead.
 func (*ExportProjectRequest) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{9}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ExportProjectRequest) GetProjectId() string {
@@ -1159,7 +1260,7 @@ type GetProjectResponse struct {
 
 func (x *GetProjectResponse) Reset() {
 	*x = GetProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[10]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1171,7 +1272,7 @@ func (x *GetProjectResponse) String() string {
 func (*GetProjectResponse) ProtoMessage() {}
 
 func (x *GetProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[10]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1184,7 +1285,7 @@ func (x *GetProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProjectResponse.ProtoReflect.Descriptor instead.
 func (*GetProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{10}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *GetProjectResponse) GetProject() *Project {
@@ -1205,7 +1306,7 @@ type GetProjectListResponse struct {
 
 func (x *GetProjectListResponse) Reset() {
 	*x = GetProjectListResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[11]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1217,7 +1318,7 @@ func (x *GetProjectListResponse) String() string {
 func (*GetProjectListResponse) ProtoMessage() {}
 
 func (x *GetProjectListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[11]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1230,7 +1331,7 @@ func (x *GetProjectListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProjectListResponse.ProtoReflect.Descriptor instead.
 func (*GetProjectListResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{11}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *GetProjectListResponse) GetProjects() []*Project {
@@ -1251,7 +1352,7 @@ type CreateProjectResponse struct {
 
 func (x *CreateProjectResponse) Reset() {
 	*x = CreateProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[12]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1263,7 +1364,7 @@ func (x *CreateProjectResponse) String() string {
 func (*CreateProjectResponse) ProtoMessage() {}
 
 func (x *CreateProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[12]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1276,7 +1377,7 @@ func (x *CreateProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateProjectResponse.ProtoReflect.Descriptor instead.
 func (*CreateProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{12}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *CreateProjectResponse) GetProject() *Project {
@@ -1297,7 +1398,7 @@ type UpdateProjectResponse struct {
 
 func (x *UpdateProjectResponse) Reset() {
 	*x = UpdateProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[13]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1309,7 +1410,7 @@ func (x *UpdateProjectResponse) String() string {
 func (*UpdateProjectResponse) ProtoMessage() {}
 
 func (x *UpdateProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[13]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1322,7 +1423,7 @@ func (x *UpdateProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProjectResponse.ProtoReflect.Descriptor instead.
 func (*UpdateProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{13}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *UpdateProjectResponse) GetProject() *Project {
@@ -1343,7 +1444,7 @@ type UpdateProjectMetadataResponse struct {
 
 func (x *UpdateProjectMetadataResponse) Reset() {
 	*x = UpdateProjectMetadataResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[14]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1355,7 +1456,7 @@ func (x *UpdateProjectMetadataResponse) String() string {
 func (*UpdateProjectMetadataResponse) ProtoMessage() {}
 
 func (x *UpdateProjectMetadataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[14]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1368,7 +1469,7 @@ func (x *UpdateProjectMetadataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProjectMetadataResponse.ProtoReflect.Descriptor instead.
 func (*UpdateProjectMetadataResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{14}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *UpdateProjectMetadataResponse) GetMetadata() *ProjectMetadata {
@@ -1389,7 +1490,7 @@ type DeleteProjectResponse struct {
 
 func (x *DeleteProjectResponse) Reset() {
 	*x = DeleteProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[15]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1401,7 +1502,7 @@ func (x *DeleteProjectResponse) String() string {
 func (*DeleteProjectResponse) ProtoMessage() {}
 
 func (x *DeleteProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[15]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1414,7 +1515,7 @@ func (x *DeleteProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProjectResponse.ProtoReflect.Descriptor instead.
 func (*DeleteProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{15}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *DeleteProjectResponse) GetProjectId() string {
@@ -1435,7 +1536,7 @@ type ExportProjectResponse struct {
 
 func (x *ExportProjectResponse) Reset() {
 	*x = ExportProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[16]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1447,7 +1548,7 @@ func (x *ExportProjectResponse) String() string {
 func (*ExportProjectResponse) ProtoMessage() {}
 
 func (x *ExportProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[16]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1460,12 +1561,122 @@ func (x *ExportProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportProjectResponse.ProtoReflect.Descriptor instead.
 func (*ExportProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{16}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ExportProjectResponse) GetProjectDataPath() string {
 	if x != nil {
 		return x.ProjectDataPath
+	}
+	return ""
+}
+
+// Response messages
+type GetProjectByAliasResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Project
+	Project       *Project `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetProjectByAliasResponse) Reset() {
+	*x = GetProjectByAliasResponse{}
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetProjectByAliasResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetProjectByAliasResponse) ProtoMessage() {}
+
+func (x *GetProjectByAliasResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetProjectByAliasResponse.ProtoReflect.Descriptor instead.
+func (*GetProjectByAliasResponse) Descriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *GetProjectByAliasResponse) GetProject() *Project {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+// Response messages
+type ValidateProjectAliasResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Project ID
+	ProjectId *string `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3,oneof" json:"project_id,omitempty"`
+	// Scene alias available
+	Available bool `protobuf:"varint,2,opt,name=available,proto3" json:"available,omitempty"`
+	// Error message
+	ErrorMessage  *string `protobuf:"bytes,3,opt,name=error_message,json=errorMessage,proto3,oneof" json:"error_message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ValidateProjectAliasResponse) Reset() {
+	*x = ValidateProjectAliasResponse{}
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ValidateProjectAliasResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ValidateProjectAliasResponse) ProtoMessage() {}
+
+func (x *ValidateProjectAliasResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ValidateProjectAliasResponse.ProtoReflect.Descriptor instead.
+func (*ValidateProjectAliasResponse) Descriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *ValidateProjectAliasResponse) GetProjectId() string {
+	if x != nil && x.ProjectId != nil {
+		return *x.ProjectId
+	}
+	return ""
+}
+
+func (x *ValidateProjectAliasResponse) GetAvailable() bool {
+	if x != nil {
+		return x.Available
+	}
+	return false
+}
+
+func (x *ValidateProjectAliasResponse) GetErrorMessage() string {
+	if x != nil && x.ErrorMessage != nil {
+		return *x.ErrorMessage
 	}
 	return ""
 }
@@ -1539,7 +1750,14 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\rauthenticated\x18\x02 \x01(\bR\rauthenticated\"2\n" +
 	"\x11GetProjectRequest\x12\x1d\n" +
 	"\n" +
-	"project_id\x18\x01 \x01(\tR\tprojectId\"\xc2\x02\n" +
+	"project_id\x18\x01 \x01(\tR\tprojectId\"0\n" +
+	"\x18GetProjectByAliasRequest\x12\x14\n" +
+	"\x05alias\x18\x01 \x01(\tR\x05alias\"f\n" +
+	"\x1bValidateProjectAliasRequest\x12\"\n" +
+	"\n" +
+	"project_id\x18\x01 \x01(\tH\x00R\tprojectId\x88\x01\x01\x12\x14\n" +
+	"\x05alias\x18\x02 \x01(\tR\x05aliasB\r\n" +
+	"\v_project_id\"\xc2\x02\n" +
 	"\x14CreateProjectRequest\x12!\n" +
 	"\fworkspace_id\x18\x01 \x01(\tR\vworkspaceId\x12A\n" +
 	"\n" +
@@ -1635,7 +1853,16 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\"C\n" +
 	"\x15ExportProjectResponse\x12*\n" +
-	"\x11project_data_path\x18\x01 \x01(\tR\x0fprojectDataPath*[\n" +
+	"\x11project_data_path\x18\x01 \x01(\tR\x0fprojectDataPath\"U\n" +
+	"\x19GetProjectByAliasResponse\x128\n" +
+	"\aproject\x18\x01 \x01(\v2\x1e.reearth.visualizer.v1.ProjectR\aproject\"\xab\x01\n" +
+	"\x1cValidateProjectAliasResponse\x12\"\n" +
+	"\n" +
+	"project_id\x18\x01 \x01(\tH\x00R\tprojectId\x88\x01\x01\x12\x1c\n" +
+	"\tavailable\x18\x02 \x01(\bR\tavailable\x12(\n" +
+	"\rerror_message\x18\x03 \x01(\tH\x01R\ferrorMessage\x88\x01\x01B\r\n" +
+	"\v_project_idB\x10\n" +
+	"\x0e_error_message*[\n" +
 	"\n" +
 	"Visualizer\x12\x1a\n" +
 	"\x16VISUALIZER_UNSPECIFIED\x10\x00\x12\x15\n" +
@@ -1651,11 +1878,13 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\x1ePUBLISHMENT_STATUS_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19PUBLISHMENT_STATUS_PUBLIC\x10\x01\x12\x1e\n" +
 	"\x1aPUBLISHMENT_STATUS_LIMITED\x10\x02\x12\x1e\n" +
-	"\x1aPUBLISHMENT_STATUS_PRIVATE\x10\x032\xa8\x06\n" +
+	"\x1aPUBLISHMENT_STATUS_PRIVATE\x10\x032\xa6\b\n" +
 	"\x11ReEarthVisualizer\x12o\n" +
 	"\x0eGetProjectList\x12,.reearth.visualizer.v1.GetProjectListRequest\x1a-.reearth.visualizer.v1.GetProjectListResponse\"\x00\x12c\n" +
 	"\n" +
-	"GetProject\x12(.reearth.visualizer.v1.GetProjectRequest\x1a).reearth.visualizer.v1.GetProjectResponse\"\x00\x12l\n" +
+	"GetProject\x12(.reearth.visualizer.v1.GetProjectRequest\x1a).reearth.visualizer.v1.GetProjectResponse\"\x00\x12x\n" +
+	"\x11GetProjectByAlias\x12/.reearth.visualizer.v1.GetProjectByAliasRequest\x1a0.reearth.visualizer.v1.GetProjectByAliasResponse\"\x00\x12\x81\x01\n" +
+	"\x14ValidateProjectAlias\x122.reearth.visualizer.v1.ValidateProjectAliasRequest\x1a3.reearth.visualizer.v1.ValidateProjectAliasResponse\"\x00\x12l\n" +
 	"\rCreateProject\x12+.reearth.visualizer.v1.CreateProjectRequest\x1a,.reearth.visualizer.v1.CreateProjectResponse\"\x00\x12l\n" +
 	"\rUpdateProject\x12+.reearth.visualizer.v1.UpdateProjectRequest\x1a,.reearth.visualizer.v1.UpdateProjectResponse\"\x00\x12\x84\x01\n" +
 	"\x15UpdateProjectMetadata\x123.reearth.visualizer.v1.UpdateProjectMetadataRequest\x1a4.reearth.visualizer.v1.UpdateProjectMetadataResponse\"\x00\x12l\n" +
@@ -1676,7 +1905,7 @@ func file_schemas_internalapi_v1_schema_proto_rawDescGZIP() []byte {
 }
 
 var file_schemas_internalapi_v1_schema_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_schemas_internalapi_v1_schema_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_schemas_internalapi_v1_schema_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_schemas_internalapi_v1_schema_proto_goTypes = []any{
 	(Visualizer)(0),                       // 0: reearth.visualizer.v1.Visualizer
 	(ProjectImportStatus)(0),              // 1: reearth.visualizer.v1.ProjectImportStatus
@@ -1686,56 +1915,65 @@ var file_schemas_internalapi_v1_schema_proto_goTypes = []any{
 	(*ProjectMetadata)(nil),               // 5: reearth.visualizer.v1.ProjectMetadata
 	(*GetProjectListRequest)(nil),         // 6: reearth.visualizer.v1.GetProjectListRequest
 	(*GetProjectRequest)(nil),             // 7: reearth.visualizer.v1.GetProjectRequest
-	(*CreateProjectRequest)(nil),          // 8: reearth.visualizer.v1.CreateProjectRequest
-	(*UpdateProjectRequest)(nil),          // 9: reearth.visualizer.v1.UpdateProjectRequest
-	(*UpdateProjectMetadataRequest)(nil),  // 10: reearth.visualizer.v1.UpdateProjectMetadataRequest
-	(*DeleteProjectRequest)(nil),          // 11: reearth.visualizer.v1.DeleteProjectRequest
-	(*ExportProjectRequest)(nil),          // 12: reearth.visualizer.v1.ExportProjectRequest
-	(*GetProjectResponse)(nil),            // 13: reearth.visualizer.v1.GetProjectResponse
-	(*GetProjectListResponse)(nil),        // 14: reearth.visualizer.v1.GetProjectListResponse
-	(*CreateProjectResponse)(nil),         // 15: reearth.visualizer.v1.CreateProjectResponse
-	(*UpdateProjectResponse)(nil),         // 16: reearth.visualizer.v1.UpdateProjectResponse
-	(*UpdateProjectMetadataResponse)(nil), // 17: reearth.visualizer.v1.UpdateProjectMetadataResponse
-	(*DeleteProjectResponse)(nil),         // 18: reearth.visualizer.v1.DeleteProjectResponse
-	(*ExportProjectResponse)(nil),         // 19: reearth.visualizer.v1.ExportProjectResponse
-	(*timestamppb.Timestamp)(nil),         // 20: google.protobuf.Timestamp
+	(*GetProjectByAliasRequest)(nil),      // 8: reearth.visualizer.v1.GetProjectByAliasRequest
+	(*ValidateProjectAliasRequest)(nil),   // 9: reearth.visualizer.v1.ValidateProjectAliasRequest
+	(*CreateProjectRequest)(nil),          // 10: reearth.visualizer.v1.CreateProjectRequest
+	(*UpdateProjectRequest)(nil),          // 11: reearth.visualizer.v1.UpdateProjectRequest
+	(*UpdateProjectMetadataRequest)(nil),  // 12: reearth.visualizer.v1.UpdateProjectMetadataRequest
+	(*DeleteProjectRequest)(nil),          // 13: reearth.visualizer.v1.DeleteProjectRequest
+	(*ExportProjectRequest)(nil),          // 14: reearth.visualizer.v1.ExportProjectRequest
+	(*GetProjectResponse)(nil),            // 15: reearth.visualizer.v1.GetProjectResponse
+	(*GetProjectListResponse)(nil),        // 16: reearth.visualizer.v1.GetProjectListResponse
+	(*CreateProjectResponse)(nil),         // 17: reearth.visualizer.v1.CreateProjectResponse
+	(*UpdateProjectResponse)(nil),         // 18: reearth.visualizer.v1.UpdateProjectResponse
+	(*UpdateProjectMetadataResponse)(nil), // 19: reearth.visualizer.v1.UpdateProjectMetadataResponse
+	(*DeleteProjectResponse)(nil),         // 20: reearth.visualizer.v1.DeleteProjectResponse
+	(*ExportProjectResponse)(nil),         // 21: reearth.visualizer.v1.ExportProjectResponse
+	(*GetProjectByAliasResponse)(nil),     // 22: reearth.visualizer.v1.GetProjectByAliasResponse
+	(*ValidateProjectAliasResponse)(nil),  // 23: reearth.visualizer.v1.ValidateProjectAliasResponse
+	(*timestamppb.Timestamp)(nil),         // 24: google.protobuf.Timestamp
 }
 var file_schemas_internalapi_v1_schema_proto_depIdxs = []int32{
 	4,  // 0: reearth.visualizer.v1.Project.stories:type_name -> reearth.visualizer.v1.Story
 	0,  // 1: reearth.visualizer.v1.Project.visualizer:type_name -> reearth.visualizer.v1.Visualizer
-	20, // 2: reearth.visualizer.v1.Project.created_at:type_name -> google.protobuf.Timestamp
-	20, // 3: reearth.visualizer.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
+	24, // 2: reearth.visualizer.v1.Project.created_at:type_name -> google.protobuf.Timestamp
+	24, // 3: reearth.visualizer.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
 	5,  // 4: reearth.visualizer.v1.Project.metadata:type_name -> reearth.visualizer.v1.ProjectMetadata
 	2,  // 5: reearth.visualizer.v1.Project.publishment_status:type_name -> reearth.visualizer.v1.PublishmentStatus
 	2,  // 6: reearth.visualizer.v1.Story.story_publishment_status:type_name -> reearth.visualizer.v1.PublishmentStatus
 	1,  // 7: reearth.visualizer.v1.ProjectMetadata.import_status:type_name -> reearth.visualizer.v1.ProjectImportStatus
-	20, // 8: reearth.visualizer.v1.ProjectMetadata.created_at:type_name -> google.protobuf.Timestamp
-	20, // 9: reearth.visualizer.v1.ProjectMetadata.updated_at:type_name -> google.protobuf.Timestamp
+	24, // 8: reearth.visualizer.v1.ProjectMetadata.created_at:type_name -> google.protobuf.Timestamp
+	24, // 9: reearth.visualizer.v1.ProjectMetadata.updated_at:type_name -> google.protobuf.Timestamp
 	0,  // 10: reearth.visualizer.v1.CreateProjectRequest.visualizer:type_name -> reearth.visualizer.v1.Visualizer
 	3,  // 11: reearth.visualizer.v1.GetProjectResponse.project:type_name -> reearth.visualizer.v1.Project
 	3,  // 12: reearth.visualizer.v1.GetProjectListResponse.projects:type_name -> reearth.visualizer.v1.Project
 	3,  // 13: reearth.visualizer.v1.CreateProjectResponse.project:type_name -> reearth.visualizer.v1.Project
 	3,  // 14: reearth.visualizer.v1.UpdateProjectResponse.project:type_name -> reearth.visualizer.v1.Project
 	5,  // 15: reearth.visualizer.v1.UpdateProjectMetadataResponse.metadata:type_name -> reearth.visualizer.v1.ProjectMetadata
-	6,  // 16: reearth.visualizer.v1.ReEarthVisualizer.GetProjectList:input_type -> reearth.visualizer.v1.GetProjectListRequest
-	7,  // 17: reearth.visualizer.v1.ReEarthVisualizer.GetProject:input_type -> reearth.visualizer.v1.GetProjectRequest
-	8,  // 18: reearth.visualizer.v1.ReEarthVisualizer.CreateProject:input_type -> reearth.visualizer.v1.CreateProjectRequest
-	9,  // 19: reearth.visualizer.v1.ReEarthVisualizer.UpdateProject:input_type -> reearth.visualizer.v1.UpdateProjectRequest
-	10, // 20: reearth.visualizer.v1.ReEarthVisualizer.UpdateProjectMetadata:input_type -> reearth.visualizer.v1.UpdateProjectMetadataRequest
-	11, // 21: reearth.visualizer.v1.ReEarthVisualizer.DeleteProject:input_type -> reearth.visualizer.v1.DeleteProjectRequest
-	12, // 22: reearth.visualizer.v1.ReEarthVisualizer.ExportProject:input_type -> reearth.visualizer.v1.ExportProjectRequest
-	14, // 23: reearth.visualizer.v1.ReEarthVisualizer.GetProjectList:output_type -> reearth.visualizer.v1.GetProjectListResponse
-	13, // 24: reearth.visualizer.v1.ReEarthVisualizer.GetProject:output_type -> reearth.visualizer.v1.GetProjectResponse
-	15, // 25: reearth.visualizer.v1.ReEarthVisualizer.CreateProject:output_type -> reearth.visualizer.v1.CreateProjectResponse
-	16, // 26: reearth.visualizer.v1.ReEarthVisualizer.UpdateProject:output_type -> reearth.visualizer.v1.UpdateProjectResponse
-	17, // 27: reearth.visualizer.v1.ReEarthVisualizer.UpdateProjectMetadata:output_type -> reearth.visualizer.v1.UpdateProjectMetadataResponse
-	18, // 28: reearth.visualizer.v1.ReEarthVisualizer.DeleteProject:output_type -> reearth.visualizer.v1.DeleteProjectResponse
-	19, // 29: reearth.visualizer.v1.ReEarthVisualizer.ExportProject:output_type -> reearth.visualizer.v1.ExportProjectResponse
-	23, // [23:30] is the sub-list for method output_type
-	16, // [16:23] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	3,  // 16: reearth.visualizer.v1.GetProjectByAliasResponse.project:type_name -> reearth.visualizer.v1.Project
+	6,  // 17: reearth.visualizer.v1.ReEarthVisualizer.GetProjectList:input_type -> reearth.visualizer.v1.GetProjectListRequest
+	7,  // 18: reearth.visualizer.v1.ReEarthVisualizer.GetProject:input_type -> reearth.visualizer.v1.GetProjectRequest
+	8,  // 19: reearth.visualizer.v1.ReEarthVisualizer.GetProjectByAlias:input_type -> reearth.visualizer.v1.GetProjectByAliasRequest
+	9,  // 20: reearth.visualizer.v1.ReEarthVisualizer.ValidateProjectAlias:input_type -> reearth.visualizer.v1.ValidateProjectAliasRequest
+	10, // 21: reearth.visualizer.v1.ReEarthVisualizer.CreateProject:input_type -> reearth.visualizer.v1.CreateProjectRequest
+	11, // 22: reearth.visualizer.v1.ReEarthVisualizer.UpdateProject:input_type -> reearth.visualizer.v1.UpdateProjectRequest
+	12, // 23: reearth.visualizer.v1.ReEarthVisualizer.UpdateProjectMetadata:input_type -> reearth.visualizer.v1.UpdateProjectMetadataRequest
+	13, // 24: reearth.visualizer.v1.ReEarthVisualizer.DeleteProject:input_type -> reearth.visualizer.v1.DeleteProjectRequest
+	14, // 25: reearth.visualizer.v1.ReEarthVisualizer.ExportProject:input_type -> reearth.visualizer.v1.ExportProjectRequest
+	16, // 26: reearth.visualizer.v1.ReEarthVisualizer.GetProjectList:output_type -> reearth.visualizer.v1.GetProjectListResponse
+	15, // 27: reearth.visualizer.v1.ReEarthVisualizer.GetProject:output_type -> reearth.visualizer.v1.GetProjectResponse
+	22, // 28: reearth.visualizer.v1.ReEarthVisualizer.GetProjectByAlias:output_type -> reearth.visualizer.v1.GetProjectByAliasResponse
+	23, // 29: reearth.visualizer.v1.ReEarthVisualizer.ValidateProjectAlias:output_type -> reearth.visualizer.v1.ValidateProjectAliasResponse
+	17, // 30: reearth.visualizer.v1.ReEarthVisualizer.CreateProject:output_type -> reearth.visualizer.v1.CreateProjectResponse
+	18, // 31: reearth.visualizer.v1.ReEarthVisualizer.UpdateProject:output_type -> reearth.visualizer.v1.UpdateProjectResponse
+	19, // 32: reearth.visualizer.v1.ReEarthVisualizer.UpdateProjectMetadata:output_type -> reearth.visualizer.v1.UpdateProjectMetadataResponse
+	20, // 33: reearth.visualizer.v1.ReEarthVisualizer.DeleteProject:output_type -> reearth.visualizer.v1.DeleteProjectResponse
+	21, // 34: reearth.visualizer.v1.ReEarthVisualizer.ExportProject:output_type -> reearth.visualizer.v1.ExportProjectResponse
+	26, // [26:35] is the sub-list for method output_type
+	17, // [17:26] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_schemas_internalapi_v1_schema_proto_init() }
@@ -1746,16 +1984,18 @@ func file_schemas_internalapi_v1_schema_proto_init() {
 	file_schemas_internalapi_v1_schema_proto_msgTypes[0].OneofWrappers = []any{}
 	file_schemas_internalapi_v1_schema_proto_msgTypes[1].OneofWrappers = []any{}
 	file_schemas_internalapi_v1_schema_proto_msgTypes[2].OneofWrappers = []any{}
-	file_schemas_internalapi_v1_schema_proto_msgTypes[5].OneofWrappers = []any{}
 	file_schemas_internalapi_v1_schema_proto_msgTypes[6].OneofWrappers = []any{}
 	file_schemas_internalapi_v1_schema_proto_msgTypes[7].OneofWrappers = []any{}
+	file_schemas_internalapi_v1_schema_proto_msgTypes[8].OneofWrappers = []any{}
+	file_schemas_internalapi_v1_schema_proto_msgTypes[9].OneofWrappers = []any{}
+	file_schemas_internalapi_v1_schema_proto_msgTypes[20].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_schemas_internalapi_v1_schema_proto_rawDesc), len(file_schemas_internalapi_v1_schema_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   17,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/server/internal/adapter/internalapi/schemas/internalapi/v1/schema_grpc.pb.go
+++ b/server/internal/adapter/internalapi/schemas/internalapi/v1/schema_grpc.pb.go
@@ -21,6 +21,8 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	ReEarthVisualizer_GetProjectList_FullMethodName        = "/reearth.visualizer.v1.ReEarthVisualizer/GetProjectList"
 	ReEarthVisualizer_GetProject_FullMethodName            = "/reearth.visualizer.v1.ReEarthVisualizer/GetProject"
+	ReEarthVisualizer_GetProjectByAlias_FullMethodName     = "/reearth.visualizer.v1.ReEarthVisualizer/GetProjectByAlias"
+	ReEarthVisualizer_ValidateProjectAlias_FullMethodName  = "/reearth.visualizer.v1.ReEarthVisualizer/ValidateProjectAlias"
 	ReEarthVisualizer_CreateProject_FullMethodName         = "/reearth.visualizer.v1.ReEarthVisualizer/CreateProject"
 	ReEarthVisualizer_UpdateProject_FullMethodName         = "/reearth.visualizer.v1.ReEarthVisualizer/UpdateProject"
 	ReEarthVisualizer_UpdateProjectMetadata_FullMethodName = "/reearth.visualizer.v1.ReEarthVisualizer/UpdateProjectMetadata"
@@ -38,10 +40,16 @@ type ReEarthVisualizerClient interface {
 	// Retrieves a specific project regardless of authentication.
 	// Request headers: user-id: <User ID>
 	GetProject(ctx context.Context, in *GetProjectRequest, opts ...grpc.CallOption) (*GetProjectResponse, error)
+	// Find a project by alias.
+	// Request headers: user-id: <User ID>
+	GetProjectByAlias(ctx context.Context, in *GetProjectByAliasRequest, opts ...grpc.CallOption) (*GetProjectByAliasResponse, error)
+	// Determines if an alias is valid.
+	// Request headers: user-id: <User ID>
+	ValidateProjectAlias(ctx context.Context, in *ValidateProjectAliasRequest, opts ...grpc.CallOption) (*ValidateProjectAliasResponse, error)
 	// Creates a new project in the specified team.
 	// Request headers: user-id: <User ID>
 	CreateProject(ctx context.Context, in *CreateProjectRequest, opts ...grpc.CallOption) (*CreateProjectResponse, error)
-	// Update  a project.
+	// Update a project.
 	// Request headers: user-id: <User ID>
 	UpdateProject(ctx context.Context, in *UpdateProjectRequest, opts ...grpc.CallOption) (*UpdateProjectResponse, error)
 	// Updates a new project metadata in the specified team.
@@ -77,6 +85,26 @@ func (c *reEarthVisualizerClient) GetProject(ctx context.Context, in *GetProject
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetProjectResponse)
 	err := c.cc.Invoke(ctx, ReEarthVisualizer_GetProject_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *reEarthVisualizerClient) GetProjectByAlias(ctx context.Context, in *GetProjectByAliasRequest, opts ...grpc.CallOption) (*GetProjectByAliasResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetProjectByAliasResponse)
+	err := c.cc.Invoke(ctx, ReEarthVisualizer_GetProjectByAlias_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *reEarthVisualizerClient) ValidateProjectAlias(ctx context.Context, in *ValidateProjectAliasRequest, opts ...grpc.CallOption) (*ValidateProjectAliasResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ValidateProjectAliasResponse)
+	err := c.cc.Invoke(ctx, ReEarthVisualizer_ValidateProjectAlias_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -143,10 +171,16 @@ type ReEarthVisualizerServer interface {
 	// Retrieves a specific project regardless of authentication.
 	// Request headers: user-id: <User ID>
 	GetProject(context.Context, *GetProjectRequest) (*GetProjectResponse, error)
+	// Find a project by alias.
+	// Request headers: user-id: <User ID>
+	GetProjectByAlias(context.Context, *GetProjectByAliasRequest) (*GetProjectByAliasResponse, error)
+	// Determines if an alias is valid.
+	// Request headers: user-id: <User ID>
+	ValidateProjectAlias(context.Context, *ValidateProjectAliasRequest) (*ValidateProjectAliasResponse, error)
 	// Creates a new project in the specified team.
 	// Request headers: user-id: <User ID>
 	CreateProject(context.Context, *CreateProjectRequest) (*CreateProjectResponse, error)
-	// Update  a project.
+	// Update a project.
 	// Request headers: user-id: <User ID>
 	UpdateProject(context.Context, *UpdateProjectRequest) (*UpdateProjectResponse, error)
 	// Updates a new project metadata in the specified team.
@@ -173,6 +207,12 @@ func (UnimplementedReEarthVisualizerServer) GetProjectList(context.Context, *Get
 }
 func (UnimplementedReEarthVisualizerServer) GetProject(context.Context, *GetProjectRequest) (*GetProjectResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetProject not implemented")
+}
+func (UnimplementedReEarthVisualizerServer) GetProjectByAlias(context.Context, *GetProjectByAliasRequest) (*GetProjectByAliasResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetProjectByAlias not implemented")
+}
+func (UnimplementedReEarthVisualizerServer) ValidateProjectAlias(context.Context, *ValidateProjectAliasRequest) (*ValidateProjectAliasResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ValidateProjectAlias not implemented")
 }
 func (UnimplementedReEarthVisualizerServer) CreateProject(context.Context, *CreateProjectRequest) (*CreateProjectResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateProject not implemented")
@@ -242,6 +282,42 @@ func _ReEarthVisualizer_GetProject_Handler(srv interface{}, ctx context.Context,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ReEarthVisualizerServer).GetProject(ctx, req.(*GetProjectRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ReEarthVisualizer_GetProjectByAlias_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetProjectByAliasRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ReEarthVisualizerServer).GetProjectByAlias(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ReEarthVisualizer_GetProjectByAlias_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ReEarthVisualizerServer).GetProjectByAlias(ctx, req.(*GetProjectByAliasRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ReEarthVisualizer_ValidateProjectAlias_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ValidateProjectAliasRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ReEarthVisualizerServer).ValidateProjectAlias(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ReEarthVisualizer_ValidateProjectAlias_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ReEarthVisualizerServer).ValidateProjectAlias(ctx, req.(*ValidateProjectAliasRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -350,6 +426,14 @@ var ReEarthVisualizer_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetProject",
 			Handler:    _ReEarthVisualizer_GetProject_Handler,
+		},
+		{
+			MethodName: "GetProjectByAlias",
+			Handler:    _ReEarthVisualizer_GetProjectByAlias_Handler,
+		},
+		{
+			MethodName: "ValidateProjectAlias",
+			Handler:    _ReEarthVisualizer_ValidateProjectAlias_Handler,
 		},
 		{
 			MethodName: "CreateProject",

--- a/server/internal/infrastructure/memory/project.go
+++ b/server/internal/infrastructure/memory/project.go
@@ -137,6 +137,15 @@ func (r *Project) FindActiveById(ctx context.Context, id id.ProjectID) (*project
 	return nil, nil
 }
 
+func (r *Project) FindActiveByAlias(ctx context.Context, alias string) (*project.Project, error) {
+	for _, p := range r.data {
+		if p.Alias() == alias && !p.IsDeleted() {
+			return p, nil
+		}
+	}
+	return nil, nil
+}
+
 func (r *Project) FindVisibilityByWorkspace(ctx context.Context, authenticated bool, isWorkspaceOwner bool, id accountdomain.WorkspaceID) ([]*project.Project, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -257,45 +257,6 @@ func (r *Project) CheckAliasUnique(ctx context.Context, newAlias string) error {
 
 	pipeline := []bson.M{
 		{
-			"$match": bson.M{"alias": newAlias},
-		},
-		{
-			"$unionWith": bson.M{
-				"coll": "scene",
-				"pipeline": []bson.M{
-					{"$match": bson.M{"id": sceneId}},
-				},
-			},
-		},
-		{
-			"$limit": 1,
-		},
-		{
-			"$count": "exists",
-		},
-	}
-
-	cursor, err := r.client.Client().Aggregate(ctx, pipeline)
-	if err != nil {
-		return err
-	}
-	defer cursor.Close(ctx)
-
-	if cursor.Next(ctx) {
-		return alias.ErrExistsProjectAlias
-	}
-
-	return nil
-}
-
-func (r *Project) CheckAliasUniqueWithFacet(ctx context.Context, newAlias string) error {
-	sceneId := newAlias
-	if strings.HasPrefix(newAlias, alias.ReservedReearthPrefixScene) {
-		sceneId = newAlias[2:]
-	}
-
-	pipeline := []bson.M{
-		{
 			"$limit": 1,
 		},
 		{

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -145,7 +145,22 @@ func (i *Project) FindActiveById(ctx context.Context, pid id.ProjectID, operator
 		return nil, err
 	}
 
-	meta, err := i.projectMetadataRepo.FindByProjectID(ctx, pid)
+	meta, err := i.projectMetadataRepo.FindByProjectID(ctx, pj.ID())
+	if err != nil {
+		return nil, err
+	}
+
+	pj.SetMetadata(meta)
+	return pj, nil
+}
+
+func (i *Project) FindActiveByAlias(ctx context.Context, alias string, operator *usecase.Operator) (*project.Project, error) {
+	pj, err := i.projectRepo.FindActiveByAlias(ctx, alias)
+	if err != nil {
+		return nil, err
+	}
+
+	meta, err := i.projectMetadataRepo.FindByProjectID(ctx, pj.ID())
 	if err != nil {
 		return nil, err
 	}
@@ -366,9 +381,26 @@ func (i *Project) UpdateImportStatus(ctx context.Context, pid id.ProjectID, impo
 
 }
 
+func (i *Project) dedicatedID(ctx context.Context, pid *id.ProjectID) (*project.Project, string, string, error) {
+
+	prj, err := i.projectRepo.FindByID(ctx, *pid)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	sce, err := i.sceneRepo.FindByProject(ctx, *pid)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	dedicatedID1 := alias.ReservedReearthPrefixScene + sce.ID().String()
+	dedicatedID2 := sce.ID().String()
+
+	return prj, dedicatedID1, dedicatedID2, err
+}
+
 func (i *Project) CheckAlias(ctx context.Context, newAlias string, pid *id.ProjectID) (bool, error) {
 	aliasName := strings.ToLower(newAlias)
-
 	if pid == nil {
 
 		if err := alias.CheckProjectAliasPattern(aliasName); err != nil {
@@ -377,62 +409,48 @@ func (i *Project) CheckAlias(ctx context.Context, newAlias string, pid *id.Proje
 		if err := i.projectRepo.CheckAliasUnique(ctx, aliasName); err != nil {
 			return false, err
 		}
-		if err := i.sceneRepo.CheckAliasUnique(ctx, aliasName); err != nil {
-			return false, err
-		}
 		if err := i.storytellingRepo.CheckAliasUnique(ctx, aliasName); err != nil {
 			return false, err
 		}
 
-		if strings.HasPrefix(aliasName, alias.ReservedReearthPrefixProject) || strings.HasPrefix(aliasName, alias.ReservedReearthPrefixStory) {
+		if strings.HasPrefix(aliasName, alias.ReservedReearthPrefixScene) || strings.HasPrefix(aliasName, alias.ReservedReearthPrefixStory) {
 			return false, alias.ErrInvalidProjectInvalidPrefixAlias.AddTemplateData("aliasName", aliasName)
 		}
 
 	} else {
 
-		prj, err := i.projectRepo.FindByID(ctx, *pid)
+		prj, dedicatedID1, dedicatedID2, err := i.dedicatedID(ctx, pid)
 		if err != nil {
 			return false, err
 		}
 
-		if aliasName == prj.Alias() {
-			// current alias
+		if aliasName == dedicatedID1 || aliasName == dedicatedID2 || aliasName == prj.Alias() {
+			// allow self sceneId or current alias
 			return true, nil
 		}
 
-		sce, err := i.sceneRepo.FindByProject(ctx, *pid)
-		if err != nil {
+		// story prefix check
+		if _, found := strings.CutPrefix(aliasName, alias.ReservedReearthPrefixStory); found {
+			// error 's-' prefix
+			return false, alias.ErrInvalidProjectInvalidPrefixAlias.AddTemplateData("aliasName", aliasName)
+		}
+
+		// scene prefix check
+		if _, found := strings.CutPrefix(aliasName, alias.ReservedReearthPrefixScene); found {
+			// error 'c-' prefix
+			return false, alias.ErrInvalidProjectInvalidPrefixAlias.AddTemplateData("aliasName", aliasName)
+		}
+
+		if err := alias.CheckProjectAliasPattern(aliasName); err != nil {
+			return false, err
+		}
+		if err := i.projectRepo.CheckAliasUnique(ctx, aliasName); err != nil {
+			return false, err
+		}
+		if err = i.storytellingRepo.CheckAliasUnique(ctx, aliasName); err != nil {
 			return false, err
 		}
 
-		if strings.HasPrefix(aliasName, alias.ReservedReearthPrefixStory) {
-			// error 's-' prefix
-			return false, alias.ErrInvalidProjectInvalidPrefixAlias.AddTemplateData("aliasName", aliasName)
-		} else if strings.HasPrefix(aliasName, alias.ReservedReearthPrefixProject) {
-			id := strings.TrimPrefix(aliasName, alias.ReservedReearthPrefixProject)
-			// only allow self ID
-			if id != sce.ID().String() {
-				// error 'c-' prefix
-				return false, alias.ErrInvalidProjectInvalidPrefixAlias.AddTemplateData("aliasName", aliasName)
-			}
-		}
-
-		if sce.ID().String() == aliasName || sce.DefaultAlias() == aliasName {
-			// allow self ProjectID
-		} else {
-			if err := alias.CheckProjectAliasPattern(aliasName); err != nil {
-				return false, err
-			}
-			if err := i.projectRepo.CheckAliasUnique(ctx, aliasName); err != nil {
-				return false, err
-			}
-			if err := i.sceneRepo.CheckAliasUnique(ctx, aliasName); err != nil {
-				return false, err
-			}
-			if err = i.storytellingRepo.CheckAliasUnique(ctx, aliasName); err != nil {
-				return false, err
-			}
-		}
 	}
 
 	return true, nil
@@ -451,12 +469,7 @@ func (i *Project) Publish(ctx context.Context, params interfaces.PublishProjectP
 		}
 	}()
 
-	prj, err := i.projectRepo.FindByID(ctx, params.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	sce, err := i.sceneRepo.FindByProject(ctx, params.ID)
+	prj, dedicatedID1, dedicatedID2, err := i.dedicatedID(ctx, &params.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -471,42 +484,43 @@ func (i *Project) Publish(ctx context.Context, params interfaces.PublishProjectP
 	if params.Alias == nil || *params.Alias == "" {
 		// if you don't have an alias, set it to default alias
 		if prj.Alias() == "" {
-			prj.UpdateAlias(sce.DefaultAlias())
+			prj.UpdateAlias(dedicatedID1)
 		}
 		// if anything is set, do nothing
 	} else {
+
 		newAlias := strings.ToLower(*params.Alias)
 
-		if strings.HasPrefix(newAlias, alias.ReservedReearthPrefixStory) {
-			// error 's-' prefix
-			return nil, alias.ErrInvalidProjectInvalidPrefixAlias.AddTemplateData("aliasName", newAlias)
-		} else if strings.HasPrefix(newAlias, alias.ReservedReearthPrefixProject) {
-			id := strings.TrimPrefix(newAlias, alias.ReservedReearthPrefixProject)
-			// only allow self ID
-			if id != sce.ID().String() {
+		if newAlias == dedicatedID1 || newAlias == dedicatedID2 || prevAlias == newAlias {
+
+			// allow self sceneId or current alias
+
+		} else {
+
+			// story prefix check
+			if _, found := strings.CutPrefix(newAlias, alias.ReservedReearthPrefixStory); found {
+				// error 's-' prefix
+				return nil, alias.ErrInvalidProjectInvalidPrefixAlias.AddTemplateData("aliasName", newAlias)
+			}
+
+			// scene prefix check
+			if _, found := strings.CutPrefix(newAlias, alias.ReservedReearthPrefixScene); found {
 				// error 'c-' prefix
 				return nil, alias.ErrInvalidProjectInvalidPrefixAlias.AddTemplateData("aliasName", newAlias)
+			}
+
+			if err := alias.CheckProjectAliasPattern(newAlias); err != nil {
+				return nil, err
+			}
+			if err := i.projectRepo.CheckAliasUnique(ctx, newAlias); err != nil {
+				return nil, err
+			}
+			if err = i.storytellingRepo.CheckAliasUnique(ctx, newAlias); err != nil {
+				return nil, err
 			}
 		}
 
 		prj.UpdateAlias(newAlias)
-	}
-
-	if prevAlias == prj.Alias() || sce.ID().String() == prj.Alias() || sce.DefaultAlias() == prj.Alias() {
-		// if do not change alias or self ProjectID, do nothing
-	} else {
-		if err := alias.CheckProjectAliasPattern(prj.Alias()); err != nil {
-			return nil, err
-		}
-		if err := i.projectRepo.CheckAliasUnique(ctx, prj.Alias()); err != nil {
-			return nil, err
-		}
-		if err := i.sceneRepo.CheckAliasUnique(ctx, prj.Alias()); err != nil {
-			return nil, err
-		}
-		if err = i.storytellingRepo.CheckAliasUnique(ctx, prj.Alias()); err != nil {
-			return nil, err
-		}
 	}
 
 	prj.UpdatePublishmentStatus(params.Status)

--- a/server/internal/usecase/interactor/scene.go
+++ b/server/internal/usecase/interactor/scene.go
@@ -136,7 +136,7 @@ func (i *Scene) Create(ctx context.Context, pid id.ProjectID, defaultExtensionWi
 	sceneID := id.NewSceneID()
 
 	if prj.Alias() == "" {
-		prj.UpdateAlias(alias.ReservedReearthPrefixProject + sceneID.String())
+		prj.UpdateAlias(alias.ReservedReearthPrefixScene + sceneID.String())
 		if err := i.projectRepo.Save(ctx, prj); err != nil {
 			return nil, err
 		}

--- a/server/internal/usecase/interactor/storytelling.go
+++ b/server/internal/usecase/interactor/storytelling.go
@@ -251,7 +251,7 @@ func (i *Storytelling) CheckAlias(ctx context.Context, newAlias string, sid *id.
 		if err := i.storytellingRepo.CheckAliasUnique(ctx, aliasName); err != nil {
 			return false, err
 		}
-		if strings.HasPrefix(aliasName, alias.ReservedReearthPrefixProject) || strings.HasPrefix(aliasName, alias.ReservedReearthPrefixStory) {
+		if strings.HasPrefix(aliasName, alias.ReservedReearthPrefixScene) || strings.HasPrefix(aliasName, alias.ReservedReearthPrefixStory) {
 			return false, alias.ErrInvalidProjectInvalidPrefixAlias.AddTemplateData("aliasName", aliasName)
 		}
 
@@ -267,7 +267,7 @@ func (i *Storytelling) CheckAlias(ctx context.Context, newAlias string, sid *id.
 			return true, nil
 		}
 
-		if strings.HasPrefix(aliasName, alias.ReservedReearthPrefixProject) {
+		if strings.HasPrefix(aliasName, alias.ReservedReearthPrefixScene) {
 			// error 'c-' prefix
 			return false, alias.ErrInvalidStorytellingInvalidPrefixAlias.AddTemplateData("aliasName", aliasName)
 		} else if strings.HasPrefix(aliasName, alias.ReservedReearthPrefixStory) {
@@ -335,7 +335,7 @@ func (i *Storytelling) Publish(ctx context.Context, inp interfaces.PublishStoryI
 	} else {
 		newAlias := strings.ToLower(*inp.Alias)
 
-		if strings.HasPrefix(newAlias, alias.ReservedReearthPrefixProject) {
+		if strings.HasPrefix(newAlias, alias.ReservedReearthPrefixScene) {
 			// error 'c-' prefix
 			return nil, alias.ErrInvalidStorytellingInvalidPrefixAlias.AddTemplateData("aliasName", newAlias)
 		} else if strings.HasPrefix(newAlias, alias.ReservedReearthPrefixStory) {

--- a/server/internal/usecase/interfaces/project.go
+++ b/server/internal/usecase/interfaces/project.go
@@ -84,6 +84,7 @@ type Project interface {
 	FindDeletedByWorkspace(context.Context, accountdomain.WorkspaceID, *usecase.Operator) ([]*project.Project, error)
 
 	FindActiveById(context.Context, id.ProjectID, *usecase.Operator) (*project.Project, error)
+	FindActiveByAlias(context.Context, string, *usecase.Operator) (*project.Project, error)
 	FindVisibilityByWorkspace(context.Context, accountdomain.WorkspaceID, bool, *usecase.Operator) ([]*project.Project, error)
 	UpdateVisibility(context.Context, id.ProjectID, string, *usecase.Operator) (*project.Project, error)
 

--- a/server/internal/usecase/repo/project.go
+++ b/server/internal/usecase/repo/project.go
@@ -25,6 +25,7 @@ type Project interface {
 	FindStarredByWorkspace(context.Context, accountdomain.WorkspaceID) ([]*project.Project, error)
 	FindDeletedByWorkspace(context.Context, accountdomain.WorkspaceID) ([]*project.Project, error)
 	FindActiveById(context.Context, id.ProjectID) (*project.Project, error)
+	FindActiveByAlias(context.Context, string) (*project.Project, error)
 	FindVisibilityByWorkspace(context.Context, bool, bool, accountdomain.WorkspaceID) ([]*project.Project, error)
 	FindByPublicName(context.Context, string) (*project.Project, error)
 	CheckAliasUnique(context.Context, string) error

--- a/server/pkg/alias/check.go
+++ b/server/pkg/alias/check.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	ReservedReearthPrefixProject = "c-"
+	ReservedReearthPrefixScene = "c-"
 
 	ReservedReearthPrefixStory = "s-"
 

--- a/server/pkg/scene/scene.go
+++ b/server/pkg/scene/scene.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/reearth/reearth/server/pkg/alias"
 	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearthx/account/accountdomain"
 )
@@ -111,8 +110,4 @@ func (s *Scene) Properties() []id.PropertyID {
 	ids = append(ids, s.plugins.Properties()...)
 	ids = append(ids, s.widgets.Properties()...)
 	return ids
-}
-
-func (s *Scene) DefaultAlias() string {
-	return alias.ReservedReearthPrefixProject + s.ID().String()
 }

--- a/server/schemas/internalapi/docs/schema.md
+++ b/server/schemas/internalapi/docs/schema.md
@@ -10,6 +10,8 @@
     - [DeleteProjectResponse](#reearth-visualizer-v1-DeleteProjectResponse)
     - [ExportProjectRequest](#reearth-visualizer-v1-ExportProjectRequest)
     - [ExportProjectResponse](#reearth-visualizer-v1-ExportProjectResponse)
+    - [GetProjectByAliasRequest](#reearth-visualizer-v1-GetProjectByAliasRequest)
+    - [GetProjectByAliasResponse](#reearth-visualizer-v1-GetProjectByAliasResponse)
     - [GetProjectListRequest](#reearth-visualizer-v1-GetProjectListRequest)
     - [GetProjectListResponse](#reearth-visualizer-v1-GetProjectListResponse)
     - [GetProjectRequest](#reearth-visualizer-v1-GetProjectRequest)
@@ -21,6 +23,8 @@
     - [UpdateProjectMetadataResponse](#reearth-visualizer-v1-UpdateProjectMetadataResponse)
     - [UpdateProjectRequest](#reearth-visualizer-v1-UpdateProjectRequest)
     - [UpdateProjectResponse](#reearth-visualizer-v1-UpdateProjectResponse)
+    - [ValidateProjectAliasRequest](#reearth-visualizer-v1-ValidateProjectAliasRequest)
+    - [ValidateProjectAliasResponse](#reearth-visualizer-v1-ValidateProjectAliasResponse)
   
     - [ProjectImportStatus](#reearth-visualizer-v1-ProjectImportStatus)
     - [PublishmentStatus](#reearth-visualizer-v1-PublishmentStatus)
@@ -131,6 +135,36 @@ Response messages
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | project_data_path | [string](#string) |  | Project Export zip file download url |
+
+
+
+
+
+
+<a name="reearth-visualizer-v1-GetProjectByAliasRequest"></a>
+
+### GetProjectByAliasRequest
+Find a project by alias.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| alias | [string](#string) |  | Scene alias |
+
+
+
+
+
+
+<a name="reearth-visualizer-v1-GetProjectByAliasResponse"></a>
+
+### GetProjectByAliasResponse
+Response messages
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project | [Project](#reearth-visualizer-v1-Project) |  | Project |
 
 
 
@@ -358,6 +392,39 @@ Response messages
 
 
 
+
+<a name="reearth-visualizer-v1-ValidateProjectAliasRequest"></a>
+
+### ValidateProjectAliasRequest
+Determines if an alias is valid.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project_id | [string](#string) | optional | Project ID |
+| alias | [string](#string) |  | Scene alias |
+
+
+
+
+
+
+<a name="reearth-visualizer-v1-ValidateProjectAliasResponse"></a>
+
+### ValidateProjectAliasResponse
+Response messages
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project_id | [string](#string) | optional | Project ID |
+| available | [bool](#bool) |  | Scene alias available |
+| error_message | [string](#string) | optional | Error message |
+
+
+
+
+
  
 
 
@@ -415,6 +482,8 @@ Response messages
 | ----------- | ------------ | ------------- | ------------|
 | GetProjectList | [GetProjectListRequest](#reearth-visualizer-v1-GetProjectListRequest) | [GetProjectListResponse](#reearth-visualizer-v1-GetProjectListResponse) | Retrieves the list of projects the user can access. Request headers: user-id: &lt;User ID&gt; |
 | GetProject | [GetProjectRequest](#reearth-visualizer-v1-GetProjectRequest) | [GetProjectResponse](#reearth-visualizer-v1-GetProjectResponse) | Retrieves a specific project regardless of authentication. Request headers: user-id: &lt;User ID&gt; |
+| GetProjectByAlias | [GetProjectByAliasRequest](#reearth-visualizer-v1-GetProjectByAliasRequest) | [GetProjectByAliasResponse](#reearth-visualizer-v1-GetProjectByAliasResponse) | Find a project by alias. Request headers: user-id: &lt;User ID&gt; |
+| ValidateProjectAlias | [ValidateProjectAliasRequest](#reearth-visualizer-v1-ValidateProjectAliasRequest) | [ValidateProjectAliasResponse](#reearth-visualizer-v1-ValidateProjectAliasResponse) | Determines if an alias is valid. Request headers: user-id: &lt;User ID&gt; |
 | CreateProject | [CreateProjectRequest](#reearth-visualizer-v1-CreateProjectRequest) | [CreateProjectResponse](#reearth-visualizer-v1-CreateProjectResponse) | Creates a new project in the specified team. Request headers: user-id: &lt;User ID&gt; |
 | UpdateProject | [UpdateProjectRequest](#reearth-visualizer-v1-UpdateProjectRequest) | [UpdateProjectResponse](#reearth-visualizer-v1-UpdateProjectResponse) | Update a project. Request headers: user-id: &lt;User ID&gt; |
 | UpdateProjectMetadata | [UpdateProjectMetadataRequest](#reearth-visualizer-v1-UpdateProjectMetadataRequest) | [UpdateProjectMetadataResponse](#reearth-visualizer-v1-UpdateProjectMetadataResponse) | Updates a new project metadata in the specified team. Request headers: user-id: &lt;User ID&gt; |

--- a/server/schemas/internalapi/v1/schema.proto
+++ b/server/schemas/internalapi/v1/schema.proto
@@ -15,11 +15,21 @@ service ReEarthVisualizer {
   // Request headers: user-id: <User ID>
   rpc GetProject(GetProjectRequest) returns (GetProjectResponse) {}
 
+  // Find a project by alias.
+  // Request headers: user-id: <User ID>
+  rpc GetProjectByAlias(GetProjectByAliasRequest)
+      returns (GetProjectByAliasResponse) {}
+
+  // Determines if an alias is valid.
+  // Request headers: user-id: <User ID>
+  rpc ValidateProjectAlias(ValidateProjectAliasRequest)
+      returns (ValidateProjectAliasResponse) {}
+
   // Creates a new project in the specified team.
   // Request headers: user-id: <User ID>
   rpc CreateProject(CreateProjectRequest) returns (CreateProjectResponse) {}
 
-  // Update  a project.
+  // Update a project.
   // Request headers: user-id: <User ID>
   rpc UpdateProject(UpdateProjectRequest) returns (UpdateProjectResponse) {}
 
@@ -173,6 +183,20 @@ message GetProjectRequest {
   string project_id = 1;
 }
 
+// Find a project by alias.
+message GetProjectByAliasRequest {
+  // Scene alias
+  string alias = 1;
+}
+
+// Determines if an alias is valid.
+message ValidateProjectAliasRequest {
+  // Project ID
+  optional string project_id = 1;
+  // Scene alias
+  string alias = 2;
+}
+
 // Creates a new project.
 // Cannot be created under a team the user does not belong to.
 message CreateProjectRequest {
@@ -292,4 +316,20 @@ message DeleteProjectResponse {
 message ExportProjectResponse {
   // Project Export zip file download url
   string project_data_path = 1;
+}
+
+// Response messages
+message GetProjectByAliasResponse {
+  // Project
+  Project project = 1;
+}
+
+// Response messages
+message ValidateProjectAliasResponse {
+  // Project ID
+  optional string project_id = 1;
+  // Scene alias available
+  bool available = 2;
+  // Error message
+  optional string error_message = 3;
 }


### PR DESCRIPTION
# Overview

### Add Validate Project Alias and Get Project by Alias as Method on the Internal API

## What I've done

### The newly added APIs are as follows:

## 1. GetProjectByAlias API
```diff
  // Find a project by alias.
  // Request headers: user-id: <User ID>
  rpc GetProjectByAlias(GetProjectByAliasRequest) returns (GetProjectByAliasResponse) {}

// Find a project by alias.
message GetProjectByAliasRequest {
  // Scene alias
  string alias = 1;
}

// Response messages
message GetProjectByAliasResponse {
  // Project
  Project project = 1;
}
```

## 2. ValidateProjectAlias API
```diff
  // Determines if an alias is valid.
  // Request headers: user-id: <User ID>
  rpc ValidateProjectAlias(ValidateProjectAliasRequest) returns (ValidateProjectAliasResponse) {}

// Determines if an alias is valid.
message ValidateProjectAliasRequest {
  // Project ID
  optional string project_id = 1;
  // Scene alias
  string alias = 2;
}

// Response messages
message ValidateProjectAliasResponse {
  // Project ID
  optional string project_id = 1;
  // Scene alias available
  bool available = 2;
  // Error message
  optional string error_message = 3;
}
```
## 3. I refactored the CheckAlias function for the project.
### It now checks both the Project and Scene collections in a single query.
https://github.com/reearth/reearth-visualizer/blob/feat/update-project-api-alias/server/internal/infrastructure/mongo/project.go#L297-L350

## What I haven't done

## How I tested

### e2e test code

## Which point I want you to review particularly

## Memo
