### PR TITLE
fix(web): type missing on project public settings

### DIFF
--- a/web/src/app/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
+++ b/web/src/app/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
@@ -32,7 +32,7 @@ import {
 } from ".";
 
 interface WithTypename {
-  type?: "project" | "story";
+  type: "project" | "story";
 }
 
 export type SettingsProjectWithTypename = SettingsProject & WithTypename;
@@ -273,7 +273,10 @@ const PublicSettingsDetail: FC<Props> = ({
                 {...(settingsItem.type === "project"
                   ? {
                       projectId: settingsItem.id,
-                      projectAlias: "scene" in settingsItem ? settingsItem.scene?.alias : undefined
+                      projectAlias:
+                        "scene" in settingsItem
+                          ? settingsItem.scene?.alias
+                          : undefined
                     }
                   : {
                       storyId: settingsItem.id,

--- a/web/src/app/features/ProjectSettings/innerPages/PublicSettings/index.tsx
+++ b/web/src/app/features/ProjectSettings/innerPages/PublicSettings/index.tsx
@@ -1,5 +1,5 @@
 import { Story } from "@reearth/services/api/storytellingApi/utils";
-import { FC } from "react";
+import { FC, useMemo } from "react";
 
 import { InnerPage, SettingsWrapper, ArchivedSettingNotice } from "../common";
 
@@ -76,16 +76,26 @@ const PublicSettings: FC<Props> = ({
   onUpdateProjectAlias,
   onUpdateProjectGA
 }) => {
+  const projectSettingsItem = useMemo(
+    () => ({ ...project, type: "project" as const }),
+    [project]
+  );
+  const storySettingsItem = useMemo(
+    () =>
+      currentStory ? { ...currentStory, type: "story" as const } : undefined,
+    [currentStory]
+  );
+
   return (
     <InnerPage wide>
       <SettingsWrapper>
         {project.isArchived ? (
           <ArchivedSettingNotice />
-        ) : isStory && currentStory ? (
+        ) : isStory && storySettingsItem ? (
           <PublicSettingsDetail
             key={currentStory?.id}
             isStory
-            settingsItem={currentStory as Story}
+            settingsItem={storySettingsItem}
             onUpdate={onUpdateStory}
             onUpdateBasicAuth={onUpdateStory}
             onUpdateAlias={onUpdateStoryAlias}
@@ -94,7 +104,7 @@ const PublicSettings: FC<Props> = ({
         ) : project ? (
           <PublicSettingsDetail
             key="map"
-            settingsItem={project}
+            settingsItem={projectSettingsItem}
             sceneId={sceneId}
             onUpdate={onUpdateProject}
             onUpdateBasicAuth={onUpdateProjectBasicAuth}


### PR DESCRIPTION
# Overview

`type` was missing on settingsItem, leading to the extension cannot be loaded.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
