### PR TITLE
feat(server): add workspace alias [VIZ-2081]

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -484,6 +484,7 @@ github.com/golang/glog v1.2.3 h1:oDTdz9f5VGVVNGu/Q7UXKWYsD0873HXLHdJUNBsSEKM=
 github.com/golang/glog v1.2.3/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/glog v1.2.4 h1:CNNw5U8lSiiBk7druxtSHHTsRWcxKoac6kZKm2peBBc=
 github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/lint v0.0.0-20170918230701-e5d664eb928e h1:ior8LN6127GsA53E9mD9nH/oP/LVbJplmLH5V8o+/Uk=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -656,6 +657,8 @@ github.com/redis/go-redis/v9 v9.5.1 h1:H1X4D3yHPaYrkL5X06Wh6xNVM/pX0Ft4RV0vMGvLB
 github.com/redis/go-redis/v9 v9.5.1/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/reearth/reearthx v0.0.0-20240229141256-04bd46953fe6 h1:7EMP5wvzOcip/Bi7KPkCMx5Vtq4V31cfkSneqZxr+as=
 github.com/reearth/reearthx v0.0.0-20240229141256-04bd46953fe6/go.mod h1:8DSD6e+h1KhfhO4TceYDDPpLkhZJH2CLF6nHxyV8hts=
+github.com/reearth/reearthx v0.0.0-20250731060631-7ef9d9421c39 h1:Qe7HIt79dTVbjHQJX3te4pPLiJ/3YdCR0Q8tAbIyx7M=
+github.com/reearth/reearthx v0.0.0-20250731060631-7ef9d9421c39/go.mod h1:LB99y3wpdleJ2LcZ/5226iaHf8HO+R3pp6omwUFDw8I=
 github.com/robertkrimen/godocdown v0.0.0-20130622164427-0bfa04905481 h1:jMxcLa+VjJKhpCwbLUXAD15wJ+hhvXMLujCl3MkXpfM=
 github.com/rogpeppe/fastuuid v1.2.0 h1:Ppwyp6VYCF1nvBTXL3trRso7mXMlRrw9ooo375wvi2s=
 github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=

