### PR TITLE
feat(server): update internal api by projectalias

### DIFF
--- a/server/e2e/proto_project_alias_test.go
+++ b/server/e2e/proto_project_alias_test.go
@@ -183,3 +183,63 @@ func TestInternalAPI_publish(t *testing.T) {
 
 	})
 }
+
+// go test -v -run TestInternalAPI_ProjectAlias_CRUD ./e2e/...
+
+func TestInternalAPI_ProjectAlias_CRUD(t *testing.T) {
+	GRPCServer(t, baseSeeder)
+
+	runTestWithUser(t, uID.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
+
+		// create public Project
+		res, err := client.CreateProject(ctx, &pb.CreateProjectRequest{
+			WorkspaceId: wID.String(),
+			Visualizer:  pb.Visualizer_VISUALIZER_CESIUM,
+			Name:        lo.ToPtr("Test Project1"),
+			Description: lo.ToPtr("Test Description1"),
+			CoreSupport: lo.ToPtr(true),
+			Visibility:  lo.ToPtr("public"),
+		})
+		require.Nil(t, err)
+
+		pj := res.GetProject()
+		projectAlias := pj.GetProjectAlias()
+
+		res2, err := client.GetProjectByProjectAlias(ctx, &pb.GetProjectByProjectAliasRequest{
+			ProjectAlias: projectAlias,
+		})
+		require.Nil(t, err)
+		require.NotNil(t, res2)
+
+		newName := "test-new-name"
+		newProjectAlias := "test-new-projectalias"
+
+		res3, err := client.UpdateByProjectAlias(ctx, &pb.UpdateByProjectAliasRequest{
+			ProjectAlias:    projectAlias,
+			Name:            lo.ToPtr(newName),
+			NewProjectAlias: lo.ToPtr(newProjectAlias),
+		})
+		require.Nil(t, err)
+		require.NotNil(t, res3)
+
+		res4, err := client.GetProjectByProjectAlias(ctx, &pb.GetProjectByProjectAliasRequest{
+			ProjectAlias: newProjectAlias,
+		})
+		require.Nil(t, err)
+		require.NotNil(t, res4)
+
+		pj = res4.GetProject()
+		require.Equal(t, newName, pj.GetName())
+
+		res5, err := client.DeleteByProjectAlias(ctx, &pb.DeleteByProjectAliasRequest{
+			ProjectAlias: newProjectAlias,
+		})
+		require.Equal(t, newProjectAlias, res5.GetProjectAlias())
+
+		res6, err := client.GetProjectByProjectAlias(ctx, &pb.GetProjectByProjectAliasRequest{
+			ProjectAlias: newProjectAlias,
+		})
+		require.NotNil(t, err)
+		require.Nil(t, res6)
+	})
+}

