### PR TITLE
fix(server): fixed the validation error during project import [VIZ-2071]

### DIFF
--- a/server/e2e/gql_project_test.go
+++ b/server/e2e/gql_project_test.go
@@ -306,35 +306,35 @@ func TestCreateUpdateProject(t *testing.T) {
 	})
 	res.Path("$.errors[0].message").IsEqual("The alias is already in use within the workspace. Please try a different value.")
 
-	// res = Request(e, uID.String(), GraphQLRequest{
-	// 	OperationName: "CreateProject",
-	// 	Query:         CreateProjectMutation,
-	// 	Variables: map[string]any{
-	// 		"name":         "test",
-	// 		"description":  "abc",
-	// 		"workspaceId":  wID.String(),
-	// 		"visualizer":   "CESIUM",
-	// 		"coreSupport":  true,
-	// 		"visibility":   "public",
-	// 		"projectAlias": "あいうえお",
-	// 	},
-	// })
-	// res.Path("$.errors[0].message").IsEqual("Invalid alias name: あいうえお")
+	res = Request(e, uID.String(), GraphQLRequest{
+		OperationName: "CreateProject",
+		Query:         CreateProjectMutation,
+		Variables: map[string]any{
+			"name":         "test",
+			"description":  "abc",
+			"workspaceId":  wID.String(),
+			"visualizer":   "CESIUM",
+			"coreSupport":  true,
+			"visibility":   "public",
+			"projectAlias": "あいうえお",
+		},
+	})
+	res.Path("$.errors[0].message").IsEqual("Invalid alias name: あいうえお")
 
-	// res = Request(e, uID.String(), GraphQLRequest{
-	// 	OperationName: "CreateProject",
-	// 	Query:         CreateProjectMutation,
-	// 	Variables: map[string]any{
-	// 		"name":         "test",
-	// 		"description":  "abc",
-	// 		"workspaceId":  wID.String(),
-	// 		"visualizer":   "CESIUM",
-	// 		"coreSupport":  true,
-	// 		"visibility":   "public",
-	// 		"projectAlias": "test/bad-alias",
-	// 	},
-	// })
-	// res.Path("$.errors[0].message").IsEqual("Invalid alias name: test/bad-alias")
+	res = Request(e, uID.String(), GraphQLRequest{
+		OperationName: "CreateProject",
+		Query:         CreateProjectMutation,
+		Variables: map[string]any{
+			"name":         "test",
+			"description":  "abc",
+			"workspaceId":  wID.String(),
+			"visualizer":   "CESIUM",
+			"coreSupport":  true,
+			"visibility":   "public",
+			"projectAlias": "test/bad-alias",
+		},
+	})
+	res.Path("$.errors[0].message").IsEqual("Invalid alias name: test/bad-alias")
 
 }
 

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -1160,12 +1160,18 @@ func (i *Project) createProject(ctx context.Context, input createProjectInput, o
 
 	newProjectAlias := alias.ReservedReearthPrefixProject + prjID.String()
 	if input.ProjectAlias != nil {
-		newProjectAlias = *input.ProjectAlias
-	}
 
-	err = i.projectRepo.CheckProjectAliasUnique(ctx, input.WorkspaceID, newProjectAlias, nil)
-	if err != nil {
-		return nil, err
+		newProjectAlias = *input.ProjectAlias
+
+		err = i.projectRepo.CheckProjectAliasUnique(ctx, input.WorkspaceID, newProjectAlias, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		ok := util.IsSafePathName(newProjectAlias)
+		if !ok {
+			return nil, alias.ErrProjectInvalidProjectAlias.AddTemplateData("aliasName", newProjectAlias)
+		}
 	}
 
 	prj.ProjectAlias(newProjectAlias)


### PR DESCRIPTION
# Overview

## Fixed the validation error during project import.

## What I've done

During project import, a temporary project is first created using **CreateProject**,
and then it is updated via **ImportProjectData**.

At this time, an error occurs in the **CheckProjectAliasUnique** check
because the **ProjectAlias** becomes the same.

However, during **ImportProjectData**, the **ProjectAlias** is not carried over,
so **input.ProjectAlias** will always be nil.

We use this behavior to avoid the **CheckProjectAliasUnique** check.


## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