--- a/server/e2e/gql_workspace_test.go
+++ b/server/e2e/gql_workspace_test.go
@@ -11,38 +11,81 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const workspaceNode = `
+workspace {
+	id
+	name
+	members {
+		userId
+		role
+	}
+	personal
+	enableToCreatePrivateProject
+	alias
+}`
+
+// export REEARTH_DB=mongodb://localhost
+// go test -v -run TestCreateWorkspace ./e2e/...
+
 func TestCreateWorkspace(t *testing.T) {
 	e, _ := StartGQLServerAndRepos(t, baseSeederUser)
-	query := `mutation { createWorkspace(input: {name: "test"}){ workspace{ id name } }}`
-	request := GraphQLRequest{
-		Query: query,
-	}
-	o := Request(e, uId1.String(), request).Object()
-	o.Value("data").Object().Value("createWorkspace").Object().Value("workspace").Object().Value("name").String().IsEqual("test")
+
+	res := Request(e, uId1.String(), GraphQLRequest{
+		Query: fmt.Sprintf(`mutation { 
+			createWorkspace(input: {name: "test"}){ %s } 
+		}`, workspaceNode),
+	})
+	wid := res.Path("$.data.createWorkspace.workspace.id").Raw().(string)
+	res.Path("$.data.createWorkspace.workspace.name").IsEqual("test")
+	res.Path("$.data.createWorkspace.workspace.personal").IsEqual(false)
+	res.Path("$.data.createWorkspace.workspace.enableToCreatePrivateProject").IsEqual(false)
+	res.Path("$.data.createWorkspace.workspace.alias").IsEqual("w-" + wid)
+
+	res = Request(e, uId1.String(), GraphQLRequest{
+		Query: fmt.Sprintf(`mutation { 
+			createWorkspace(input: {name: "test" alias: "test-alias"}){ %s } 
+		}`, workspaceNode),
+	})
+
+	res.Path("$.data.createWorkspace.workspace.name").IsEqual("test")
+	res.Path("$.data.createWorkspace.workspace.personal").IsEqual(false)
+	res.Path("$.data.createWorkspace.workspace.enableToCreatePrivateProject").IsEqual(false)
+	res.Path("$.data.createWorkspace.workspace.alias").IsEqual("test-alias")
+
+	res = Request(e, uId1.String(), GraphQLRequest{
+		Query: fmt.Sprintf(`mutation { 
+			createWorkspace(input: {name: "test" alias: "test-alias"}){ %s } 
+		}`, workspaceNode),
+	})
+
+	res.Path("$.errors[0].message").IsEqual("alias is already used in another workspace")
 }
 
 func TestDeleteWorkspace(t *testing.T) {
 	e, r := StartGQLServerAndRepos(t, baseSeederUser)
+
 	_, err := r.Workspace.FindByID(context.Background(), wId1)
 	assert.Nil(t, err)
-	query := fmt.Sprintf(`mutation { deleteWorkspace(input: {workspaceId: "%s"}){ workspaceId }}`, wId1)
-	request := GraphQLRequest{
-		Query: query,
-	}
-	o := Request(e, uId1.String(), request).Object()
-	o.Value("data").Object().Value("deleteWorkspace").Object().Value("workspaceId").String().IsEqual(wId1.String())
+
+	res := Request(e, uId1.String(), GraphQLRequest{
+		Query: fmt.Sprintf(`mutation { 
+			deleteWorkspace(input: {workspaceId: "%s"}){ workspaceId }}`,
+			wId1),
+	})
+	res.Path("$.data.deleteWorkspace.workspaceId").IsEqual(wId1.String())
 
 	_, err = r.Workspace.FindByID(context.Background(), wId1)
 	assert.Equal(t, rerror.ErrNotFound, err)
 
-	query = fmt.Sprintf(`mutation { deleteWorkspace(input: {workspaceId: "%s"}){ workspaceId }}`, accountdomain.NewWorkspaceID())
-	request = GraphQLRequest{
-		Query: query,
-	}
-	o = Request(e, uId1.String(), request).Object()
-
-	o.Value("errors").Array().Value(0).Object().Value("message").IsEqual("operation denied")
+	res = Request(e, uId1.String(), GraphQLRequest{
+		Query: fmt.Sprintf(`mutation { 
+			deleteWorkspace(input: {workspaceId: "%s"}){ workspaceId }}`,
+			accountdomain.NewWorkspaceID()),
+	})
+	res.Path("$.errors[0].message").IsEqual("operation denied")
 }