--- a/server/e2e/proto_project_test.go
+++ b/server/e2e/proto_project_test.go
@@ -444,6 +444,7 @@ func runTestWithUser(t *testing.T, userID string, testFunc func(client pb.ReEart
 	testFunc(client, ctx)
 }
 
+// go test -v -run TestCreateProjectForInternal ./e2e/...
 func TestCreateProjectForInternal(t *testing.T) {
 
 	GRPCServer(t, baseSeeder)
@@ -452,20 +453,36 @@ func TestCreateProjectForInternal(t *testing.T) {
 
 		res, err := client.CreateProject(ctx,
 			&pb.CreateProjectRequest{
-				WorkspaceId: wID.String(),
-				Visualizer:  pb.Visualizer_VISUALIZER_CESIUM,
-				Name:        lo.ToPtr("Test Project1"),
-				Description: lo.ToPtr("Test Description1"),
-				CoreSupport: lo.ToPtr(true),
-				Visibility:  lo.ToPtr("public"),
-				Readme:      lo.ToPtr("readme-xxxxxxxxxxx"),
-				License:     lo.ToPtr("license-xxxxxxxxxxx"),
-				Topics:      lo.ToPtr("topics-xxxxxxxxxxx"),
+				WorkspaceId:  wID.String(),
+				Visualizer:   pb.Visualizer_VISUALIZER_CESIUM,
+				Name:         lo.ToPtr("Test Project1"),
+				Description:  lo.ToPtr("Test Description1"),
+				CoreSupport:  lo.ToPtr(true),
+				Visibility:   lo.ToPtr("public"),
+				ProjectAlias: lo.ToPtr("projectalias-xxxxxxxxxxxx"),
+				Readme:       lo.ToPtr("readme-xxxxxxxxxxx"),
+				License:      lo.ToPtr("license-xxxxxxxxxxx"),
+				Topics:       lo.ToPtr("topics-xxxxxxxxxxx"),
 			})
 		require.Nil(t, err)
 
 		prj := res.GetProject()
+		assert.Equal(t, "projectalias-xxxxxxxxxxxx", prj.ProjectAlias)
+
 		metadata := prj.GetMetadata()
+		assert.Equal(t, "readme-xxxxxxxxxxx", *metadata.Readme)
+		assert.Equal(t, "license-xxxxxxxxxxx", *metadata.License)
+		assert.Equal(t, "topics-xxxxxxxxxxx", *metadata.Topics)
+
+		res2, err := client.GetProject(ctx, &pb.GetProjectRequest{
+			ProjectId: res.Project.Id,
+		})
+		require.Nil(t, err)
+
+		prj = res2.GetProject()
+		assert.Equal(t, "projectalias-xxxxxxxxxxxx", prj.ProjectAlias)
+
+		metadata = prj.GetMetadata()
 		assert.Equal(t, "readme-xxxxxxxxxxx", *metadata.Readme)
 		assert.Equal(t, "license-xxxxxxxxxxx", *metadata.License)
 		assert.Equal(t, "topics-xxxxxxxxxxx", *metadata.Topics)

--- a/server/internal/adapter/internalapi/schemas/internalapi/v1/schema.pb.go
+++ b/server/internal/adapter/internalapi/schemas/internalapi/v1/schema.pb.go
@@ -1659,6 +1659,309 @@ func (x *DeleteProjectRequest) GetProjectId() string {
 	return ""
 }
 
+// Find a project by project alias.
+type GetProjectByProjectAliasRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Scene alias
+	ProjectAlias  string `protobuf:"bytes,1,opt,name=project_alias,json=projectAlias,proto3" json:"project_alias,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetProjectByProjectAliasRequest) Reset() {
+	*x = GetProjectByProjectAliasRequest{}
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetProjectByProjectAliasRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetProjectByProjectAliasRequest) ProtoMessage() {}
+
+func (x *GetProjectByProjectAliasRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetProjectByProjectAliasRequest.ProtoReflect.Descriptor instead.
+func (*GetProjectByProjectAliasRequest) Descriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *GetProjectByProjectAliasRequest) GetProjectAlias() string {
+	if x != nil {
+		return x.ProjectAlias
+	}
+	return ""
+}
+
+// Update project fields.
+// Only the project owner can operate this
+type UpdateByProjectAliasRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Project alias (required)
+	ProjectAlias string `protobuf:"bytes,1,opt,name=project_alias,json=projectAlias,proto3" json:"project_alias,omitempty"`
+	// Project basic info (optional)
+	Name           *string `protobuf:"bytes,2,opt,name=name,proto3,oneof" json:"name,omitempty"`
+	Description    *string `protobuf:"bytes,3,opt,name=description,proto3,oneof" json:"description,omitempty"`
+	Archived       *bool   `protobuf:"varint,4,opt,name=archived,proto3,oneof" json:"archived,omitempty"`
+	ImageUrl       *string `protobuf:"bytes,5,opt,name=image_url,json=imageUrl,proto3,oneof" json:"image_url,omitempty"`
+	DeleteImageUrl *bool   `protobuf:"varint,6,opt,name=delete_image_url,json=deleteImageUrl,proto3,oneof" json:"delete_image_url,omitempty"`
+	SceneId        *string `protobuf:"bytes,7,opt,name=scene_id,json=sceneId,proto3,oneof" json:"scene_id,omitempty"`
+	Starred        *bool   `protobuf:"varint,8,opt,name=starred,proto3,oneof" json:"starred,omitempty"`
+	Deleted        *bool   `protobuf:"varint,9,opt,name=deleted,proto3,oneof" json:"deleted,omitempty"`
+	Visibility     *string `protobuf:"bytes,10,opt,name=visibility,proto3,oneof" json:"visibility,omitempty"`
+	// Publishment settings (optional)
+	PublicTitle       *string `protobuf:"bytes,11,opt,name=public_title,json=publicTitle,proto3,oneof" json:"public_title,omitempty"`
+	PublicDescription *string `protobuf:"bytes,12,opt,name=public_description,json=publicDescription,proto3,oneof" json:"public_description,omitempty"`
+	PublicImage       *string `protobuf:"bytes,13,opt,name=public_image,json=publicImage,proto3,oneof" json:"public_image,omitempty"`
+	PublicNoIndex     *bool   `protobuf:"varint,14,opt,name=public_no_index,json=publicNoIndex,proto3,oneof" json:"public_no_index,omitempty"`
+	DeletePublicImage *bool   `protobuf:"varint,15,opt,name=delete_public_image,json=deletePublicImage,proto3,oneof" json:"delete_public_image,omitempty"`
+	IsBasicAuthActive *bool   `protobuf:"varint,16,opt,name=is_basic_auth_active,json=isBasicAuthActive,proto3,oneof" json:"is_basic_auth_active,omitempty"`
+	BasicAuthUsername *string `protobuf:"bytes,17,opt,name=basic_auth_username,json=basicAuthUsername,proto3,oneof" json:"basic_auth_username,omitempty"`
+	BasicAuthPassword *string `protobuf:"bytes,18,opt,name=basic_auth_password,json=basicAuthPassword,proto3,oneof" json:"basic_auth_password,omitempty"`
+	EnableGa          *bool   `protobuf:"varint,19,opt,name=enable_ga,json=enableGa,proto3,oneof" json:"enable_ga,omitempty"`
+	TrackingId        *string `protobuf:"bytes,20,opt,name=tracking_id,json=trackingId,proto3,oneof" json:"tracking_id,omitempty"`
+	NewProjectAlias   *string `protobuf:"bytes,21,opt,name=new_project_alias,json=newProjectAlias,proto3,oneof" json:"new_project_alias,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *UpdateByProjectAliasRequest) Reset() {
+	*x = UpdateByProjectAliasRequest{}
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateByProjectAliasRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateByProjectAliasRequest) ProtoMessage() {}
+
+func (x *UpdateByProjectAliasRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateByProjectAliasRequest.ProtoReflect.Descriptor instead.
+func (*UpdateByProjectAliasRequest) Descriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *UpdateByProjectAliasRequest) GetProjectAlias() string {
+	if x != nil {
+		return x.ProjectAlias
+	}
+	return ""
+}
+
+func (x *UpdateByProjectAliasRequest) GetName() string {
+	if x != nil && x.Name != nil {
+		return *x.Name
+	}
+	return ""
+}
+
+func (x *UpdateByProjectAliasRequest) GetDescription() string {
+	if x != nil && x.Description != nil {
+		return *x.Description
+	}
+	return ""
+}
+
+func (x *UpdateByProjectAliasRequest) GetArchived() bool {
+	if x != nil && x.Archived != nil {
+		return *x.Archived
+	}
+	return false
+}
+
+func (x *UpdateByProjectAliasRequest) GetImageUrl() string {
+	if x != nil && x.ImageUrl != nil {
+		return *x.ImageUrl
+	}
+	return ""
+}
+
+func (x *UpdateByProjectAliasRequest) GetDeleteImageUrl() bool {
+	if x != nil && x.DeleteImageUrl != nil {
+		return *x.DeleteImageUrl
+	}
+	return false
+}
+
+func (x *UpdateByProjectAliasRequest) GetSceneId() string {
+	if x != nil && x.SceneId != nil {
+		return *x.SceneId
+	}
+	return ""
+}
+
+func (x *UpdateByProjectAliasRequest) GetStarred() bool {
+	if x != nil && x.Starred != nil {
+		return *x.Starred
+	}
+	return false
+}
+
+func (x *UpdateByProjectAliasRequest) GetDeleted() bool {
+	if x != nil && x.Deleted != nil {
+		return *x.Deleted
+	}
+	return false
+}
+
+func (x *UpdateByProjectAliasRequest) GetVisibility() string {
+	if x != nil && x.Visibility != nil {
+		return *x.Visibility
+	}
+	return ""
+}
+
+func (x *UpdateByProjectAliasRequest) GetPublicTitle() string {
+	if x != nil && x.PublicTitle != nil {
+		return *x.PublicTitle
+	}
+	return ""
+}
+
+func (x *UpdateByProjectAliasRequest) GetPublicDescription() string {
+	if x != nil && x.PublicDescription != nil {
+		return *x.PublicDescription
+	}
+	return ""
+}
+
+func (x *UpdateByProjectAliasRequest) GetPublicImage() string {
+	if x != nil && x.PublicImage != nil {
+		return *x.PublicImage
+	}
+	return ""
+}
+
+func (x *UpdateByProjectAliasRequest) GetPublicNoIndex() bool {
+	if x != nil && x.PublicNoIndex != nil {
+		return *x.PublicNoIndex
+	}
+	return false
+}
+
+func (x *UpdateByProjectAliasRequest) GetDeletePublicImage() bool {
+	if x != nil && x.DeletePublicImage != nil {
+		return *x.DeletePublicImage
+	}
+	return false
+}
+
+func (x *UpdateByProjectAliasRequest) GetIsBasicAuthActive() bool {
+	if x != nil && x.IsBasicAuthActive != nil {
+		return *x.IsBasicAuthActive
+	}
+	return false
+}
+
+func (x *UpdateByProjectAliasRequest) GetBasicAuthUsername() string {
+	if x != nil && x.BasicAuthUsername != nil {
+		return *x.BasicAuthUsername
+	}
+	return ""
+}
+
+func (x *UpdateByProjectAliasRequest) GetBasicAuthPassword() string {
+	if x != nil && x.BasicAuthPassword != nil {
+		return *x.BasicAuthPassword
+	}
+	return ""
+}
+
+func (x *UpdateByProjectAliasRequest) GetEnableGa() bool {
+	if x != nil && x.EnableGa != nil {
+		return *x.EnableGa
+	}
+	return false
+}
+
+func (x *UpdateByProjectAliasRequest) GetTrackingId() string {
+	if x != nil && x.TrackingId != nil {
+		return *x.TrackingId
+	}
+	return ""
+}
+
+func (x *UpdateByProjectAliasRequest) GetNewProjectAlias() string {
+	if x != nil && x.NewProjectAlias != nil {
+		return *x.NewProjectAlias
+	}
+	return ""
+}
+
+// Deletes a project.
+// This is a physical deletion, not a logical deletion. Data cannot be restored.
+// Only the project owner can operate this
+type DeleteByProjectAliasRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Project alias
+	ProjectAlias  string `protobuf:"bytes,1,opt,name=project_alias,json=projectAlias,proto3" json:"project_alias,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteByProjectAliasRequest) Reset() {
+	*x = DeleteByProjectAliasRequest{}
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteByProjectAliasRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteByProjectAliasRequest) ProtoMessage() {}
+
+func (x *DeleteByProjectAliasRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteByProjectAliasRequest.ProtoReflect.Descriptor instead.
+func (*DeleteByProjectAliasRequest) Descriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *DeleteByProjectAliasRequest) GetProjectAlias() string {
+	if x != nil {
+		return x.ProjectAlias
+	}
+	return ""
+}
+
 // Export a project.
 type ExportProjectRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1670,7 +1973,7 @@ type ExportProjectRequest struct {
 
 func (x *ExportProjectRequest) Reset() {
 	*x = ExportProjectRequest{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[15]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1682,7 +1985,7 @@ func (x *ExportProjectRequest) String() string {
 func (*ExportProjectRequest) ProtoMessage() {}
 
 func (x *ExportProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[15]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1695,7 +1998,7 @@ func (x *ExportProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportProjectRequest.ProtoReflect.Descriptor instead.
 func (*ExportProjectRequest) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{15}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ExportProjectRequest) GetProjectId() string {
@@ -1716,7 +2019,7 @@ type GetProjectResponse struct {
 
 func (x *GetProjectResponse) Reset() {
 	*x = GetProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[16]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1728,7 +2031,7 @@ func (x *GetProjectResponse) String() string {
 func (*GetProjectResponse) ProtoMessage() {}
 
 func (x *GetProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[16]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1741,7 +2044,7 @@ func (x *GetProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProjectResponse.ProtoReflect.Descriptor instead.
 func (*GetProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{16}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *GetProjectResponse) GetProject() *Project {
@@ -1766,7 +2069,7 @@ type GetProjectListResponse struct {
 
 func (x *GetProjectListResponse) Reset() {
 	*x = GetProjectListResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[17]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1778,7 +2081,7 @@ func (x *GetProjectListResponse) String() string {
 func (*GetProjectListResponse) ProtoMessage() {}
 
 func (x *GetProjectListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[17]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1791,7 +2094,7 @@ func (x *GetProjectListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProjectListResponse.ProtoReflect.Descriptor instead.
 func (*GetProjectListResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{17}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *GetProjectListResponse) GetProjects() []*Project {
@@ -1826,7 +2129,7 @@ type CreateProjectResponse struct {
 
 func (x *CreateProjectResponse) Reset() {
 	*x = CreateProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[18]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1838,7 +2141,7 @@ func (x *CreateProjectResponse) String() string {
 func (*CreateProjectResponse) ProtoMessage() {}
 
 func (x *CreateProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[18]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1851,7 +2154,7 @@ func (x *CreateProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateProjectResponse.ProtoReflect.Descriptor instead.
 func (*CreateProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{18}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *CreateProjectResponse) GetProject() *Project {
@@ -1872,7 +2175,7 @@ type UpdateProjectResponse struct {
 
 func (x *UpdateProjectResponse) Reset() {
 	*x = UpdateProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[19]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1884,7 +2187,7 @@ func (x *UpdateProjectResponse) String() string {
 func (*UpdateProjectResponse) ProtoMessage() {}
 
 func (x *UpdateProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[19]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1897,7 +2200,7 @@ func (x *UpdateProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProjectResponse.ProtoReflect.Descriptor instead.
 func (*UpdateProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{19}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *UpdateProjectResponse) GetProject() *Project {
@@ -1918,7 +2221,7 @@ type PublishProjectResponse struct {
 
 func (x *PublishProjectResponse) Reset() {
 	*x = PublishProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[20]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1930,7 +2233,7 @@ func (x *PublishProjectResponse) String() string {
 func (*PublishProjectResponse) ProtoMessage() {}
 
 func (x *PublishProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[20]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1943,7 +2246,7 @@ func (x *PublishProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PublishProjectResponse.ProtoReflect.Descriptor instead.
 func (*PublishProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{20}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *PublishProjectResponse) GetProject() *Project {
@@ -1964,7 +2267,7 @@ type UpdateProjectMetadataResponse struct {
 
 func (x *UpdateProjectMetadataResponse) Reset() {
 	*x = UpdateProjectMetadataResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[21]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1976,7 +2279,7 @@ func (x *UpdateProjectMetadataResponse) String() string {
 func (*UpdateProjectMetadataResponse) ProtoMessage() {}
 
 func (x *UpdateProjectMetadataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[21]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1989,7 +2292,7 @@ func (x *UpdateProjectMetadataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProjectMetadataResponse.ProtoReflect.Descriptor instead.
 func (*UpdateProjectMetadataResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{21}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *UpdateProjectMetadataResponse) GetMetadata() *ProjectMetadata {
@@ -2010,7 +2313,7 @@ type DeleteProjectResponse struct {
 
 func (x *DeleteProjectResponse) Reset() {
 	*x = DeleteProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[22]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2022,7 +2325,7 @@ func (x *DeleteProjectResponse) String() string {
 func (*DeleteProjectResponse) ProtoMessage() {}
 
 func (x *DeleteProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[22]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2035,7 +2338,7 @@ func (x *DeleteProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProjectResponse.ProtoReflect.Descriptor instead.
 func (*DeleteProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{22}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *DeleteProjectResponse) GetProjectId() string {
@@ -2056,7 +2359,7 @@ type ExportProjectResponse struct {
 
 func (x *ExportProjectResponse) Reset() {
 	*x = ExportProjectResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[23]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2068,7 +2371,7 @@ func (x *ExportProjectResponse) String() string {
 func (*ExportProjectResponse) ProtoMessage() {}
 
 func (x *ExportProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[23]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2081,7 +2384,7 @@ func (x *ExportProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportProjectResponse.ProtoReflect.Descriptor instead.
 func (*ExportProjectResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{23}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ExportProjectResponse) GetProjectDataPath() string {
@@ -2102,7 +2405,7 @@ type GetProjectByAliasResponse struct {
 
 func (x *GetProjectByAliasResponse) Reset() {
 	*x = GetProjectByAliasResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[24]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2114,7 +2417,7 @@ func (x *GetProjectByAliasResponse) String() string {
 func (*GetProjectByAliasResponse) ProtoMessage() {}
 
 func (x *GetProjectByAliasResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[24]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2127,7 +2430,7 @@ func (x *GetProjectByAliasResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProjectByAliasResponse.ProtoReflect.Descriptor instead.
 func (*GetProjectByAliasResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{24}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetProjectByAliasResponse) GetProject() *Project {
@@ -2152,7 +2455,7 @@ type ValidateProjectAliasResponse struct {
 
 func (x *ValidateProjectAliasResponse) Reset() {
 	*x = ValidateProjectAliasResponse{}
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[25]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2164,7 +2467,7 @@ func (x *ValidateProjectAliasResponse) String() string {
 func (*ValidateProjectAliasResponse) ProtoMessage() {}
 
 func (x *ValidateProjectAliasResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[25]
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2177,7 +2480,7 @@ func (x *ValidateProjectAliasResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateProjectAliasResponse.ProtoReflect.Descriptor instead.
 func (*ValidateProjectAliasResponse) Descriptor() ([]byte, []int) {
-	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{25}
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ValidateProjectAliasResponse) GetProjectId() string {
@@ -2197,6 +2500,144 @@ func (x *ValidateProjectAliasResponse) GetAvailable() bool {
 func (x *ValidateProjectAliasResponse) GetErrorMessage() string {
 	if x != nil && x.ErrorMessage != nil {
 		return *x.ErrorMessage
+	}
+	return ""
+}
+
+// Response messages
+type GetProjectByProjectAliasResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Project
+	Project       *Project `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetProjectByProjectAliasResponse) Reset() {
+	*x = GetProjectByProjectAliasResponse{}
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetProjectByProjectAliasResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetProjectByProjectAliasResponse) ProtoMessage() {}
+
+func (x *GetProjectByProjectAliasResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetProjectByProjectAliasResponse.ProtoReflect.Descriptor instead.
+func (*GetProjectByProjectAliasResponse) Descriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *GetProjectByProjectAliasResponse) GetProject() *Project {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+// Response messages
+type UpdateByProjectAliasResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Project
+	Project       *Project `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateByProjectAliasResponse) Reset() {
+	*x = UpdateByProjectAliasResponse{}
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateByProjectAliasResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateByProjectAliasResponse) ProtoMessage() {}
+
+func (x *UpdateByProjectAliasResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateByProjectAliasResponse.ProtoReflect.Descriptor instead.
+func (*UpdateByProjectAliasResponse) Descriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *UpdateByProjectAliasResponse) GetProject() *Project {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+// Response messages
+type DeleteByProjectAliasResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Project alias
+	ProjectAlias  string `protobuf:"bytes,1,opt,name=project_alias,json=projectAlias,proto3" json:"project_alias,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteByProjectAliasResponse) Reset() {
+	*x = DeleteByProjectAliasResponse{}
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteByProjectAliasResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteByProjectAliasResponse) ProtoMessage() {}
+
+func (x *DeleteByProjectAliasResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_schemas_internalapi_v1_schema_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteByProjectAliasResponse.ProtoReflect.Descriptor instead.
+func (*DeleteByProjectAliasResponse) Descriptor() ([]byte, []int) {
+	return file_schemas_internalapi_v1_schema_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *DeleteByProjectAliasResponse) GetProjectAlias() string {
+	if x != nil {
+		return x.ProjectAlias
 	}
 	return ""
 }
@@ -2411,7 +2852,62 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\a_topics\"5\n" +
 	"\x14DeleteProjectRequest\x12\x1d\n" +
 	"\n" +
-	"project_id\x18\x01 \x01(\tR\tprojectId\"5\n" +
+	"project_id\x18\x01 \x01(\tR\tprojectId\"F\n" +
+	"\x1fGetProjectByProjectAliasRequest\x12#\n" +
+	"\rproject_alias\x18\x01 \x01(\tR\fprojectAlias\"\xd5\t\n" +
+	"\x1bUpdateByProjectAliasRequest\x12#\n" +
+	"\rproject_alias\x18\x01 \x01(\tR\fprojectAlias\x12\x17\n" +
+	"\x04name\x18\x02 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n" +
+	"\vdescription\x18\x03 \x01(\tH\x01R\vdescription\x88\x01\x01\x12\x1f\n" +
+	"\barchived\x18\x04 \x01(\bH\x02R\barchived\x88\x01\x01\x12 \n" +
+	"\timage_url\x18\x05 \x01(\tH\x03R\bimageUrl\x88\x01\x01\x12-\n" +
+	"\x10delete_image_url\x18\x06 \x01(\bH\x04R\x0edeleteImageUrl\x88\x01\x01\x12\x1e\n" +
+	"\bscene_id\x18\a \x01(\tH\x05R\asceneId\x88\x01\x01\x12\x1d\n" +
+	"\astarred\x18\b \x01(\bH\x06R\astarred\x88\x01\x01\x12\x1d\n" +
+	"\adeleted\x18\t \x01(\bH\aR\adeleted\x88\x01\x01\x12#\n" +
+	"\n" +
+	"visibility\x18\n" +
+	" \x01(\tH\bR\n" +
+	"visibility\x88\x01\x01\x12&\n" +
+	"\fpublic_title\x18\v \x01(\tH\tR\vpublicTitle\x88\x01\x01\x122\n" +
+	"\x12public_description\x18\f \x01(\tH\n" +
+	"R\x11publicDescription\x88\x01\x01\x12&\n" +
+	"\fpublic_image\x18\r \x01(\tH\vR\vpublicImage\x88\x01\x01\x12+\n" +
+	"\x0fpublic_no_index\x18\x0e \x01(\bH\fR\rpublicNoIndex\x88\x01\x01\x123\n" +
+	"\x13delete_public_image\x18\x0f \x01(\bH\rR\x11deletePublicImage\x88\x01\x01\x124\n" +
+	"\x14is_basic_auth_active\x18\x10 \x01(\bH\x0eR\x11isBasicAuthActive\x88\x01\x01\x123\n" +
+	"\x13basic_auth_username\x18\x11 \x01(\tH\x0fR\x11basicAuthUsername\x88\x01\x01\x123\n" +
+	"\x13basic_auth_password\x18\x12 \x01(\tH\x10R\x11basicAuthPassword\x88\x01\x01\x12 \n" +
+	"\tenable_ga\x18\x13 \x01(\bH\x11R\benableGa\x88\x01\x01\x12$\n" +
+	"\vtracking_id\x18\x14 \x01(\tH\x12R\n" +
+	"trackingId\x88\x01\x01\x12/\n" +
+	"\x11new_project_alias\x18\x15 \x01(\tH\x13R\x0fnewProjectAlias\x88\x01\x01B\a\n" +
+	"\x05_nameB\x0e\n" +
+	"\f_descriptionB\v\n" +
+	"\t_archivedB\f\n" +
+	"\n" +
+	"_image_urlB\x13\n" +
+	"\x11_delete_image_urlB\v\n" +
+	"\t_scene_idB\n" +
+	"\n" +
+	"\b_starredB\n" +
+	"\n" +
+	"\b_deletedB\r\n" +
+	"\v_visibilityB\x0f\n" +
+	"\r_public_titleB\x15\n" +
+	"\x13_public_descriptionB\x0f\n" +
+	"\r_public_imageB\x12\n" +
+	"\x10_public_no_indexB\x16\n" +
+	"\x14_delete_public_imageB\x17\n" +
+	"\x15_is_basic_auth_activeB\x16\n" +
+	"\x14_basic_auth_usernameB\x16\n" +
+	"\x14_basic_auth_passwordB\f\n" +
+	"\n" +
+	"_enable_gaB\x0e\n" +
+	"\f_tracking_idB\x14\n" +
+	"\x12_new_project_alias\"B\n" +
+	"\x1bDeleteByProjectAliasRequest\x12#\n" +
+	"\rproject_alias\x18\x01 \x01(\tR\fprojectAlias\"5\n" +
 	"\x14ExportProjectRequest\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\"N\n" +
@@ -2443,7 +2939,13 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\tavailable\x18\x02 \x01(\bR\tavailable\x12(\n" +
 	"\rerror_message\x18\x03 \x01(\tH\x01R\ferrorMessage\x88\x01\x01B\r\n" +
 	"\v_project_idB\x10\n" +
-	"\x0e_error_message*[\n" +
+	"\x0e_error_message\"\\\n" +
+	" GetProjectByProjectAliasResponse\x128\n" +
+	"\aproject\x18\x01 \x01(\v2\x1e.reearth.visualizer.v1.ProjectR\aproject\"X\n" +
+	"\x1cUpdateByProjectAliasResponse\x128\n" +
+	"\aproject\x18\x01 \x01(\v2\x1e.reearth.visualizer.v1.ProjectR\aproject\"C\n" +
+	"\x1cDeleteByProjectAliasResponse\x12#\n" +
+	"\rproject_alias\x18\x01 \x01(\tR\fprojectAlias*[\n" +
 	"\n" +
 	"Visualizer\x12\x1a\n" +
 	"\x16VISUALIZER_UNSPECIFIED\x10\x00\x12\x15\n" +
@@ -2467,7 +2969,7 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\rSortDirection\x12\x1e\n" +
 	"\x1aSORT_DIRECTION_UNSPECIFIED\x10\x00\x12\a\n" +
 	"\x03ASC\x10\x01\x12\b\n" +
-	"\x04DESC\x10\x022\x97\t\n" +
+	"\x04DESC\x10\x022\xaf\f\n" +
 	"\x11ReEarthVisualizer\x12o\n" +
 	"\x0eGetProjectList\x12,.reearth.visualizer.v1.GetProjectListRequest\x1a-.reearth.visualizer.v1.GetProjectListResponse\"\x00\x12c\n" +
 	"\n" +
@@ -2479,7 +2981,10 @@ const file_schemas_internalapi_v1_schema_proto_rawDesc = "" +
 	"\x0ePublishProject\x12,.reearth.visualizer.v1.PublishProjectRequest\x1a-.reearth.visualizer.v1.PublishProjectResponse\"\x00\x12\x84\x01\n" +
 	"\x15UpdateProjectMetadata\x123.reearth.visualizer.v1.UpdateProjectMetadataRequest\x1a4.reearth.visualizer.v1.UpdateProjectMetadataResponse\"\x00\x12l\n" +
 	"\rDeleteProject\x12+.reearth.visualizer.v1.DeleteProjectRequest\x1a,.reearth.visualizer.v1.DeleteProjectResponse\"\x00\x12l\n" +
-	"\rExportProject\x12+.reearth.visualizer.v1.ExportProjectRequest\x1a,.reearth.visualizer.v1.ExportProjectResponse\"\x00B\n" +
+	"\rExportProject\x12+.reearth.visualizer.v1.ExportProjectRequest\x1a,.reearth.visualizer.v1.ExportProjectResponse\"\x00\x12\x8d\x01\n" +
+	"\x18GetProjectByProjectAlias\x126.reearth.visualizer.v1.GetProjectByProjectAliasRequest\x1a7.reearth.visualizer.v1.GetProjectByProjectAliasResponse\"\x00\x12\x81\x01\n" +
+	"\x14UpdateByProjectAlias\x122.reearth.visualizer.v1.UpdateByProjectAliasRequest\x1a3.reearth.visualizer.v1.UpdateByProjectAliasResponse\"\x00\x12\x81\x01\n" +
+	"\x14DeleteByProjectAlias\x122.reearth.visualizer.v1.DeleteByProjectAliasRequest\x1a3.reearth.visualizer.v1.DeleteByProjectAliasResponse\"\x00B\n" +
 	"Z\bproto/v1b\x06proto3"
 
 var (
@@ -2495,52 +3000,58 @@ func file_schemas_internalapi_v1_schema_proto_rawDescGZIP() []byte {
 }
 
 var file_schemas_internalapi_v1_schema_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_schemas_internalapi_v1_schema_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_schemas_internalapi_v1_schema_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
 var file_schemas_internalapi_v1_schema_proto_goTypes = []any{
-	(Visualizer)(0),                       // 0: reearth.visualizer.v1.Visualizer
-	(ProjectImportStatus)(0),              // 1: reearth.visualizer.v1.ProjectImportStatus
-	(PublishmentStatus)(0),                // 2: reearth.visualizer.v1.PublishmentStatus
-	(ProjectSortField)(0),                 // 3: reearth.visualizer.v1.ProjectSortField
-	(SortDirection)(0),                    // 4: reearth.visualizer.v1.SortDirection
-	(*Project)(nil),                       // 5: reearth.visualizer.v1.Project
-	(*Story)(nil),                         // 6: reearth.visualizer.v1.Story
-	(*ProjectMetadata)(nil),               // 7: reearth.visualizer.v1.ProjectMetadata
-	(*Pagination)(nil),                    // 8: reearth.visualizer.v1.Pagination
-	(*ProjectSort)(nil),                   // 9: reearth.visualizer.v1.ProjectSort
-	(*PageInfo)(nil),                      // 10: reearth.visualizer.v1.PageInfo
-	(*GetProjectListRequest)(nil),         // 11: reearth.visualizer.v1.GetProjectListRequest
-	(*GetProjectRequest)(nil),             // 12: reearth.visualizer.v1.GetProjectRequest
-	(*GetProjectByAliasRequest)(nil),      // 13: reearth.visualizer.v1.GetProjectByAliasRequest
-	(*ValidateProjectAliasRequest)(nil),   // 14: reearth.visualizer.v1.ValidateProjectAliasRequest
-	(*CreateProjectRequest)(nil),          // 15: reearth.visualizer.v1.CreateProjectRequest
-	(*UpdateProjectRequest)(nil),          // 16: reearth.visualizer.v1.UpdateProjectRequest
-	(*PublishProjectRequest)(nil),         // 17: reearth.visualizer.v1.PublishProjectRequest
-	(*UpdateProjectMetadataRequest)(nil),  // 18: reearth.visualizer.v1.UpdateProjectMetadataRequest
-	(*DeleteProjectRequest)(nil),          // 19: reearth.visualizer.v1.DeleteProjectRequest
-	(*ExportProjectRequest)(nil),          // 20: reearth.visualizer.v1.ExportProjectRequest
-	(*GetProjectResponse)(nil),            // 21: reearth.visualizer.v1.GetProjectResponse
-	(*GetProjectListResponse)(nil),        // 22: reearth.visualizer.v1.GetProjectListResponse
-	(*CreateProjectResponse)(nil),         // 23: reearth.visualizer.v1.CreateProjectResponse
-	(*UpdateProjectResponse)(nil),         // 24: reearth.visualizer.v1.UpdateProjectResponse
-	(*PublishProjectResponse)(nil),        // 25: reearth.visualizer.v1.PublishProjectResponse
-	(*UpdateProjectMetadataResponse)(nil), // 26: reearth.visualizer.v1.UpdateProjectMetadataResponse
-	(*DeleteProjectResponse)(nil),         // 27: reearth.visualizer.v1.DeleteProjectResponse
-	(*ExportProjectResponse)(nil),         // 28: reearth.visualizer.v1.ExportProjectResponse
-	(*GetProjectByAliasResponse)(nil),     // 29: reearth.visualizer.v1.GetProjectByAliasResponse
-	(*ValidateProjectAliasResponse)(nil),  // 30: reearth.visualizer.v1.ValidateProjectAliasResponse
-	(*timestamppb.Timestamp)(nil),         // 31: google.protobuf.Timestamp
+	(Visualizer)(0),                          // 0: reearth.visualizer.v1.Visualizer
+	(ProjectImportStatus)(0),                 // 1: reearth.visualizer.v1.ProjectImportStatus
+	(PublishmentStatus)(0),                   // 2: reearth.visualizer.v1.PublishmentStatus
+	(ProjectSortField)(0),                    // 3: reearth.visualizer.v1.ProjectSortField
+	(SortDirection)(0),                       // 4: reearth.visualizer.v1.SortDirection
+	(*Project)(nil),                          // 5: reearth.visualizer.v1.Project
+	(*Story)(nil),                            // 6: reearth.visualizer.v1.Story
+	(*ProjectMetadata)(nil),                  // 7: reearth.visualizer.v1.ProjectMetadata
+	(*Pagination)(nil),                       // 8: reearth.visualizer.v1.Pagination
+	(*ProjectSort)(nil),                      // 9: reearth.visualizer.v1.ProjectSort
+	(*PageInfo)(nil),                         // 10: reearth.visualizer.v1.PageInfo
+	(*GetProjectListRequest)(nil),            // 11: reearth.visualizer.v1.GetProjectListRequest
+	(*GetProjectRequest)(nil),                // 12: reearth.visualizer.v1.GetProjectRequest
+	(*GetProjectByAliasRequest)(nil),         // 13: reearth.visualizer.v1.GetProjectByAliasRequest
+	(*ValidateProjectAliasRequest)(nil),      // 14: reearth.visualizer.v1.ValidateProjectAliasRequest
+	(*CreateProjectRequest)(nil),             // 15: reearth.visualizer.v1.CreateProjectRequest
+	(*UpdateProjectRequest)(nil),             // 16: reearth.visualizer.v1.UpdateProjectRequest
+	(*PublishProjectRequest)(nil),            // 17: reearth.visualizer.v1.PublishProjectRequest
+	(*UpdateProjectMetadataRequest)(nil),     // 18: reearth.visualizer.v1.UpdateProjectMetadataRequest
+	(*DeleteProjectRequest)(nil),             // 19: reearth.visualizer.v1.DeleteProjectRequest
+	(*GetProjectByProjectAliasRequest)(nil),  // 20: reearth.visualizer.v1.GetProjectByProjectAliasRequest
+	(*UpdateByProjectAliasRequest)(nil),      // 21: reearth.visualizer.v1.UpdateByProjectAliasRequest
+	(*DeleteByProjectAliasRequest)(nil),      // 22: reearth.visualizer.v1.DeleteByProjectAliasRequest
+	(*ExportProjectRequest)(nil),             // 23: reearth.visualizer.v1.ExportProjectRequest
+	(*GetProjectResponse)(nil),               // 24: reearth.visualizer.v1.GetProjectResponse
+	(*GetProjectListResponse)(nil),           // 25: reearth.visualizer.v1.GetProjectListResponse
+	(*CreateProjectResponse)(nil),            // 26: reearth.visualizer.v1.CreateProjectResponse
+	(*UpdateProjectResponse)(nil),            // 27: reearth.visualizer.v1.UpdateProjectResponse
+	(*PublishProjectResponse)(nil),           // 28: reearth.visualizer.v1.PublishProjectResponse
+	(*UpdateProjectMetadataResponse)(nil),    // 29: reearth.visualizer.v1.UpdateProjectMetadataResponse
+	(*DeleteProjectResponse)(nil),            // 30: reearth.visualizer.v1.DeleteProjectResponse
+	(*ExportProjectResponse)(nil),            // 31: reearth.visualizer.v1.ExportProjectResponse
+	(*GetProjectByAliasResponse)(nil),        // 32: reearth.visualizer.v1.GetProjectByAliasResponse
+	(*ValidateProjectAliasResponse)(nil),     // 33: reearth.visualizer.v1.ValidateProjectAliasResponse
+	(*GetProjectByProjectAliasResponse)(nil), // 34: reearth.visualizer.v1.GetProjectByProjectAliasResponse
+	(*UpdateByProjectAliasResponse)(nil),     // 35: reearth.visualizer.v1.UpdateByProjectAliasResponse
+	(*DeleteByProjectAliasResponse)(nil),     // 36: reearth.visualizer.v1.DeleteByProjectAliasResponse
+	(*timestamppb.Timestamp)(nil),            // 37: google.protobuf.Timestamp
 }
 var file_schemas_internalapi_v1_schema_proto_depIdxs = []int32{
 	6,  // 0: reearth.visualizer.v1.Project.stories:type_name -> reearth.visualizer.v1.Story
 	0,  // 1: reearth.visualizer.v1.Project.visualizer:type_name -> reearth.visualizer.v1.Visualizer
-	31, // 2: reearth.visualizer.v1.Project.created_at:type_name -> google.protobuf.Timestamp
-	31, // 3: reearth.visualizer.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
+	37, // 2: reearth.visualizer.v1.Project.created_at:type_name -> google.protobuf.Timestamp
+	37, // 3: reearth.visualizer.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
 	7,  // 4: reearth.visualizer.v1.Project.metadata:type_name -> reearth.visualizer.v1.ProjectMetadata
 	2,  // 5: reearth.visualizer.v1.Project.publishment_status:type_name -> reearth.visualizer.v1.PublishmentStatus
 	2,  // 6: reearth.visualizer.v1.Story.story_publishment_status:type_name -> reearth.visualizer.v1.PublishmentStatus
 	1,  // 7: reearth.visualizer.v1.ProjectMetadata.import_status:type_name -> reearth.visualizer.v1.ProjectImportStatus
-	31, // 8: reearth.visualizer.v1.ProjectMetadata.created_at:type_name -> google.protobuf.Timestamp
-	31, // 9: reearth.visualizer.v1.ProjectMetadata.updated_at:type_name -> google.protobuf.Timestamp
+	37, // 8: reearth.visualizer.v1.ProjectMetadata.created_at:type_name -> google.protobuf.Timestamp
+	37, // 9: reearth.visualizer.v1.ProjectMetadata.updated_at:type_name -> google.protobuf.Timestamp
 	3,  // 10: reearth.visualizer.v1.ProjectSort.field:type_name -> reearth.visualizer.v1.ProjectSortField
 	4,  // 11: reearth.visualizer.v1.ProjectSort.direction:type_name -> reearth.visualizer.v1.SortDirection
 	9,  // 12: reearth.visualizer.v1.GetProjectListRequest.sort:type_name -> reearth.visualizer.v1.ProjectSort
@@ -2555,31 +3066,39 @@ var file_schemas_internalapi_v1_schema_proto_depIdxs = []int32{
 	5,  // 21: reearth.visualizer.v1.PublishProjectResponse.project:type_name -> reearth.visualizer.v1.Project
 	7,  // 22: reearth.visualizer.v1.UpdateProjectMetadataResponse.metadata:type_name -> reearth.visualizer.v1.ProjectMetadata
 	5,  // 23: reearth.visualizer.v1.GetProjectByAliasResponse.project:type_name -> reearth.visualizer.v1.Project
-	11, // 24: reearth.visualizer.v1.ReEarthVisualizer.GetProjectList:input_type -> reearth.visualizer.v1.GetProjectListRequest
-	12, // 25: reearth.visualizer.v1.ReEarthVisualizer.GetProject:input_type -> reearth.visualizer.v1.GetProjectRequest
-	13, // 26: reearth.visualizer.v1.ReEarthVisualizer.GetProjectByAlias:input_type -> reearth.visualizer.v1.GetProjectByAliasRequest
-	14, // 27: reearth.visualizer.v1.ReEarthVisualizer.ValidateProjectAlias:input_type -> reearth.visualizer.v1.ValidateProjectAliasRequest
-	15, // 28: reearth.visualizer.v1.ReEarthVisualizer.CreateProject:input_type -> reearth.visualizer.v1.CreateProjectRequest
-	16, // 29: reearth.visualizer.v1.ReEarthVisualizer.UpdateProject:input_type -> reearth.visualizer.v1.UpdateProjectRequest
-	17, // 30: reearth.visualizer.v1.ReEarthVisualizer.PublishProject:input_type -> reearth.visualizer.v1.PublishProjectRequest
-	18, // 31: reearth.visualizer.v1.ReEarthVisualizer.UpdateProjectMetadata:input_type -> reearth.visualizer.v1.UpdateProjectMetadataRequest
-	19, // 32: reearth.visualizer.v1.ReEarthVisualizer.DeleteProject:input_type -> reearth.visualizer.v1.DeleteProjectRequest
-	20, // 33: reearth.visualizer.v1.ReEarthVisualizer.ExportProject:input_type -> reearth.visualizer.v1.ExportProjectRequest
-	22, // 34: reearth.visualizer.v1.ReEarthVisualizer.GetProjectList:output_type -> reearth.visualizer.v1.GetProjectListResponse
-	21, // 35: reearth.visualizer.v1.ReEarthVisualizer.GetProject:output_type -> reearth.visualizer.v1.GetProjectResponse
-	29, // 36: reearth.visualizer.v1.ReEarthVisualizer.GetProjectByAlias:output_type -> reearth.visualizer.v1.GetProjectByAliasResponse
-	30, // 37: reearth.visualizer.v1.ReEarthVisualizer.ValidateProjectAlias:output_type -> reearth.visualizer.v1.ValidateProjectAliasResponse
-	23, // 38: reearth.visualizer.v1.ReEarthVisualizer.CreateProject:output_type -> reearth.visualizer.v1.CreateProjectResponse
-	24, // 39: reearth.visualizer.v1.ReEarthVisualizer.UpdateProject:output_type -> reearth.visualizer.v1.UpdateProjectResponse
-	25, // 40: reearth.visualizer.v1.ReEarthVisualizer.PublishProject:output_type -> reearth.visualizer.v1.PublishProjectResponse
-	26, // 41: reearth.visualizer.v1.ReEarthVisualizer.UpdateProjectMetadata:output_type -> reearth.visualizer.v1.UpdateProjectMetadataResponse
-	27, // 42: reearth.visualizer.v1.ReEarthVisualizer.DeleteProject:output_type -> reearth.visualizer.v1.DeleteProjectResponse
-	28, // 43: reearth.visualizer.v1.ReEarthVisualizer.ExportProject:output_type -> reearth.visualizer.v1.ExportProjectResponse
-	34, // [34:44] is the sub-list for method output_type
-	24, // [24:34] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	5,  // 24: reearth.visualizer.v1.GetProjectByProjectAliasResponse.project:type_name -> reearth.visualizer.v1.Project
+	5,  // 25: reearth.visualizer.v1.UpdateByProjectAliasResponse.project:type_name -> reearth.visualizer.v1.Project
+	11, // 26: reearth.visualizer.v1.ReEarthVisualizer.GetProjectList:input_type -> reearth.visualizer.v1.GetProjectListRequest
+	12, // 27: reearth.visualizer.v1.ReEarthVisualizer.GetProject:input_type -> reearth.visualizer.v1.GetProjectRequest
+	13, // 28: reearth.visualizer.v1.ReEarthVisualizer.GetProjectByAlias:input_type -> reearth.visualizer.v1.GetProjectByAliasRequest
+	14, // 29: reearth.visualizer.v1.ReEarthVisualizer.ValidateProjectAlias:input_type -> reearth.visualizer.v1.ValidateProjectAliasRequest
+	15, // 30: reearth.visualizer.v1.ReEarthVisualizer.CreateProject:input_type -> reearth.visualizer.v1.CreateProjectRequest
+	16, // 31: reearth.visualizer.v1.ReEarthVisualizer.UpdateProject:input_type -> reearth.visualizer.v1.UpdateProjectRequest
+	17, // 32: reearth.visualizer.v1.ReEarthVisualizer.PublishProject:input_type -> reearth.visualizer.v1.PublishProjectRequest
+	18, // 33: reearth.visualizer.v1.ReEarthVisualizer.UpdateProjectMetadata:input_type -> reearth.visualizer.v1.UpdateProjectMetadataRequest
+	19, // 34: reearth.visualizer.v1.ReEarthVisualizer.DeleteProject:input_type -> reearth.visualizer.v1.DeleteProjectRequest
+	23, // 35: reearth.visualizer.v1.ReEarthVisualizer.ExportProject:input_type -> reearth.visualizer.v1.ExportProjectRequest
+	20, // 36: reearth.visualizer.v1.ReEarthVisualizer.GetProjectByProjectAlias:input_type -> reearth.visualizer.v1.GetProjectByProjectAliasRequest
+	21, // 37: reearth.visualizer.v1.ReEarthVisualizer.UpdateByProjectAlias:input_type -> reearth.visualizer.v1.UpdateByProjectAliasRequest
+	22, // 38: reearth.visualizer.v1.ReEarthVisualizer.DeleteByProjectAlias:input_type -> reearth.visualizer.v1.DeleteByProjectAliasRequest
+	25, // 39: reearth.visualizer.v1.ReEarthVisualizer.GetProjectList:output_type -> reearth.visualizer.v1.GetProjectListResponse
+	24, // 40: reearth.visualizer.v1.ReEarthVisualizer.GetProject:output_type -> reearth.visualizer.v1.GetProjectResponse
+	32, // 41: reearth.visualizer.v1.ReEarthVisualizer.GetProjectByAlias:output_type -> reearth.visualizer.v1.GetProjectByAliasResponse
+	33, // 42: reearth.visualizer.v1.ReEarthVisualizer.ValidateProjectAlias:output_type -> reearth.visualizer.v1.ValidateProjectAliasResponse
+	26, // 43: reearth.visualizer.v1.ReEarthVisualizer.CreateProject:output_type -> reearth.visualizer.v1.CreateProjectResponse
+	27, // 44: reearth.visualizer.v1.ReEarthVisualizer.UpdateProject:output_type -> reearth.visualizer.v1.UpdateProjectResponse
+	28, // 45: reearth.visualizer.v1.ReEarthVisualizer.PublishProject:output_type -> reearth.visualizer.v1.PublishProjectResponse
+	29, // 46: reearth.visualizer.v1.ReEarthVisualizer.UpdateProjectMetadata:output_type -> reearth.visualizer.v1.UpdateProjectMetadataResponse
+	30, // 47: reearth.visualizer.v1.ReEarthVisualizer.DeleteProject:output_type -> reearth.visualizer.v1.DeleteProjectResponse
+	31, // 48: reearth.visualizer.v1.ReEarthVisualizer.ExportProject:output_type -> reearth.visualizer.v1.ExportProjectResponse
+	34, // 49: reearth.visualizer.v1.ReEarthVisualizer.GetProjectByProjectAlias:output_type -> reearth.visualizer.v1.GetProjectByProjectAliasResponse
+	35, // 50: reearth.visualizer.v1.ReEarthVisualizer.UpdateByProjectAlias:output_type -> reearth.visualizer.v1.UpdateByProjectAliasResponse
+	36, // 51: reearth.visualizer.v1.ReEarthVisualizer.DeleteByProjectAlias:output_type -> reearth.visualizer.v1.DeleteByProjectAliasResponse
+	39, // [39:52] is the sub-list for method output_type
+	26, // [26:39] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_schemas_internalapi_v1_schema_proto_init() }
@@ -2598,14 +3117,15 @@ func file_schemas_internalapi_v1_schema_proto_init() {
 	file_schemas_internalapi_v1_schema_proto_msgTypes[11].OneofWrappers = []any{}
 	file_schemas_internalapi_v1_schema_proto_msgTypes[12].OneofWrappers = []any{}
 	file_schemas_internalapi_v1_schema_proto_msgTypes[13].OneofWrappers = []any{}
-	file_schemas_internalapi_v1_schema_proto_msgTypes[25].OneofWrappers = []any{}
+	file_schemas_internalapi_v1_schema_proto_msgTypes[16].OneofWrappers = []any{}
+	file_schemas_internalapi_v1_schema_proto_msgTypes[28].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_schemas_internalapi_v1_schema_proto_rawDesc), len(file_schemas_internalapi_v1_schema_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   26,
+			NumMessages:   32,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/server/internal/adapter/internalapi/schemas/internalapi/v1/schema_grpc.pb.go
+++ b/server/internal/adapter/internalapi/schemas/internalapi/v1/schema_grpc.pb.go
@@ -19,16 +19,19 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ReEarthVisualizer_GetProjectList_FullMethodName        = "/reearth.visualizer.v1.ReEarthVisualizer/GetProjectList"
-	ReEarthVisualizer_GetProject_FullMethodName            = "/reearth.visualizer.v1.ReEarthVisualizer/GetProject"
-	ReEarthVisualizer_GetProjectByAlias_FullMethodName     = "/reearth.visualizer.v1.ReEarthVisualizer/GetProjectByAlias"
-	ReEarthVisualizer_ValidateProjectAlias_FullMethodName  = "/reearth.visualizer.v1.ReEarthVisualizer/ValidateProjectAlias"
-	ReEarthVisualizer_CreateProject_FullMethodName         = "/reearth.visualizer.v1.ReEarthVisualizer/CreateProject"
-	ReEarthVisualizer_UpdateProject_FullMethodName         = "/reearth.visualizer.v1.ReEarthVisualizer/UpdateProject"
-	ReEarthVisualizer_PublishProject_FullMethodName        = "/reearth.visualizer.v1.ReEarthVisualizer/PublishProject"
-	ReEarthVisualizer_UpdateProjectMetadata_FullMethodName = "/reearth.visualizer.v1.ReEarthVisualizer/UpdateProjectMetadata"
-	ReEarthVisualizer_DeleteProject_FullMethodName         = "/reearth.visualizer.v1.ReEarthVisualizer/DeleteProject"
-	ReEarthVisualizer_ExportProject_FullMethodName         = "/reearth.visualizer.v1.ReEarthVisualizer/ExportProject"
+	ReEarthVisualizer_GetProjectList_FullMethodName           = "/reearth.visualizer.v1.ReEarthVisualizer/GetProjectList"
+	ReEarthVisualizer_GetProject_FullMethodName               = "/reearth.visualizer.v1.ReEarthVisualizer/GetProject"
+	ReEarthVisualizer_GetProjectByAlias_FullMethodName        = "/reearth.visualizer.v1.ReEarthVisualizer/GetProjectByAlias"
+	ReEarthVisualizer_ValidateProjectAlias_FullMethodName     = "/reearth.visualizer.v1.ReEarthVisualizer/ValidateProjectAlias"
+	ReEarthVisualizer_CreateProject_FullMethodName            = "/reearth.visualizer.v1.ReEarthVisualizer/CreateProject"
+	ReEarthVisualizer_UpdateProject_FullMethodName            = "/reearth.visualizer.v1.ReEarthVisualizer/UpdateProject"
+	ReEarthVisualizer_PublishProject_FullMethodName           = "/reearth.visualizer.v1.ReEarthVisualizer/PublishProject"
+	ReEarthVisualizer_UpdateProjectMetadata_FullMethodName    = "/reearth.visualizer.v1.ReEarthVisualizer/UpdateProjectMetadata"
+	ReEarthVisualizer_DeleteProject_FullMethodName            = "/reearth.visualizer.v1.ReEarthVisualizer/DeleteProject"
+	ReEarthVisualizer_ExportProject_FullMethodName            = "/reearth.visualizer.v1.ReEarthVisualizer/ExportProject"
+	ReEarthVisualizer_GetProjectByProjectAlias_FullMethodName = "/reearth.visualizer.v1.ReEarthVisualizer/GetProjectByProjectAlias"
+	ReEarthVisualizer_UpdateByProjectAlias_FullMethodName     = "/reearth.visualizer.v1.ReEarthVisualizer/UpdateByProjectAlias"
+	ReEarthVisualizer_DeleteByProjectAlias_FullMethodName     = "/reearth.visualizer.v1.ReEarthVisualizer/DeleteByProjectAlias"
 )
 
 // ReEarthVisualizerClient is the client API for ReEarthVisualizer service.
@@ -65,6 +68,15 @@ type ReEarthVisualizerClient interface {
 	// Export a project.
 	// Request headers: user-id: <User ID>
 	ExportProject(ctx context.Context, in *ExportProjectRequest, opts ...grpc.CallOption) (*ExportProjectResponse, error)
+	// Find a project by project alias.
+	// Request headers: user-id: <User ID>
+	GetProjectByProjectAlias(ctx context.Context, in *GetProjectByProjectAliasRequest, opts ...grpc.CallOption) (*GetProjectByProjectAliasResponse, error)
+	// Update a project by project alias.
+	// Request headers: user-id: <User ID>
+	UpdateByProjectAlias(ctx context.Context, in *UpdateByProjectAliasRequest, opts ...grpc.CallOption) (*UpdateByProjectAliasResponse, error)
+	// Deletes a project by project alias.
+	// Request headers: user-id: <User ID>
+	DeleteByProjectAlias(ctx context.Context, in *DeleteByProjectAliasRequest, opts ...grpc.CallOption) (*DeleteByProjectAliasResponse, error)
 }
 
 type reEarthVisualizerClient struct {
@@ -175,6 +187,36 @@ func (c *reEarthVisualizerClient) ExportProject(ctx context.Context, in *ExportP
 	return out, nil
 }
 
+func (c *reEarthVisualizerClient) GetProjectByProjectAlias(ctx context.Context, in *GetProjectByProjectAliasRequest, opts ...grpc.CallOption) (*GetProjectByProjectAliasResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetProjectByProjectAliasResponse)
+	err := c.cc.Invoke(ctx, ReEarthVisualizer_GetProjectByProjectAlias_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *reEarthVisualizerClient) UpdateByProjectAlias(ctx context.Context, in *UpdateByProjectAliasRequest, opts ...grpc.CallOption) (*UpdateByProjectAliasResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UpdateByProjectAliasResponse)
+	err := c.cc.Invoke(ctx, ReEarthVisualizer_UpdateByProjectAlias_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *reEarthVisualizerClient) DeleteByProjectAlias(ctx context.Context, in *DeleteByProjectAliasRequest, opts ...grpc.CallOption) (*DeleteByProjectAliasResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteByProjectAliasResponse)
+	err := c.cc.Invoke(ctx, ReEarthVisualizer_DeleteByProjectAlias_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ReEarthVisualizerServer is the server API for ReEarthVisualizer service.
 // All implementations must embed UnimplementedReEarthVisualizerServer
 // for forward compatibility.
@@ -209,6 +251,15 @@ type ReEarthVisualizerServer interface {
 	// Export a project.
 	// Request headers: user-id: <User ID>
 	ExportProject(context.Context, *ExportProjectRequest) (*ExportProjectResponse, error)
+	// Find a project by project alias.
+	// Request headers: user-id: <User ID>
+	GetProjectByProjectAlias(context.Context, *GetProjectByProjectAliasRequest) (*GetProjectByProjectAliasResponse, error)
+	// Update a project by project alias.
+	// Request headers: user-id: <User ID>
+	UpdateByProjectAlias(context.Context, *UpdateByProjectAliasRequest) (*UpdateByProjectAliasResponse, error)
+	// Deletes a project by project alias.
+	// Request headers: user-id: <User ID>
+	DeleteByProjectAlias(context.Context, *DeleteByProjectAliasRequest) (*DeleteByProjectAliasResponse, error)
 	mustEmbedUnimplementedReEarthVisualizerServer()
 }
 
@@ -248,6 +299,15 @@ func (UnimplementedReEarthVisualizerServer) DeleteProject(context.Context, *Dele
 }
 func (UnimplementedReEarthVisualizerServer) ExportProject(context.Context, *ExportProjectRequest) (*ExportProjectResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ExportProject not implemented")
+}
+func (UnimplementedReEarthVisualizerServer) GetProjectByProjectAlias(context.Context, *GetProjectByProjectAliasRequest) (*GetProjectByProjectAliasResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetProjectByProjectAlias not implemented")
+}
+func (UnimplementedReEarthVisualizerServer) UpdateByProjectAlias(context.Context, *UpdateByProjectAliasRequest) (*UpdateByProjectAliasResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateByProjectAlias not implemented")
+}
+func (UnimplementedReEarthVisualizerServer) DeleteByProjectAlias(context.Context, *DeleteByProjectAliasRequest) (*DeleteByProjectAliasResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteByProjectAlias not implemented")
 }
 func (UnimplementedReEarthVisualizerServer) mustEmbedUnimplementedReEarthVisualizerServer() {}
 func (UnimplementedReEarthVisualizerServer) testEmbeddedByValue()                           {}
@@ -450,6 +510,60 @@ func _ReEarthVisualizer_ExportProject_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ReEarthVisualizer_GetProjectByProjectAlias_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetProjectByProjectAliasRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ReEarthVisualizerServer).GetProjectByProjectAlias(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ReEarthVisualizer_GetProjectByProjectAlias_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ReEarthVisualizerServer).GetProjectByProjectAlias(ctx, req.(*GetProjectByProjectAliasRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ReEarthVisualizer_UpdateByProjectAlias_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateByProjectAliasRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ReEarthVisualizerServer).UpdateByProjectAlias(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ReEarthVisualizer_UpdateByProjectAlias_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ReEarthVisualizerServer).UpdateByProjectAlias(ctx, req.(*UpdateByProjectAliasRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ReEarthVisualizer_DeleteByProjectAlias_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteByProjectAliasRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ReEarthVisualizerServer).DeleteByProjectAlias(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ReEarthVisualizer_DeleteByProjectAlias_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ReEarthVisualizerServer).DeleteByProjectAlias(ctx, req.(*DeleteByProjectAliasRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ReEarthVisualizer_ServiceDesc is the grpc.ServiceDesc for ReEarthVisualizer service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -496,6 +610,18 @@ var ReEarthVisualizer_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ExportProject",
 			Handler:    _ReEarthVisualizer_ExportProject_Handler,
+		},
+		{
+			MethodName: "GetProjectByProjectAlias",
+			Handler:    _ReEarthVisualizer_GetProjectByProjectAlias_Handler,
+		},
+		{
+			MethodName: "UpdateByProjectAlias",
+			Handler:    _ReEarthVisualizer_UpdateByProjectAlias_Handler,
+		},
+		{
+			MethodName: "DeleteByProjectAlias",
+			Handler:    _ReEarthVisualizer_DeleteByProjectAlias_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/server/internal/adapter/internalapi/server.go
+++ b/server/internal/adapter/internalapi/server.go
@@ -480,7 +480,7 @@ func (s server) UpdateByProjectAlias(ctx context.Context, req *pb.UpdateByProjec
 		Starred:        req.Starred,
 		Deleted:        req.Deleted,
 		Visibility:     req.Visibility,
-		ProjectAlias:   &req.ProjectAlias,
+		ProjectAlias:   req.NewProjectAlias,
 
 		// publishment
 		PublicTitle:       req.PublicTitle,

--- a/server/internal/adapter/internalapi/server.go
+++ b/server/internal/adapter/internalapi/server.go
@@ -434,6 +434,98 @@ func (s server) ExportProject(ctx context.Context, req *pb.ExportProjectRequest)
 	}, nil
 }
 
+func (s server) GetProjectByProjectAlias(ctx context.Context, req *pb.GetProjectByProjectAliasRequest) (*pb.GetProjectByProjectAliasResponse, error) {
+	op, uc := adapter.Operator(ctx), adapter.Usecases(ctx)
+
+	pj, err := uc.Project.FindByProjectAlias(ctx, req.ProjectAlias, op)
+	if err != nil {
+		return nil, err
+	}
+
+	prj, err := s.getSceneAndStorytelling(ctx, pj)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.GetProjectByProjectAliasResponse{
+		Project: prj,
+	}, nil
+}
+
+func (s server) UpdateByProjectAlias(ctx context.Context, req *pb.UpdateByProjectAliasRequest) (*pb.UpdateByProjectAliasResponse, error) {
+	op, uc := adapter.Operator(ctx), adapter.Usecases(ctx)
+
+	pj, err := uc.Project.FindByProjectAlias(ctx, req.ProjectAlias, op)
+	if err != nil {
+		return nil, err
+	}
+
+	var imageURL *url.URL
+	if req.ImageUrl != nil {
+		parsedURL, err := url.Parse(*req.ImageUrl)
+		if err != nil {
+			return nil, fmt.Errorf("invalid image_url: %w", err)
+		}
+		imageURL = parsedURL
+	}
+
+	pj, err = uc.Project.Update(ctx, interfaces.UpdateProjectParam{
+		ID:             pj.ID(),
+		Name:           req.Name,
+		Description:    req.Description,
+		Archived:       req.Archived,
+		ImageURL:       imageURL,
+		DeleteImageURL: req.DeleteImageUrl != nil && *req.DeleteImageUrl,
+		SceneID:        id.SceneIDFromRef(req.SceneId),
+		Starred:        req.Starred,
+		Deleted:        req.Deleted,
+		Visibility:     req.Visibility,
+		ProjectAlias:   &req.ProjectAlias,
+
+		// publishment
+		PublicTitle:       req.PublicTitle,
+		PublicDescription: req.PublicDescription,
+		PublicImage:       req.PublicImage,
+		PublicNoIndex:     req.PublicNoIndex,
+		DeletePublicImage: req.DeletePublicImage != nil && *req.DeletePublicImage,
+		IsBasicAuthActive: req.IsBasicAuthActive,
+		BasicAuthUsername: req.BasicAuthUsername,
+		BasicAuthPassword: req.BasicAuthPassword,
+		EnableGa:          req.EnableGa,
+		TrackingID:        req.TrackingId,
+	}, op)
+	if err != nil {
+		return nil, err
+	}
+
+	prj, err := s.getSceneAndStorytelling(ctx, pj)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.UpdateByProjectAliasResponse{
+		Project: prj,
+	}, nil
+}
+
+func (s server) DeleteByProjectAlias(ctx context.Context, req *pb.DeleteByProjectAliasRequest) (*pb.DeleteByProjectAliasResponse, error) {
+	op, uc := adapter.Operator(ctx), adapter.Usecases(ctx)
+
+	pj, err := uc.Project.FindByProjectAlias(ctx, req.ProjectAlias, op)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := uc.Project.Delete(ctx, pj.ID(), op); err != nil {
+		return nil, err
+	}
+
+	return &pb.DeleteByProjectAliasResponse{
+		ProjectAlias: req.ProjectAlias,
+	}, nil
+
+}
+
 func Normalize(data any) map[string]any {
 	if b, err := json.Marshal(data); err == nil {
 		var result map[string]any

--- a/server/internal/infrastructure/memory/project.go
+++ b/server/internal/infrastructure/memory/project.go
@@ -150,6 +150,15 @@ func (r *Project) FindActiveByAlias(ctx context.Context, alias string) (*project
 	return nil, nil
 }
 
+func (r *Project) FindByProjectAlias(ctx context.Context, projectAlias string) (*project.Project, error) {
+	for _, p := range r.data {
+		if p.ProjectAlias() == projectAlias {
+			return p, nil
+		}
+	}
+	return nil, nil
+}
+
 func (r *Project) FindIDsByWorkspace(ctx context.Context, id accountdomain.WorkspaceID) (res []id.ProjectID, _ error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -507,6 +507,21 @@ func (r *Project) FindActiveByAlias(ctx context.Context, alias string) (*project
 	return prj, nil
 }
 
+func (r *Project) FindByProjectAlias(ctx context.Context, alias string) (*project.Project, error) {
+	prj, err := r.findOne(ctx, bson.M{
+		"projectalias": alias,
+	}, true)
+
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, repo.ErrResourceNotFound
+		}
+		return nil, err
+	}
+
+	return prj, nil
+}
+
 func (r *Project) FindByPublicName(ctx context.Context, name string) (*project.Project, error) {
 	if name == "" {
 		return nil, rerror.ErrNotFound

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -176,6 +176,21 @@ func (i *Project) FindActiveByAlias(ctx context.Context, alias string, operator 
 	return pj, nil
 }
 
+func (i *Project) FindByProjectAlias(ctx context.Context, alias string, operator *usecase.Operator) (*project.Project, error) {
+	pj, err := i.projectRepo.FindByProjectAlias(ctx, alias)
+	if err != nil {
+		return nil, err
+	}
+
+	meta, err := i.projectMetadataRepo.FindByProjectID(ctx, pj.ID())
+	if err != nil {
+		return nil, err
+	}
+
+	pj.SetMetadata(meta)
+	return pj, nil
+}
+
 func (i *Project) FindVisibilityByUser(
 	ctx context.Context,
 	u *user.User,

--- a/server/internal/usecase/interfaces/project.go
+++ b/server/internal/usecase/interfaces/project.go
@@ -99,6 +99,8 @@ type Project interface {
 
 	FindActiveById(context.Context, id.ProjectID, *usecase.Operator) (*project.Project, error)
 	FindActiveByAlias(context.Context, string, *usecase.Operator) (*project.Project, error)
+	FindByProjectAlias(context.Context, string, *usecase.Operator) (*project.Project, error)
+
 	FindVisibilityByUser(context.Context, *user.User, bool, *usecase.Operator, *string, *project.SortType, *usecasex.Pagination, *ProjectListParam) ([]*project.Project, *usecasex.PageInfo, error)
 	FindVisibilityByWorkspace(context.Context, accountdomain.WorkspaceID, bool, *usecase.Operator, *string, *project.SortType, *usecasex.Pagination, *ProjectListParam) ([]*project.Project, *usecasex.PageInfo, error)
 	UpdateVisibility(context.Context, id.ProjectID, string, *usecase.Operator) (*project.Project, error)

--- a/server/internal/usecase/repo/project.go
+++ b/server/internal/usecase/repo/project.go
@@ -29,6 +29,7 @@ type Project interface {
 	FindDeletedByWorkspace(context.Context, accountdomain.WorkspaceID) ([]*project.Project, error)
 	FindActiveById(context.Context, id.ProjectID) (*project.Project, error)
 	FindActiveByAlias(context.Context, string) (*project.Project, error)
+	FindByProjectAlias(context.Context, string) (*project.Project, error)
 	FindByPublicName(context.Context, string) (*project.Project, error)
 	CheckProjectAliasUnique(context.Context, accountdomain.WorkspaceID, string, *id.ProjectID) error
 	CheckAliasUnique(context.Context, string) error

--- a/server/schemas/internalapi/docs/schema.md
+++ b/server/schemas/internalapi/docs/schema.md
@@ -6,12 +6,16 @@
 - [schemas/internalapi/v1/schema.proto](#schemas_internalapi_v1_schema-proto)
     - [CreateProjectRequest](#reearth-visualizer-v1-CreateProjectRequest)
     - [CreateProjectResponse](#reearth-visualizer-v1-CreateProjectResponse)
+    - [DeleteByProjectAliasRequest](#reearth-visualizer-v1-DeleteByProjectAliasRequest)
+    - [DeleteByProjectAliasResponse](#reearth-visualizer-v1-DeleteByProjectAliasResponse)
     - [DeleteProjectRequest](#reearth-visualizer-v1-DeleteProjectRequest)
     - [DeleteProjectResponse](#reearth-visualizer-v1-DeleteProjectResponse)
     - [ExportProjectRequest](#reearth-visualizer-v1-ExportProjectRequest)
     - [ExportProjectResponse](#reearth-visualizer-v1-ExportProjectResponse)
     - [GetProjectByAliasRequest](#reearth-visualizer-v1-GetProjectByAliasRequest)
     - [GetProjectByAliasResponse](#reearth-visualizer-v1-GetProjectByAliasResponse)
+    - [GetProjectByProjectAliasRequest](#reearth-visualizer-v1-GetProjectByProjectAliasRequest)
+    - [GetProjectByProjectAliasResponse](#reearth-visualizer-v1-GetProjectByProjectAliasResponse)
     - [GetProjectListRequest](#reearth-visualizer-v1-GetProjectListRequest)
     - [GetProjectListResponse](#reearth-visualizer-v1-GetProjectListResponse)
     - [GetProjectRequest](#reearth-visualizer-v1-GetProjectRequest)
@@ -24,6 +28,8 @@
     - [PublishProjectRequest](#reearth-visualizer-v1-PublishProjectRequest)
     - [PublishProjectResponse](#reearth-visualizer-v1-PublishProjectResponse)
     - [Story](#reearth-visualizer-v1-Story)
+    - [UpdateByProjectAliasRequest](#reearth-visualizer-v1-UpdateByProjectAliasRequest)
+    - [UpdateByProjectAliasResponse](#reearth-visualizer-v1-UpdateByProjectAliasResponse)
     - [UpdateProjectMetadataRequest](#reearth-visualizer-v1-UpdateProjectMetadataRequest)
     - [UpdateProjectMetadataResponse](#reearth-visualizer-v1-UpdateProjectMetadataResponse)
     - [UpdateProjectRequest](#reearth-visualizer-v1-UpdateProjectRequest)
@@ -84,6 +90,38 @@ Response messages
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | project | [Project](#reearth-visualizer-v1-Project) |  | Project |
+
+
+
+
+
+
+<a name="reearth-visualizer-v1-DeleteByProjectAliasRequest"></a>
+
+### DeleteByProjectAliasRequest
+Deletes a project.
+This is a physical deletion, not a logical deletion. Data cannot be restored.
+Only the project owner can operate this
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project_alias | [string](#string) |  | Project alias |
+
+
+
+
+
+
+<a name="reearth-visualizer-v1-DeleteByProjectAliasResponse"></a>
+
+### DeleteByProjectAliasResponse
+Response messages
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project_alias | [string](#string) |  | Project alias |
 
 
 
@@ -170,6 +208,36 @@ Find a project by alias.
 <a name="reearth-visualizer-v1-GetProjectByAliasResponse"></a>
 
 ### GetProjectByAliasResponse
+Response messages
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project | [Project](#reearth-visualizer-v1-Project) |  | Project |
+
+
+
+
+
+
+<a name="reearth-visualizer-v1-GetProjectByProjectAliasRequest"></a>
+
+### GetProjectByProjectAliasRequest
+Find a project by project alias.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project_alias | [string](#string) |  | Scene alias |
+
+
+
+
+
+
+<a name="reearth-visualizer-v1-GetProjectByProjectAliasResponse"></a>
+
+### GetProjectByProjectAliasResponse
 Response messages
 
 
@@ -414,6 +482,57 @@ Response messages
 
 
 
+<a name="reearth-visualizer-v1-UpdateByProjectAliasRequest"></a>
+
+### UpdateByProjectAliasRequest
+Update project fields.
+Only the project owner can operate this
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project_alias | [string](#string) |  | Project alias (required) |
+| name | [string](#string) | optional | Project basic info (optional) |
+| description | [string](#string) | optional |  |
+| archived | [bool](#bool) | optional |  |
+| image_url | [string](#string) | optional |  |
+| delete_image_url | [bool](#bool) | optional |  |
+| scene_id | [string](#string) | optional |  |
+| starred | [bool](#bool) | optional |  |
+| deleted | [bool](#bool) | optional |  |
+| visibility | [string](#string) | optional |  |
+| public_title | [string](#string) | optional | Publishment settings (optional) |
+| public_description | [string](#string) | optional |  |
+| public_image | [string](#string) | optional |  |
+| public_no_index | [bool](#bool) | optional |  |
+| delete_public_image | [bool](#bool) | optional |  |
+| is_basic_auth_active | [bool](#bool) | optional |  |
+| basic_auth_username | [string](#string) | optional |  |
+| basic_auth_password | [string](#string) | optional |  |
+| enable_ga | [bool](#bool) | optional |  |
+| tracking_id | [string](#string) | optional |  |
+| new_project_alias | [string](#string) | optional |  |
+
+
+
+
+
+
+<a name="reearth-visualizer-v1-UpdateByProjectAliasResponse"></a>
+
+### UpdateByProjectAliasResponse
+Response messages
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| project | [Project](#reearth-visualizer-v1-Project) |  | Project |
+
+
+
+
+
+
 <a name="reearth-visualizer-v1-UpdateProjectMetadataRequest"></a>
 
 ### UpdateProjectMetadataRequest
@@ -622,6 +741,9 @@ Response messages
 | UpdateProjectMetadata | [UpdateProjectMetadataRequest](#reearth-visualizer-v1-UpdateProjectMetadataRequest) | [UpdateProjectMetadataResponse](#reearth-visualizer-v1-UpdateProjectMetadataResponse) | Updates a new project metadata in the specified team. Request headers: user-id: &lt;User ID&gt; |
 | DeleteProject | [DeleteProjectRequest](#reearth-visualizer-v1-DeleteProjectRequest) | [DeleteProjectResponse](#reearth-visualizer-v1-DeleteProjectResponse) | Deletes a project. Request headers: user-id: &lt;User ID&gt; |
 | ExportProject | [ExportProjectRequest](#reearth-visualizer-v1-ExportProjectRequest) | [ExportProjectResponse](#reearth-visualizer-v1-ExportProjectResponse) | Export a project. Request headers: user-id: &lt;User ID&gt; |
+| GetProjectByProjectAlias | [GetProjectByProjectAliasRequest](#reearth-visualizer-v1-GetProjectByProjectAliasRequest) | [GetProjectByProjectAliasResponse](#reearth-visualizer-v1-GetProjectByProjectAliasResponse) | Find a project by project alias. Request headers: user-id: &lt;User ID&gt; |
+| UpdateByProjectAlias | [UpdateByProjectAliasRequest](#reearth-visualizer-v1-UpdateByProjectAliasRequest) | [UpdateByProjectAliasResponse](#reearth-visualizer-v1-UpdateByProjectAliasResponse) | Update a project by project alias. Request headers: user-id: &lt;User ID&gt; |
+| DeleteByProjectAlias | [DeleteByProjectAliasRequest](#reearth-visualizer-v1-DeleteByProjectAliasRequest) | [DeleteByProjectAliasResponse](#reearth-visualizer-v1-DeleteByProjectAliasResponse) | Deletes a project by project alias. Request headers: user-id: &lt;User ID&gt; |
 
  
 

--- a/server/schemas/internalapi/v1/schema.proto
+++ b/server/schemas/internalapi/v1/schema.proto
@@ -49,6 +49,21 @@ service ReEarthVisualizer {
   // Export a project.
   // Request headers: user-id: <User ID>
   rpc ExportProject(ExportProjectRequest) returns (ExportProjectResponse) {}
+
+  // Find a project by project alias.
+  // Request headers: user-id: <User ID>
+  rpc GetProjectByProjectAlias(GetProjectByProjectAliasRequest)
+      returns (GetProjectByProjectAliasResponse) {}
+
+  // Update a project by project alias.
+  // Request headers: user-id: <User ID>
+  rpc UpdateByProjectAlias(UpdateByProjectAliasRequest)
+      returns (UpdateByProjectAliasResponse) {}
+
+  // Deletes a project by project alias.
+  // Request headers: user-id: <User ID>
+  rpc DeleteByProjectAlias(DeleteByProjectAliasRequest)
+      returns (DeleteByProjectAliasResponse) {}
 }
 
 // Core Project messages
@@ -344,6 +359,52 @@ message DeleteProjectRequest {
   string project_id = 1;
 }
 
+// Find a project by project alias.
+message GetProjectByProjectAliasRequest {
+  // Scene alias
+  string project_alias = 1;
+}
+
+// Update project fields.
+// Only the project owner can operate this
+message UpdateByProjectAliasRequest {
+  // Project alias (required)
+  string project_alias = 1;
+
+  // Project basic info (optional)
+  optional string name = 2;
+  optional string description = 3;
+  optional bool archived = 4;
+  optional string image_url = 5;
+  optional bool delete_image_url = 6;
+  optional string scene_id = 7;
+  optional bool starred = 8;
+  optional bool deleted = 9;
+  optional string visibility = 10;
+
+  // Publishment settings (optional)
+  optional string public_title = 11;
+  optional string public_description = 12;
+  optional string public_image = 13;
+  optional bool public_no_index = 14;
+  optional bool delete_public_image = 15;
+  optional bool is_basic_auth_active = 16;
+  optional string basic_auth_username = 17;
+  optional string basic_auth_password = 18;
+  optional bool enable_ga = 19;
+  optional string tracking_id = 20;
+
+  optional string new_project_alias = 21;
+}
+
+// Deletes a project.
+// This is a physical deletion, not a logical deletion. Data cannot be restored.
+// Only the project owner can operate this
+message DeleteByProjectAliasRequest {
+  // Project alias
+  string project_alias = 1;
+}
+
 // Export a project.
 message ExportProjectRequest {
   // Project ID
@@ -416,4 +477,22 @@ message ValidateProjectAliasResponse {
   bool available = 2;
   // Error message
   optional string error_message = 3;
+}
+
+// Response messages
+message GetProjectByProjectAliasResponse {
+  // Project
+  Project project = 1;
+}
+
+// Response messages
+message UpdateByProjectAliasResponse {
+  // Project
+  Project project = 1;
+}
+
+// Response messages
+message DeleteByProjectAliasResponse {
+  // Project alias
+  string project_alias = 1;
 }


### PR DESCRIPTION
# Overview

### We have added internal APIs that use projectAlias as the key.

## What I've done
### The following APIs have been added:

# 1. GetProjectByProjectAlias
```diff
+ rpc GetProjectByProjectAlias(GetProjectByProjectAliasRequest) returns (GetProjectByProjectAliasResponse) {}

+ message GetProjectByProjectAliasRequest {
+   // project alias
+   string project_alias = 1;
+ }
```

# 2. UpdateByProjectAlias
project_alias is required.
If you want to update the project_alias, use new_project_alias.
```diff
+ rpc UpdateByProjectAlias(UpdateByProjectAliasRequest) returns (UpdateByProjectAliasResponse) {}

+ message UpdateByProjectAliasRequest {
+   // Project alias (required)
+   string project_alias = 1;

+   // Project basic info (optional)
+   optional string name = 2;
+   optional string description = 3;
+   optional bool archived = 4;
+   optional string image_url = 5;
+   optional bool delete_image_url = 6;
+   optional string scene_id = 7;
+   optional bool starred = 8;
+   optional bool deleted = 9;
+   optional string visibility = 10;

+   // Publishment settings (optional)
+   optional string public_title = 11;
+   optional string public_description = 12;
+   optional string public_image = 13;
+   optional bool public_no_index = 14;
+   optional bool delete_public_image = 15;
+   optional bool is_basic_auth_active = 16;
+   optional string basic_auth_username = 17;
+   optional string basic_auth_password = 18;
+   optional bool enable_ga = 19;
+   optional string tracking_id = 20;

+   optional string new_project_alias = 21;
+ }
```

# 3. DeleteByProjectAlias
```diff
+ rpc DeleteByProjectAlias(DeleteByProjectAliasRequest) returns (DeleteByProjectAliasResponse) {}

+ message DeleteByProjectAliasRequest {
+   // Project alias
+   string project_alias = 1;
+ }
```

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
