### PR TITLE
feat(server): adjust visibility handling [VIZ-2110]

### DIFF
--- a/server/e2e/gql_project_test.go
+++ b/server/e2e/gql_project_test.go
@@ -573,10 +573,10 @@ func TestFindVisibilityProjects(t *testing.T) {
 		},
 	}
 
-	// default private
+	// default public
 	edges := Request(e, uID.String(), requestBody).
 		Path("$.data.projects.edges").Array()
-	edges.Value(1).Path("$.node.visibility").IsEqual("private")
+	edges.Value(1).Path("$.node.visibility").IsEqual("public")
 
 	// update public
 	updateVisibilityProject(e, project1ID)

--- a/server/e2e/gql_project_test.go
+++ b/server/e2e/gql_project_test.go
@@ -732,10 +732,10 @@ func testData(e *httpexpect.Expect) {
 		"visualizer":  "CESIUM",
 	}).Object().
 		HasValue("name", "test1-1").
-		HasValue("coreSupport", false).   //default(=false)
-		HasValue("visibility", "private") //default(=private)
+		HasValue("coreSupport", false).  //default(=false)
+		HasValue("visibility", "public") //default(=private)
 
-	// create coreSupport default(=false) visibility default(=private) `delete` project
+	// create coreSupport default(=false) visibility default(=public) `delete` project
 	id := createProject2(e, uID, map[string]any{
 		"name":        "test1-2",
 		"description": "abc",
@@ -743,8 +743,8 @@ func testData(e *httpexpect.Expect) {
 		"visualizer":  "CESIUM",
 	}).Object().
 		HasValue("name", "test1-2").
-		HasValue("coreSupport", false).    //default(=false)
-		HasValue("visibility", "private"). //default(=private)
+		HasValue("coreSupport", false).   //default(=false)
+		HasValue("visibility", "public"). //default(=public)
 		Value("id").Raw().(string)
 
 	deleteProject(e, id) // delete

--- a/server/e2e/proto_project_user_test.go
+++ b/server/e2e/proto_project_user_test.go
@@ -26,8 +26,8 @@ func TestInternalAPI_private(t *testing.T) {
 	// user1 call api
 	runTestWithUser(t, uID.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
 
-		// create default Project -> private
-		createProjectInternal(t, ctx, r, client, "private", &pb.CreateProjectRequest{
+		// create default Project -> public
+		createProjectInternal(t, ctx, r, client, "public", &pb.CreateProjectRequest{
 			WorkspaceId: testWorkspace1,
 			Visualizer:  pb.Visualizer_VISUALIZER_CESIUM,
 			Name:        lo.ToPtr("Test User1 Default Project1"),
@@ -76,7 +76,7 @@ func TestInternalAPI_private(t *testing.T) {
 		assert.Equal(t, res.Projects[1].Id, res.Projects[1].Metadata.ProjectId)
 
 		assert.Equal(t, "Test User1 Default Project1", res.Projects[2].Name)
-		assert.Equal(t, "private", res.Projects[2].Visibility)
+		assert.Equal(t, "public", res.Projects[2].Visibility)
 		assert.Equal(t, res.Projects[2].Id, res.Projects[2].Metadata.ProjectId)
 	})
 
@@ -88,8 +88,8 @@ func TestInternalAPI_private(t *testing.T) {
 	// user2 call api
 	runTestWithUser(t, uID2.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
 
-		// create default Project -> private
-		createProjectInternal(t, ctx, r, client, "private", &pb.CreateProjectRequest{
+		// create default Project -> public
+		createProjectInternal(t, ctx, r, client, "public", &pb.CreateProjectRequest{
 			WorkspaceId: testWorkspace2,
 			Visualizer:  pb.Visualizer_VISUALIZER_CESIUM,
 			Name:        lo.ToPtr("Test User2 Default Project1"),
@@ -138,7 +138,7 @@ func TestInternalAPI_private(t *testing.T) {
 		assert.Equal(t, res.Projects[1].Id, res.Projects[1].Metadata.ProjectId)
 
 		assert.Equal(t, "Test User2 Default Project1", res.Projects[2].Name)
-		assert.Equal(t, "private", res.Projects[2].Visibility)
+		assert.Equal(t, "public", res.Projects[2].Visibility)
 		assert.Equal(t, res.Projects[2].Id, res.Projects[2].Metadata.ProjectId)
 
 		// get User1 Workspace => list size 1 public only
@@ -148,7 +148,7 @@ func TestInternalAPI_private(t *testing.T) {
 		})
 
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(res.Projects))
+		assert.Equal(t, 2, len(res.Projects))
 
 		assert.Equal(t, "Test User1 Public Project3", res.Projects[0].Name)
 		assert.Equal(t, "public", res.Projects[0].Visibility)
@@ -167,7 +167,7 @@ func TestInternalAPI_private(t *testing.T) {
 			WorkspaceId:   &testWorkspace2, // User2 Workspace
 		})
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(res.Projects))
+		assert.Equal(t, 2, len(res.Projects))
 
 		assert.Equal(t, "Test User2 Public Project3", res.Projects[0].Name)
 		assert.Equal(t, "public", res.Projects[0].Visibility)
@@ -192,7 +192,7 @@ func TestInternalAPI_private(t *testing.T) {
 		})
 
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(res.Projects)) // Enmpty!
+		assert.Equal(t, 1, len(res.Projects))
 
 	})
 }

--- a/server/internal/adapter/gql/gqlmodel/convert_project.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_project.go
@@ -158,6 +158,8 @@ type ProjectExport struct {
 	Description string     `json:"description"`
 	ImageURL    *url.URL   `json:"imageUrl,omitempty"`
 
+	Visibility string `json:"visibility,omitempty"`
+
 	License *string `json:"readme,omitempty"`
 	Readme  *string `json:"license,omitempty"`
 	Topics  *string `json:"topics,omitempty"`
@@ -173,6 +175,7 @@ func ToProjectExport(p *project.Project) *ProjectExport {
 		Name:        p.Name(),
 		Description: p.Description(),
 		ImageURL:    p.ImageURL(),
+		Visibility:  p.Visibility(),
 	}
 
 	if pm := p.Metadata(); pm != nil {

--- a/server/internal/adapter/gql/resolver_mutation_project.go
+++ b/server/internal/adapter/gql/resolver_mutation_project.go
@@ -37,7 +37,10 @@ func (r *mutationResolver) CreateProject(ctx context.Context, input gqlmodel.Cre
 		Readme:       input.Readme,
 		License:      input.License,
 		Topics:       input.Topics,
-	}, getOperator(ctx))
+	},
+		getOperator(ctx),
+		false, // isImport
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/adapter/internalapi/server.go
+++ b/server/internal/adapter/internalapi/server.go
@@ -214,7 +214,10 @@ func (s server) CreateProject(ctx context.Context, req *pb.CreateProjectRequest)
 		Readme:       req.Readme,
 		License:      req.License,
 		Topics:       req.Topics,
-	}, op)
+	},
+		op,
+		false, // isImport
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/app/file_uploader.go
+++ b/server/internal/app/file_uploader.go
@@ -142,7 +142,10 @@ func CreateProcessingProject(ctx context.Context, usecases *interfaces.Container
 		CoreSupport:  &coreSupport,
 		Visibility:   &visibility,
 		ImportStatus: project.ProjectImportStatusProcessing, // PROCESSING
-	}, op)
+	},
+		op,
+		true, // isImport
+	)
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusBadRequest, "Failed to create project")
 	}

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -309,14 +309,45 @@ func (i *Project) getMetadata(ctx context.Context, pList []*project.Project) ([]
 	return pList, err
 }
 