+
+// go test -v -run TestUpdateWorkspace ./e2e/...
 
 func TestUpdateWorkspace(t *testing.T) {
 	e, r := StartGQLServerAndRepos(t, baseSeederUser)
@@ -51,23 +94,41 @@ func TestUpdateWorkspace(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "e2e", w.Name())
 
-	query := fmt.Sprintf(`mutation { updateWorkspace(input: {workspaceId: "%s",name: "%s"}){ workspace{ id name } }}`, wId1, "updated")
-	request := GraphQLRequest{
-		Query: query,
-	}
-	o := Request(e, uId1.String(), request).Object()
-	o.Value("data").Object().Value("updateWorkspace").Object().Value("workspace").Object().Value("name").String().IsEqual("updated")
+	res := Request(e, uId1.String(), GraphQLRequest{
+		Query: fmt.Sprintf(`mutation {
+			updateWorkspace(input: { workspaceId: "%s", name: "%s", alias: "%s" }) { %s } }`,
+			wId1, "updated", "updated-alias", workspaceNode),
+	})
+	res.Path("$.data.updateWorkspace.workspace.name").IsEqual("updated")
+	res.Path("$.data.updateWorkspace.workspace.alias").IsEqual("updated-alias")
 
 	w, err = r.Workspace.FindByID(context.Background(), wId1)
 	assert.Nil(t, err)
 	assert.Equal(t, "updated", w.Name())
 
-	query = fmt.Sprintf(`mutation { updateWorkspace(input: {workspaceId: "%s",name: "%s"}){ workspace{ id name } }}`, accountdomain.NewWorkspaceID(), "updated")
-	request = GraphQLRequest{
-		Query: query,
-	}
-	o = Request(e, uId1.String(), request).Object()
-	o.Value("errors").Array().Value(0).Object().Value("message").IsEqual("not found")
+	res = Request(e, uId1.String(), GraphQLRequest{
+		Query: fmt.Sprintf(`mutation {
+			updateWorkspace(input: { workspaceId: "%s", name: "%s" }) { %s } }`,
+			accountdomain.NewWorkspaceID(), "updated", workspaceNode),
+	})
+
+	res.Path("$.errors[0].message").IsEqual("not found")
+
+	res = Request(e, uId2.String(), GraphQLRequest{
+		Query: fmt.Sprintf(`mutation { 
+			createWorkspace(input: {name: "test2"}){ %s } 
+		}`, workspaceNode),
+	})
+	wid2 := res.Path("$.data.createWorkspace.workspace.id").Raw().(string)
+	res.Path("$.data.createWorkspace.workspace.alias").IsEqual("w-" + wid2)
+
+	res = Request(e, uId2.String(), GraphQLRequest{
+		Query: fmt.Sprintf(`mutation {
+			updateWorkspace(input: { workspaceId: "%s", name: "%s", alias: "%s" }) { %s } }`,
+			wid2, "updated", "updated-alias", workspaceNode),
+	})
+
+	res.Path("$.errors[0].message").IsEqual("alias is already used in another workspace")
 }
 
 func TestAddMemberToWorkspace(t *testing.T) {
@@ -77,23 +138,23 @@ func TestAddMemberToWorkspace(t *testing.T) {
 	assert.Nil(t, err)
 	assert.False(t, w.Members().HasUser(uId2))
 
-	query := fmt.Sprintf(`mutation { addMemberToWorkspace(input: {workspaceId: "%s", userId: "%s", role: READER}){ workspace{ id } }}`, wId1, uId2)
-	request := GraphQLRequest{
-		Query: query,
-	}
-	Request(e, uId1.String(), request)
+	Request(e, uId1.String(), GraphQLRequest{
+		Query: fmt.Sprintf(`mutation {
+			addMemberToWorkspace( input: { workspaceId: "%s", userId: "%s", role: READER } ) { %s } }`,
+			wId1, uId2, workspaceNode),
+	})
 
 	w, err = r.Workspace.FindByID(context.Background(), wId1)
 	assert.Nil(t, err)
 	assert.True(t, w.Members().HasUser(uId2))
 	assert.Equal(t, w.Members().User(uId2).Role, workspace.RoleReader)
 
-	query = fmt.Sprintf(`mutation { addMemberToWorkspace(input: {workspaceId: "%s", userId: "%s", role: READER}){ workspace{ id } }}`, wId1, uId2)
-	request = GraphQLRequest{
-		Query: query,
-	}
-	Request(e, uId1.String(), request).Object().
-		Value("errors").Array().Value(0).Object().Value("message").IsEqual("user already joined")
+	res := Request(e, uId1.String(), GraphQLRequest{
+		Query: fmt.Sprintf(`mutation {
+			addMemberToWorkspace( input: { workspaceId: "%s", userId: "%s", role: READER } ) { %s } }`,
+			wId1, uId2, workspaceNode),
+	})
+	res.Path("$.errors[0].message").IsEqual("user already joined")
 }
 
 func TestRemoveMemberFromWorkspace(t *testing.T) {
@@ -103,18 +164,22 @@ func TestRemoveMemberFromWorkspace(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, w.Members().HasUser(uId3))
 
-	query := fmt.Sprintf(`mutation { removeMemberFromWorkspace(input: {workspaceId: "%s", userId: "%s"}){ workspace{ id } }}`, wId2, uId3)
-	request := GraphQLRequest{
-		Query: query,
-	}
-	Request(e, uId1.String(), request)
+	Request(e, uId1.String(), GraphQLRequest{
+		Query: fmt.Sprintf(`mutation {
+			removeMemberFromWorkspace(input: { workspaceId: "%s", userId: "%s" }) { %s } }`,
+			wId2, uId3, workspaceNode),
+	})
 
 	w, err = r.Workspace.FindByID(context.Background(), wId1)
 	assert.Nil(t, err)
 	assert.False(t, w.Members().HasUser(uId3))
 
-	o := Request(e, uId1.String(), request).Object()
-	o.Value("errors").Array().Value(0).Object().Value("message").IsEqual("target user does not exist in the workspace")
+	res := Request(e, uId1.String(), GraphQLRequest{
+		Query: fmt.Sprintf(`mutation {
+			removeMemberFromWorkspace(input: { workspaceId: "%s", userId: "%s" }) { %s } }`,
+			wId2, uId3, workspaceNode),
+	})
+	res.Path("$.errors[0].message").IsEqual("target user does not exist in the workspace")
 }
 
 func TestUpdateMemberOfWorkspace(t *testing.T) {
@@ -123,19 +188,21 @@ func TestUpdateMemberOfWorkspace(t *testing.T) {
 	w, err := r.Workspace.FindByID(context.Background(), wId2)
 	assert.Nil(t, err)
 	assert.Equal(t, w.Members().User(uId3).Role, workspace.RoleReader)
-	query := fmt.Sprintf(`mutation { updateMemberOfWorkspace(input: {workspaceId: "%s", userId: "%s", role: WRITER}){ workspace{ id } }}`, wId2, uId3)
-	request := GraphQLRequest{
-		Query: query,
-	}
-	Request(e, uId1.String(), request)
+
+	Request(e, uId1.String(), GraphQLRequest{
+		Query: fmt.Sprintf(`mutation {
+			updateMemberOfWorkspace( input: { workspaceId: "%s", userId: "%s", role: WRITER } ) { %s } }`,
+			wId2, uId3, workspaceNode),
+	})
+
 	w, err = r.Workspace.FindByID(context.Background(), wId2)
 	assert.Nil(t, err)
 	assert.Equal(t, w.Members().User(uId3).Role, workspace.RoleWriter)
 
-	query = fmt.Sprintf(`mutation { updateMemberOfWorkspace(input: {workspaceId: "%s", userId: "%s", role: WRITER}){ workspace{ id } }}`, accountdomain.NewWorkspaceID(), uId3)
-	request = GraphQLRequest{
-		Query: query,
-	}
-	o := Request(e, uId1.String(), request).Object()
-	o.Value("errors").Array().Value(0).Object().Value("message").IsEqual("operation denied")
+	res := Request(e, uId1.String(), GraphQLRequest{
+		Query: fmt.Sprintf(`mutation {
+			updateMemberOfWorkspace( input: { workspaceId: "%s", userId: "%s", role: WRITER } ) { %s } }`,
+			accountdomain.NewWorkspaceID(), uId3, workspaceNode),
+	})
+	res.Path("$.errors[0].message").IsEqual("operation denied")
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gavv/httpexpect/v2 v2.16.0
 	github.com/globusdigital/deep-copy v0.5.4
 	github.com/go-faker/faker/v4 v4.6.0
+	github.com/go-playground/validator/v10 v10.27.0
 	github.com/goccy/go-yaml v1.17.1
 	github.com/google/uuid v1.6.0
 	github.com/hellofresh/health-go/v5 v5.5.4
@@ -29,6 +30,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/ravilushqa/otelgqlgen v0.17.0
 	github.com/reearth/orb v0.0.0-20250123044717-f6f70ce16355
+	github.com/reearth/reearthx v0.0.0-20250731060631-7ef9d9421c39
 	github.com/samber/lo v1.50.0
 	github.com/spf13/afero v1.14.0
 	github.com/square/mongo-lock v0.0.0-20230808145049-cfcf499f6bf0
@@ -53,11 +55,6 @@ require (
 	google.golang.org/protobuf v1.36.6
 	gopkg.in/h2non/gock.v1 v1.1.2
 	gopkg.in/square/go-jose.v2 v2.6.0
-)
-
-require (
-	github.com/go-playground/validator/v10 v10.27.0
-	github.com/reearth/reearthx v0.0.0-20250711044138-418475ad1421
 )
 
 require (

--- a/server/go.sum
+++ b/server/go.sum
@@ -314,8 +314,8 @@ github.com/ravilushqa/otelgqlgen v0.17.0 h1:bLwQfKqtj9P24QpjM2sc1ipBm5Fqv2u7DKN5
 github.com/ravilushqa/otelgqlgen v0.17.0/go.mod h1:orOIikuYsay1y3CmLgd5gsHcT9EsnXwNKmkAplzzYXQ=
 github.com/reearth/orb v0.0.0-20250123044717-f6f70ce16355 h1:hmQfd74d4+CdE7vz72n8OPAFocOwVo6yoczZ8eLYKi4=
 github.com/reearth/orb v0.0.0-20250123044717-f6f70ce16355/go.mod h1:YWoaA2PfCxtfLyH9+pz5tZh9kwKbPEbRoaIA/DSCt10=
-github.com/reearth/reearthx v0.0.0-20250711044138-418475ad1421 h1:PpguVY3+KaSkRl1lMvNLCfUVdvTa3xKdX5SZfEM8Sqw=
-github.com/reearth/reearthx v0.0.0-20250711044138-418475ad1421/go.mod h1:LB99y3wpdleJ2LcZ/5226iaHf8HO+R3pp6omwUFDw8I=
+github.com/reearth/reearthx v0.0.0-20250731060631-7ef9d9421c39 h1:Qe7HIt79dTVbjHQJX3te4pPLiJ/3YdCR0Q8tAbIyx7M=
+github.com/reearth/reearthx v0.0.0-20250731060631-7ef9d9421c39/go.mod h1:LB99y3wpdleJ2LcZ/5226iaHf8HO+R3pp6omwUFDw8I=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=

--- a/server/gql/workspace.graphql
+++ b/server/gql/workspace.graphql
@@ -20,6 +20,7 @@ type Workspace implements Node {
     before: Cursor
   ): ProjectConnection!
   enableToCreatePrivateProject: Boolean!
+  alias: String!
 }
 
 type WorkspaceMember {
@@ -56,11 +57,13 @@ enum Role {
 
 input CreateWorkspaceInput {
   name: String!
+  alias: String
 }
 
 input UpdateWorkspaceInput {
   workspaceId: ID!
   name: String!
+  alias: String
 }
 
 input AddMemberToWorkspaceInput {
@@ -116,9 +119,13 @@ extend type Mutation {
   createWorkspace(input: CreateWorkspaceInput!): CreateWorkspacePayload
   deleteWorkspace(input: DeleteWorkspaceInput!): DeleteWorkspacePayload
   updateWorkspace(input: UpdateWorkspaceInput!): UpdateWorkspacePayload
-  addMemberToWorkspace(input: AddMemberToWorkspaceInput!): AddMemberToWorkspacePayload
+  addMemberToWorkspace(
+    input: AddMemberToWorkspaceInput!
+  ): AddMemberToWorkspacePayload
   removeMemberFromWorkspace(
     input: RemoveMemberFromWorkspaceInput!
   ): RemoveMemberFromWorkspacePayload
-  updateMemberOfWorkspace(input: UpdateMemberOfWorkspaceInput!): UpdateMemberOfWorkspacePayload
+  updateMemberOfWorkspace(
+    input: UpdateMemberOfWorkspaceInput!
+  ): UpdateMemberOfWorkspacePayload
 }

--- a/server/internal/adapter/gql/generated.go
+++ b/server/internal/adapter/gql/generated.go
@@ -1038,6 +1038,7 @@ type ComplexityRoot struct {
 	}
 
 	Workspace struct {
+		Alias                        func(childComplexity int) int
 		Assets                       func(childComplexity int, projectID *gqlmodel.ID, first *int, last *int, after *usecasex.Cursor, before *usecasex.Cursor) int
 		EnableToCreatePrivateProject func(childComplexity int) int
 		ID                           func(childComplexity int) int
@@ -6003,6 +6004,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.WidgetZone.Right(childComplexity), true
 
+	case "Workspace.alias":
+		if e.complexity.Workspace.Alias == nil {
+			break
+		}
+
+		return e.complexity.Workspace.Alias(childComplexity), true
+
 	case "Workspace.assets":
 		if e.complexity.Workspace.Assets == nil {
 			break
@@ -8038,6 +8046,7 @@ extend type Mutation {
     before: Cursor
   ): ProjectConnection!
   enableToCreatePrivateProject: Boolean!
+  alias: String!
 }
 
 type WorkspaceMember {
@@ -8074,11 +8083,13 @@ enum Role {
 
 input CreateWorkspaceInput {
   name: String!
+  alias: String
 }
 
 input UpdateWorkspaceInput {
   workspaceId: ID!
   name: String!
+  alias: String
 }
 
 input AddMemberToWorkspaceInput {
@@ -8134,11 +8145,15 @@ extend type Mutation {
   createWorkspace(input: CreateWorkspaceInput!): CreateWorkspacePayload
   deleteWorkspace(input: DeleteWorkspaceInput!): DeleteWorkspacePayload
   updateWorkspace(input: UpdateWorkspaceInput!): UpdateWorkspacePayload
-  addMemberToWorkspace(input: AddMemberToWorkspaceInput!): AddMemberToWorkspacePayload
+  addMemberToWorkspace(
+    input: AddMemberToWorkspaceInput!
+  ): AddMemberToWorkspacePayload
   removeMemberFromWorkspace(
     input: RemoveMemberFromWorkspaceInput!
   ): RemoveMemberFromWorkspacePayload
-  updateMemberOfWorkspace(input: UpdateMemberOfWorkspaceInput!): UpdateMemberOfWorkspacePayload
+  updateMemberOfWorkspace(
+    input: UpdateMemberOfWorkspaceInput!
+  ): UpdateMemberOfWorkspacePayload
 }
 `, BuiltIn: false},
 }
@@ -11664,6 +11679,8 @@ func (ec *executionContext) fieldContext_AddMemberToWorkspacePayload_workspace(_
 				return ec.fieldContext_Workspace_projects(ctx, field)
 			case "enableToCreatePrivateProject":
 				return ec.fieldContext_Workspace_enableToCreatePrivateProject(ctx, field)
+			case "alias":
+				return ec.fieldContext_Workspace_alias(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Workspace", field.Name)
 		},
@@ -12191,6 +12208,8 @@ func (ec *executionContext) fieldContext_Asset_workspace(_ context.Context, fiel
 				return ec.fieldContext_Workspace_projects(ctx, field)
 			case "enableToCreatePrivateProject":
 				return ec.fieldContext_Workspace_enableToCreatePrivateProject(ctx, field)
+			case "alias":
+				return ec.fieldContext_Workspace_alias(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Workspace", field.Name)
 		},
@@ -13687,6 +13706,8 @@ func (ec *executionContext) fieldContext_CreateWorkspacePayload_workspace(_ cont
 				return ec.fieldContext_Workspace_projects(ctx, field)
 			case "enableToCreatePrivateProject":
 				return ec.fieldContext_Workspace_enableToCreatePrivateProject(ctx, field)
+			case "alias":
+				return ec.fieldContext_Workspace_alias(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Workspace", field.Name)
 		},
@@ -15904,6 +15925,8 @@ func (ec *executionContext) fieldContext_Me_workspaces(_ context.Context, field 
 				return ec.fieldContext_Workspace_projects(ctx, field)
 			case "enableToCreatePrivateProject":
 				return ec.fieldContext_Workspace_enableToCreatePrivateProject(ctx, field)
+			case "alias":
+				return ec.fieldContext_Workspace_alias(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Workspace", field.Name)
 		},
@@ -15965,6 +15988,8 @@ func (ec *executionContext) fieldContext_Me_myWorkspace(_ context.Context, field
 				return ec.fieldContext_Workspace_projects(ctx, field)
 			case "enableToCreatePrivateProject":
 				return ec.fieldContext_Workspace_enableToCreatePrivateProject(ctx, field)
+			case "alias":
+				return ec.fieldContext_Workspace_alias(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Workspace", field.Name)
 		},
@@ -26890,6 +26915,8 @@ func (ec *executionContext) fieldContext_Project_workspace(_ context.Context, fi
 				return ec.fieldContext_Workspace_projects(ctx, field)
 			case "enableToCreatePrivateProject":
 				return ec.fieldContext_Workspace_enableToCreatePrivateProject(ctx, field)
+			case "alias":
+				return ec.fieldContext_Workspace_alias(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Workspace", field.Name)
 		},
@@ -34426,6 +34453,8 @@ func (ec *executionContext) fieldContext_RemoveMemberFromWorkspacePayload_worksp
 				return ec.fieldContext_Workspace_projects(ctx, field)
 			case "enableToCreatePrivateProject":
 				return ec.fieldContext_Workspace_enableToCreatePrivateProject(ctx, field)
+			case "alias":
+				return ec.fieldContext_Workspace_alias(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Workspace", field.Name)
 		},
@@ -35609,6 +35638,8 @@ func (ec *executionContext) fieldContext_Scene_workspace(_ context.Context, fiel
 				return ec.fieldContext_Workspace_projects(ctx, field)
 			case "enableToCreatePrivateProject":
 				return ec.fieldContext_Workspace_enableToCreatePrivateProject(ctx, field)
+			case "alias":
+				return ec.fieldContext_Workspace_alias(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Workspace", field.Name)
 		},
@@ -36788,6 +36819,8 @@ func (ec *executionContext) fieldContext_SignupPayload_workspace(_ context.Conte
 				return ec.fieldContext_Workspace_projects(ctx, field)
 			case "enableToCreatePrivateProject":
 				return ec.fieldContext_Workspace_enableToCreatePrivateProject(ctx, field)
+			case "alias":
+				return ec.fieldContext_Workspace_alias(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Workspace", field.Name)
 		},
@@ -40465,6 +40498,8 @@ func (ec *executionContext) fieldContext_UpdateMemberOfWorkspacePayload_workspac
 				return ec.fieldContext_Workspace_projects(ctx, field)
 			case "enableToCreatePrivateProject":
 				return ec.fieldContext_Workspace_enableToCreatePrivateProject(ctx, field)
+			case "alias":
+				return ec.fieldContext_Workspace_alias(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Workspace", field.Name)
 		},
@@ -40893,6 +40928,8 @@ func (ec *executionContext) fieldContext_UpdateWorkspacePayload_workspace(_ cont
 				return ec.fieldContext_Workspace_projects(ctx, field)
 			case "enableToCreatePrivateProject":
 				return ec.fieldContext_Workspace_enableToCreatePrivateProject(ctx, field)
+			case "alias":
+				return ec.fieldContext_Workspace_alias(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Workspace", field.Name)
 		},
@@ -43130,6 +43167,50 @@ func (ec *executionContext) fieldContext_Workspace_enableToCreatePrivateProject(
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Workspace_alias(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.Workspace) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Workspace_alias(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Alias, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Workspace_alias(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Workspace",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -46041,7 +46122,7 @@ func (ec *executionContext) unmarshalInputCreateWorkspaceInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name"}
+	fieldsInOrder := [...]string{"name", "alias"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -46055,6 +46136,13 @@ func (ec *executionContext) unmarshalInputCreateWorkspaceInput(ctx context.Conte
 				return it, err
 			}
 			it.Name = data
+		case "alias":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("alias"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Alias = data
 		}
 	}
 
@@ -48478,7 +48566,7 @@ func (ec *executionContext) unmarshalInputUpdateWorkspaceInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"workspaceId", "name"}
+	fieldsInOrder := [...]string{"workspaceId", "name", "alias"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -48499,6 +48587,13 @@ func (ec *executionContext) unmarshalInputUpdateWorkspaceInput(ctx context.Conte
 				return it, err
 			}
 			it.Name = data
+		case "alias":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("alias"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Alias = data
 		}
 	}
 
@@ -58039,6 +58134,11 @@ func (ec *executionContext) _Workspace(ctx context.Context, sel ast.SelectionSet
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "enableToCreatePrivateProject":
 			out.Values[i] = ec._Workspace_enableToCreatePrivateProject(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "alias":
+			out.Values[i] = ec._Workspace_alias(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}

--- a/server/internal/adapter/gql/gqlmodel/convert_workspace.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_workspace.go
@@ -5,12 +5,12 @@ import (
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
 )
 
-func ToWorkspace(t *workspace.Workspace) *Workspace {
-	if t == nil {
+func ToWorkspace(w *workspace.Workspace) *Workspace {
+	if w == nil {
 		return nil
 	}
 
-	memberMap := t.Members().Users()
+	memberMap := w.Members().Users()
 	members := make([]*WorkspaceMember, 0, len(memberMap))
 	for u, r := range memberMap {
 		members = append(members, &WorkspaceMember{
@@ -20,11 +20,12 @@ func ToWorkspace(t *workspace.Workspace) *Workspace {
 	}
 
 	return &Workspace{
-		ID:       IDFrom(t.ID()),
-		Name:     t.Name(),
-		Personal: t.IsPersonal(),
-		PolicyID: (*ID)(t.Policy()),
+		ID:       IDFrom(w.ID()),
+		Name:     w.Name(),
+		Personal: w.IsPersonal(),
+		PolicyID: (*ID)(w.Policy()),
 		Members:  members,
+		Alias:    w.Alias(),
 	}
 }
 

--- a/server/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/server/internal/adapter/gql/gqlmodel/models_gen.go
@@ -245,7 +245,8 @@ type CreateStoryPageInput struct {
 }
 
 type CreateWorkspaceInput struct {
-	Name string `json:"name"`
+	Name  string  `json:"name"`
+	Alias *string `json:"alias,omitempty"`
 }
 
 type CreateWorkspacePayload struct {
@@ -1374,8 +1375,9 @@ type UpdateWidgetPayload struct {
 }
 
 type UpdateWorkspaceInput struct {
-	WorkspaceID ID     `json:"workspaceId"`
-	Name        string `json:"name"`
+	WorkspaceID ID      `json:"workspaceId"`
+	Name        string  `json:"name"`
+	Alias       *string `json:"alias,omitempty"`
 }
 
 type UpdateWorkspacePayload struct {
@@ -1497,6 +1499,7 @@ type Workspace struct {
 	Assets                       *AssetConnection   `json:"assets"`
 	Projects                     *ProjectConnection `json:"projects"`
 	EnableToCreatePrivateProject bool               `json:"enableToCreatePrivateProject"`
+	Alias                        string             `json:"alias"`
 }
 
 func (Workspace) IsNode()        {}

--- a/server/internal/adapter/gql/resolver_mutation_workspace.go
+++ b/server/internal/adapter/gql/resolver_mutation_workspace.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (r *mutationResolver) CreateWorkspace(ctx context.Context, input gqlmodel.CreateWorkspaceInput) (*gqlmodel.CreateWorkspacePayload, error) {
-	res, err := usecases(ctx).Workspace.Create(ctx, input.Name, getUser(ctx).ID(), getAcOperator(ctx))
+	res, err := usecases(ctx).Workspace.Create(ctx, input.Name, getUser(ctx).ID(), input.Alias, getAcOperator(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func (r *mutationResolver) UpdateWorkspace(ctx context.Context, input gqlmodel.U
 		return nil, err
 	}
 
-	res, err := usecases(ctx).Workspace.Update(ctx, tid, input.Name, getAcOperator(ctx))
+	res, err := usecases(ctx).Workspace.Update(ctx, tid, input.Name, input.Alias, getAcOperator(ctx))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Overview

# Add alias to the workspace API

## What I've done

## 1. The alias field is added to both workspace creation and update.
```diff
input CreateWorkspaceInput {
    name: String!
+    alias: String
}

input UpdateWorkspaceInput {
    workspaceId: ID!
    name: String!
+    alias: String
}
```
## 2.A uniqueness check will be performed when registering an alias.
```
CheckWorkspaceAliasUnique(context.Context, workspace.ID, string) error
```
## 3.If no alias is specified, it will be set to `w-{WorkspaceID}` by default.
```
	newAlias := fmt.Sprintf("w-%s", newId.String())
	if alias != nil {
		err := i.repos.Workspace.CheckWorkspaceAliasUnique(ctx, newId, *alias)
		if err != nil {
			return nil, err
		}
		newAlias = *alias
	}
```

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
