### PR TITLE
fix(web): event off

### DIFF
--- a/web/src/app/features/Visualizer/Crust/Plugins/utils/fingerprint.test.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/utils/fingerprint.test.ts
@@ -1,0 +1,272 @@
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
+import { getQuickJS } from "quickjs-emscripten";
+import { Arena } from "quickjs-emscripten-sync";
+import { describe, expect, test } from "vitest";
+
+import {
+  getFunctionFingerprint,
+  getFunctionFingerprintString,
+  areFunctionsSame,
+  FingerprintEventSystem
+} from "./fingerprint";
+
+describe("function fingerprinting", () => {
+  test("generates consistent fingerprints for identical functions", () => {
+    const fn1 = function testFunction() {
+      console.log("test");
+    };
+    const fn2 = function testFunction() {
+      console.log("test");
+    };
+
+    const fp1 = getFunctionFingerprint(fn1);
+    const fp2 = getFunctionFingerprint(fn2);
+
+    expect(fp1.hash).toBe(fp2.hash);
+    expect(areFunctionsSame(fn1, fn2)).toBe(true);
+  });
+
+  test("generates different fingerprints for different functions", () => {
+    const fn1 = function testFunction() {
+      console.log("test1");
+    };
+    const fn2 = function testFunction() {
+      console.log("test2");
+    };
+
+    const fp1 = getFunctionFingerprint(fn1);
+    const fp2 = getFunctionFingerprint(fn2);
+
+    expect(fp1.hash).not.toBe(fp2.hash);
+    expect(areFunctionsSame(fn1, fn2)).toBe(false);
+  });
+
+  test("CRITICAL: same fingerprint for QuickJS function before and after marshaling", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    // Create a function in QuickJS and get it multiple times
+    arena.evalCode(`
+      globalThis.myTestFunction = function clickHandler() {
+        console.log('button clicked');
+        return 42;
+      };
+    `);
+
+    // Get the function multiple times - these will be different JS objects
+    const fn1 = arena.evalCode(`myTestFunction`);
+    const fn2 = arena.evalCode(`myTestFunction`);
+    const fn3 = arena.evalCode(`myTestFunction`);
+
+    // Verify they are different objects (the original problem)
+    expect(fn1).not.toBe(fn2);
+    expect(fn2).not.toBe(fn3);
+
+    // BUT their fingerprints should be identical!
+    const fp1 = getFunctionFingerprintString(fn1);
+    const fp2 = getFunctionFingerprintString(fn2);
+    const fp3 = getFunctionFingerprintString(fn3);
+
+    expect(fp1).toBe(fp2);
+    expect(fp2).toBe(fp3);
+    expect(areFunctionsSame(fn1, fn2)).toBe(true);
+    expect(areFunctionsSame(fn2, fn3)).toBe(true);
+
+    // Test the detailed fingerprint
+    const detailed1 = getFunctionFingerprint(fn1);
+    const detailed2 = getFunctionFingerprint(fn2);
+
+    expect(detailed1.name).toBe(detailed2.name);
+    expect(detailed1.source).toBe(detailed2.source);
+    expect(detailed1.length).toBe(detailed2.length);
+    expect(detailed1.hash).toBe(detailed2.hash);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("fingerprint-based event system solves addEventListener/removeEventListener", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    // Create event system
+    const eventSystem = new FingerprintEventSystem();
+
+    // Expose event system to QuickJS
+    arena.expose({
+      addEventListener: (event: string, handler: Function) => {
+        return eventSystem.addEventListener(event, handler);
+      },
+      removeEventListener: (event: string, fingerprint: string) => {
+        return eventSystem.removeEventListener(event, fingerprint);
+      },
+      dispatchEvent: (event: string) => {
+        eventSystem.dispatchEvent(event);
+        return eventSystem.getListenerCount(event);
+      },
+      getListenerCount: (event: string) => {
+        return eventSystem.getListenerCount(event);
+      }
+    });
+
+    // Test the complete flow in QuickJS
+    const result = arena.evalCode(`
+      // Define a function in QuickJS
+      const myHandler = function clickHandler() {
+        console.log('Button was clicked!');
+      };
+
+      // Add the listener and get the fingerprint
+      const fingerprint = addEventListener('click', myHandler);
+      const countAfterAdd = getListenerCount('click');
+
+      // Remove using the fingerprint
+      const removed = removeEventListener('click', fingerprint);
+      const countAfterRemove = getListenerCount('click');
+
+      // Return results
+      ({
+        fingerprint,
+        countAfterAdd,
+        removed,
+        countAfterRemove
+      });
+    `);
+
+    expect(result.countAfterAdd).toBe(1);
+    expect(result.removed).toBe(true);
+    expect(result.countAfterRemove).toBe(0);
+    expect(typeof result.fingerprint).toBe("string");
+    expect(result.fingerprint.length).toBeGreaterThan(0);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("manual fingerprint generation for user control", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    const eventSystem = new FingerprintEventSystem();
+
+    // Expose fingerprint utilities to QuickJS
+    arena.expose({
+      addEventListener: (
+        event: string,
+        handler: Function,
+        customFingerprint?: string
+      ) => {
+        return eventSystem.addEventListener(event, handler, customFingerprint);
+      },
+      removeEventListener: (event: string, fingerprint: string) => {
+        return eventSystem.removeEventListener(event, fingerprint);
+      },
+      getListenerCount: (event: string) => {
+        return eventSystem.getListenerCount(event);
+      },
+      // Expose fingerprint generation function
+      generateFingerprint: (fn: Function) => {
+        return getFunctionFingerprintString(fn);
+      }
+    });
+
+    const result = arena.evalCode(`
+      const myHandler = function mySpecialHandler() {
+        return 'clicked';
+      };
+
+      // User generates their own fingerprint
+      const userFingerprint = generateFingerprint(myHandler);
+      
+      // User can also create a custom fingerprint
+      const customFingerprint = 'my-custom-id-' + myHandler.name;
+
+      // Add with auto-generated fingerprint
+      const autoFP = addEventListener('click', myHandler);
+      
+      // Add with custom fingerprint  
+      const customFP = addEventListener('scroll', myHandler, customFingerprint);
+
+      ({
+        userFingerprint,
+        customFingerprint,
+        autoFP,
+        customFP,
+        autoSameAsUser: autoFP === userFingerprint,
+        customSameAsProvided: customFP === customFingerprint
+      });
+    `);
+
+    expect(result.autoSameAsUser).toBe(true);
+    expect(result.customSameAsProvided).toBe(true);
+    expect(result.userFingerprint).toBe(result.autoFP);
+    expect(result.customFingerprint).toBe(result.customFP);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("event system handles multiple listeners and events", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    const eventSystem = new FingerprintEventSystem();
+    const dispatchLog: string[] = [];
+
+    arena.expose({
+      addEventListener: (event: string, handler: Function) => {
+        return eventSystem.addEventListener(event, handler);
+      },
+      removeEventListener: (event: string, fingerprint: string) => {
+        return eventSystem.removeEventListener(event, fingerprint);
+      },
+      dispatchEvent: (event: string) => {
+        // Capture dispatch for testing
+        dispatchLog.push(`Dispatching ${event}`);
+        eventSystem.dispatchEvent(event);
+        return eventSystem.getListenerCount(event);
+      },
+      getListenerCount: (event: string) => {
+        return eventSystem.getListenerCount(event);
+      },
+      log: (message: string) => {
+        dispatchLog.push(message);
+      }
+    });
+
+    arena.evalCode(`
+      // Create multiple handlers
+      const handler1 = function clickHandler1() { log('Handler 1 called'); };
+      const handler2 = function clickHandler2() { log('Handler 2 called'); };
+      const handler3 = function scrollHandler() { log('Scroll handler called'); };
+
+      // Add listeners
+      const fp1 = addEventListener('click', handler1);
+      const fp2 = addEventListener('click', handler2);  
+      const fp3 = addEventListener('scroll', handler3);
+
+      // Dispatch events
+      dispatchEvent('click');   // Should call handler1 and handler2
+      dispatchEvent('scroll');  // Should call handler3
+
+      // Remove one click handler
+      removeEventListener('click', fp1);
+      
+      // Dispatch again
+      dispatchEvent('click');   // Should only call handler2
+    `);
+
+    expect(dispatchLog).toEqual([
+      "Dispatching click",
+      "Handler 1 called",
+      "Handler 2 called",
+      "Dispatching scroll",
+      "Scroll handler called",
+      "Dispatching click",
+      "Handler 2 called"
+    ]);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+});

--- a/web/src/app/features/Visualizer/Crust/Plugins/utils/fingerprint.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/utils/fingerprint.ts
@@ -1,0 +1,151 @@
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
+/**
+ * Generates a consistent fingerprint for functions that remains stable
+ * even after functions are marshaled/unmarshaled through QuickJS.
+ *
+ * This is useful for scenarios like addEventListener/removeEventListener
+ * where you need to identify the same logical function even though
+ * different JavaScript wrapper objects are created each time.
+ */
+
+export interface FunctionFingerprint {
+  name: string;
+  source: string;
+  length: number;
+  hash: string;
+}
+
+/**
+ * Simple hash function for strings (djb2 algorithm)
+ */
+function hashString(str: string): string {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash << 5) + hash + str.charCodeAt(i);
+  }
+  return (hash >>> 0).toString(36); // Convert to base36 for shorter string
+}
+
+/**
+ * Generate a fingerprint object for a function
+ */
+export function getFunctionFingerprint(fn: Function): FunctionFingerprint {
+  const name = fn.name || "";
+  const source = fn.toString();
+  const length = fn.length;
+
+  // Create a composite hash from all properties
+  const composite = `${name}|${source}|${length}`;
+  const hash = hashString(composite);
+
+  return {
+    name,
+    source,
+    length,
+    hash
+  };
+}
+
+/**
+ * Generate a simple string fingerprint for a function
+ * This is the most convenient form for use as a Map key
+ */
+export function getFunctionFingerprintString(fn: Function): string {
+  const fingerprint = getFunctionFingerprint(fn);
+  return fingerprint.hash;
+}
+
+/**
+ * Compare two functions by their fingerprints
+ */
+export function areFunctionsSame(fn1: Function, fn2: Function): boolean {
+  const fp1 = getFunctionFingerprint(fn1);
+  const fp2 = getFunctionFingerprint(fn2);
+
+  return fp1.hash === fp2.hash;
+}
+
+/**
+ * Enhanced event listener system using function fingerprints
+ * This solves the function identity problem for QuickJS functions
+ */
+export class FingerprintEventSystem {
+  private listeners = new Map<string, Map<string, Function>>();
+
+  /**
+   * Add an event listener using function fingerprint for identification
+   */
+  addEventListener(
+    event: string,
+    handler: Function,
+    customFingerprint?: string
+  ): string {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Map());
+    }
+
+    const fingerprint =
+      customFingerprint || getFunctionFingerprintString(handler);
+    const eventListeners = this.listeners.get(event);
+    if (eventListeners) {
+      eventListeners.set(fingerprint, handler);
+    }
+
+    return fingerprint;
+  }
+
+  /**
+   * Remove an event listener by fingerprint
+   */
+  removeEventListener(event: string, fingerprint: string): boolean {
+    const eventListeners = this.listeners.get(event);
+    if (!eventListeners) return false;
+
+    return eventListeners.delete(fingerprint);
+  }
+
+  /**
+   * Remove an event listener by function (automatically generates fingerprint)
+   */
+  removeEventListenerByFunction(event: string, handler: Function): boolean {
+    const fingerprint = getFunctionFingerprintString(handler);
+    return this.removeEventListener(event, fingerprint);
+  }
+
+  /**
+   * Dispatch an event to all registered listeners
+   */
+  dispatchEvent(event: string, ...args: any[]): void {
+    const eventListeners = this.listeners.get(event);
+    if (!eventListeners) return;
+
+    for (const handler of eventListeners.values()) {
+      try {
+        handler(...args);
+      } catch (error) {
+        console.error("Error in event handler:", error);
+      }
+    }
+  }
+
+  /**
+   * Get count of listeners for an event
+   */
+  getListenerCount(event: string): number {
+    return this.listeners.get(event)?.size || 0;
+  }
+
+  /**
+   * Clear all listeners for an event
+   */
+  clearEventListeners(event: string): void {
+    this.listeners.delete(event);
+  }
+
+  /**
+   * Clear all listeners
+   */
+  clearAllListeners(): void {
+    this.listeners.clear();
+  }
+}


### PR DESCRIPTION
# Overview

When using addEventListener and removeEventListener with functions created in QuickJS, the removal fails because the same logical function creates different JavaScript wrapper objects each time it's accessed from the host side.

  Example of the problem:
```
  // In QuickJS code
  const myHandler = function() { console.log('clicked'); };

  addEventListener('click', myHandler);        // Works - adds listener
  removeEventListener('click', myHandler);     // Fails - myHandler is a different object!
```

  This happens because:
  1. QuickJS functions are marshaled/unmarshaled across the boundary
  2. Each access creates a new JavaScript wrapper object
  3. myHandler !== myHandler when accessed multiple times
  4. removeEventListener can't find the handler to remove

  Root Cause

  The quickjs-emscripten-sync library creates new JavaScript wrapper objects for QuickJS functions on each access, even for the same underlying QuickJS function. This breaks reference-based APIs like event listeners.

Solution

Generate a fingerprint for each callback function, and use it as the key instead of the function itself on application level for bind/unbind event callbacks.

## What I've done

## What I haven't done

## How I tested
[ReEarth Visualizer Plugin.zip](https://github.com/user-attachments/files/21014446/ReEarth.Visualizer.Plugin.zip)

## Which point I want you to review particularly

## Memo
