### PR TITLE
feat(server): add metadata for create project [VIZ-2026]

### DIFF
--- a/server/e2e/gql_project_test.go
+++ b/server/e2e/gql_project_test.go
@@ -120,6 +120,9 @@ mutation CreateProject(
   $coreSupport: Boolean
   $visibility: String
   $projectAlias: String
+  $readme: String
+  $license: String
+  $topics: String
 ) {
   createProject(
     input: {
@@ -130,6 +133,9 @@ mutation CreateProject(
       coreSupport: $coreSupport
 	  visibility: $visibility
 	  projectAlias: $projectAlias
+	  readme: $readme
+	  license: $license
+	  topics: $topics
     }
   ) {
     project {
@@ -210,8 +216,17 @@ func TestCreateUpdateProject(t *testing.T) {
 			"coreSupport":  true,
 			"visibility":   "public",
 			"projectAlias": "test-xxxxxx",
+
+			"readme":  "readme-xxxxxx",
+			"license": "license-xxxxxx",
+			"topics":  "topics-xxxxxx",
 		},
 	})
+
+	res.Path("$.data.createProject.project.metadata.readme").IsEqual("readme-xxxxxx")
+	res.Path("$.data.createProject.project.metadata.license").IsEqual("license-xxxxxx")
+	res.Path("$.data.createProject.project.metadata.topics").IsEqual("topics-xxxxxx")
+
 	res.Path("$.data.createProject.project.projectAlias").IsEqual("test-xxxxxx")
 	projectID := res.Path("$.data.createProject.project.id").Raw().(string)
 

--- a/server/e2e/proto_project_test.go
+++ b/server/e2e/proto_project_test.go
@@ -444,6 +444,36 @@ func runTestWithUser(t *testing.T, userID string, testFunc func(client pb.ReEart
 	testFunc(client, ctx)
 }
 
+func TestCreateProjectForInternal(t *testing.T) {
+
+	GRPCServer(t, baseSeeder)
+
+	runTestWithUser(t, uID.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
+
+		res, err := client.CreateProject(ctx,
+			&pb.CreateProjectRequest{
+				WorkspaceId: wID.String(),
+				Visualizer:  pb.Visualizer_VISUALIZER_CESIUM,
+				Name:        lo.ToPtr("Test Project1"),
+				Description: lo.ToPtr("Test Description1"),
+				CoreSupport: lo.ToPtr(true),
+				Visibility:  lo.ToPtr("public"),
+				Readme:      lo.ToPtr("readme-xxxxxxxxxxx"),
+				License:     lo.ToPtr("license-xxxxxxxxxxx"),
+				Topics:      lo.ToPtr("topics-xxxxxxxxxxx"),
+			})
+		require.Nil(t, err)
+
+		prj := res.GetProject()
+		metadata := prj.GetMetadata()
+		assert.Equal(t, "readme-xxxxxxxxxxx", *metadata.Readme)
+		assert.Equal(t, "license-xxxxxxxxxxx", *metadata.License)
+		assert.Equal(t, "topics-xxxxxxxxxxx", *metadata.Topics)
+
+	})
+
+}
+
 func createProjectInternal(t *testing.T, ctx context.Context, r *repo.Container, client pb.ReEarthVisualizerClient, visibility string, req *pb.CreateProjectRequest) id.ProjectID {
 	// test CreateProject
 	res, err := client.CreateProject(ctx, req)

--- a/server/gql/project.graphql
+++ b/server/gql/project.graphql
@@ -79,6 +79,11 @@ input CreateProjectInput {
   coreSupport: Boolean
   visibility: String
   projectAlias: String
+
+  # metadata
+  readme: String
+  license: String
+  topics: String
 }
 
 input UpdateProjectInput {

--- a/server/internal/adapter/gql/generated.go
+++ b/server/internal/adapter/gql/generated.go
@@ -6966,6 +6966,11 @@ input CreateProjectInput {
   coreSupport: Boolean
   visibility: String
   projectAlias: String
+
+  # metadata
+  readme: String
+  license: String
+  topics: String
 }
 
 input UpdateProjectInput {
@@ -45413,7 +45418,7 @@ func (ec *executionContext) unmarshalInputCreateProjectInput(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"teamId", "visualizer", "name", "description", "coreSupport", "visibility", "projectAlias"}
+	fieldsInOrder := [...]string{"teamId", "visualizer", "name", "description", "coreSupport", "visibility", "projectAlias", "readme", "license", "topics"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -45469,6 +45474,27 @@ func (ec *executionContext) unmarshalInputCreateProjectInput(ctx context.Context
 				return it, err
 			}
 			it.ProjectAlias = data
+		case "readme":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("readme"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Readme = data
+		case "license":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("license"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.License = data
+		case "topics":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("topics"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Topics = data
 		}
 	}
 

--- a/server/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/server/internal/adapter/gql/gqlmodel/models_gen.go
@@ -200,6 +200,9 @@ type CreateProjectInput struct {
 	CoreSupport  *bool      `json:"coreSupport,omitempty"`
 	Visibility   *string    `json:"visibility,omitempty"`
 	ProjectAlias *string    `json:"projectAlias,omitempty"`
+	Readme       *string    `json:"readme,omitempty"`
+	License      *string    `json:"license,omitempty"`
+	Topics       *string    `json:"topics,omitempty"`
 }
 
 type CreateSceneInput struct {

--- a/server/internal/adapter/gql/resolver_mutation_project.go
+++ b/server/internal/adapter/gql/resolver_mutation_project.go
@@ -24,6 +24,7 @@ func (r *mutationResolver) CreateProject(ctx context.Context, input gqlmodel.Cre
 	if err != nil {
 		return nil, err
 	}
+
 	res, err := usecases(ctx).Project.Create(ctx, interfaces.CreateProjectParam{
 		WorkspaceID:  tid,
 		Visualizer:   visualizer.Visualizer(input.Visualizer),
@@ -33,6 +34,9 @@ func (r *mutationResolver) CreateProject(ctx context.Context, input gqlmodel.Cre
 		Visibility:   input.Visibility,
 		ImportStatus: project.ProjectImportStatusNone,
 		ProjectAlias: input.ProjectAlias,
+		Readme:       input.Readme,
+		License:      input.License,
+		Topics:       input.Topics,
 	}, getOperator(ctx))
 	if err != nil {
 		return nil, err

--- a/server/internal/adapter/internalapi/schemas/internalapi/v1/schema.pb.go
+++ b/server/internal/adapter/internalapi/schemas/internalapi/v1/schema.pb.go
@@ -1152,7 +1152,13 @@ type CreateProjectRequest struct {
 	// Visibility of the project (e.g., "public", "private")
 	Visibility *string `protobuf:"bytes,6,opt,name=visibility,proto3,oneof" json:"visibility,omitempty"`
 	// Project alias
-	ProjectAlias  *string `protobuf:"bytes,7,opt,name=project_alias,json=projectAlias,proto3,oneof" json:"project_alias,omitempty"`
+	ProjectAlias *string `protobuf:"bytes,7,opt,name=project_alias,json=projectAlias,proto3,oneof" json:"project_alias,omitempty"`
+	// Project readme
+	Readme *string `protobuf:"bytes,8,opt,name=readme,proto3,oneof" json:"readme,omitempty"`
+	// Project license
+	License *string `protobuf:"bytes,9,opt,name=license,proto3,oneof" json:"license,omitempty"`
+	// Project topics
+	Topics        *string `protobuf:"bytes,10,opt,name=topics,proto3,oneof" json:"topics,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1232,6 +1238,27 @@ func (x *CreateProjectRequest) GetVisibility() string {
 func (x *CreateProjectRequest) GetProjectAlias() string {
 	if x != nil && x.ProjectAlias != nil {
 		return *x.ProjectAlias
+	}
+	return ""
+}
+
+func (x *CreateProjectRequest) GetReadme() string {
+	if x != nil && x.Readme != nil {
+		return *x.Readme
+	}
+	return ""
+}
+
+func (x *CreateProjectRequest) GetLicense() string {
+	if x != nil && x.License != nil {
+		return *x.License
+	}
+	return ""
+}
+
+func (x *CreateProjectRequest) GetTopics() string {
+	if x != nil && x.Topics != nil {
+		return *x.Topics
 	}
 	return ""
 }
@@ -2288,7 +2315,7 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tH\x00R\tprojectId\x88\x01\x01\x12\x14\n" +
 	"\x05alias\x18\x02 \x01(\tR\x05aliasB\r\n" +
-	"\v_project_id\"\xfe\x02\n" +
+	"\v_project_id\"\xf9\x03\n" +
 	"\x14CreateProjectRequest\x12!\n" +
 	"\fworkspace_id\x18\x01 \x01(\tR\vworkspaceId\x12A\n" +
 	"\n" +
@@ -2300,12 +2327,20 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\n" +
 	"visibility\x18\x06 \x01(\tH\x03R\n" +
 	"visibility\x88\x01\x01\x12(\n" +
-	"\rproject_alias\x18\a \x01(\tH\x04R\fprojectAlias\x88\x01\x01B\a\n" +
+	"\rproject_alias\x18\a \x01(\tH\x04R\fprojectAlias\x88\x01\x01\x12\x1b\n" +
+	"\x06readme\x18\b \x01(\tH\x05R\x06readme\x88\x01\x01\x12\x1d\n" +
+	"\alicense\x18\t \x01(\tH\x06R\alicense\x88\x01\x01\x12\x1b\n" +
+	"\x06topics\x18\n" +
+	" \x01(\tH\aR\x06topics\x88\x01\x01B\a\n" +
 	"\x05_nameB\x0e\n" +
 	"\f_descriptionB\x0f\n" +
 	"\r_core_supportB\r\n" +
 	"\v_visibilityB\x10\n" +
-	"\x0e_project_alias\"\xbd\t\n" +
+	"\x0e_project_aliasB\t\n" +
+	"\a_readmeB\n" +
+	"\n" +
+	"\b_licenseB\t\n" +
+	"\a_topics\"\xbd\t\n" +
 	"\x14UpdateProjectRequest\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x17\n" +

--- a/server/internal/adapter/internalapi/server.go
+++ b/server/internal/adapter/internalapi/server.go
@@ -188,6 +188,9 @@ func (s server) CreateProject(ctx context.Context, req *pb.CreateProjectRequest)
 		CoreSupport:  req.CoreSupport,
 		Visibility:   req.Visibility,
 		ProjectAlias: req.ProjectAlias,
+		Readme:       req.Readme,
+		License:      req.License,
+		Topics:       req.Topics,
 	}, op)
 	if err != nil {
 		return nil, err

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -299,6 +299,9 @@ func (i *Project) Create(ctx context.Context, input interfaces.CreateProjectPara
 		Visibility:   input.Visibility,
 		ImportStatus: input.ImportStatus,
 		ProjectAlias: input.ProjectAlias,
+		Readme:       input.Readme,
+		License:      input.License,
+		Topics:       input.Topics,
 	}, operator)
 }
 
@@ -964,6 +967,9 @@ func (i *Project) ImportProjectData(ctx context.Context, workspace string, proje
 		Alias:        &alias,
 		Archived:     &archived,
 		CoreSupport:  &coreSupport,
+		Readme:       nil,
+		License:      nil,
+		Topics:       nil,
 	}, op)
 	if err != nil {
 		return nil, err
@@ -1015,6 +1021,11 @@ type createProjectInput struct {
 	CoreSupport  *bool
 	Visibility   *string
 	ProjectAlias *string
+
+	// metadata
+	Readme  *string
+	License *string
+	Topics  *string
 }
 
 func (i *Project) createProject(ctx context.Context, input createProjectInput, operator *usecase.Operator) (_ *project.Project, err error) {
@@ -1081,6 +1092,16 @@ func (i *Project) createProject(ctx context.Context, input createProjectInput, o
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if input.Readme != nil {
+		metadata.SetReadme(input.Readme)
+	}
+	if input.License != nil {
+		metadata.SetLicense(input.License)
+	}
+	if input.Topics != nil {
+		metadata.SetTopics(input.Topics)
 	}
 
 	prj := project.New().

--- a/server/internal/usecase/interfaces/project.go
+++ b/server/internal/usecase/interfaces/project.go
@@ -29,6 +29,11 @@ type CreateProjectParam struct {
 	Visibility   *string
 	ImportStatus project.ProjectImportStatus
 	ProjectAlias *string
+
+	// metadata
+	Readme  *string
+	License *string
+	Topics  *string
 }
 
 type UpdateProjectParam struct {

--- a/server/schemas/internalapi/docs/schema.md
+++ b/server/schemas/internalapi/docs/schema.md
@@ -66,6 +66,9 @@ Cannot be created under a team the user does not belong to.
 | core_support | [bool](#bool) | optional | Set to true |
 | visibility | [string](#string) | optional | Visibility of the project (e.g., &#34;public&#34;, &#34;private&#34;) |
 | project_alias | [string](#string) | optional | Project alias |
+| readme | [string](#string) | optional | Project readme |
+| license | [string](#string) | optional | Project license |
+| topics | [string](#string) | optional | Project topics |
 
 
 
@@ -278,6 +281,8 @@ Pagination
 | last | [int32](#int32) | optional |  |
 | after | [string](#string) | optional |  |
 | before | [string](#string) | optional |  |
+| limit | [int64](#int64) | optional |  |
+| offset | [int64](#int64) | optional |  |
 
 
 

--- a/server/schemas/internalapi/v1/schema.proto
+++ b/server/schemas/internalapi/v1/schema.proto
@@ -181,7 +181,6 @@ message Pagination {
   optional string after = 3;
   optional string before = 4;
 
-
   optional int64 limit = 6;
   optional int64 offset = 7;
 }
@@ -270,6 +269,15 @@ message CreateProjectRequest {
 
   // Project alias
   optional string project_alias = 7;
+
+  // Project readme
+  optional string readme = 8;
+
+  // Project license
+  optional string license = 9;
+
+  // Project topics
+  optional string topics = 10;
 }
 
 // Update project fields.


### PR DESCRIPTION
# Overview

# Adding metadata to CreateProject

## What I've done

### adding a parameter to create metadata at the same time as creating a project.

* GraphQL
```diff
input CreateProjectInput {
  teamId: ID!
  visualizer: Visualizer!
  name: String
  description: String
  coreSupport: Boolean
  visibility: String
  projectAlias: String

+  # metadata
+  readme: String
+  license: String
+  topics: String
}
```
* Internal API
```diff
message CreateProjectRequest {
 ....
  // Project alias
  optional string project_alias = 7;

+  // Project readme
+  optional string readme = 8;

+  // Project license
+  optional string license = 9;

+  // Project topics
+  optional string topics = 10;
}

```
## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
