### PR TITLE
feat(server): migration add default dataAttribution for mobile

### DIFF
--- a/server/internal/infrastructure/mongo/migration/250822121249_add_default_data_attribution_for_mobile.go
+++ b/server/internal/infrastructure/mongo/migration/250822121249_add_default_data_attribution_for_mobile.go
@@ -1,0 +1,220 @@
+package migration
+
+import (
+	"context"
+	"errors"
+
+	"github.com/reearth/reearth/server/internal/infrastructure/mongo"
+	"github.com/reearth/reearth/server/internal/usecase/interactor"
+	"github.com/reearth/reearth/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth/server/internal/usecase/repo"
+	"github.com/reearth/reearth/server/pkg/id"
+	"github.com/reearth/reearth/server/pkg/plugin"
+	"github.com/reearth/reearth/server/pkg/property"
+	"github.com/reearth/reearth/server/pkg/scene"
+	"github.com/reearth/reearthx/rerror"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+type DataAttribution struct {
+	sceneRepo    repo.Scene
+	propertyRepo repo.Property
+	pluginRepo   repo.Plugin
+}
+
+func NewDataAttribution(c DBClient) *DataAttribution {
+	return &DataAttribution{
+		sceneRepo:    mongo.NewScene(c),
+		propertyRepo: mongo.NewProperty(c),
+		pluginRepo:   mongo.NewPlugin(c),
+	}
+}
+
+func AddDefaultDataAttributionForMobile(ctx context.Context, c DBClient) error {
+	migration := NewDataAttribution(c)
+	return migration.Do(ctx, c)
+}
+
+func (m *DataAttribution) Do(ctx context.Context, c DBClient) error {
+	filter := bson.M{
+		"alignsystems": bson.M{"$exists": true},
+	}
+	collection := c.WithCollection("scene").Client()
+
+	cur, err := collection.Find(ctx, filter)
+	if err != nil {
+		return err
+	}
+	defer cur.Close(ctx)
+
+	for cur.Next(ctx) {
+		var doc bson.M
+		if err := cur.Decode(&doc); err != nil {
+			continue
+		}
+		idStr, ok := doc["id"].(string)
+		if !ok {
+			continue
+		}
+
+		sceID, err := id.SceneIDFrom(idStr)
+		if err != nil {
+			continue
+		}
+
+		sce, err := m.sceneRepo.FindByID(ctx, sceID)
+		if err != nil {
+			continue
+		}
+
+		widget, location, err := m.buildDataAttribution(ctx, sceID)
+		if err != nil {
+			return err
+		}
+		// Type Mobile Attribution
+		sce.Widgets().Add(widget)
+
+		if location != nil {
+			// Type Mobile Location
+			sce.Widgets().Alignment().System(scene.WidgetAlignSystemTypeMobile).Area(*location).Add(widget.ID(), -1)
+		}
+
+		if err = m.sceneRepo.Save(ctx, sce); err != nil {
+			continue
+		}
+	}
+
+	return cur.Err()
+}
+
+func Filter(s id.SceneID) repo.SceneFilter {
+	return repo.SceneFilter{Readable: id.SceneIDList{s}, Writable: id.SceneIDList{s}}
+}
+
+func (m *DataAttribution) getWidgePlugin(ctx context.Context, pid id.PluginID, eid id.PluginExtensionID, readableFilter *repo.SceneFilter) (*plugin.Extension, error) {
+	var pr *plugin.Plugin
+	var err error
+	if readableFilter == nil {
+		pr, err = m.pluginRepo.FindByID(ctx, pid)
+	} else {
+		pr, err = m.pluginRepo.Filtered(*readableFilter).FindByID(ctx, pid)
+	}
+	if err != nil {
+		if errors.Is(err, rerror.ErrNotFound) {
+			return nil, interactor.ErrPluginNotFound
+		}
+		return nil, err
+	}
+	extension := pr.Extension(eid)
+	if extension == nil {
+		return nil, interactor.ErrExtensionNotFound
+	}
+	if extension.Type() != plugin.ExtensionTypeWidget {
+		return nil, interfaces.ErrExtensionTypeMustBeWidget
+	}
+	return extension, nil
+}
+
+func (m *DataAttribution) addNewProperty(ctx context.Context, schemaID id.PropertySchemaID, sceneID id.SceneID, filter *repo.SceneFilter) (*property.Property, error) {
+	prop, err := property.New().NewID().Schema(schemaID).Scene(sceneID).Build()
+	if err != nil {
+		return nil, err
+	}
+	if filter == nil {
+		if err = m.propertyRepo.Save(ctx, prop); err != nil {
+			return nil, err
+		}
+	} else {
+		if err = m.propertyRepo.Filtered(*filter).Save(ctx, prop); err != nil {
+			return nil, err
+		}
+	}
+	return prop, nil
+}
+
+func (m *DataAttribution) getWidgePluginWithID(ctx context.Context, pid string, eid string, readableFilter *repo.SceneFilter) (*id.PluginID, *id.PluginExtensionID, *plugin.Extension, error) {
+	pluginID, err := id.PluginIDFrom(pid)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	extensionID := id.PluginExtensionID(eid)
+	extension, err := m.getWidgePlugin(ctx, pluginID, extensionID, readableFilter)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return &pluginID, &extensionID, extension, nil
+}
+
+func (m *DataAttribution) buildDataAttribution(ctx context.Context, sceneID id.SceneID) (*scene.Widget, *scene.WidgetLocation, error) {
+	filter := Filter(sceneID)
+
+	pluginID, extensionID, extension, err := m.getWidgePluginWithID(ctx, "reearth", "dataAttribution", &filter)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	prop, err := m.addNewProperty(ctx, extension.Schema(), sceneID, &filter)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	extended := false
+	floating := false
+	var specifiedLocation *plugin.WidgetLocation
+	if widgetLayout := extension.WidgetLayout(); widgetLayout != nil {
+		extended = widgetLayout.Extended()
+		floating = widgetLayout.Floating()
+		specifiedLocation = widgetLayout.DefaultLocation()
+	}
+
+	widget, err := scene.NewWidget(
+		id.NewWidgetID(),
+		*pluginID,
+		*extensionID,
+		prop.ID(),
+		true,
+		extended,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var location *scene.WidgetLocation
+	if !floating {
+		if specifiedLocation != nil {
+			location = &scene.WidgetLocation{
+				Zone:    scene.WidgetZoneType(specifiedLocation.Zone),
+				Section: scene.WidgetSectionType(specifiedLocation.Section),
+				Area:    scene.WidgetAreaType(specifiedLocation.Area),
+			}
+		} else {
+			location = &scene.WidgetLocation{
+				Zone:    scene.WidgetZoneOuter,
+				Section: scene.WidgetSectionLeft,
+				Area:    scene.WidgetAreaTop,
+			}
+		}
+	}
+
+	return widget, location, nil
+}
+
+func GetWidgePlugin(ctx context.Context, c DBClient, pid id.PluginID, eid id.PluginExtensionID, readableFilter *repo.SceneFilter) (*plugin.Extension, error) {
+	migration := NewDataAttribution(c)
+	return migration.getWidgePlugin(ctx, pid, eid, readableFilter)
+}
+
+func AddNewProperty(ctx context.Context, c DBClient, schemaID id.PropertySchemaID, sceneID id.SceneID, filter *repo.SceneFilter) (*property.Property, error) {
+	migration := NewDataAttribution(c)
+	return migration.addNewProperty(ctx, schemaID, sceneID, filter)
+}
+
+func GetWidgePluginWithID(ctx context.Context, c DBClient, pid string, eid string, readableFilter *repo.SceneFilter) (*id.PluginID, *id.PluginExtensionID, *plugin.Extension, error) {
+	migration := NewDataAttribution(c)
+	return migration.getWidgePluginWithID(ctx, pid, eid, readableFilter)
+}
+
+func BuildDataAttribution(ctx context.Context, c DBClient, sceneID id.SceneID) (*scene.Widget, *scene.WidgetLocation, error) {
+	migration := NewDataAttribution(c)
+	return migration.buildDataAttribution(ctx, sceneID)
+}

--- a/server/internal/infrastructure/mongo/migration/250822121249_add_default_data_attribution_for_mobile_test.go
+++ b/server/internal/infrastructure/mongo/migration/250822121249_add_default_data_attribution_for_mobile_test.go
@@ -1,0 +1,108 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	mongo2 "github.com/reearth/reearth/server/internal/infrastructure/mongo"
+	"github.com/reearth/reearth/server/pkg/id"
+	"github.com/reearth/reearthx/mongox"
+	"github.com/reearth/reearthx/mongox/mongotest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// go test -v -run TestAddDefaultDataAttributionForMobile ./internal/infrastructure/mongo/migration/...
+
+func TestAddDefaultDataAttributionForMobile(t *testing.T) {
+	t.Parallel()
+
+	db := mongotest.Connect(t)(t)
+	c := mongox.NewClientWithDatabase(db)
+	ctx := context.Background()
+
+	// Get scene collection
+	sceneCollection := c.WithCollection("scene").Client()
+
+	// Create DataAttribution migration instance
+	migration := &DataAttribution{
+		// Initialize with necessary dependencies
+		sceneRepo:    mongo2.NewScene(c),
+		propertyRepo: mongo2.NewProperty(c),
+		pluginRepo:   mongo2.NewPlugin(c),
+	}
+
+	// Setup test data
+	testScenes := createTestScenes(t, ctx, sceneCollection)
+
+	// Verify initial state: confirm that widgets don't exist
+	for _, sceneID := range testScenes {
+		var scene bson.M
+		err := sceneCollection.FindOne(ctx, bson.M{"id": sceneID.String()}).Decode(&scene)
+		require.NoError(t, err)
+
+		// Check if widgets field exists and is empty
+		if widgets, exists := scene["widgets"]; exists {
+			assert.Empty(t, widgets, "Widgets should not exist in initial state")
+		}
+	}
+
+	// Execute migration
+	err := migration.Do(ctx, c)
+	assert.NoError(t, err, "Migration should complete without errors")
+
+	// Verify results: confirm that widgets have been added to each scene
+	for _, sceneID := range testScenes {
+		verifyWidgetAdded(t, ctx, sceneCollection, sceneID)
+	}
+}
+
+// Helper functions
+
+// createTestScenes creates multiple test scenes and adds records with alignSystems to DB
+func createTestScenes(t *testing.T, ctx context.Context, collection *mongo.Collection) []id.SceneID {
+	var sceneIDs []id.SceneID
+
+	// Create 3 test scenes
+	for i := 0; i < 3; i++ {
+		sceneID := id.NewSceneID()
+		sceneIDs = append(sceneIDs, sceneID)
+
+		// Add scene to DB as record with alignSystems
+		_, err := collection.InsertOne(ctx, bson.M{
+			"id":           sceneID.String(),
+			"alignsystems": bson.M{"mobile": true, "desktop": true},
+		})
+		require.NoError(t, err)
+	}
+
+	return sceneIDs
+}
+
+// verifyWidgetAdded confirms that widgets have been added to the scene
+func verifyWidgetAdded(t *testing.T, ctx context.Context, collection *mongo.Collection, sceneID id.SceneID) {
+	var scene bson.M
+	err := collection.FindOne(ctx, bson.M{"id": sceneID.String()}).Decode(&scene)
+	require.NoError(t, err, "Failed to get scene")
+
+	// Check if widgets have been added
+	if widgets, exists := scene["widgets"]; !exists {
+		t.Logf("No widgets field found in scene %s (possibly due to plugin not configured)", sceneID)
+		return
+	} else if widgetList, ok := widgets.([]interface{}); !ok || len(widgetList) == 0 {
+		t.Logf("No widgets added to scene %s (possibly due to plugin not configured)", sceneID)
+		return
+	} else {
+		// Verify widgets if they exist
+		assert.NotEmpty(t, widgetList, "Widgets should be added")
+		t.Logf("Scene %s has %d widgets", sceneID, len(widgetList))
+	}
+
+	// Check alignment systems
+	if alignSystems, exists := scene["alignsystems"]; exists {
+		t.Logf("Scene %s has alignment systems configured", sceneID)
+		assert.NotNil(t, alignSystems)
+	}
+}

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -35,4 +35,5 @@ var migrations = migration.Migrations[DBClient]{
   250725133631: SetPhotoOverlayDefault,
   250725145932: ConvertNonValidProjectAliases,
   250820145437: MultipleWidgetAlignSystems,
+  250822121249: AddDefaultDataAttributionForMobile,
 }

--- a/server/internal/usecase/interactor/scene.go
+++ b/server/internal/usecase/interactor/scene.go
@@ -207,26 +207,55 @@ func (i *Scene) addDefaultVisualizerTilesProperty(ctx context.Context, sceneID i
 	return prop, nil
 }
 
-func (i *Scene) addDefaultExtensionWidget(ctx context.Context, sceneID id.SceneID, res *scene.Scene) error {
+func (i *Scene) addDefaultExtensionWidget(ctx context.Context, sceneID id.SceneID, sce *scene.Scene) error {
+
+	widget, location, err := i.buidDataAttribution(ctx, sceneID)
+	if err != nil {
+		return err
+	}
+	// Type Desktop Attribution
+	sce.Widgets().Add(widget)
+
+	if location != nil {
+		// Type Desktop Location
+		sce.Widgets().Alignment().System(scene.WidgetAlignSystemTypeDesktop).Area(*location).Add(widget.ID(), -1)
+	}
+
+	widget, location, err = i.buidDataAttribution(ctx, sceneID)
+	if err != nil {
+		return err
+	}
+	// Type Mobile Attribution
+	sce.Widgets().Add(widget)
+
+	if location != nil {
+		// Type Mobile Location
+		sce.Widgets().Alignment().System(scene.WidgetAlignSystemTypeMobile).Area(*location).Add(widget.ID(), -1)
+	}
+
+	return nil
+}
+
+func (i *Scene) buidDataAttribution(ctx context.Context, sceneID id.SceneID) (*scene.Widget, *scene.WidgetLocation, error) {
 	filter := Filter(sceneID)
 
 	pluginID, extensionID, extension, err := i.getWidgePluginWithID(ctx, "reearth", "dataAttribution", &filter)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	prop, err := i.addNewProperty(ctx, extension.Schema(), sceneID, &filter)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	extended := false
 	floating := false
-	var location *plugin.WidgetLocation
+	var specifiedLocation *plugin.WidgetLocation
 	if widgetLayout := extension.WidgetLayout(); widgetLayout != nil {
 		extended = widgetLayout.Extended()
 		floating = widgetLayout.Floating()
-		location = widgetLayout.DefaultLocation()
+		specifiedLocation = widgetLayout.DefaultLocation()
 	}
 
 	widget, err := scene.NewWidget(
@@ -238,30 +267,27 @@ func (i *Scene) addDefaultExtensionWidget(ctx context.Context, sceneID id.SceneI
 		extended,
 	)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
-	res.Widgets().Add(widget)
+	var location *scene.WidgetLocation
 	if !floating {
-		var loc scene.WidgetLocation
-		if location != nil {
-			loc = scene.WidgetLocation{
-				Zone:    scene.WidgetZoneType(location.Zone),
-				Section: scene.WidgetSectionType(location.Section),
-				Area:    scene.WidgetAreaType(location.Area),
+		if specifiedLocation != nil {
+			location = &scene.WidgetLocation{
+				Zone:    scene.WidgetZoneType(specifiedLocation.Zone),
+				Section: scene.WidgetSectionType(specifiedLocation.Section),
+				Area:    scene.WidgetAreaType(specifiedLocation.Area),
 			}
 		} else {
-			loc = scene.WidgetLocation{
+			location = &scene.WidgetLocation{
 				Zone:    scene.WidgetZoneOuter,
 				Section: scene.WidgetSectionLeft,
 				Area:    scene.WidgetAreaTop,
 			}
 		}
-		res.Widgets().Alignment().System(scene.WidgetAlignSystemTypeDesktop).Area(loc).Add(widget.ID(), -1)
-		res.Widgets().Alignment().System(scene.WidgetAlignSystemTypeMobile).Area(loc).Add(widget.ID(), -1)
 	}
 
-	return nil
+	return widget, location, nil
 }
 
 func (i *Scene) AddWidget(ctx context.Context, _type scene.WidgetAlignSystemType, sid id.SceneID, pid id.PluginID, eid id.PluginExtensionID, operator *usecase.Operator) (_ *scene.Scene, widget *scene.Widget, err error) {


### PR DESCRIPTION
# Overview

### Add a migration to include dataAttribution in the mobile WidgetAlignSystem.
### 🔔This adds dataAttribution to the previous migration.

## What I've done

### The position where it will be added is the same as the desktop: outer.left.bottom.widgetids.

```
"mobile": {
  "outer": {
    "left": {
      "bottom": {
        "widgetids": [
          "01k37vx1558wzbcfvk1nfrtjja"
        ],
      }
    },
  }
}
```

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
