### PR TITLE
fix(web): fix issue where error occurs during file creation in plugin playground [VIZ-2016]

### DIFF
--- a/web/src/app/features/PluginPlayground/Plugins/FileListItem.tsx
+++ b/web/src/app/features/PluginPlayground/Plugins/FileListItem.tsx
@@ -29,7 +29,7 @@ const FileListItem: FC<Props> = ({
 
   const handleInputConfirm = useCallback(
     (value: string) => {
-      if (value) {
+      if (value.trim()) {
         confirmFileTitle(value, file.id);
         setIsEditing(false);
       }

--- a/web/src/app/features/PluginPlayground/Plugins/FileListItem.tsx
+++ b/web/src/app/features/PluginPlayground/Plugins/FileListItem.tsx
@@ -29,8 +29,10 @@ const FileListItem: FC<Props> = ({
 
   const handleInputConfirm = useCallback(
     (value: string) => {
-      confirmFileTitle(value, file.id);
-      setIsEditing(false);
+      if (value) {
+        confirmFileTitle(value, file.id);
+        setIsEditing(false);
+      }
     },
     [confirmFileTitle, file.id]
   );


### PR DESCRIPTION
- Fixes issue where error occurs during file creation in plugin playground
- Adds a conditional check to prevent confirming a file when the input value is empty. 
