### PR TITLE
refactor(web): enhance event callback management with fingerprint support

### DIFF
--- a/web/src/app/features/Visualizer/Crust/Plugins/utils/events.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/utils/events.ts
@@ -85,9 +85,9 @@ export function events<
         ecbs.delete(cb);
       } else {
         // try delete by fingerprint
-        for (const [_key, value] of ecbs.entries()) {
+        for (const [key, value] of ecbs.entries()) {
           if (value.fingerprint === fingerprint) {
-            ecbs.delete(_key);
+            ecbs.delete(key);
             break;
           }
         }
@@ -102,21 +102,21 @@ export function events<
     const fingerprint = getFunctionFingerprintString(callback);
     // Note: when binding callbacks, we don't check fingerprint,
     // because the previous one could be out of lifecycle but with the same fingerprint.
-    const ecb = getEventCallback(type, callback, fingerprint);
-    e.addEventListener(String(type), ecb);
+    const ecbFn = getEventCallback(type, callback, fingerprint);
+    e.addEventListener(String(type), ecbFn);
   };
   const off = <T extends keyof E>(type: T, callback: EventCallback<E[T]>) => {
     const fingerprint = getFunctionFingerprintString(callback);
-    const ecb = getEventCallback(type, callback, fingerprint, true);
+    const ecbFn = getEventCallback(type, callback, fingerprint, true);
     // Note: we check fingerprint here to ensure we remove the correct callback.
     // because the same callback becomes different after synchronization, but the fingerprint remains the same.
-    e.removeEventListener(String(type), ecb);
-    deleteEventCallback(type, ecb, fingerprint);
+    e.removeEventListener(String(type), ecbFn);
+    deleteEventCallback(type, ecbFn, fingerprint);
   };
   const once = <T extends keyof E>(type: T, callback: EventCallback<E[T]>) => {
     const fingerprint = getFunctionFingerprintString(callback);
-    const ecb = getEventCallback(type, callback, fingerprint);
-    e.addEventListener(String(type), ecb, { once: true });
+    const ecbFn = getEventCallback(type, callback, fingerprint);
+    e.addEventListener(String(type), ecbFn, { once: true });
   };
 
   const events = {


### PR DESCRIPTION
# Overview

After using fingerprint as the key, we resolved the issue that the callback cannot be removed correctly issue, but at the same time, it leads to another issue: once user bind the same function but the previous one is already out of lifecycle, it still returns the old one, it usually happens on plugin dev case.
Therefore this PR combined the solution, keep using callback itself as the key, but also check fingerprint when needed.
In detail, 
- when binding event, we use callback as key, and append fingerprint, in this case the new binding could always bind the correct one.
- when unbinding event, we check callback as key and also check fingerprint, so that the unbind could work as well.


## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
