### PR TITLE
feat(server): change project filter [VIZ-2160]

### DIFF
--- a/server/e2e/common.go
+++ b/server/e2e/common.go
@@ -64,8 +64,8 @@ func init() {
 	mongotest.Env = "REEARTH_DB"
 }
 
-func initRepos(t *testing.T, useMongo bool, seeder Seeder) (repos *repo.Container, file gateway.File) {
-	ctx := context.Background()
+func initRepos(t *testing.T, useMongo bool, seeder Seeder) (repos *repo.Container, file gateway.File, ctx context.Context) {
+	ctx = context.Background()
 
 	if useMongo {
 		db := mongotest.Connect(t)(t)
@@ -84,7 +84,7 @@ func initRepos(t *testing.T, useMongo bool, seeder Seeder) (repos *repo.Containe
 		}
 	}
 
-	return repos, file
+	return repos, file, ctx
 }
 
 func initGateway() *gateway.Container {
@@ -173,15 +173,21 @@ func StartGQLServerWithRepos(t *testing.T, cfg *config.Config, repos *repo.Conta
 }
 
 func StartGQLServerAndRepos(t *testing.T, seeder Seeder) (*httpexpect.Expect, *accountrepo.Container) {
-	repos, _ := initRepos(t, true, seeder)
+	repos, _, _ := initRepos(t, true, seeder)
 	e, _, _ := StartGQLServerWithRepos(t, disabledAuthConfig, repos)
 	return e, repos.AccountRepos()
 }
 
 func startServer(t *testing.T, cfg *config.Config, useMongo bool, seeder Seeder) (*httpexpect.Expect, *repo.Container, *gateway.Container) {
-	repos, _ := initRepos(t, useMongo, seeder)
+	repos, _, _ := initRepos(t, useMongo, seeder)
 	e, gateways, _ := StartGQLServerWithRepos(t, cfg, repos)
 	return e, repos, gateways
+}
+
+func startServerWithCtx(t *testing.T, cfg *config.Config, useMongo bool, seeder Seeder) (*httpexpect.Expect, *repo.Container, *gateway.Container, context.Context) {
+	repos, _, ctx := initRepos(t, useMongo, seeder)
+	e, gateways, _ := StartGQLServerWithRepos(t, cfg, repos)
+	return e, repos, gateways, ctx
 }
 
 func ServerAndRepos(t *testing.T, seeder Seeder) (*httpexpect.Expect, *repo.Container, *gateway.Container) {
@@ -190,6 +196,10 @@ func ServerAndRepos(t *testing.T, seeder Seeder) (*httpexpect.Expect, *repo.Cont
 
 func GRPCServer(t *testing.T, seeder Seeder) (*httpexpect.Expect, *repo.Container, *gateway.Container) {
 	return startServer(t, internalApiConfig, true, seeder)
+}
+
+func GRPCServeWithCtx(t *testing.T, seeder Seeder) (*httpexpect.Expect, *repo.Container, *gateway.Container, context.Context) {
+	return startServerWithCtx(t, internalApiConfig, true, seeder)
 }
 
 func Server(t *testing.T, seeder Seeder) *httpexpect.Expect {

--- a/server/e2e/proto_project_test.go
+++ b/server/e2e/proto_project_test.go
@@ -24,9 +24,9 @@ import (
 )
 
 // export REEARTH_DB=mongodb://localhost
-// go test -v -run TestInternalAPI ./e2e/...
+// go test -v -run TestInternalAPI_Basic ./e2e/...
 
-func TestInternalAPI(t *testing.T) {
+func TestInternalAPI_Basic(t *testing.T) {
 	_, r, _ := GRPCServer(t, baseSeeder)
 	testWorkspace := wID.String()
 
@@ -100,22 +100,19 @@ func TestInternalAPI(t *testing.T) {
 
 	// user2 call api
 	runTestWithUser(t, uID2.String(), func(client pb.ReEarthVisualizerClient, ctx context.Context) {
-		// get list size 1
 		res3, err := client.GetProjectList(ctx, &pb.GetProjectListRequest{
 			Authenticated: false,
 			WorkspaceId:   &testWorkspace,
 		})
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(res3.Projects))
-		// 3: creante public  => public   delete => false
+		assert.Equal(t, 2, len(res3.Projects))
 
-		// Authenticated => get list size 1
 		res4, err := client.GetProjectList(ctx, &pb.GetProjectListRequest{
 			Authenticated: true,
 			WorkspaceId:   &testWorkspace,
 		})
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(res4.Projects))
+		assert.Equal(t, 2, len(res4.Projects))
 
 	})
 
@@ -127,10 +124,7 @@ func TestInternalAPI(t *testing.T) {
 			WorkspaceId:   &testWorkspace,
 		})
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(res3.Projects))
-
-		// 2: creante public  => public   delete => false
-		// 3: creante private => private  delete => false
+		assert.Equal(t, 4, len(res3.Projects))
 	})
 
 }

--- a/server/internal/adapter/internalapi/server.go
+++ b/server/internal/adapter/internalapi/server.go
@@ -52,10 +52,12 @@ func (s server) GetProjectList(ctx context.Context, req *pb.GetProjectListReques
 		}
 	}
 
