### PR TITLE
feat(server): set visibility public

### DIFF
--- a/server/internal/infrastructure/mongo/migration/250724121006_set_visibility_public.go
+++ b/server/internal/infrastructure/mongo/migration/250724121006_set_visibility_public.go
@@ -1,0 +1,30 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func SetVisibilityPublic(ctx context.Context, c DBClient) error {
+	projectCollection := c.WithCollection("project").Client()
+
+	filter := bson.M{}
+
+	update := bson.M{
+		"$set": bson.M{
+			"visibility": "public",
+		},
+	}
+
+	result, err := projectCollection.UpdateMany(ctx, filter, update)
+	if err != nil {
+		return fmt.Errorf("failed to update project visibility: %w", err)
+	}
+
+	log.Printf("Updated %d project(s) visibility to public", result.ModifiedCount)
+
+	return nil
+}

--- a/server/internal/infrastructure/mongo/migration/250724121006_set_visibility_public_test.go
+++ b/server/internal/infrastructure/mongo/migration/250724121006_set_visibility_public_test.go
@@ -1,0 +1,62 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearthx/mongox"
+	"github.com/reearth/reearthx/mongox/mongotest"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// go test -v -run TestSetVisibilityPublic ./internal/infrastructure/mongo/migration/...
+
+func TestSetVisibilityPublic(t *testing.T) {
+	db := mongotest.Connect(t)(t)
+	client := mongox.NewClientWithDatabase(db)
+	ctx := context.Background()
+
+	projectCollection := client.WithCollection("project").Client()
+
+	testProjects := []interface{}{
+		bson.M{
+			"id":         "01k0rpgzzxb8afnast3008ndde",
+			"workspace":  "01k0rpgh7em0h3atf0qtsz9kcg",
+			"name":       "test1",
+			"visibility": "private",
+		},
+		bson.M{
+			"id":         "01k0rpgzzxb8afnast3008nddf",
+			"workspace":  "01k0rpgh7em0h3atf0qtsz9kcg",
+			"name":       "test2",
+			"visibility": nil,
+		},
+		bson.M{
+			"id":         "01k0rpgzzxb8afnast3008nddg",
+			"workspace":  "01k0rpgh7em0h3atf0qtsz9kcg",
+			"name":       "test3",
+			"visibility": "public", // already public
+		},
+	}
+
+	_, err := projectCollection.InsertMany(ctx, testProjects)
+	assert.NoError(t, err)
+
+	err = SetVisibilityPublic(ctx, client)
+	assert.NoError(t, err)
+
+	cursor, err := projectCollection.Find(ctx, bson.M{})
+	assert.NoError(t, err)
+	defer cursor.Close(ctx)
+
+	var results []bson.M
+	err = cursor.All(ctx, &results)
+	assert.NoError(t, err)
+
+	for _, result := range results {
+		assert.Equal(t, "public", result["visibility"])
+	}
+
+	assert.Equal(t, 3, len(results))
+}

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -27,4 +27,5 @@ var migrations = migration.Migrations[DBClient]{
   250709145819: SetProjectAlias,
   250711143148: AddProjectAlias,
   250716145417: TeamToWorkspace,
+  250724121006: SetVisibilityPublic,
 }


### PR DESCRIPTION
# Overview

# Set all Re:Earth project data to public.

## What I've done

### This PR only adds a migration. It does not include any changes to the existing logic.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
