### PR TITLE
fix(web): update japanese translations for project visibility terminology [VIZ-2153]

### DIFF
--- a/server/pkg/builtin/manifest.yml
+++ b/server/pkg/builtin/manifest.yml
@@ -2802,9 +2802,9 @@ extensions:
               placeholder: ${your property key}
               ui: property_selector
   - id: markdownInfoboxBetaBlock
-    name: MD Text
+    name: Markdown Text
     type: infoboxBlock
-    description: Infobox MD Text Block
+    description: Infobox Markdown Text Block
     schema:
       groups:
         - id: panel
@@ -2817,7 +2817,7 @@ extensions:
               min: 0
               max: 100
         - id: default
-          title: MD Text Block
+          title: Markdown Text Block
           fields:
             - id: src
               type: string

--- a/server/pkg/builtin/manifest_ja.yml
+++ b/server/pkg/builtin/manifest_ja.yml
@@ -1392,11 +1392,11 @@ extensions:
           padding:
             title: 余白
   markdownInfoboxBetaBlock:
-    name: MDテキスト
-    description: インフォボックスMDテキストブロック
+    name: マークダウンテキスト
+    description: インフォボックスマークダウンテキストブロック
     propertySchema:
       default:
-        title: MDテキストブロック
+        title: マークダウンテキストブロック
         fields:
           src:
             title: コンテンツ

--- a/web/src/services/i18n/translations/ja.yml
+++ b/web/src/services/i18n/translations/ja.yml
@@ -89,7 +89,7 @@ Project Alias *: プロジェクト別名 *
 'Used to create the project URL. Only lowercase letters, numbers, and hyphens are allowed. Example: https://reearth.io/team-alias/project-alias': >-
   プロジェクトURLの作成に使用されます。小文字の英字、数字、ハイフンのみ使用可能です。例:
   https://reearth.io/team-alias/project-alias
-Project Visibility *: プロジェクトの可視性 *
+Project Visibility *: プロジェクトの公開範囲 *
 For Open & Public projects, anyone can view the project. For Private projects, only members of the workspace can see it.: オープンおよび公開プロジェクトでは、誰でもプロジェクトを閲覧できます。非公開プロジェクトでは、ワークスペースのメンバーのみが閲覧できます。
 Description: 説明
 Write down your content: 内容を書き込む
@@ -99,7 +99,7 @@ Your project will be moved to Recycle Bin.: プロジェクトはゴミ箱に移
 This means the project will no longer be published. But you can still see and recover your project from the Recycle bin.: これによりプロジェクトは公開されなくなりますが、ゴミ箱から閲覧と復元が可能です。
 Change Visibility: 表示を変更する
 Confirm visibility: 表示を確認する
-Project Visibility: プロジェクトの可視性
+Project Visibility: プロジェクトの公開範囲
 Private projects are only available on paid plans. Please upgrade your plan.: 非公開プロジェクトは有料プランでのみ利用可能です。プランをアップグレードしてください。
 Starred: スター付き
 No Project in Recycle bin.: ゴミ箱にプロジェクトはありません。
@@ -405,7 +405,7 @@ Most project settings are hidden when the project is archived. Please unarchive 
 Basic settings: 基本設定
 Thumbnail: サムネイル画像
 Danger Zone: 重要操作
-Change project visibility: プロジェクトの可視性を変更
+Change project visibility: プロジェクトの公開範囲を変更
 You can choose whether your project is Public or Private.: あなたのプロジェクトを公開または非公開にすることができます。
 Public projects are visible to everyone and can be discovered by others.: 公開プロジェクトは誰でも閲覧可能で、他の人に発見されることがあります。
 Private projects are only accessible to members of the workspace and are available only for workspaces on a paid plan.: 非公開プロジェクトはワークスペースのメンバーのみがアクセスでき、有料プランのワークスペースでのみ利用可能です。


### PR DESCRIPTION
- Revises the Japanese translations to use "公開範囲" instead of "可視性" for project visibility-related terms. 
- Improves clarity and consistency in the UI by aligning terminology with intended meaning.
- Updates "MD Text" English and Japanese translation