+	var err error
 	if req.WorkspaceId == nil {
-		var err error
+
 		res, info, err = uc.Project.FindVisibilityByUser(
-			ctx, adapter.User(ctx),
+			ctx,
+			adapter.User(ctx),
 			req.Authenticated,
 			op,
 			req.Keyword,
@@ -79,11 +81,17 @@ func (s server) GetProjectList(ctx context.Context, req *pb.GetProjectListReques
 			param.Limit = req.Pagination.Limit
 			param.Offset = req.Pagination.Offset
 		}
+
 		res, info, err = uc.Project.FindVisibilityByWorkspace(
-			ctx, wId, req.Authenticated, op, req.Keyword, sort, pagination,
+			ctx,
+			wId,
+			req.Authenticated,
+			op,
+			req.Keyword,
+			sort,
+			pagination,
 			param,
 		)
-
 		if err != nil {
 			return nil, err
 		}
@@ -99,6 +107,7 @@ func (s server) GetProjectList(ctx context.Context, req *pb.GetProjectListReques
 		Projects: projects,
 		PageInfo: internalapimodel.ToProjectPageInfo(info),
 	}, nil
+
 }
 
 func (s server) GetProject(ctx context.Context, req *pb.GetProjectRequest) (*pb.GetProjectResponse, error) {

--- a/server/internal/infrastructure/memory/project.go
+++ b/server/internal/infrastructure/memory/project.go
@@ -84,7 +84,7 @@ func (r *Project) FindByWorkspace(ctx context.Context, id accountdomain.Workspac
 	), nil
 }
 
-func (r *Project) FindByWorkspaces(ctx context.Context, authenticated bool, pFilter repo.ProjectFilter, owningWorkspaces accountdomain.WorkspaceIDList, wList accountdomain.WorkspaceIDList) ([]*project.Project, *usecasex.PageInfo, error) {
+func (r *Project) FindByWorkspaces(ctx context.Context, authenticated bool, pFilter repo.ProjectFilter, ownedWorkspaces []string, memberWorkspaces []string, targetWsList []string) ([]*project.Project, *usecasex.PageInfo, error) {
 	return nil, nil, nil
 }
 

--- a/server/internal/infrastructure/mongo/project_test.go
+++ b/server/internal/infrastructure/mongo/project_test.go
@@ -2,7 +2,6 @@ package mongo
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -222,101 +221,4 @@ func TestProject_FindDeletedByWorkspace(t *testing.T) {
 		assert.Equal(t, 1, len(got))
 	})
 
-}
-
-func TestProject_FindByWorkspaces_OffsetPagination(t *testing.T) {
-	c := mongotest.Connect(t)(t)
-	ctx := context.Background()
-
-	wid := accountdomain.NewWorkspaceID()
-
-	// Create 25 test projects
-	docs := make([]any, 25)
-	for i := 0; i < 25; i++ {
-		pid := id.NewProjectID()
-		docs[i] = bson.M{
-			"id":         pid.String(),
-			"workspace":  wid.String(),
-			"name":       fmt.Sprintf("Project %d", i),
-			"visibility": "public",
-			"deleted":    false,
-		}
-	}
-
-	_, err := c.Collection("project").InsertMany(ctx, docs)
-	assert.NoError(t, err)
-
-	r := NewProject(mongox.NewClientWithDatabase(c))
-
-	t.Run("First page with offset pagination", func(t *testing.T) {
-		offset := int64(0)
-		limit := int64(10)
-
-		pFilter := repo.ProjectFilter{
-			Offset: &offset,
-			Limit:  &limit,
-		}
-
-		projects, pageInfo, err := r.FindByWorkspaces(ctx, true, pFilter, accountdomain.WorkspaceIDList{wid}, accountdomain.WorkspaceIDList{wid})
-
-		assert.NoError(t, err)
-		assert.Equal(t, 10, len(projects))
-		assert.Equal(t, int64(25), pageInfo.TotalCount)
-		assert.True(t, pageInfo.HasNextPage)
-		assert.False(t, pageInfo.HasPreviousPage)
-	})
-
-	t.Run("Middle page with offset pagination", func(t *testing.T) {
-		offset := int64(10)
-		limit := int64(10)
-
-		pFilter := repo.ProjectFilter{
-			Offset: &offset,
-			Limit:  &limit,
-		}
-
-		projects, pageInfo, err := r.FindByWorkspaces(ctx, true, pFilter, accountdomain.WorkspaceIDList{wid}, accountdomain.WorkspaceIDList{wid})
-
-		assert.NoError(t, err)
-		assert.Equal(t, 10, len(projects))
-		assert.Equal(t, int64(25), pageInfo.TotalCount)
-		assert.True(t, pageInfo.HasNextPage)
-		assert.True(t, pageInfo.HasPreviousPage)
-	})
-
-	t.Run("Last page with offset pagination", func(t *testing.T) {
-		offset := int64(20)
-		limit := int64(10)
-
-		pFilter := repo.ProjectFilter{
-			Offset: &offset,
-			Limit:  &limit,
-		}
-
-		projects, pageInfo, err := r.FindByWorkspaces(ctx, true, pFilter, accountdomain.WorkspaceIDList{wid}, accountdomain.WorkspaceIDList{wid})
-
-		assert.NoError(t, err)
-		assert.Equal(t, 5, len(projects)) // Only 5 remaining projects
-		assert.Equal(t, int64(25), pageInfo.TotalCount)
-		assert.False(t, pageInfo.HasNextPage)
-		assert.True(t, pageInfo.HasPreviousPage)
-	})
-
-	t.Run("Offset beyond total count", func(t *testing.T) {
-		offset := int64(30)
-		limit := int64(10)
-
-		pFilter := repo.ProjectFilter{
-			Offset: &offset,
-			Limit:  &limit,
-		}
-
-		projects, pageInfo, err := r.FindByWorkspaces(ctx, true, pFilter, accountdomain.WorkspaceIDList{wid}, accountdomain.WorkspaceIDList{wid})
-
-		assert.NoError(t, err)
-		assert.Equal(t, 0, len(projects))
-		assert.Equal(t, int64(25), pageInfo.TotalCount)
-		assert.False(t, pageInfo.HasNextPage)
-		assert.True(t, pageInfo.HasPreviousPage)
-	})
 }

