### PR TITLE
refactor(web): show login only when use external signup flow

### DIFF
--- a/web/src/ee/features/Welcome/index.tsx
+++ b/web/src/ee/features/Welcome/index.tsx
@@ -12,7 +12,7 @@ const Welcome: FC = () => {
   const currentUrl = window.location.href;
   const linkDisabled = !config()?.platformUrl;
   const platformUrl = `${config()?.platformUrl}`;
-  const signupUrl = `${config()?.platformUrl}/login?from=${currentUrl}`;
+  const signupUrl = `${config()?.platformUrl}/login?from=${currentUrl}&action=signup`;
 
   return (
     <Wrapper>

--- a/web/src/services/auth/auth0Auth.ts
+++ b/web/src/services/auth/auth0Auth.ts
@@ -2,6 +2,8 @@ import { useAuth0 } from "@auth0/auth0-react";
 import { logOutFromTenant } from "@reearth/services/config";
 import { useEffect } from "react";
 
+import { appFeature } from "../config/appFeatureConfig";
+
 import type { AuthHook } from "./authHook";
 
 export const errorKey = "reeartherror";
@@ -40,7 +42,15 @@ export const useAuth0Auth = (): AuthHook => {
     getAccessToken: () => getAccessTokenSilently(),
     login: () => {
       logOutFromTenant();
-      return loginWithRedirect();
+      return loginWithRedirect({
+        ...(appFeature().externalAuth0Signup
+          ? {}
+          : {
+              authorizationParams: {
+                screen_hint: "login"
+              }
+            })
+      });
     },
     logout: () => {
       logOutFromTenant();


### PR DESCRIPTION
# Overview

- Show login only for Auth0 when external signup flow in use
- Add additional params for signup url

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