-func (i *Project) Create(ctx context.Context, input interfaces.CreateProjectParam, operator *usecase.Operator) (_ *project.Project, err error) {
+func (i *Project) Create(ctx context.Context, input interfaces.CreateProjectParam, operator *usecase.Operator, isImport bool) (_ *project.Project, err error) {
+
+	// Default to VisibilityPrivate if not specified
+	visibility := project.VisibilityPrivate
+	if input.Visibility != nil {
+		visibility = project.Visibility(*input.Visibility)
+	}
+
+	if i.policyChecker != nil {
+
+		if err = i.checkGeneralPolicy(ctx, input.WorkspaceID, visibility); err != nil {
+			// If this is an import, try the opposite visibility as a fallback
+			if isImport {
+				if visibility == project.VisibilityPrivate {
+					visibility = project.VisibilityPublic
+				} else if visibility == project.VisibilityPublic {
+					visibility = project.VisibilityPrivate
+				} else {
+					return nil, err
+				}
+				// Retry policy check with the new visibility
+				if err = i.checkGeneralPolicy(ctx, input.WorkspaceID, visibility); err != nil {
+					return nil, err
+				}
+			} else {
+				return nil, err
+			}
+		}
+
+	}
+
+	// project.Visibility(input.Visibility),
 	return i.createProject(ctx, createProjectInput{
 		WorkspaceID:  input.WorkspaceID,
 		Visualizer:   input.Visualizer,
 		Name:         input.Name,
 		Description:  input.Description,
 		CoreSupport:  input.CoreSupport,
-		Visibility:   input.Visibility,
+		Visibility:   &visibility,
 		ImportStatus: input.ImportStatus,
 		ProjectAlias: input.ProjectAlias,
 		Readme:       input.Readme,
@@ -420,9 +451,24 @@ func (i *Project) Update(ctx context.Context, p interfaces.UpdateProjectParam, o
 	}
 
 	if p.Visibility != nil {
+
+		visibility := project.Visibility(*p.Visibility)
+
+		if i.policyChecker != nil {
+
+			// If the visibility is going to change
+			if !strings.EqualFold(*p.Visibility, prj.Visibility()) {
+				if err = i.checkGeneralPolicy(ctx, prj.Workspace(), visibility); err != nil {
+					return nil, err
+				}
+			}
+
+		}
+
 		if err := prj.UpdateVisibility(*p.Visibility); err != nil {
 			return nil, err
 		}
+
 	}
 
 	if p.ProjectAlias != nil {
@@ -1041,6 +1087,7 @@ func (i *Project) ImportProjectData(ctx context.Context, workspace string, proje
 		Readme:       readme,
 		License:      license,
 		Topics:       topics,
+		// skip Visibility
 	}, op)
 	if err != nil {
 		return nil, err
@@ -1090,7 +1137,7 @@ type createProjectInput struct {
 	Alias        *string
 	Archived     *bool
 	CoreSupport  *bool
-	Visibility   *string
+	Visibility   *project.Visibility
 	ProjectAlias *string
 
 	// metadata
@@ -1202,18 +1249,9 @@ func (i *Project) createProject(ctx context.Context, input createProjectInput, o
 		prj = prj.Name(*input.Name)
 	}
 
-	visibility := project.VisibilityPrivate
 	if input.Visibility != nil {
-		visibility = project.Visibility(*input.Visibility)
+		prj = prj.Visibility(*input.Visibility)
 	}
-
-	if i.policyChecker != nil {
-		if err = i.checkGeneralPolicy(ctx, input.WorkspaceID, visibility); err != nil {
-			return nil, err
-		}
-	}
-
-	prj = prj.Visibility(visibility)
 
 	proj, err := prj.Build()
 	if err != nil {

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -322,11 +322,12 @@ func (i *Project) Create(ctx context.Context, input interfaces.CreateProjectPara
 		if err = i.checkGeneralPolicy(ctx, input.WorkspaceID, visibility); err != nil {
 			// If this is an import, try the opposite visibility as a fallback
 			if isImport {
-				if visibility == project.VisibilityPrivate {
+				switch visibility {
+				case project.VisibilityPrivate:
 					visibility = project.VisibilityPublic
-				} else if visibility == project.VisibilityPublic {
+				case project.VisibilityPublic:
 					visibility = project.VisibilityPrivate
-				} else {
+				default:
 					return nil, err
 				}
 				// Retry policy check with the new visibility

--- a/server/internal/usecase/interfaces/project.go
+++ b/server/internal/usecase/interfaces/project.go
@@ -105,7 +105,7 @@ type Project interface {
 	FindVisibilityByWorkspace(context.Context, accountdomain.WorkspaceID, bool, *usecase.Operator, *string, *project.SortType, *usecasex.Pagination, *ProjectListParam) ([]*project.Project, *usecasex.PageInfo, error)
 	UpdateVisibility(context.Context, id.ProjectID, string, *usecase.Operator) (*project.Project, error)
 
-	Create(context.Context, CreateProjectParam, *usecase.Operator) (*project.Project, error)
+	Create(context.Context, CreateProjectParam, *usecase.Operator, bool) (*project.Project, error)
 	Update(context.Context, UpdateProjectParam, *usecase.Operator) (*project.Project, error)
 	Delete(context.Context, id.ProjectID, *usecase.Operator) error
 


### PR DESCRIPTION
# Overview

## Adjust visibility handling for imported projects

## What I've done
### The handling of project visibility has been updated as follows:

### 1. Added the following field to the exported project data:
* visibility

### 2. createProject

If the specified visibility is not allowed by the policy check, an error will be returned.

### 3. updateProject

If the specified visibility is not allowed by the policy check, an error will be returned.

### 4. importProject

If the imported data has visibility set to private and it is not allowed, the system will attempt to create the project with public visibility.

If the visibility is public and not allowed, the system will attempt to create the project with private visibility instead.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