--- a/server/internal/usecase/interactor/project_test.go
+++ b/server/internal/usecase/interactor/project_test.go
@@ -325,64 +325,6 @@ func TestProject_FindActiveById(t *testing.T) {
 	})
 }
 
-func TestProject_FindVisibilityByWorkspace(t *testing.T) {
-	ctx := context.Background()
-
-	db := mongotest.Connect(t)(t)
-	client := mongox.NewClient(db.Name(), db.Client())
-	uc := createNewProjectUC(client)
-
-	us := factory.NewUser()
-	_ = uc.userRepo.Save(ctx, us)
-
-	ws := factory.NewWorkspace(func(w *workspace.Builder) {
-		w.Members(map[accountdomain.UserID]workspace.Member{
-			accountdomain.NewUserID(): {
-				Role:      workspace.RoleOwner,
-				Disabled:  false,
-				InvitedBy: workspace.UserID(us.ID()),
-				Host:      "",
-			},
-		})
-	})
-	_ = uc.workspaceRepo.Save(ctx, ws)
-
-	pj := factory.NewProject(func(p *project.Builder) {
-		p.Workspace(ws.ID()).
-			Visibility(project.VisibilityPublic)
-	})
-	_ = uc.projectRepo.Save(ctx, pj)
-
-	meta := factory.NewProjectMeta(func(m *project.MetadataBuilder) {
-		m.Project(pj.ID())
-		m.Workspace(ws.ID())
-	})
-	_ = uc.projectMetadataRepo.Save(ctx, meta)
-
-	t.Run("when project is public", func(t *testing.T) {
-		result, _, err := uc.FindVisibilityByWorkspace(ctx, ws.ID(), false, &usecase.Operator{
-			AcOperator: &accountusecase.Operator{
-				WritableWorkspaces: workspace.IDList{ws.ID()},
-			},
-		}, nil, nil, nil, nil)
-		assert.NoError(t, err)
-		assert.Equal(t, pj.ID(), result[0].ID())
-	})
-
-	t.Run("when project is private and authenticated is false", func(t *testing.T) {
-		err := pj.UpdateVisibility(string(project.VisibilityPrivate))
-		assert.NoError(t, err)
-		_ = uc.projectRepo.Save(ctx, pj)
-		result, _, err := uc.FindVisibilityByWorkspace(ctx, ws.ID(), false, &usecase.Operator{
-			AcOperator: &accountusecase.Operator{
-				WritableWorkspaces: workspace.IDList{ws.ID()},
-			},
-		}, nil, nil, nil, nil)
-		assert.NoError(t, err)
-		assert.Equal(t, 0, len(result))
-	})
-}
-
 func TestProject_FindVisibilityByUser_OffsetPagination(t *testing.T) {
 	ctx := context.Background()
 

--- a/server/internal/usecase/repo/project.go
+++ b/server/internal/usecase/repo/project.go
@@ -24,7 +24,7 @@ type Project interface {
 	FindByID(context.Context, id.ProjectID) (*project.Project, error)
 	FindByScene(context.Context, id.SceneID) (*project.Project, error)
 	FindByWorkspace(context.Context, accountdomain.WorkspaceID, ProjectFilter) ([]*project.Project, *usecasex.PageInfo, error)
-	FindByWorkspaces(context.Context, bool, ProjectFilter, accountdomain.WorkspaceIDList, accountdomain.WorkspaceIDList) ([]*project.Project, *usecasex.PageInfo, error)
+	FindByWorkspaces(context.Context, bool, ProjectFilter, []string, []string, []string) ([]*project.Project, *usecasex.PageInfo, error)
 	FindStarredByWorkspace(context.Context, accountdomain.WorkspaceID) ([]*project.Project, error)
 	FindDeletedByWorkspace(context.Context, accountdomain.WorkspaceID) ([]*project.Project, error)
 	FindActiveById(context.Context, id.ProjectID) (*project.Project, error)


### PR DESCRIPTION
# Overview

### Project search filter adjustments

## What I've done

### We will modify the project search filter in the internal API as follows.

|                                    	| Owner 	| Member 	| Anonymous 	|
|------------------------------------	|-------	|--------	|-----------	|
| Public Project                     	| 🟢     	| 🟢      	| 🟢         	| 
| Public Project (In the trash can)  	| 🟢     	| ❌      	| ❌         	|
| Private Project                    	| 🟢     	| 🟢      	| ❌         	|
| Private Project (In the trash can) 	| 🟢     	| ❌      	| ❌         	|

👇 We’ll update it to ignore the trash flag.

|                                    	| Owner 	| Member 	| Anonymous 	|
|------------------------------------	|-------	|--------	|-----------	|
| Public Project                     	| 🟢     	| 🟢      	| 🟢         	|
| Public Project (In the trash can)  	| 🟢     	| 🟢      	| 🟢         	|
| Private Project                    	| 🟢     	| 🟢      	| ❌         	|
| Private Project (In the trash can) 	| 🟢     	| 🟢      	| ❌         	|



### The filter currently checks whether the user is an owner or a member, but this is not needed right now.
### We’ll keep the logic in place for future use.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
