### PR TITLE
feat(server): update internal project api [VIZ-1962,VIZ-1961]

### DIFF
--- a/server/e2e/proto_project_sort_pagination_test.go
+++ b/server/e2e/proto_project_sort_pagination_test.go
@@ -1,0 +1,413 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	pb "github.com/reearth/reearth/server/internal/adapter/internalapi/schemas/internalapi/v1"
+	"github.com/reearth/reearth/server/internal/usecase/repo"
+	"github.com/reearth/reearth/server/pkg/builtin"
+	"github.com/reearth/reearth/server/pkg/id"
+	"github.com/reearth/reearth/server/pkg/project"
+	"github.com/reearth/reearth/server/pkg/property"
+	"github.com/reearth/reearth/server/pkg/scene"
+	"github.com/reearth/reearth/server/pkg/storytelling"
+	"github.com/reearth/reearth/server/pkg/visualizer"
+	"github.com/reearth/reearthx/account/accountdomain"
+	"github.com/stretchr/testify/assert"
+)
+
+// go test -v -run TestInternalAPI_GetProjectList ./e2e/...
+
+func TestInternalAPI_GetProjectList(t *testing.T) {
+	_, r, _ := GRPCServer(t, baseSeeder)
+
+	testDataCount := 20
+	testWorkspace := wID2.String()
+	limit := 5
+
+	runTestWithUser(t, uID2.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
+
+		SetupTestProjectDatas(t, ctx, r, wID2, testDataCount)
+
+		// ASC UpdateAt
+		checkGetProjectsASC(
+			t,
+			client,
+			ctx,
+			true,
+			&testWorkspace,
+			&pb.ProjectSort{
+				Field:     pb.ProjectSortField_UPDATEDAT,
+				Direction: pb.SortDirection_ASC,
+			},
+			limit,
+			testDataCount*2,
+		)
+
+		// ASC Name
+		checkGetProjectsASC(
+			t,
+			client,
+			ctx,
+			true,
+			&testWorkspace,
+			&pb.ProjectSort{
+				Field:     pb.ProjectSortField_NAME,
+				Direction: pb.SortDirection_ASC,
+			},
+			limit,
+			testDataCount*2,
+		)
+
+		// DESC UpdateAt
+		checkGetProjectsDESC(
+			t,
+			client,
+			ctx,
+			true,
+			&testWorkspace,
+			&pb.ProjectSort{
+				Field:     pb.ProjectSortField_UPDATEDAT,
+				Direction: pb.SortDirection_DESC,
+			},
+			limit,
+			testDataCount*2,
+		)
+
+		// DESC Name
+		checkGetProjectsDESC(
+			t,
+			client,
+			ctx,
+			true,
+			&testWorkspace,
+			&pb.ProjectSort{
+				Field:     pb.ProjectSortField_NAME,
+				Direction: pb.SortDirection_DESC,
+			},
+			limit,
+			testDataCount*2,
+		)
+
+		// keyword search
+		keyword := "2"
+		checkGetProjectsASCWithKeyword(
+			t,
+			client,
+			ctx,
+			true,
+			&testWorkspace,
+			&pb.ProjectSort{
+				Field:     pb.ProjectSortField_UPDATEDAT,
+				Direction: pb.SortDirection_ASC,
+			},
+			&keyword,
+			limit,
+			22,
+		)
+
+	})
+}
+
+func checkGetProjectsASC(
+	t *testing.T,
+	client pb.ReEarthVisualizerClient,
+	ctx context.Context,
+	authenticated bool,
+	workspaceId *string,
+	sort *pb.ProjectSort,
+	limit int,
+	testDataCount int,
+) {
+	var endCursor *string
+	limit_int32 := int32(limit)
+
+	for i := 0; i < testDataCount/limit; i++ {
+
+		var pagination *pb.Pagination
+		if i == 0 {
+			// firtst loop
+			pagination = &pb.Pagination{
+				First: &limit_int32,
+			}
+		} else {
+			pagination = &pb.Pagination{
+				First: &limit_int32,
+				After: endCursor,
+			}
+		}
+
+		res, err := client.GetProjectList(ctx, &pb.GetProjectListRequest{
+			Authenticated: authenticated,
+			WorkspaceId:   workspaceId,
+			Sort:          sort,
+			Pagination:    pagination,
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, int64(testDataCount), res.PageInfo.TotalCount)
+
+		// for _, v := range res.Projects {
+		// 	fmt.Println("==============", v.Id, v.Name)
+		// }
+		// PbDump(res.PageInfo)
+
+		if i < testDataCount/limit-1 {
+			assert.Equal(t, limit, len(res.Projects))
+			assert.Equal(t, true, res.PageInfo.HasNextPage)
+			assert.Equal(t, false, res.PageInfo.HasPreviousPage)
+			endCursor = res.PageInfo.EndCursor
+		} else {
+			// last loop
+			assert.Equal(t, false, res.PageInfo.HasNextPage)
+			assert.Equal(t, false, res.PageInfo.HasPreviousPage)
+		}
+	}
+
+}
+
+func checkGetProjectsASCWithKeyword(
+	t *testing.T,
+	client pb.ReEarthVisualizerClient,
+	ctx context.Context,
+	authenticated bool,
+	workspaceId *string,
+	sort *pb.ProjectSort,
+	keyword *string,
+	limit int,
+	testDataCount int,
+) {
+	var endCursor *string
+	limit_int32 := int32(limit)
+
+	for i := 0; i < testDataCount/limit; i++ {
+
+		var pagination *pb.Pagination
+		if i == 0 {
+			// firtst loop
+			pagination = &pb.Pagination{
+				First: &limit_int32,
+			}
+		} else {
+			pagination = &pb.Pagination{
+				First: &limit_int32,
+				After: endCursor,
+			}
+		}
+
+		res, err := client.GetProjectList(ctx, &pb.GetProjectListRequest{
+			Authenticated: authenticated,
+			WorkspaceId:   workspaceId,
+			Sort:          sort,
+			Keyword:       keyword,
+			Pagination:    pagination,
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, int64(testDataCount), res.PageInfo.TotalCount)
+
+		// for _, v := range res.Projects {
+		// 	fmt.Println("==============", v.Id, v.Name)
+		// }
+		// PbDump(res.PageInfo)
+
+		if i < testDataCount/limit {
+			assert.Equal(t, limit, len(res.Projects))
+			assert.Equal(t, true, res.PageInfo.HasNextPage)
+			assert.Equal(t, false, res.PageInfo.HasPreviousPage)
+			endCursor = res.PageInfo.EndCursor
+		} else {
+			// last loop
+			assert.Equal(t, false, res.PageInfo.HasNextPage)
+			assert.Equal(t, false, res.PageInfo.HasPreviousPage)
+		}
+	}
+
+}
+
+func checkGetProjectsDESC(
+	t *testing.T,
+	client pb.ReEarthVisualizerClient,
+	ctx context.Context,
+	authenticated bool,
+	workspaceId *string,
+	sort *pb.ProjectSort,
+	limit int,
+	testDataCount int,
+) {
+	var startCursor *string
+	limit_int32 := int32(limit)
+
+	for i := 0; i < testDataCount/limit; i++ {
+
+		var pagination *pb.Pagination
+		if i == 0 {
+			// firtst loop
+			pagination = &pb.Pagination{
+				Last: &limit_int32,
+			}
+		} else {
+			pagination = &pb.Pagination{
+				Last:   &limit_int32,
+				Before: startCursor,
+			}
+		}
+
+		res, err := client.GetProjectList(ctx, &pb.GetProjectListRequest{
+			Authenticated: authenticated,
+			WorkspaceId:   workspaceId,
+			Sort:          sort,
+			Pagination:    pagination,
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, int64(testDataCount), res.PageInfo.TotalCount)
+
+		// for _, v := range res.Projects {
+		// 	fmt.Println("==============", v.Id, v.Name)
+		// }
+		// PbDump(res.PageInfo)
+
+		if i < testDataCount/limit-1 {
+			assert.Equal(t, limit, len(res.Projects))
+			assert.Equal(t, false, res.PageInfo.HasNextPage)
+			assert.Equal(t, true, res.PageInfo.HasPreviousPage)
+			startCursor = res.PageInfo.StartCursor
+		} else {
+			// last loop
+			assert.Equal(t, false, res.PageInfo.HasNextPage)
+			assert.Equal(t, false, res.PageInfo.HasPreviousPage)
+		}
+	}
+}
+
+// --- test data ---------------------------------------
+
+type ProjectConfig struct {
+	workspace   accountdomain.WorkspaceID
+	name        string
+	coreSupport bool
+	isDeleted   bool
+	visibility  string
+	updatedAt   time.Time
+}
+
+func SetupTestProjectDatas(t *testing.T, ctx context.Context, r *repo.Container, workspace accountdomain.WorkspaceID, dataCount int) {
+
+	startTime := time.Now()
+
+	startCount := 1000 // isDeleted: false visibility: "public"
+	for i := startCount; i < startCount+dataCount; i++ {
+		conf := ProjectConfig{
+			workspace:   workspace,
+			name:        fmt.Sprintf("%d", startCount+i),
+			coreSupport: true,
+			isDeleted:   false,
+			visibility:  "public",
+			updatedAt:   startTime.Add(time.Duration(i-1000) * time.Second),
+		}
+		AddProjectSceneStorytelling(t, ctx, r, conf)
+	}
+
+	startCount = 2000 // isDeleted: false visibility: "private"
+	for i := startCount; i < startCount+dataCount; i++ {
+		conf := ProjectConfig{
+			workspace:   workspace,
+			name:        fmt.Sprintf("%d", startCount+i),
+			coreSupport: true,
+			isDeleted:   false,
+			visibility:  "private",
+			updatedAt:   startTime.Add(time.Duration(i-1000) * time.Second),
+		}
+		AddProjectSceneStorytelling(t, ctx, r, conf)
+	}
+
+	startCount = 3000 // isDeleted: true visibility: "public"
+	for i := startCount; i < startCount+dataCount; i++ {
+		conf := ProjectConfig{
+			workspace:   workspace,
+			name:        fmt.Sprintf("%d", startCount+i),
+			coreSupport: true,
+			isDeleted:   true,
+			visibility:  "public",
+			updatedAt:   startTime.Add(time.Duration(i-1000) * time.Second),
+		}
+		AddProjectSceneStorytelling(t, ctx, r, conf)
+	}
+
+	startCount = 4000 // isDeleted: true visibility: "private"
+	for i := startCount; i < startCount+dataCount; i++ {
+		conf := ProjectConfig{
+			workspace:   workspace,
+			name:        fmt.Sprintf("%d", startCount+i),
+			coreSupport: true,
+			isDeleted:   true,
+			visibility:  "private",
+			updatedAt:   startTime.Add(time.Duration(i-1000) * time.Second),
+		}
+		AddProjectSceneStorytelling(t, ctx, r, conf)
+	}
+
+}
+
+func AddProjectSceneStorytelling(t *testing.T, ctx context.Context, r *repo.Container, conf ProjectConfig) {
+
+	// project
+	pj := project.New().
+		NewID().
+		Workspace(conf.workspace).
+		Name(conf.name).
+		Description(conf.name + " Description").
+		CoreSupport(conf.coreSupport).
+		Deleted(conf.isDeleted).
+		Visibility(conf.visibility).
+		UpdatedAt(conf.updatedAt).
+		MustBuild()
+	err := r.Project.Save(ctx, pj)
+	assert.Nil(t, err)
+
+	schema := builtin.GetPropertySchemaByVisualizer(visualizer.VisualizerCesiumBeta)
+	prop, err := property.New().NewID().Schema(schema.ID()).Scene(sID).Build()
+
+	assert.Nil(t, err)
+	ps := scene.NewPlugins([]*scene.Plugin{
+		scene.NewPlugin(id.OfficialPluginID, nil),
+	})
+
+	// scene
+	sc := scene.New().
+		NewID().
+		Project(pj.ID()).
+		Property(prop.ID()).
+		Workspace(pj.Workspace()).
+		UpdatedAt(conf.updatedAt).
+		Plugins(ps).
+		MustBuild()
+	err = r.Scene.Save(ctx, sc)
+	assert.Nil(t, err)
+	err = r.Property.Save(ctx, prop)
+	assert.Nil(t, err)
+
+	schema2 := builtin.GetPropertySchema(builtin.PropertySchemaIDStory)
+	prop2, err := property.New().NewID().Schema(schema2.ID()).Scene(sc.ID()).Build()
+	assert.Nil(t, err)
+	pages := []*storytelling.Page{}
+	page, err := _createPage(ctx, r)
+	assert.Nil(t, err)
+	pages = append(pages, page)
+
+	// storytelling
+	st := storytelling.NewStory().
+		NewID().
+		Title(conf.name).
+		Pages(storytelling.NewPageList(pages)).
+		Scene(sc.ID()).
+		Property(prop2.ID()).
+		UpdatedAt(conf.updatedAt).
+		MustBuild()
+	err = r.Storytelling.Save(ctx, *st)
+	assert.Nil(t, err)
+	err = r.Property.Save(ctx, prop2)
+	assert.Nil(t, err)
+
+}

--- a/server/e2e/proto_project_user_test.go
+++ b/server/e2e/proto_project_user_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestInternalAPI_private(t *testing.T) {
 	_, r, _ := GRPCServer(t, baseSeeder)
+	testWorkspace := wID.String()
 
 	// user1: workspaceId: wID   userId: uID
 	// user2: workspaceId: wID2  userId: uID2
@@ -22,7 +23,7 @@ func TestInternalAPI_private(t *testing.T) {
 		createProjectInternal(
 			t, ctx, r, client, "private",
 			&pb.CreateProjectRequest{
-				WorkspaceId: wID.String(),
+				WorkspaceId: testWorkspace,
 				Visualizer:  pb.Visualizer_VISUALIZER_CESIUM,
 				Name:        lo.ToPtr("Test Project1"),
 				Description: lo.ToPtr("Test Description1"),
@@ -34,7 +35,7 @@ func TestInternalAPI_private(t *testing.T) {
 		createProjectInternal(
 			t, ctx, r, client, "private",
 			&pb.CreateProjectRequest{
-				WorkspaceId: wID.String(),
+				WorkspaceId: testWorkspace,
 				Visualizer:  pb.Visualizer_VISUALIZER_CESIUM,
 				Name:        lo.ToPtr("Test Project1"),
 				Description: lo.ToPtr("Test Description1"),
@@ -47,7 +48,8 @@ func TestInternalAPI_private(t *testing.T) {
 
 		// get list size 3
 		res3, err := client.GetProjectList(ctx, &pb.GetProjectListRequest{
-			WorkspaceId: wID.String(),
+			Authenticated: true,
+			WorkspaceId:   &testWorkspace,
 		})
 		assert.Nil(t, err)
 		assert.Equal(t, 2, len(res3.Projects))
@@ -60,16 +62,18 @@ func TestInternalAPI_private(t *testing.T) {
 	runTestWithUser(t, uID2.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
 		// get list size 0
 		res4, err := client.GetProjectList(ctx, &pb.GetProjectListRequest{
-			WorkspaceId: wID.String(), // not wID2
+			Authenticated: true,
+			WorkspaceId:   &testWorkspace, // not wID2
 		})
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(res4.Projects))
+		assert.Equal(t, 2, len(res4.Projects))
 	})
 
 }
 
 func TestInternalAPI_public(t *testing.T) {
 	_, r, _ := GRPCServer(t, baseSeeder)
+	testWorkspace := wID.String()
 
 	var publicProjectId string
 
@@ -80,7 +84,7 @@ func TestInternalAPI_public(t *testing.T) {
 		createProjectInternal(
 			t, ctx, r, client, "public",
 			&pb.CreateProjectRequest{
-				WorkspaceId: wID.String(),
+				WorkspaceId: testWorkspace,
 				Visualizer:  pb.Visualizer_VISUALIZER_CESIUM,
 				Name:        lo.ToPtr("Test Project1"),
 				Description: lo.ToPtr("Test Description1"),
@@ -92,7 +96,7 @@ func TestInternalAPI_public(t *testing.T) {
 		createProjectInternal(
 			t, ctx, r, client, "private",
 			&pb.CreateProjectRequest{
-				WorkspaceId: wID.String(),
+				WorkspaceId: testWorkspace,
 				Visualizer:  pb.Visualizer_VISUALIZER_CESIUM,
 				Name:        lo.ToPtr("Test Project1"),
 				Description: lo.ToPtr("Test Description1"),
@@ -105,12 +109,13 @@ func TestInternalAPI_public(t *testing.T) {
 
 		// get list size 3
 		res3, err := client.GetProjectList(ctx, &pb.GetProjectListRequest{
-			WorkspaceId: wID.String(),
+			Authenticated: true,
+			WorkspaceId:   &testWorkspace,
 		})
 		assert.Nil(t, err)
 		assert.Equal(t, 2, len(res3.Projects))
-		assert.Equal(t, "public", res3.Projects[0].Visibility)
-		assert.Equal(t, "private", res3.Projects[1].Visibility)
+		assert.Equal(t, "private", res3.Projects[0].Visibility)
+		assert.Equal(t, "public", res3.Projects[1].Visibility)
 
 		publicProjectId = res3.Projects[0].Id
 
@@ -120,10 +125,11 @@ func TestInternalAPI_public(t *testing.T) {
 	runTestWithUser(t, uID2.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
 		// get list size 1
 		res4, err := client.GetProjectList(ctx, &pb.GetProjectListRequest{
-			WorkspaceId: wID.String(), // not wID2
+			Authenticated: true,
+			WorkspaceId:   &testWorkspace, // not wID2
 		})
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(res4.Projects))
+		assert.Equal(t, 2, len(res4.Projects))
 
 		// test DeleteProject
 		res5, err := client.DeleteProject(ctx, &pb.DeleteProjectRequest{
@@ -149,12 +155,12 @@ func TestInternalAPI_public(t *testing.T) {
 	// user2 call api
 	runTestWithUser(t, uID2.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
 
-		// get list size 0
 		res7, err := client.GetProjectList(ctx, &pb.GetProjectListRequest{
-			WorkspaceId: wID.String(), // not wID2
+			Authenticated: true,
+			WorkspaceId:   &testWorkspace, // not wID2
 		})
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(res7.Projects))
+		assert.Equal(t, 1, len(res7.Projects))
 
 	})
 

--- a/server/internal/adapter/gql/loader_project.go
+++ b/server/internal/adapter/gql/loader_project.go
@@ -131,7 +131,7 @@ func (c *ProjectLoader) VisibilityByWorkspace(ctx context.Context, wsID gqlmodel
 		return nil, err
 	}
 
-	res, err := c.usecase.FindVisibilityByWorkspace(ctx, tid, authenticated, getOperator(ctx))
+	res, _, err := c.usecase.FindVisibilityByWorkspace(ctx, tid, authenticated, getOperator(ctx), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/adapter/internalapi/schemas/internalapi/v1/schema.pb.go
+++ b/server/internal/adapter/internalapi/schemas/internalapi/v1/schema.pb.go
@@ -178,6 +178,104 @@ func (PublishmentStatus) EnumDescriptor() ([]byte, []int) {
 	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{2}
 }
 
+type ProjectSortField int32
+
+const (
+	ProjectSortField_PROJECT_SORT_FIELD_UNSPECIFIED ProjectSortField = 0
+	ProjectSortField_UPDATEDAT                      ProjectSortField = 1
+	ProjectSortField_NAME                           ProjectSortField = 2
+)
+
+// Enum value maps for ProjectSortField.
+var (
+	ProjectSortField_name = map[int32]string{
+		0: "PROJECT_SORT_FIELD_UNSPECIFIED",
+		1: "UPDATEDAT",
+		2: "NAME",
+	}
+	ProjectSortField_value = map[string]int32{
+		"PROJECT_SORT_FIELD_UNSPECIFIED": 0,
+		"UPDATEDAT":                      1,
+		"NAME":                           2,
+	}
+)
+
+func (x ProjectSortField) Enum() *ProjectSortField {
+	p := new(ProjectSortField)
+	*p = x
+	return p
+}
+
+func (x ProjectSortField) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ProjectSortField) Descriptor() protoreflect.EnumDescriptor {
+	return file_schemas_internalapi_v1_schema_proto_enumTypes[3].Descriptor()
+}
+
+func (ProjectSortField) Type() protoreflect.EnumType {
+	return &file_schemas_internalapi_v1_schema_proto_enumTypes[3]
+}
+
+func (x ProjectSortField) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ProjectSortField.Descriptor instead.
+func (ProjectSortField) EnumDescriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{3}
+}
+
+type SortDirection int32
+
+const (
+	SortDirection_SORT_DIRECTION_UNSPECIFIED SortDirection = 0
+	SortDirection_ASC                        SortDirection = 1
+	SortDirection_DESC                       SortDirection = 2
+)
+
+// Enum value maps for SortDirection.
+var (
+	SortDirection_name = map[int32]string{
+		0: "SORT_DIRECTION_UNSPECIFIED",
+		1: "ASC",
+		2: "DESC",
+	}
+	SortDirection_value = map[string]int32{
+		"SORT_DIRECTION_UNSPECIFIED": 0,
+		"ASC":                        1,
+		"DESC":                       2,
+	}
+)
+
+func (x SortDirection) Enum() *SortDirection {
+	p := new(SortDirection)
+	*p = x
+	return p
+}
+
+func (x SortDirection) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SortDirection) Descriptor() protoreflect.EnumDescriptor {
+	return file_schemas_internalapi_v1_schema_proto_enumTypes[4].Descriptor()
+}
+
+func (SortDirection) Type() protoreflect.EnumType {
+	return &file_schemas_internalapi_v1_schema_proto_enumTypes[4]
+}
+
+func (x SortDirection) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SortDirection.Descriptor instead.
+func (SortDirection) EnumDescriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{4}
+}
+
 // Core Project messages
 type Project struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -584,21 +682,224 @@ func (x *ProjectMetadata) GetUpdatedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+// Pagination
+type Pagination struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	First         *int32                 `protobuf:"varint,1,opt,name=first,proto3,oneof" json:"first,omitempty"`
+	Last          *int32                 `protobuf:"varint,2,opt,name=last,proto3,oneof" json:"last,omitempty"`
+	After         *string                `protobuf:"bytes,3,opt,name=after,proto3,oneof" json:"after,omitempty"`
+	Before        *string                `protobuf:"bytes,4,opt,name=before,proto3,oneof" json:"before,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Pagination) Reset() {
+	*x = Pagination{}
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Pagination) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Pagination) ProtoMessage() {}
+
+func (x *Pagination) ProtoReflect() protoreflect.Message {
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Pagination.ProtoReflect.Descriptor instead.
+func (*Pagination) Descriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *Pagination) GetFirst() int32 {
+	if x != nil && x.First != nil {
+		return *x.First
+	}
+	return 0
+}
+
+func (x *Pagination) GetLast() int32 {
+	if x != nil && x.Last != nil {
+		return *x.Last
+	}
+	return 0
+}
+
+func (x *Pagination) GetAfter() string {
+	if x != nil && x.After != nil {
+		return *x.After
+	}
+	return ""
+}
+
+func (x *Pagination) GetBefore() string {
+	if x != nil && x.Before != nil {
+		return *x.Before
+	}
+	return ""
+}
+
+type ProjectSort struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Field         ProjectSortField       `protobuf:"varint,1,opt,name=field,proto3,enum=reearth.visualizer.v1.ProjectSortField" json:"field,omitempty"`
+	Direction     SortDirection          `protobuf:"varint,2,opt,name=direction,proto3,enum=reearth.visualizer.v1.SortDirection" json:"direction,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProjectSort) Reset() {
+	*x = ProjectSort{}
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProjectSort) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProjectSort) ProtoMessage() {}
+
+func (x *ProjectSort) ProtoReflect() protoreflect.Message {
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProjectSort.ProtoReflect.Descriptor instead.
+func (*ProjectSort) Descriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ProjectSort) GetField() ProjectSortField {
+	if x != nil {
+		return x.Field
+	}
+	return ProjectSortField_PROJECT_SORT_FIELD_UNSPECIFIED
+}
+
+func (x *ProjectSort) GetDirection() SortDirection {
+	if x != nil {
+		return x.Direction
+	}
+	return SortDirection_SORT_DIRECTION_UNSPECIFIED
+}
+
+type PageInfo struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	TotalCount      int64                  `protobuf:"varint,1,opt,name=total_count,json=totalCount,proto3" json:"total_count,omitempty"`
+	StartCursor     *string                `protobuf:"bytes,2,opt,name=start_cursor,json=startCursor,proto3,oneof" json:"start_cursor,omitempty"`
+	EndCursor       *string                `protobuf:"bytes,3,opt,name=end_cursor,json=endCursor,proto3,oneof" json:"end_cursor,omitempty"`
+	HasNextPage     bool                   `protobuf:"varint,4,opt,name=has_next_page,json=hasNextPage,proto3" json:"has_next_page,omitempty"`
+	HasPreviousPage bool                   `protobuf:"varint,5,opt,name=has_previous_page,json=hasPreviousPage,proto3" json:"has_previous_page,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *PageInfo) Reset() {
+	*x = PageInfo{}
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PageInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PageInfo) ProtoMessage() {}
+
+func (x *PageInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PageInfo.ProtoReflect.Descriptor instead.
+func (*PageInfo) Descriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *PageInfo) GetTotalCount() int64 {
+	if x != nil {
+		return x.TotalCount
+	}
+	return 0
+}
+
+func (x *PageInfo) GetStartCursor() string {
+	if x != nil && x.StartCursor != nil {
+		return *x.StartCursor
+	}
+	return ""
+}
+
+func (x *PageInfo) GetEndCursor() string {
+	if x != nil && x.EndCursor != nil {
+		return *x.EndCursor
+	}
+	return ""
+}
+
+func (x *PageInfo) GetHasNextPage() bool {
+	if x != nil {
+		return x.HasNextPage
+	}
+	return false
+}
+
+func (x *PageInfo) GetHasPreviousPage() bool {
+	if x != nil {
+		return x.HasPreviousPage
+	}
+	return false
+}
+
 // If the authenticated flag is true, private items will also be included in the
 // response. However, deleted items are excluded.
 type GetProjectListRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Workspace ID
-	WorkspaceId string `protobuf:"bytes,1,opt,name=workspace_id,json=workspaceId,proto3" json:"workspace_id,omitempty"`
+	WorkspaceId *string `protobuf:"bytes,1,opt,name=workspace_id,json=workspaceId,proto3,oneof" json:"workspace_id,omitempty"`
 	// Authenticated Flag
 	Authenticated bool `protobuf:"varint,2,opt,name=authenticated,proto3" json:"authenticated,omitempty"`
+	// Keyword search
+	Keyword *string `protobuf:"bytes,3,opt,name=keyword,proto3,oneof" json:"keyword,omitempty"`
+	// Sort options
+	Sort *ProjectSort `protobuf:"bytes,4,opt,name=sort,proto3,oneof" json:"sort,omitempty"`
+	// Pagination info
+	Pagination    *Pagination `protobuf:"bytes,5,opt,name=pagination,proto3,oneof" json:"pagination,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetProjectListRequest) Reset() {
 	*x = GetProjectListRequest{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[3]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -610,7 +911,7 @@ func (x *GetProjectListRequest) String() string {
 func (*GetProjectListRequest) ProtoMessage() {}
 
 func (x *GetProjectListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[3]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -623,12 +924,12 @@ func (x *GetProjectListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProjectListRequest.ProtoReflect.Descriptor instead.
 func (*GetProjectListRequest) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{3}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *GetProjectListRequest) GetWorkspaceId() string {
-	if x != nil {
-		return x.WorkspaceId
+	if x != nil && x.WorkspaceId != nil {
+		return *x.WorkspaceId
 	}
 	return ""
 }
@@ -638,6 +939,27 @@ func (x *GetProjectListRequest) GetAuthenticated() bool {
 		return x.Authenticated
 	}
 	return false
+}
+
+func (x *GetProjectListRequest) GetKeyword() string {
+	if x != nil && x.Keyword != nil {
+		return *x.Keyword
+	}
+	return ""
+}
+
+func (x *GetProjectListRequest) GetSort() *ProjectSort {
+	if x != nil {
+		return x.Sort
+	}
+	return nil
+}
+
+func (x *GetProjectListRequest) GetPagination() *Pagination {
+	if x != nil {
+		return x.Pagination
+	}
+	return nil
 }
 
 // Retrieves a project regardless of authentication.
@@ -652,7 +974,7 @@ type GetProjectRequest struct {
 
 func (x *GetProjectRequest) Reset() {
 	*x = GetProjectRequest{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[4]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -664,7 +986,7 @@ func (x *GetProjectRequest) String() string {
 func (*GetProjectRequest) ProtoMessage() {}
 
 func (x *GetProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[4]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -677,7 +999,7 @@ func (x *GetProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProjectRequest.ProtoReflect.Descriptor instead.
 func (*GetProjectRequest) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{4}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *GetProjectRequest) GetProjectId() string {
@@ -698,7 +1020,7 @@ type GetProjectByAliasRequest struct {
 
 func (x *GetProjectByAliasRequest) Reset() {
 	*x = GetProjectByAliasRequest{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[5]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -710,7 +1032,7 @@ func (x *GetProjectByAliasRequest) String() string {
 func (*GetProjectByAliasRequest) ProtoMessage() {}
 
 func (x *GetProjectByAliasRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[5]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -723,7 +1045,7 @@ func (x *GetProjectByAliasRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProjectByAliasRequest.ProtoReflect.Descriptor instead.
 func (*GetProjectByAliasRequest) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{5}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetProjectByAliasRequest) GetAlias() string {
@@ -746,7 +1068,7 @@ type ValidateProjectAliasRequest struct {
 
 func (x *ValidateProjectAliasRequest) Reset() {
 	*x = ValidateProjectAliasRequest{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[6]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -758,7 +1080,7 @@ func (x *ValidateProjectAliasRequest) String() string {
 func (*ValidateProjectAliasRequest) ProtoMessage() {}
 
 func (x *ValidateProjectAliasRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[6]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -771,7 +1093,7 @@ func (x *ValidateProjectAliasRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateProjectAliasRequest.ProtoReflect.Descriptor instead.
 func (*ValidateProjectAliasRequest) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{6}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ValidateProjectAliasRequest) GetProjectId() string {
@@ -810,7 +1132,7 @@ type CreateProjectRequest struct {
 
 func (x *CreateProjectRequest) Reset() {
 	*x = CreateProjectRequest{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[7]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -822,7 +1144,7 @@ func (x *CreateProjectRequest) String() string {
 func (*CreateProjectRequest) ProtoMessage() {}
 
 func (x *CreateProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[7]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -835,7 +1157,7 @@ func (x *CreateProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateProjectRequest.ProtoReflect.Descriptor instead.
 func (*CreateProjectRequest) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{7}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *CreateProjectRequest) GetWorkspaceId() string {
@@ -913,7 +1235,7 @@ type UpdateProjectRequest struct {
 
 func (x *UpdateProjectRequest) Reset() {
 	*x = UpdateProjectRequest{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[8]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -925,7 +1247,7 @@ func (x *UpdateProjectRequest) String() string {
 func (*UpdateProjectRequest) ProtoMessage() {}
 
 func (x *UpdateProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[8]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -938,7 +1260,7 @@ func (x *UpdateProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProjectRequest.ProtoReflect.Descriptor instead.
 func (*UpdateProjectRequest) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{8}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *UpdateProjectRequest) GetProjectId() string {
@@ -1081,6 +1403,71 @@ func (x *UpdateProjectRequest) GetTrackingId() string {
 	return ""
 }
 
+// Update project publish fields.
+// Only the project owner can operate this
+type PublishProjectRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Project ID (required)
+	ProjectId string `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	// Scene Publishment alias
+	Alias *string `protobuf:"bytes,2,opt,name=alias,proto3,oneof" json:"alias,omitempty"`
+	// Scene Publishment status
+	PublishmentStatus PublishmentStatus `protobuf:"varint,3,opt,name=publishment_status,json=publishmentStatus,proto3,enum=reearth.visualizer.v1.PublishmentStatus" json:"publishment_status,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *PublishProjectRequest) Reset() {
+	*x = PublishProjectRequest{}
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PublishProjectRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PublishProjectRequest) ProtoMessage() {}
+
+func (x *PublishProjectRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PublishProjectRequest.ProtoReflect.Descriptor instead.
+func (*PublishProjectRequest) Descriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *PublishProjectRequest) GetProjectId() string {
+	if x != nil {
+		return x.ProjectId
+	}
+	return ""
+}
+
+func (x *PublishProjectRequest) GetAlias() string {
+	if x != nil && x.Alias != nil {
+		return *x.Alias
+	}
+	return ""
+}
+
+func (x *PublishProjectRequest) GetPublishmentStatus() PublishmentStatus {
+	if x != nil {
+		return x.PublishmentStatus
+	}
+	return PublishmentStatus_PUBLISHMENT_STATUS_UNSPECIFIED
+}
+
 // Updates a new project metadata.
 // Cannot be updated under a team the user does not belong to.
 type UpdateProjectMetadataRequest struct {
@@ -1099,7 +1486,7 @@ type UpdateProjectMetadataRequest struct {
 
 func (x *UpdateProjectMetadataRequest) Reset() {
 	*x = UpdateProjectMetadataRequest{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[9]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1111,7 +1498,7 @@ func (x *UpdateProjectMetadataRequest) String() string {
 func (*UpdateProjectMetadataRequest) ProtoMessage() {}
 
 func (x *UpdateProjectMetadataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[9]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1124,7 +1511,7 @@ func (x *UpdateProjectMetadataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProjectMetadataRequest.ProtoReflect.Descriptor instead.
 func (*UpdateProjectMetadataRequest) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{9}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *UpdateProjectMetadataRequest) GetProjectId() string {
@@ -1168,7 +1555,7 @@ type DeleteProjectRequest struct {
 
 func (x *DeleteProjectRequest) Reset() {
 	*x = DeleteProjectRequest{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[10]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1180,7 +1567,7 @@ func (x *DeleteProjectRequest) String() string {
 func (*DeleteProjectRequest) ProtoMessage() {}
 
 func (x *DeleteProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[10]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1193,7 +1580,7 @@ func (x *DeleteProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProjectRequest.ProtoReflect.Descriptor instead.
 func (*DeleteProjectRequest) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{10}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *DeleteProjectRequest) GetProjectId() string {
@@ -1214,7 +1601,7 @@ type ExportProjectRequest struct {
 
 func (x *ExportProjectRequest) Reset() {
 	*x = ExportProjectRequest{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[11]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1226,7 +1613,7 @@ func (x *ExportProjectRequest) String() string {
 func (*ExportProjectRequest) ProtoMessage() {}
 
 func (x *ExportProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[11]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1239,7 +1626,7 @@ func (x *ExportProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportProjectRequest.ProtoReflect.Descriptor instead.
 func (*ExportProjectRequest) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{11}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ExportProjectRequest) GetProjectId() string {
@@ -1260,7 +1647,7 @@ type GetProjectResponse struct {
 
 func (x *GetProjectResponse) Reset() {
 	*x = GetProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[12]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1272,7 +1659,7 @@ func (x *GetProjectResponse) String() string {
 func (*GetProjectResponse) ProtoMessage() {}
 
 func (x *GetProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[12]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1285,7 +1672,7 @@ func (x *GetProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProjectResponse.ProtoReflect.Descriptor instead.
 func (*GetProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{12}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GetProjectResponse) GetProject() *Project {
@@ -1299,14 +1686,18 @@ func (x *GetProjectResponse) GetProject() *Project {
 type GetProjectListResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Project List
-	Projects      []*Project `protobuf:"bytes,1,rep,name=projects,proto3" json:"projects,omitempty"`
+	Projects []*Project `protobuf:"bytes,1,rep,name=projects,proto3" json:"projects,omitempty"`
+	// PageInfo
+	PageInfo *PageInfo `protobuf:"bytes,2,opt,name=page_info,json=pageInfo,proto3" json:"page_info,omitempty"`
+	// TotalCount
+	TotalCount    int32 `protobuf:"varint,3,opt,name=total_count,json=totalCount,proto3" json:"total_count,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetProjectListResponse) Reset() {
 	*x = GetProjectListResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[13]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1318,7 +1709,7 @@ func (x *GetProjectListResponse) String() string {
 func (*GetProjectListResponse) ProtoMessage() {}
 
 func (x *GetProjectListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[13]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1331,7 +1722,7 @@ func (x *GetProjectListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProjectListResponse.ProtoReflect.Descriptor instead.
 func (*GetProjectListResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{13}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GetProjectListResponse) GetProjects() []*Project {
@@ -1339,6 +1730,20 @@ func (x *GetProjectListResponse) GetProjects() []*Project {
 		return x.Projects
 	}
 	return nil
+}
+
+func (x *GetProjectListResponse) GetPageInfo() *PageInfo {
+	if x != nil {
+		return x.PageInfo
+	}
+	return nil
+}
+
+func (x *GetProjectListResponse) GetTotalCount() int32 {
+	if x != nil {
+		return x.TotalCount
+	}
+	return 0
 }
 
 // Response messages
@@ -1352,7 +1757,7 @@ type CreateProjectResponse struct {
 
 func (x *CreateProjectResponse) Reset() {
 	*x = CreateProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[14]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1364,7 +1769,7 @@ func (x *CreateProjectResponse) String() string {
 func (*CreateProjectResponse) ProtoMessage() {}
 
 func (x *CreateProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[14]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1377,7 +1782,7 @@ func (x *CreateProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateProjectResponse.ProtoReflect.Descriptor instead.
 func (*CreateProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{14}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *CreateProjectResponse) GetProject() *Project {
@@ -1398,7 +1803,7 @@ type UpdateProjectResponse struct {
 
 func (x *UpdateProjectResponse) Reset() {
 	*x = UpdateProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[15]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1410,7 +1815,7 @@ func (x *UpdateProjectResponse) String() string {
 func (*UpdateProjectResponse) ProtoMessage() {}
 
 func (x *UpdateProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[15]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1423,10 +1828,56 @@ func (x *UpdateProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProjectResponse.ProtoReflect.Descriptor instead.
 func (*UpdateProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{15}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *UpdateProjectResponse) GetProject() *Project {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+// Response messages
+type PublishProjectResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Project
+	Project       *Project `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PublishProjectResponse) Reset() {
+	*x = PublishProjectResponse{}
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PublishProjectResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PublishProjectResponse) ProtoMessage() {}
+
+func (x *PublishProjectResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PublishProjectResponse.ProtoReflect.Descriptor instead.
+func (*PublishProjectResponse) Descriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *PublishProjectResponse) GetProject() *Project {
 	if x != nil {
 		return x.Project
 	}
@@ -1444,7 +1895,7 @@ type UpdateProjectMetadataResponse struct {
 
 func (x *UpdateProjectMetadataResponse) Reset() {
 	*x = UpdateProjectMetadataResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[16]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1456,7 +1907,7 @@ func (x *UpdateProjectMetadataResponse) String() string {
 func (*UpdateProjectMetadataResponse) ProtoMessage() {}
 
 func (x *UpdateProjectMetadataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[16]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1469,7 +1920,7 @@ func (x *UpdateProjectMetadataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProjectMetadataResponse.ProtoReflect.Descriptor instead.
 func (*UpdateProjectMetadataResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{16}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *UpdateProjectMetadataResponse) GetMetadata() *ProjectMetadata {
@@ -1490,7 +1941,7 @@ type DeleteProjectResponse struct {
 
 func (x *DeleteProjectResponse) Reset() {
 	*x = DeleteProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[17]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1502,7 +1953,7 @@ func (x *DeleteProjectResponse) String() string {
 func (*DeleteProjectResponse) ProtoMessage() {}
 
 func (x *DeleteProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[17]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1515,7 +1966,7 @@ func (x *DeleteProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProjectResponse.ProtoReflect.Descriptor instead.
 func (*DeleteProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{17}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *DeleteProjectResponse) GetProjectId() string {
@@ -1536,7 +1987,7 @@ type ExportProjectResponse struct {
 
 func (x *ExportProjectResponse) Reset() {
 	*x = ExportProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[18]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1548,7 +1999,7 @@ func (x *ExportProjectResponse) String() string {
 func (*ExportProjectResponse) ProtoMessage() {}
 
 func (x *ExportProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[18]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1561,7 +2012,7 @@ func (x *ExportProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportProjectResponse.ProtoReflect.Descriptor instead.
 func (*ExportProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{18}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ExportProjectResponse) GetProjectDataPath() string {
@@ -1582,7 +2033,7 @@ type GetProjectByAliasResponse struct {
 
 func (x *GetProjectByAliasResponse) Reset() {
 	*x = GetProjectByAliasResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[19]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1594,7 +2045,7 @@ func (x *GetProjectByAliasResponse) String() string {
 func (*GetProjectByAliasResponse) ProtoMessage() {}
 
 func (x *GetProjectByAliasResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[19]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1607,7 +2058,7 @@ func (x *GetProjectByAliasResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProjectByAliasResponse.ProtoReflect.Descriptor instead.
 func (*GetProjectByAliasResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{19}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetProjectByAliasResponse) GetProject() *Project {
@@ -1632,7 +2083,7 @@ type ValidateProjectAliasResponse struct {
 
 func (x *ValidateProjectAliasResponse) Reset() {
 	*x = ValidateProjectAliasResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[20]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1644,7 +2095,7 @@ func (x *ValidateProjectAliasResponse) String() string {
 func (*ValidateProjectAliasResponse) ProtoMessage() {}
 
 func (x *ValidateProjectAliasResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[20]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1657,7 +2108,7 @@ func (x *ValidateProjectAliasResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateProjectAliasResponse.ProtoReflect.Descriptor instead.
 func (*ValidateProjectAliasResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{20}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ValidateProjectAliasResponse) GetProjectId() string {
@@ -1744,10 +2195,43 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\a_readmeB\n" +
 	"\n" +
 	"\b_licenseB\t\n" +
-	"\a_topics\"`\n" +
-	"\x15GetProjectListRequest\x12!\n" +
-	"\fworkspace_id\x18\x01 \x01(\tR\vworkspaceId\x12$\n" +
-	"\rauthenticated\x18\x02 \x01(\bR\rauthenticated\"2\n" +
+	"\a_topics\"\xa0\x01\n" +
+	"\n" +
+	"Pagination\x12\x19\n" +
+	"\x05first\x18\x01 \x01(\x05H\x00R\x05first\x88\x01\x01\x12\x17\n" +
+	"\x04last\x18\x02 \x01(\x05H\x01R\x04last\x88\x01\x01\x12\x19\n" +
+	"\x05after\x18\x03 \x01(\tH\x02R\x05after\x88\x01\x01\x12\x1b\n" +
+	"\x06before\x18\x04 \x01(\tH\x03R\x06before\x88\x01\x01B\b\n" +
+	"\x06_firstB\a\n" +
+	"\x05_lastB\b\n" +
+	"\x06_afterB\t\n" +
+	"\a_before\"\x90\x01\n" +
+	"\vProjectSort\x12=\n" +
+	"\x05field\x18\x01 \x01(\x0e2'.reearth.visualizer.v1.ProjectSortFieldR\x05field\x12B\n" +
+	"\tdirection\x18\x02 \x01(\x0e2$.reearth.visualizer.v1.SortDirectionR\tdirection\"\xe7\x01\n" +
+	"\bPageInfo\x12\x1f\n" +
+	"\vtotal_count\x18\x01 \x01(\x03R\n" +
+	"totalCount\x12&\n" +
+	"\fstart_cursor\x18\x02 \x01(\tH\x00R\vstartCursor\x88\x01\x01\x12\"\n" +
+	"\n" +
+	"end_cursor\x18\x03 \x01(\tH\x01R\tendCursor\x88\x01\x01\x12\"\n" +
+	"\rhas_next_page\x18\x04 \x01(\bR\vhasNextPage\x12*\n" +
+	"\x11has_previous_page\x18\x05 \x01(\bR\x0fhasPreviousPageB\x0f\n" +
+	"\r_start_cursorB\r\n" +
+	"\v_end_cursor\"\xbe\x02\n" +
+	"\x15GetProjectListRequest\x12&\n" +
+	"\fworkspace_id\x18\x01 \x01(\tH\x00R\vworkspaceId\x88\x01\x01\x12$\n" +
+	"\rauthenticated\x18\x02 \x01(\bR\rauthenticated\x12\x1d\n" +
+	"\akeyword\x18\x03 \x01(\tH\x01R\akeyword\x88\x01\x01\x12;\n" +
+	"\x04sort\x18\x04 \x01(\v2\".reearth.visualizer.v1.ProjectSortH\x02R\x04sort\x88\x01\x01\x12F\n" +
+	"\n" +
+	"pagination\x18\x05 \x01(\v2!.reearth.visualizer.v1.PaginationH\x03R\n" +
+	"pagination\x88\x01\x01B\x0f\n" +
+	"\r_workspace_idB\n" +
+	"\n" +
+	"\b_keywordB\a\n" +
+	"\x05_sortB\r\n" +
+	"\v_pagination\"2\n" +
 	"\x11GetProjectRequest\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\"0\n" +
@@ -1822,7 +2306,13 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\x14_basic_auth_passwordB\f\n" +
 	"\n" +
 	"_enable_gaB\x0e\n" +
-	"\f_tracking_id\"\xb8\x01\n" +
+	"\f_tracking_id\"\xb4\x01\n" +
+	"\x15PublishProjectRequest\x12\x1d\n" +
+	"\n" +
+	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x19\n" +
+	"\x05alias\x18\x02 \x01(\tH\x00R\x05alias\x88\x01\x01\x12W\n" +
+	"\x12publishment_status\x18\x03 \x01(\x0e2(.reearth.visualizer.v1.PublishmentStatusR\x11publishmentStatusB\b\n" +
+	"\x06_alias\"\xb8\x01\n" +
 	"\x1cUpdateProjectMetadataRequest\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x1b\n" +
@@ -1840,12 +2330,17 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\"N\n" +
 	"\x12GetProjectResponse\x128\n" +
-	"\aproject\x18\x01 \x01(\v2\x1e.reearth.visualizer.v1.ProjectR\aproject\"T\n" +
+	"\aproject\x18\x01 \x01(\v2\x1e.reearth.visualizer.v1.ProjectR\aproject\"\xb3\x01\n" +
 	"\x16GetProjectListResponse\x12:\n" +
-	"\bprojects\x18\x01 \x03(\v2\x1e.reearth.visualizer.v1.ProjectR\bprojects\"Q\n" +
+	"\bprojects\x18\x01 \x03(\v2\x1e.reearth.visualizer.v1.ProjectR\bprojects\x12<\n" +
+	"\tpage_info\x18\x02 \x01(\v2\x1f.reearth.visualizer.v1.PageInfoR\bpageInfo\x12\x1f\n" +
+	"\vtotal_count\x18\x03 \x01(\x05R\n" +
+	"totalCount\"Q\n" +
 	"\x15CreateProjectResponse\x128\n" +
 	"\aproject\x18\x01 \x01(\v2\x1e.reearth.visualizer.v1.ProjectR\aproject\"Q\n" +
 	"\x15UpdateProjectResponse\x128\n" +
+	"\aproject\x18\x01 \x01(\v2\x1e.reearth.visualizer.v1.ProjectR\aproject\"R\n" +
+	"\x16PublishProjectResponse\x128\n" +
 	"\aproject\x18\x01 \x01(\v2\x1e.reearth.visualizer.v1.ProjectR\aproject\"c\n" +
 	"\x1dUpdateProjectMetadataResponse\x12B\n" +
 	"\bmetadata\x18\x01 \x01(\v2&.reearth.visualizer.v1.ProjectMetadataR\bmetadata\"6\n" +
@@ -1878,7 +2373,15 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\x1ePUBLISHMENT_STATUS_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19PUBLISHMENT_STATUS_PUBLIC\x10\x01\x12\x1e\n" +
 	"\x1aPUBLISHMENT_STATUS_LIMITED\x10\x02\x12\x1e\n" +
-	"\x1aPUBLISHMENT_STATUS_PRIVATE\x10\x032\xa6\b\n" +
+	"\x1aPUBLISHMENT_STATUS_PRIVATE\x10\x03*O\n" +
+	"\x10ProjectSortField\x12\"\n" +
+	"\x1ePROJECT_SORT_FIELD_UNSPECIFIED\x10\x00\x12\r\n" +
+	"\tUPDATEDAT\x10\x01\x12\b\n" +
+	"\x04NAME\x10\x02*B\n" +
+	"\rSortDirection\x12\x1e\n" +
+	"\x1aSORT_DIRECTION_UNSPECIFIED\x10\x00\x12\a\n" +
+	"\x03ASC\x10\x01\x12\b\n" +
+	"\x04DESC\x10\x022\x97\t\n" +
 	"\x11ReEarthVisualizer\x12o\n" +
 	"\x0eGetProjectList\x12,.reearth.visualizer.v1.GetProjectListRequest\x1a-.reearth.visualizer.v1.GetProjectListResponse\"\x00\x12c\n" +
 	"\n" +
@@ -1886,7 +2389,8 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\x11GetProjectByAlias\x12/.reearth.visualizer.v1.GetProjectByAliasRequest\x1a0.reearth.visualizer.v1.GetProjectByAliasResponse\"\x00\x12\x81\x01\n" +
 	"\x14ValidateProjectAlias\x122.reearth.visualizer.v1.ValidateProjectAliasRequest\x1a3.reearth.visualizer.v1.ValidateProjectAliasResponse\"\x00\x12l\n" +
 	"\rCreateProject\x12+.reearth.visualizer.v1.CreateProjectRequest\x1a,.reearth.visualizer.v1.CreateProjectResponse\"\x00\x12l\n" +
-	"\rUpdateProject\x12+.reearth.visualizer.v1.UpdateProjectRequest\x1a,.reearth.visualizer.v1.UpdateProjectResponse\"\x00\x12\x84\x01\n" +
+	"\rUpdateProject\x12+.reearth.visualizer.v1.UpdateProjectRequest\x1a,.reearth.visualizer.v1.UpdateProjectResponse\"\x00\x12o\n" +
+	"\x0ePublishProject\x12,.reearth.visualizer.v1.PublishProjectRequest\x1a-.reearth.visualizer.v1.PublishProjectResponse\"\x00\x12\x84\x01\n" +
 	"\x15UpdateProjectMetadata\x123.reearth.visualizer.v1.UpdateProjectMetadataRequest\x1a4.reearth.visualizer.v1.UpdateProjectMetadataResponse\"\x00\x12l\n" +
 	"\rDeleteProject\x12+.reearth.visualizer.v1.DeleteProjectRequest\x1a,.reearth.visualizer.v1.DeleteProjectResponse\"\x00\x12l\n" +
 	"\rExportProject\x12+.reearth.visualizer.v1.ExportProjectRequest\x1a,.reearth.visualizer.v1.ExportProjectResponse\"\x00B\n" +
@@ -1904,76 +2408,92 @@ func file_schemas_internalapi_v1_schema_proto_rawDescGZIP() []byte {
 	return file_schemas_internalapi_v1_schema_proto_rawDescData
 }
 
-var file_schemas_internalapi_v1_schema_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_schemas_internalapi_v1_schema_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
+var file_schemas_internalapi_v1_schema_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_schemas_internalapi_v1_schema_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_schemas_internalapi_v1_schema_proto_goTypes = []any{
 	(Visualizer)(0),                       // 0: reearth.visualizer.v1.Visualizer
 	(ProjectImportStatus)(0),              // 1: reearth.visualizer.v1.ProjectImportStatus
 	(PublishmentStatus)(0),                // 2: reearth.visualizer.v1.PublishmentStatus
-	(*Project)(nil),                       // 3: reearth.visualizer.v1.Project
-	(*Story)(nil),                         // 4: reearth.visualizer.v1.Story
-	(*ProjectMetadata)(nil),               // 5: reearth.visualizer.v1.ProjectMetadata
-	(*GetProjectListRequest)(nil),         // 6: reearth.visualizer.v1.GetProjectListRequest
-	(*GetProjectRequest)(nil),             // 7: reearth.visualizer.v1.GetProjectRequest
-	(*GetProjectByAliasRequest)(nil),      // 8: reearth.visualizer.v1.GetProjectByAliasRequest
-	(*ValidateProjectAliasRequest)(nil),   // 9: reearth.visualizer.v1.ValidateProjectAliasRequest
-	(*CreateProjectRequest)(nil),          // 10: reearth.visualizer.v1.CreateProjectRequest
-	(*UpdateProjectRequest)(nil),          // 11: reearth.visualizer.v1.UpdateProjectRequest
-	(*UpdateProjectMetadataRequest)(nil),  // 12: reearth.visualizer.v1.UpdateProjectMetadataRequest
-	(*DeleteProjectRequest)(nil),          // 13: reearth.visualizer.v1.DeleteProjectRequest
-	(*ExportProjectRequest)(nil),          // 14: reearth.visualizer.v1.ExportProjectRequest
-	(*GetProjectResponse)(nil),            // 15: reearth.visualizer.v1.GetProjectResponse
-	(*GetProjectListResponse)(nil),        // 16: reearth.visualizer.v1.GetProjectListResponse
-	(*CreateProjectResponse)(nil),         // 17: reearth.visualizer.v1.CreateProjectResponse
-	(*UpdateProjectResponse)(nil),         // 18: reearth.visualizer.v1.UpdateProjectResponse
-	(*UpdateProjectMetadataResponse)(nil), // 19: reearth.visualizer.v1.UpdateProjectMetadataResponse
-	(*DeleteProjectResponse)(nil),         // 20: reearth.visualizer.v1.DeleteProjectResponse
-	(*ExportProjectResponse)(nil),         // 21: reearth.visualizer.v1.ExportProjectResponse
-	(*GetProjectByAliasResponse)(nil),     // 22: reearth.visualizer.v1.GetProjectByAliasResponse
-	(*ValidateProjectAliasResponse)(nil),  // 23: reearth.visualizer.v1.ValidateProjectAliasResponse
-	(*timestamppb.Timestamp)(nil),         // 24: google.protobuf.Timestamp
+	(ProjectSortField)(0),                 // 3: reearth.visualizer.v1.ProjectSortField
+	(SortDirection)(0),                    // 4: reearth.visualizer.v1.SortDirection
+	(*Project)(nil),                       // 5: reearth.visualizer.v1.Project
+	(*Story)(nil),                         // 6: reearth.visualizer.v1.Story
+	(*ProjectMetadata)(nil),               // 7: reearth.visualizer.v1.ProjectMetadata
+	(*Pagination)(nil),                    // 8: reearth.visualizer.v1.Pagination
+	(*ProjectSort)(nil),                   // 9: reearth.visualizer.v1.ProjectSort
+	(*PageInfo)(nil),                      // 10: reearth.visualizer.v1.PageInfo
+	(*GetProjectListRequest)(nil),         // 11: reearth.visualizer.v1.GetProjectListRequest
+	(*GetProjectRequest)(nil),             // 12: reearth.visualizer.v1.GetProjectRequest
+	(*GetProjectByAliasRequest)(nil),      // 13: reearth.visualizer.v1.GetProjectByAliasRequest
+	(*ValidateProjectAliasRequest)(nil),   // 14: reearth.visualizer.v1.ValidateProjectAliasRequest
+	(*CreateProjectRequest)(nil),          // 15: reearth.visualizer.v1.CreateProjectRequest
+	(*UpdateProjectRequest)(nil),          // 16: reearth.visualizer.v1.UpdateProjectRequest
+	(*PublishProjectRequest)(nil),         // 17: reearth.visualizer.v1.PublishProjectRequest
+	(*UpdateProjectMetadataRequest)(nil),  // 18: reearth.visualizer.v1.UpdateProjectMetadataRequest
+	(*DeleteProjectRequest)(nil),          // 19: reearth.visualizer.v1.DeleteProjectRequest
+	(*ExportProjectRequest)(nil),          // 20: reearth.visualizer.v1.ExportProjectRequest
+	(*GetProjectResponse)(nil),            // 21: reearth.visualizer.v1.GetProjectResponse
+	(*GetProjectListResponse)(nil),        // 22: reearth.visualizer.v1.GetProjectListResponse
+	(*CreateProjectResponse)(nil),         // 23: reearth.visualizer.v1.CreateProjectResponse
+	(*UpdateProjectResponse)(nil),         // 24: reearth.visualizer.v1.UpdateProjectResponse
+	(*PublishProjectResponse)(nil),        // 25: reearth.visualizer.v1.PublishProjectResponse
+	(*UpdateProjectMetadataResponse)(nil), // 26: reearth.visualizer.v1.UpdateProjectMetadataResponse
+	(*DeleteProjectResponse)(nil),         // 27: reearth.visualizer.v1.DeleteProjectResponse
+	(*ExportProjectResponse)(nil),         // 28: reearth.visualizer.v1.ExportProjectResponse
+	(*GetProjectByAliasResponse)(nil),     // 29: reearth.visualizer.v1.GetProjectByAliasResponse
+	(*ValidateProjectAliasResponse)(nil),  // 30: reearth.visualizer.v1.ValidateProjectAliasResponse
+	(*timestamppb.Timestamp)(nil),         // 31: google.protobuf.Timestamp
 }
 var file_schemas_internalapi_v1_schema_proto_depIdxs = []int32{
-	4,  // 0: reearth.visualizer.v1.Project.stories:type_name -> reearth.visualizer.v1.Story
+	6,  // 0: reearth.visualizer.v1.Project.stories:type_name -> reearth.visualizer.v1.Story
 	0,  // 1: reearth.visualizer.v1.Project.visualizer:type_name -> reearth.visualizer.v1.Visualizer
-	24, // 2: reearth.visualizer.v1.Project.created_at:type_name -> google.protobuf.Timestamp
-	24, // 3: reearth.visualizer.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
-	5,  // 4: reearth.visualizer.v1.Project.metadata:type_name -> reearth.visualizer.v1.ProjectMetadata
+	31, // 2: reearth.visualizer.v1.Project.created_at:type_name -> google.protobuf.Timestamp
+	31, // 3: reearth.visualizer.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
+	7,  // 4: reearth.visualizer.v1.Project.metadata:type_name -> reearth.visualizer.v1.ProjectMetadata
 	2,  // 5: reearth.visualizer.v1.Project.publishment_status:type_name -> reearth.visualizer.v1.PublishmentStatus
 	2,  // 6: reearth.visualizer.v1.Story.story_publishment_status:type_name -> reearth.visualizer.v1.PublishmentStatus
 	1,  // 7: reearth.visualizer.v1.ProjectMetadata.import_status:type_name -> reearth.visualizer.v1.ProjectImportStatus
-	24, // 8: reearth.visualizer.v1.ProjectMetadata.created_at:type_name -> google.protobuf.Timestamp
-	24, // 9: reearth.visualizer.v1.ProjectMetadata.updated_at:type_name -> google.protobuf.Timestamp
-	0,  // 10: reearth.visualizer.v1.CreateProjectRequest.visualizer:type_name -> reearth.visualizer.v1.Visualizer
-	3,  // 11: reearth.visualizer.v1.GetProjectResponse.project:type_name -> reearth.visualizer.v1.Project
-	3,  // 12: reearth.visualizer.v1.GetProjectListResponse.projects:type_name -> reearth.visualizer.v1.Project
-	3,  // 13: reearth.visualizer.v1.CreateProjectResponse.project:type_name -> reearth.visualizer.v1.Project
-	3,  // 14: reearth.visualizer.v1.UpdateProjectResponse.project:type_name -> reearth.visualizer.v1.Project
-	5,  // 15: reearth.visualizer.v1.UpdateProjectMetadataResponse.metadata:type_name -> reearth.visualizer.v1.ProjectMetadata
-	3,  // 16: reearth.visualizer.v1.GetProjectByAliasResponse.project:type_name -> reearth.visualizer.v1.Project
-	6,  // 17: reearth.visualizer.v1.ReEarthVisualizer.GetProjectList:input_type -> reearth.visualizer.v1.GetProjectListRequest
-	7,  // 18: reearth.visualizer.v1.ReEarthVisualizer.GetProject:input_type -> reearth.visualizer.v1.GetProjectRequest
-	8,  // 19: reearth.visualizer.v1.ReEarthVisualizer.GetProjectByAlias:input_type -> reearth.visualizer.v1.GetProjectByAliasRequest
-	9,  // 20: reearth.visualizer.v1.ReEarthVisualizer.ValidateProjectAlias:input_type -> reearth.visualizer.v1.ValidateProjectAliasRequest
-	10, // 21: reearth.visualizer.v1.ReEarthVisualizer.CreateProject:input_type -> reearth.visualizer.v1.CreateProjectRequest
-	11, // 22: reearth.visualizer.v1.ReEarthVisualizer.UpdateProject:input_type -> reearth.visualizer.v1.UpdateProjectRequest
-	12, // 23: reearth.visualizer.v1.ReEarthVisualizer.UpdateProjectMetadata:input_type -> reearth.visualizer.v1.UpdateProjectMetadataRequest
-	13, // 24: reearth.visualizer.v1.ReEarthVisualizer.DeleteProject:input_type -> reearth.visualizer.v1.DeleteProjectRequest
-	14, // 25: reearth.visualizer.v1.ReEarthVisualizer.ExportProject:input_type -> reearth.visualizer.v1.ExportProjectRequest
-	16, // 26: reearth.visualizer.v1.ReEarthVisualizer.GetProjectList:output_type -> reearth.visualizer.v1.GetProjectListResponse
-	15, // 27: reearth.visualizer.v1.ReEarthVisualizer.GetProject:output_type -> reearth.visualizer.v1.GetProjectResponse
-	22, // 28: reearth.visualizer.v1.ReEarthVisualizer.GetProjectByAlias:output_type -> reearth.visualizer.v1.GetProjectByAliasResponse
-	23, // 29: reearth.visualizer.v1.ReEarthVisualizer.ValidateProjectAlias:output_type -> reearth.visualizer.v1.ValidateProjectAliasResponse
-	17, // 30: reearth.visualizer.v1.ReEarthVisualizer.CreateProject:output_type -> reearth.visualizer.v1.CreateProjectResponse
-	18, // 31: reearth.visualizer.v1.ReEarthVisualizer.UpdateProject:output_type -> reearth.visualizer.v1.UpdateProjectResponse
-	19, // 32: reearth.visualizer.v1.ReEarthVisualizer.UpdateProjectMetadata:output_type -> reearth.visualizer.v1.UpdateProjectMetadataResponse
-	20, // 33: reearth.visualizer.v1.ReEarthVisualizer.DeleteProject:output_type -> reearth.visualizer.v1.DeleteProjectResponse
-	21, // 34: reearth.visualizer.v1.ReEarthVisualizer.ExportProject:output_type -> reearth.visualizer.v1.ExportProjectResponse
-	26, // [26:35] is the sub-list for method output_type
-	17, // [17:26] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	31, // 8: reearth.visualizer.v1.ProjectMetadata.created_at:type_name -> google.protobuf.Timestamp
+	31, // 9: reearth.visualizer.v1.ProjectMetadata.updated_at:type_name -> google.protobuf.Timestamp
+	3,  // 10: reearth.visualizer.v1.ProjectSort.field:type_name -> reearth.visualizer.v1.ProjectSortField
+	4,  // 11: reearth.visualizer.v1.ProjectSort.direction:type_name -> reearth.visualizer.v1.SortDirection
+	9,  // 12: reearth.visualizer.v1.GetProjectListRequest.sort:type_name -> reearth.visualizer.v1.ProjectSort
+	8,  // 13: reearth.visualizer.v1.GetProjectListRequest.pagination:type_name -> reearth.visualizer.v1.Pagination
+	0,  // 14: reearth.visualizer.v1.CreateProjectRequest.visualizer:type_name -> reearth.visualizer.v1.Visualizer
+	2,  // 15: reearth.visualizer.v1.PublishProjectRequest.publishment_status:type_name -> reearth.visualizer.v1.PublishmentStatus
+	5,  // 16: reearth.visualizer.v1.GetProjectResponse.project:type_name -> reearth.visualizer.v1.Project
+	5,  // 17: reearth.visualizer.v1.GetProjectListResponse.projects:type_name -> reearth.visualizer.v1.Project
+	10, // 18: reearth.visualizer.v1.GetProjectListResponse.page_info:type_name -> reearth.visualizer.v1.PageInfo
+	5,  // 19: reearth.visualizer.v1.CreateProjectResponse.project:type_name -> reearth.visualizer.v1.Project
+	5,  // 20: reearth.visualizer.v1.UpdateProjectResponse.project:type_name -> reearth.visualizer.v1.Project
+	5,  // 21: reearth.visualizer.v1.PublishProjectResponse.project:type_name -> reearth.visualizer.v1.Project
+	7,  // 22: reearth.visualizer.v1.UpdateProjectMetadataResponse.metadata:type_name -> reearth.visualizer.v1.ProjectMetadata
+	5,  // 23: reearth.visualizer.v1.GetProjectByAliasResponse.project:type_name -> reearth.visualizer.v1.Project
+	11, // 24: reearth.visualizer.v1.ReEarthVisualizer.GetProjectList:input_type -> reearth.visualizer.v1.GetProjectListRequest
+	12, // 25: reearth.visualizer.v1.ReEarthVisualizer.GetProject:input_type -> reearth.visualizer.v1.GetProjectRequest
+	13, // 26: reearth.visualizer.v1.ReEarthVisualizer.GetProjectByAlias:input_type -> reearth.visualizer.v1.GetProjectByAliasRequest
+	14, // 27: reearth.visualizer.v1.ReEarthVisualizer.ValidateProjectAlias:input_type -> reearth.visualizer.v1.ValidateProjectAliasRequest
+	15, // 28: reearth.visualizer.v1.ReEarthVisualizer.CreateProject:input_type -> reearth.visualizer.v1.CreateProjectRequest
+	16, // 29: reearth.visualizer.v1.ReEarthVisualizer.UpdateProject:input_type -> reearth.visualizer.v1.UpdateProjectRequest
+	17, // 30: reearth.visualizer.v1.ReEarthVisualizer.PublishProject:input_type -> reearth.visualizer.v1.PublishProjectRequest
+	18, // 31: reearth.visualizer.v1.ReEarthVisualizer.UpdateProjectMetadata:input_type -> reearth.visualizer.v1.UpdateProjectMetadataRequest
+	19, // 32: reearth.visualizer.v1.ReEarthVisualizer.DeleteProject:input_type -> reearth.visualizer.v1.DeleteProjectRequest
+	20, // 33: reearth.visualizer.v1.ReEarthVisualizer.ExportProject:input_type -> reearth.visualizer.v1.ExportProjectRequest
+	22, // 34: reearth.visualizer.v1.ReEarthVisualizer.GetProjectList:output_type -> reearth.visualizer.v1.GetProjectListResponse
+	21, // 35: reearth.visualizer.v1.ReEarthVisualizer.GetProject:output_type -> reearth.visualizer.v1.GetProjectResponse
+	29, // 36: reearth.visualizer.v1.ReEarthVisualizer.GetProjectByAlias:output_type -> reearth.visualizer.v1.GetProjectByAliasResponse
+	30, // 37: reearth.visualizer.v1.ReEarthVisualizer.ValidateProjectAlias:output_type -> reearth.visualizer.v1.ValidateProjectAliasResponse
+	23, // 38: reearth.visualizer.v1.ReEarthVisualizer.CreateProject:output_type -> reearth.visualizer.v1.CreateProjectResponse
+	24, // 39: reearth.visualizer.v1.ReEarthVisualizer.UpdateProject:output_type -> reearth.visualizer.v1.UpdateProjectResponse
+	25, // 40: reearth.visualizer.v1.ReEarthVisualizer.PublishProject:output_type -> reearth.visualizer.v1.PublishProjectResponse
+	26, // 41: reearth.visualizer.v1.ReEarthVisualizer.UpdateProjectMetadata:output_type -> reearth.visualizer.v1.UpdateProjectMetadataResponse
+	27, // 42: reearth.visualizer.v1.ReEarthVisualizer.DeleteProject:output_type -> reearth.visualizer.v1.DeleteProjectResponse
+	28, // 43: reearth.visualizer.v1.ReEarthVisualizer.ExportProject:output_type -> reearth.visualizer.v1.ExportProjectResponse
+	34, // [34:44] is the sub-list for method output_type
+	24, // [24:34] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_schemas_internalapi_v1_schema_proto_init() }
@@ -1984,18 +2504,22 @@ func file_schemas_internalapi_v1_schema_proto_init() {
 	file_schemas_internalapi_v1_schema_proto_msgTypes[0].OneofWrappers = []any{}
 	file_schemas_internalapi_v1_schema_proto_msgTypes[1].OneofWrappers = []any{}
 	file_schemas_internalapi_v1_schema_proto_msgTypes[2].OneofWrappers = []any{}
+	file_schemas_internalapi_v1_schema_proto_msgTypes[3].OneofWrappers = []any{}
+	file_schemas_internalapi_v1_schema_proto_msgTypes[5].OneofWrappers = []any{}
 	file_schemas_internalapi_v1_schema_proto_msgTypes[6].OneofWrappers = []any{}
-	file_schemas_internalapi_v1_schema_proto_msgTypes[7].OneofWrappers = []any{}
-	file_schemas_internalapi_v1_schema_proto_msgTypes[8].OneofWrappers = []any{}
 	file_schemas_internalapi_v1_schema_proto_msgTypes[9].OneofWrappers = []any{}
-	file_schemas_internalapi_v1_schema_proto_msgTypes[20].OneofWrappers = []any{}
+	file_schemas_internalapi_v1_schema_proto_msgTypes[10].OneofWrappers = []any{}
+	file_schemas_internalapi_v1_schema_proto_msgTypes[11].OneofWrappers = []any{}
+	file_schemas_internalapi_v1_schema_proto_msgTypes[12].OneofWrappers = []any{}
+	file_schemas_internalapi_v1_schema_proto_msgTypes[13].OneofWrappers = []any{}
+	file_schemas_internalapi_v1_schema_proto_msgTypes[25].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_schemas_internalapi_v1_schema_proto_rawDesc), len(file_schemas_internalapi_v1_schema_proto_rawDesc)),
-			NumEnums:      3,
-			NumMessages:   21,
+			NumEnums:      5,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/server/internal/adapter/internalapi/schemas/internalapi/v1/schema_grpc.pb.go
+++ b/server/internal/adapter/internalapi/schemas/internalapi/v1/schema_grpc.pb.go
@@ -25,6 +25,7 @@ const (
 	ReEarthVisualizer_ValidateProjectAlias_FullMethodName  = "/reearth.visualizer.v1.ReEarthVisualizer/ValidateProjectAlias"
 	ReEarthVisualizer_CreateProject_FullMethodName         = "/reearth.visualizer.v1.ReEarthVisualizer/CreateProject"
 	ReEarthVisualizer_UpdateProject_FullMethodName         = "/reearth.visualizer.v1.ReEarthVisualizer/UpdateProject"
+	ReEarthVisualizer_PublishProject_FullMethodName        = "/reearth.visualizer.v1.ReEarthVisualizer/PublishProject"
 	ReEarthVisualizer_UpdateProjectMetadata_FullMethodName = "/reearth.visualizer.v1.ReEarthVisualizer/UpdateProjectMetadata"
 	ReEarthVisualizer_DeleteProject_FullMethodName         = "/reearth.visualizer.v1.ReEarthVisualizer/DeleteProject"
 	ReEarthVisualizer_ExportProject_FullMethodName         = "/reearth.visualizer.v1.ReEarthVisualizer/ExportProject"
@@ -52,6 +53,9 @@ type ReEarthVisualizerClient interface {
 	// Update a project.
 	// Request headers: user-id: <User ID>
 	UpdateProject(ctx context.Context, in *UpdateProjectRequest, opts ...grpc.CallOption) (*UpdateProjectResponse, error)
+	// Publish a project.
+	// Request headers: user-id: <User ID>
+	PublishProject(ctx context.Context, in *PublishProjectRequest, opts ...grpc.CallOption) (*PublishProjectResponse, error)
 	// Updates a new project metadata in the specified team.
 	// Request headers: user-id: <User ID>
 	UpdateProjectMetadata(ctx context.Context, in *UpdateProjectMetadataRequest, opts ...grpc.CallOption) (*UpdateProjectMetadataResponse, error)
@@ -131,6 +135,16 @@ func (c *reEarthVisualizerClient) UpdateProject(ctx context.Context, in *UpdateP
 	return out, nil
 }
 
+func (c *reEarthVisualizerClient) PublishProject(ctx context.Context, in *PublishProjectRequest, opts ...grpc.CallOption) (*PublishProjectResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PublishProjectResponse)
+	err := c.cc.Invoke(ctx, ReEarthVisualizer_PublishProject_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *reEarthVisualizerClient) UpdateProjectMetadata(ctx context.Context, in *UpdateProjectMetadataRequest, opts ...grpc.CallOption) (*UpdateProjectMetadataResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(UpdateProjectMetadataResponse)
@@ -183,6 +197,9 @@ type ReEarthVisualizerServer interface {
 	// Update a project.
 	// Request headers: user-id: <User ID>
 	UpdateProject(context.Context, *UpdateProjectRequest) (*UpdateProjectResponse, error)
+	// Publish a project.
+	// Request headers: user-id: <User ID>
+	PublishProject(context.Context, *PublishProjectRequest) (*PublishProjectResponse, error)
 	// Updates a new project metadata in the specified team.
 	// Request headers: user-id: <User ID>
 	UpdateProjectMetadata(context.Context, *UpdateProjectMetadataRequest) (*UpdateProjectMetadataResponse, error)
@@ -219,6 +236,9 @@ func (UnimplementedReEarthVisualizerServer) CreateProject(context.Context, *Crea
 }
 func (UnimplementedReEarthVisualizerServer) UpdateProject(context.Context, *UpdateProjectRequest) (*UpdateProjectResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateProject not implemented")
+}
+func (UnimplementedReEarthVisualizerServer) PublishProject(context.Context, *PublishProjectRequest) (*PublishProjectResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PublishProject not implemented")
 }
 func (UnimplementedReEarthVisualizerServer) UpdateProjectMetadata(context.Context, *UpdateProjectMetadataRequest) (*UpdateProjectMetadataResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateProjectMetadata not implemented")
@@ -358,6 +378,24 @@ func _ReEarthVisualizer_UpdateProject_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ReEarthVisualizer_PublishProject_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PublishProjectRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ReEarthVisualizerServer).PublishProject(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ReEarthVisualizer_PublishProject_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ReEarthVisualizerServer).PublishProject(ctx, req.(*PublishProjectRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ReEarthVisualizer_UpdateProjectMetadata_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(UpdateProjectMetadataRequest)
 	if err := dec(in); err != nil {
@@ -442,6 +480,10 @@ var ReEarthVisualizer_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpdateProject",
 			Handler:    _ReEarthVisualizer_UpdateProject_Handler,
+		},
+		{
+			MethodName: "PublishProject",
+			Handler:    _ReEarthVisualizer_PublishProject_Handler,
 		},
 		{
 			MethodName: "UpdateProjectMetadata",

--- a/server/internal/infrastructure/memory/project.go
+++ b/server/internal/infrastructure/memory/project.go
@@ -84,6 +84,10 @@ func (r *Project) FindByWorkspace(ctx context.Context, id accountdomain.Workspac
 	), nil
 }
 
+func (r *Project) FindByWorkspaces(ctx context.Context, authenticated bool, pFilter repo.ProjectFilter, owningWorkspaces accountdomain.WorkspaceIDList, wList accountdomain.WorkspaceIDList) ([]*project.Project, *usecasex.PageInfo, error) {
+	return nil, nil, nil
+}
+
 func (r *Project) FindStarredByWorkspace(ctx context.Context, id accountdomain.WorkspaceID) ([]*project.Project, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
@@ -146,40 +150,40 @@ func (r *Project) FindActiveByAlias(ctx context.Context, alias string) (*project
 	return nil, nil
 }
 
-func (r *Project) FindVisibilityByWorkspace(ctx context.Context, authenticated bool, isWorkspaceOwner bool, id accountdomain.WorkspaceID) ([]*project.Project, error) {
-	r.lock.Lock()
-	defer r.lock.Unlock()
+// func (r *Project) FindVisibilityByWorkspace(ctx context.Context, authenticated bool, isWorkspaceOwner bool, id accountdomain.WorkspaceID) ([]*project.Project, error) {
+// 	r.lock.Lock()
+// 	defer r.lock.Unlock()
 
-	var result []*project.Project
+// 	var result []*project.Project
 
-	if authenticated {
-		for _, p := range r.data {
-			if p.Workspace() == id {
-				result = append(result, p)
-			}
-		}
-	} else {
-		if isWorkspaceOwner {
-			for _, p := range r.data {
-				if p.Workspace() == id && !p.IsDeleted() {
-					result = append(result, p)
-				}
-			}
-		} else {
-			for _, p := range r.data {
-				if p.Workspace() == id && !p.IsDeleted() && p.Visibility() == "public" {
-					result = append(result, p)
-				}
-			}
-		}
-	}
+// 	if authenticated {
+// 		for _, p := range r.data {
+// 			if p.Workspace() == id {
+// 				result = append(result, p)
+// 			}
+// 		}
+// 	} else {
+// 		if isWorkspaceOwner {
+// 			for _, p := range r.data {
+// 				if p.Workspace() == id && !p.IsDeleted() {
+// 					result = append(result, p)
+// 				}
+// 			}
+// 		} else {
+// 			for _, p := range r.data {
+// 				if p.Workspace() == id && !p.IsDeleted() && p.Visibility() == "public" {
+// 					result = append(result, p)
+// 				}
+// 			}
+// 		}
+// 	}
 
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].UpdatedAt().After(result[j].UpdatedAt())
-	})
+// 	sort.Slice(result, func(i, j int) bool {
+// 		return result[i].UpdatedAt().After(result[j].UpdatedAt())
+// 	})
 
-	return result, nil
-}
+// 	return result, nil
+// }
 
 func (r *Project) FindIDsByWorkspace(ctx context.Context, id accountdomain.WorkspaceID) (res []id.ProjectID, _ error) {
 	r.lock.Lock()

--- a/server/internal/infrastructure/memory/project.go
+++ b/server/internal/infrastructure/memory/project.go
@@ -150,41 +150,6 @@ func (r *Project) FindActiveByAlias(ctx context.Context, alias string) (*project
 	return nil, nil
 }
 
-// func (r *Project) FindVisibilityByWorkspace(ctx context.Context, authenticated bool, isWorkspaceOwner bool, id accountdomain.WorkspaceID) ([]*project.Project, error) {
-// 	r.lock.Lock()
-// 	defer r.lock.Unlock()
-
-// 	var result []*project.Project
-
-// 	if authenticated {
-// 		for _, p := range r.data {
-// 			if p.Workspace() == id {
-// 				result = append(result, p)
-// 			}
-// 		}
-// 	} else {
-// 		if isWorkspaceOwner {
-// 			for _, p := range r.data {
-// 				if p.Workspace() == id && !p.IsDeleted() {
-// 					result = append(result, p)
-// 				}
-// 			}
-// 		} else {
-// 			for _, p := range r.data {
-// 				if p.Workspace() == id && !p.IsDeleted() && p.Visibility() == "public" {
-// 					result = append(result, p)
-// 				}
-// 			}
-// 		}
-// 	}
-
-// 	sort.Slice(result, func(i, j int) bool {
-// 		return result[i].UpdatedAt().After(result[j].UpdatedAt())
-// 	})
-
-// 	return result, nil
-// }
-
 func (r *Project) FindIDsByWorkspace(ctx context.Context, id accountdomain.WorkspaceID) (res []id.ProjectID, _ error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()

--- a/server/internal/usecase/interfaces/project.go
+++ b/server/internal/usecase/interfaces/project.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"net/url"
 
+	"github.com/reearth/reearthx/account/accountdomain/user"
+
 	"github.com/reearth/reearth/server/internal/app/i18n/message/errmsg"
 	"github.com/reearth/reearth/server/internal/usecase"
 	"github.com/reearth/reearth/server/pkg/i18n/message"
@@ -85,7 +87,8 @@ type Project interface {
 
 	FindActiveById(context.Context, id.ProjectID, *usecase.Operator) (*project.Project, error)
 	FindActiveByAlias(context.Context, string, *usecase.Operator) (*project.Project, error)
-	FindVisibilityByWorkspace(context.Context, accountdomain.WorkspaceID, bool, *usecase.Operator) ([]*project.Project, error)
+	FindVisibilityByUser(context.Context, *user.User, bool, *usecase.Operator, *string, *project.SortType, *usecasex.Pagination) ([]*project.Project, *usecasex.PageInfo, error)
+	FindVisibilityByWorkspace(context.Context, accountdomain.WorkspaceID, bool, *usecase.Operator, *string, *project.SortType, *usecasex.Pagination) ([]*project.Project, *usecasex.PageInfo, error)
 	UpdateVisibility(context.Context, id.ProjectID, string, *usecase.Operator) (*project.Project, error)
 
 	Create(context.Context, CreateProjectParam, *usecase.Operator) (*project.Project, error)

--- a/server/internal/usecase/repo/project.go
+++ b/server/internal/usecase/repo/project.go
@@ -22,11 +22,11 @@ type Project interface {
 	FindByID(context.Context, id.ProjectID) (*project.Project, error)
 	FindByScene(context.Context, id.SceneID) (*project.Project, error)
 	FindByWorkspace(context.Context, accountdomain.WorkspaceID, ProjectFilter) ([]*project.Project, *usecasex.PageInfo, error)
+	FindByWorkspaces(context.Context, bool, ProjectFilter, accountdomain.WorkspaceIDList, accountdomain.WorkspaceIDList) ([]*project.Project, *usecasex.PageInfo, error)
 	FindStarredByWorkspace(context.Context, accountdomain.WorkspaceID) ([]*project.Project, error)
 	FindDeletedByWorkspace(context.Context, accountdomain.WorkspaceID) ([]*project.Project, error)
 	FindActiveById(context.Context, id.ProjectID) (*project.Project, error)
 	FindActiveByAlias(context.Context, string) (*project.Project, error)
-	FindVisibilityByWorkspace(context.Context, bool, bool, accountdomain.WorkspaceID) ([]*project.Project, error)
 	FindByPublicName(context.Context, string) (*project.Project, error)
 	CheckAliasUnique(context.Context, string) error
 	CountByWorkspace(context.Context, accountdomain.WorkspaceID) (int, error)

--- a/server/pkg/project/sort_type.go
+++ b/server/pkg/project/sort_type.go
@@ -1,7 +1,5 @@
 package project
 
-import "strings"
-
 type SortType struct {
 	Key  string
 	Desc bool
@@ -9,19 +7,19 @@ type SortType struct {
 
 var (
 	SortTypeID        = SortType{Key: "id"}
-	SortTypeUpdatedAt = SortType{Key: "updatedAt"}
+	SortTypeUpdatedAt = SortType{Key: "updatedat"}
 	SortTypeName      = SortType{Key: "name"}
 )
 
-func SortTypeFromString(r string, desc bool) SortType {
-	switch strings.ToLower(r) {
-	case "id":
-		return SortType{Key: "id", Desc: desc}
-	case "updatedAt":
-		return SortType{Key: "updatedAt", Desc: desc}
-	case "name":
-		return SortType{Key: "name", Desc: desc}
-	default:
-		return SortType{Key: "id", Desc: desc} // Default to ID sorting
-	}
-}
+// func SortTypeFromString(r string, desc bool) SortType {
+// 	switch strings.ToLower(r) {
+// 	case "id":
+// 		return SortType{Key: "id", Desc: desc}
+// 	case "updatedat":
+// 		return SortType{Key: "updatedat", Desc: desc}
+// 	case "name":
+// 		return SortType{Key: "name", Desc: desc}
+// 	default:
+// 		return SortType{Key: "id", Desc: desc} // Default to ID sorting
+// 	}
+// }

--- a/server/pkg/project/sort_type.go
+++ b/server/pkg/project/sort_type.go
@@ -10,16 +10,3 @@ var (
 	SortTypeUpdatedAt = SortType{Key: "updatedat"}
 	SortTypeName      = SortType{Key: "name"}
 )
-
-// func SortTypeFromString(r string, desc bool) SortType {
-// 	switch strings.ToLower(r) {
-// 	case "id":
-// 		return SortType{Key: "id", Desc: desc}
-// 	case "updatedat":
-// 		return SortType{Key: "updatedat", Desc: desc}
-// 	case "name":
-// 		return SortType{Key: "name", Desc: desc}
-// 	default:
-// 		return SortType{Key: "id", Desc: desc} // Default to ID sorting
-// 	}
-// }

--- a/server/schemas/internalapi/docs/schema.md
+++ b/server/schemas/internalapi/docs/schema.md
@@ -16,8 +16,13 @@
     - [GetProjectListResponse](#reearth-visualizer-v1-GetProjectListResponse)
     - [GetProjectRequest](#reearth-visualizer-v1-GetProjectRequest)
     - [GetProjectResponse](#reearth-visualizer-v1-GetProjectResponse)
+    - [PageInfo](#reearth-visualizer-v1-PageInfo)
+    - [Pagination](#reearth-visualizer-v1-Pagination)
     - [Project](#reearth-visualizer-v1-Project)
     - [ProjectMetadata](#reearth-visualizer-v1-ProjectMetadata)
+    - [ProjectSort](#reearth-visualizer-v1-ProjectSort)
+    - [PublishProjectRequest](#reearth-visualizer-v1-PublishProjectRequest)
+    - [PublishProjectResponse](#reearth-visualizer-v1-PublishProjectResponse)
     - [Story](#reearth-visualizer-v1-Story)
     - [UpdateProjectMetadataRequest](#reearth-visualizer-v1-UpdateProjectMetadataRequest)
     - [UpdateProjectMetadataResponse](#reearth-visualizer-v1-UpdateProjectMetadataResponse)
@@ -27,7 +32,9 @@
     - [ValidateProjectAliasResponse](#reearth-visualizer-v1-ValidateProjectAliasResponse)
   
     - [ProjectImportStatus](#reearth-visualizer-v1-ProjectImportStatus)
+    - [ProjectSortField](#reearth-visualizer-v1-ProjectSortField)
     - [PublishmentStatus](#reearth-visualizer-v1-PublishmentStatus)
+    - [SortDirection](#reearth-visualizer-v1-SortDirection)
     - [Visualizer](#reearth-visualizer-v1-Visualizer)
   
     - [ReEarthVisualizer](#reearth-visualizer-v1-ReEarthVisualizer)
@@ -180,8 +187,11 @@ response. However, deleted items are excluded.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| workspace_id | [string](#string) |  | Workspace ID |
+| workspace_id | [string](#string) | optional | Workspace ID |
 | authenticated | [bool](#bool) |  | Authenticated Flag |
+| keyword | [string](#string) | optional | Keyword search |
+| sort | [ProjectSort](#reearth-visualizer-v1-ProjectSort) | optional | Sort options |
+| pagination | [Pagination](#reearth-visualizer-v1-Pagination) | optional | Pagination info |
 
 
 
@@ -228,6 +238,44 @@ Response messages
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | project | [Project](#reearth-visualizer-v1-Project) |  | Project |
+| page_info | [PageInfo](#reearth-visualizer-v1-PageInfo) |  | PageInfo |
+| total_count | [int32](#int32) |  | TotalCount |
+
+
+
+
+
+
+<a name="reearth-visualizer-v1-PageInfo"></a>
+
+### PageInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| start_cursor | [string](#string) | optional |  |
+| end_cursor | [string](#string) | optional |  |
+| has_next_page | [bool](#bool) |  |  |
+| has_previous_page | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="reearth-visualizer-v1-Pagination"></a>
+
+### Pagination
+Pagination
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| first | [int32](#int32) | optional |  |
+| last | [int32](#int32) | optional |  |
+| after | [string](#string) | optional |  |
+| before | [string](#string) | optional |  |
 
 
 
@@ -285,6 +333,55 @@ Core Project messages
 | import_status | [ProjectImportStatus](#reearth-visualizer-v1-ProjectImportStatus) |  | Project import status — if PROCESSING, data should not be retrieved |
 | created_at | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | ProjectMetadata created date |
 | updated_at | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | ProjectMetadata updated date |
+
+
+
+
+
+
+<a name="reearth-visualizer-v1-ProjectSort"></a>
+
+### ProjectSort
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| field | [ProjectSortField](#reearth-visualizer-v1-ProjectSortField) |  |  |
+| direction | [SortDirection](#reearth-visualizer-v1-SortDirection) |  |  |
+
+
+
+
+
+
+<a name="reearth-visualizer-v1-PublishProjectRequest"></a>
+
+### PublishProjectRequest
+Update project publish fields.
+Only the project owner can operate this
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project_id | [string](#string) |  | Project ID (required) |
+| alias | [string](#string) | optional | Scene Publishment alias |
+| publishment_status | [PublishmentStatus](#reearth-visualizer-v1-PublishmentStatus) |  | Scene Publishment status |
+
+
+
+
+
+
+<a name="reearth-visualizer-v1-PublishProjectResponse"></a>
+
+### PublishProjectResponse
+Response messages
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project | [Project](#reearth-visualizer-v1-Project) |  | Project |
 
 
 
@@ -442,6 +539,19 @@ Response messages
 
 
 
+<a name="reearth-visualizer-v1-ProjectSortField"></a>
+
+### ProjectSortField
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| PROJECT_SORT_FIELD_UNSPECIFIED | 0 |  |
+| UPDATEDAT | 1 |  |
+| NAME | 2 |  |
+
+
+
 <a name="reearth-visualizer-v1-PublishmentStatus"></a>
 
 ### PublishmentStatus
@@ -453,6 +563,19 @@ Response messages
 | PUBLISHMENT_STATUS_PUBLIC | 1 | The project is published and publicly accessible. |
 | PUBLISHMENT_STATUS_LIMITED | 2 | The project is published with limited access. |
 | PUBLISHMENT_STATUS_PRIVATE | 3 | The project is unpublished (web files have been deleted). |
+
+
+
+<a name="reearth-visualizer-v1-SortDirection"></a>
+
+### SortDirection
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| SORT_DIRECTION_UNSPECIFIED | 0 |  |
+| ASC | 1 |  |
+| DESC | 2 |  |
 
 
 
@@ -486,6 +609,7 @@ Response messages
 | ValidateProjectAlias | [ValidateProjectAliasRequest](#reearth-visualizer-v1-ValidateProjectAliasRequest) | [ValidateProjectAliasResponse](#reearth-visualizer-v1-ValidateProjectAliasResponse) | Determines if an alias is valid. Request headers: user-id: &lt;User ID&gt; |
 | CreateProject | [CreateProjectRequest](#reearth-visualizer-v1-CreateProjectRequest) | [CreateProjectResponse](#reearth-visualizer-v1-CreateProjectResponse) | Creates a new project in the specified team. Request headers: user-id: &lt;User ID&gt; |
 | UpdateProject | [UpdateProjectRequest](#reearth-visualizer-v1-UpdateProjectRequest) | [UpdateProjectResponse](#reearth-visualizer-v1-UpdateProjectResponse) | Update a project. Request headers: user-id: &lt;User ID&gt; |
+| PublishProject | [PublishProjectRequest](#reearth-visualizer-v1-PublishProjectRequest) | [PublishProjectResponse](#reearth-visualizer-v1-PublishProjectResponse) | Publish a project. Request headers: user-id: &lt;User ID&gt; |
 | UpdateProjectMetadata | [UpdateProjectMetadataRequest](#reearth-visualizer-v1-UpdateProjectMetadataRequest) | [UpdateProjectMetadataResponse](#reearth-visualizer-v1-UpdateProjectMetadataResponse) | Updates a new project metadata in the specified team. Request headers: user-id: &lt;User ID&gt; |
 | DeleteProject | [DeleteProjectRequest](#reearth-visualizer-v1-DeleteProjectRequest) | [DeleteProjectResponse](#reearth-visualizer-v1-DeleteProjectResponse) | Deletes a project. Request headers: user-id: &lt;User ID&gt; |
 | ExportProject | [ExportProjectRequest](#reearth-visualizer-v1-ExportProjectRequest) | [ExportProjectResponse](#reearth-visualizer-v1-ExportProjectResponse) | Export a project. Request headers: user-id: &lt;User ID&gt; |

--- a/server/schemas/internalapi/v1/schema.proto
+++ b/server/schemas/internalapi/v1/schema.proto
@@ -33,6 +33,10 @@ service ReEarthVisualizer {
   // Request headers: user-id: <User ID>
   rpc UpdateProject(UpdateProjectRequest) returns (UpdateProjectResponse) {}
 
+  // Publish a project.
+  // Request headers: user-id: <User ID>
+  rpc PublishProject(PublishProjectRequest) returns (PublishProjectResponse) {}
+
   // Updates a new project metadata in the specified team.
   // Request headers: user-id: <User ID>
   rpc UpdateProjectMetadata(UpdateProjectMetadataRequest)
@@ -167,13 +171,52 @@ enum PublishmentStatus {
   PUBLISHMENT_STATUS_PRIVATE = 3;
 }
 
+// Pagination
+message Pagination {
+  optional int32 first = 1;
+  optional int32 last = 2;
+  optional string after = 3;
+  optional string before = 4;
+}
+
+enum ProjectSortField {
+  PROJECT_SORT_FIELD_UNSPECIFIED = 0;
+  UPDATEDAT = 1;
+  NAME = 2;
+}
+
+enum SortDirection {
+  SORT_DIRECTION_UNSPECIFIED = 0;
+  ASC = 1;
+  DESC = 2;
+}
+
+message ProjectSort {
+  ProjectSortField field = 1;
+  SortDirection direction = 2;
+}
+
+message PageInfo {
+  int64 total_count = 1;
+  optional string start_cursor = 2;
+  optional string end_cursor = 3;
+  bool has_next_page = 4;
+  bool has_previous_page = 5;
+}
+
 // If the authenticated flag is true, private items will also be included in the
 // response. However, deleted items are excluded.
 message GetProjectListRequest {
   // Workspace ID
-  string workspace_id = 1;
+  optional string workspace_id = 1;
   // Authenticated Flag
   bool authenticated = 2;
+  // Keyword search
+  optional string keyword = 3;
+  // Sort options
+  optional ProjectSort sort = 4;
+  // Pagination info
+  optional Pagination pagination = 5;
 }
 
 // Retrieves a project regardless of authentication.
@@ -249,6 +292,17 @@ message UpdateProjectRequest {
   optional string tracking_id = 20;
 }
 
+// Update project publish fields.
+// Only the project owner can operate this
+message PublishProjectRequest {
+  // Project ID (required)
+  string project_id = 1;
+  // Scene Publishment alias
+  optional string alias = 2;
+  // Scene Publishment status
+  PublishmentStatus publishment_status = 3;
+}
+
 // Updates a new project metadata.
 // Cannot be updated under a team the user does not belong to.
 message UpdateProjectMetadataRequest {
@@ -286,6 +340,10 @@ message GetProjectResponse {
 message GetProjectListResponse {
   // Project List
   repeated Project projects = 1;
+  // PageInfo
+  PageInfo page_info = 2;
+  // TotalCount
+  int32 total_count = 3;
 }
 
 // Response messages
@@ -296,6 +354,12 @@ message CreateProjectResponse {
 
 // Response messages
 message UpdateProjectResponse {
+  // Project
+  Project project = 1;
+}
+
+// Response messages
+message PublishProjectResponse {
   // Project
   Project project = 1;
 }


### PR DESCRIPTION
# Overview

## What I've done
### 1. Added a new internal API: PublishProject
This API is identical to the GraphQL API.
```diff
+rpc PublishProject(PublishProjectRequest) returns (PublishProjectResponse) {}

+message PublishProjectRequest {
+  // Project ID (required)
+  string project_id = 1;
+  // Scene publication alias
+  optional string alias = 2;
+  // Scene publication status
+  PublishmentStatus publishment_status = 3;
+}
```
### 2. Updated GetProjectList
* When the workspace ID is not specified, it retrieves all projects from workspaces that the user either owns (owner) or belongs to (member).
Note: If the user is only a workspace member, projects marked as deleted will not be retrieved.

* Added options for sorting, keyword search, and pagination.
A dedicated sorting logic has been newly implemented instead of using reearthx.
Unlike the GraphQL GetProject, this implementation fixes a bug that caused an infinite loop when searching in descending order.

```diff
message GetProjectListRequest {
  // Workspace ID
-  string workspace_id = 1;
+  optional string workspace_id = 1;
  // Authenticated flag
  bool authenticated = 2;
  // Keyword search
+  optional string keyword = 3;
+  // Sort options
+  optional ProjectSort sort = 4;
+  // Pagination information
+  optional Pagination pagination = 5;
}
```
## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
