### PR TITLE
chore(server): Error due to Project Export Failure

### DIFF
--- a/server/internal/adapter/gql/resolver_mutation_project.go
+++ b/server/internal/adapter/gql/resolver_mutation_project.go
@@ -199,8 +199,15 @@ func (r *mutationResolver) ExportProject(ctx context.Context, input gqlmodel.Exp
 		"project":   prj.ID().String(),
 		"timestamp": time.Now().Format(time.RFC3339),
 	}
-
-	err = uc.Project.UploadExportProjectZip(ctx, zipWriter, zipFile, Normalize(exportData), prj)
+	b, err := json.Marshal(exportData)
+	if err != nil {
+		return nil, fmt.Errorf("Fail normalize export data marshal: %w", err)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(b, &data); err != nil {
+		return nil, fmt.Errorf("Fail normalize export data unmarshal: %w", err)
+	}
+	err = uc.Project.UploadExportProjectZip(ctx, zipWriter, zipFile, data, prj)
 	if err != nil {
 		return nil, errors.New("Fail UploadExportProjectZip :" + err.Error())
 	}
@@ -208,14 +215,4 @@ func (r *mutationResolver) ExportProject(ctx context.Context, input gqlmodel.Exp
 	return &gqlmodel.ExportProjectPayload{
 		ProjectDataPath: "/export/" + zipFile.Name(),
 	}, nil
-}
-
-func Normalize(data any) map[string]any {
-	if b, err := json.Marshal(data); err == nil {
-		var result map[string]any
-		if err := json.Unmarshal(b, &result); err == nil {
-			return result
-		}
-	}
-	return nil
 }

--- a/server/internal/adapter/internalapi/server.go
+++ b/server/internal/adapter/internalapi/server.go
@@ -458,7 +458,15 @@ func (s server) ExportProject(ctx context.Context, req *pb.ExportProjectRequest)
 		"timestamp": time.Now().Format(time.RFC3339),
 	}
 
-	err = uc.Project.UploadExportProjectZip(ctx, zipWriter, zipFile, Normalize(exportData), prj)
+	b, err := json.Marshal(exportData)
+	if err != nil {
+		return nil, fmt.Errorf("Fail normalize export data marshal: %w", err)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(b, &data); err != nil {
+		return nil, fmt.Errorf("Fail normalize export data unmarshal: %w", err)
+	}
+	err = uc.Project.UploadExportProjectZip(ctx, zipWriter, zipFile, data, prj)
 	if err != nil {
 		return nil, errors.New("Fail UploadExportProjectZip :" + err.Error())
 	}
@@ -558,16 +566,6 @@ func (s server) DeleteByProjectAlias(ctx context.Context, req *pb.DeleteByProjec
 		ProjectAlias: req.ProjectAlias,
 	}, nil
 
-}
-
-func Normalize(data any) map[string]any {
-	if b, err := json.Marshal(data); err == nil {
-		var result map[string]any
-		if err := json.Unmarshal(b, &result); err == nil {
-			return result
-		}
-	}
-	return nil
 }
 
 func (s server) getScenesAndStorytellings(ctx context.Context, res []*project.Project) ([]*pb.Project, error) {


### PR DESCRIPTION
# Overview
### Error due to Project Export Failure
## What I've done


### During project export, there are cases where marshal/unmarshal fails because of data issues.
### Currently, the error is being ignored, so we will modify it to explicitly return an error.

### This includes past cases where characters such as backslashes \ were present.


## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
