### PR TITLE
fix(server): story publishing isn't working

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -3,9 +3,9 @@ PORT=8080
 REEARTH_DB=mongodb://localhost     # for reearth database url
 REEARTH_DB_ACCOUNT=reearth_account # for reearth account database name
 REEARTH_DB_VIS=reearth             # for reearth visualizer database name
-REEARTH_HOST=https://localhost:8080
-REEARTH_HOST_WEB=https://localhost:3000
-REEARTH_ASSETBASEURL=https://localhost:8080/assets
+REEARTH_HOST=http://localhost:8080
+REEARTH_HOST_WEB=http://localhost:3000
+REEARTH_ASSETBASEURL=http://localhost:8080/assets
 REEARTH_DEV=false
 
 # GCP
@@ -82,6 +82,8 @@ REEARTH_SES_NAME=
 #REEARTH_S3_PUBLICATIONCACHECONTROL=
 
 # Storage Google GCS
+# if you want to use fake gcs on local, please set true on REEARTH_USE_FAKE_GCS
+#REEARTH_GCS_ISFAKE=false
 #REEARTH_GCS_BUCKETNAME=bucket_name
 #REEARTH_GCS_PUBLICATIONCACHECONTROL=
 
@@ -110,3 +112,9 @@ REEARTH_VISUALIZER_POLICY_CHECKER_TOKEN=''
 # "http": Uses external HTTP service for policy validation (requires Endpoint)
 # "permissive" (default): Allows all operations without restrictions (OSS mode)
 REEARTH_VISUALIZER_POLICY_CHECKER_TYPE=permissive
+
+# CORS config
+# Comma-separated list of allowed origins for CORS. Use '*' to allow all origins.
+#REEARTH_VISUALIZER_DOMAINCHECHECKER_TYPE=http
+#REEARTH_VISUALIZER_DOMAINCHECHECKER_ENDURL=http://localhost/api/internal/domain
+#REEARTH_VISUALIZER_DOMAINCHECHECKER_TOKEN=token

--- a/server/internal/app/config/file.go
+++ b/server/internal/app/config/file.go
@@ -1,6 +1,7 @@
 package config
 
 type GCSConfig struct {
+	IsFake                  bool   `pp:",omitempty"`
 	BucketName              string `pp:",omitempty"`
 	PublicationCacheControl string `pp:",omitempty"`
 }

--- a/server/internal/app/internal/middleware/assets_cors_middleware.go
+++ b/server/internal/app/internal/middleware/assets_cors_middleware.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"net/http"
 	"net/url"
 	"strings"
 
@@ -14,9 +13,7 @@ func AssetsCORSMiddleware(domainChecker gateway.DomainChecker, allowedOrigins []
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			origin := c.Request().Header.Get("Origin")
-			if origin == "" {
-				return c.NoContent(http.StatusBadRequest)
-			}
+
 			allowedOrigin := ""
 			for _, allowed := range allowedOrigins {
 				if allowed == origin {

--- a/server/internal/app/internal/middleware/assets_cors_middleware_test.go
+++ b/server/internal/app/internal/middleware/assets_cors_middleware_test.go
@@ -24,7 +24,7 @@ func (m *mockDomainChecker) CheckDomain(ctx context.Context, req gateway.DomainC
 }
 
 func TestAssetsCORSMiddleware(t *testing.T) {
-	t.Run("no origin header returns bad request", func(t *testing.T) {
+	t.Run("no origin header continues without CORS headers", func(t *testing.T) {
 		e := echo.New()
 		req := httptest.NewRequest("GET", "/", nil)
 		rec := httptest.NewRecorder()
@@ -40,7 +40,11 @@ func TestAssetsCORSMiddleware(t *testing.T) {
 
 		err := h(c)
 		assert.NoError(t, err)
-		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+		assert.Empty(t, rec.Header().Get("Access-Control-Allow-Methods"))
+		assert.Empty(t, rec.Header().Get("Access-Control-Allow-Headers"))
+		assert.Empty(t, rec.Header().Get("Access-Control-Max-Age"))
 	})
 
 	t.Run("origin in allowed list", func(t *testing.T) {
@@ -184,7 +188,7 @@ func TestAssetsCORSMiddleware(t *testing.T) {
 			assert.Equal(t, "86400", rec.Header().Get("Access-Control-Max-Age"))
 		})
 
-		t.Run("returns bad request when no origin header", func(t *testing.T) {
+		t.Run("continues without CORS headers when no origin header", func(t *testing.T) {
 			e := echo.New()
 			req := httptest.NewRequest("OPTIONS", "/", nil)
 			rec := httptest.NewRecorder()
@@ -200,7 +204,11 @@ func TestAssetsCORSMiddleware(t *testing.T) {
 
 			err := h(c)
 			assert.NoError(t, err)
-			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+			assert.Empty(t, rec.Header().Get("Access-Control-Allow-Methods"))
+			assert.Empty(t, rec.Header().Get("Access-Control-Allow-Headers"))
+			assert.Empty(t, rec.Header().Get("Access-Control-Max-Age"))
 		})
 	})
 

--- a/server/internal/app/repo.go
+++ b/server/internal/app/repo.go
@@ -154,9 +154,8 @@ func initReposAndGateways(ctx context.Context, conf *config.Config, debug bool) 
 func initFile(ctx context.Context, conf *config.Config) (fileRepo gateway.File) {
 	var err error
 	if conf.GCS.IsConfigured() {
-		log.Infofc(ctx, "file: GCS storage is used: %s\n", conf.GCS.BucketName)
-		log.Infofc(ctx, "file: GCS storage base URL: %s\n", conf.AssetBaseURL)
-		fileRepo, err = gcs.NewFile(false, conf.GCS.BucketName, conf.AssetBaseURL, conf.GCS.PublicationCacheControl)
+		isFake := conf.GCS.IsFake
+		fileRepo, err = gcs.NewFile(isFake, conf.GCS.BucketName, conf.AssetBaseURL, conf.GCS.PublicationCacheControl)
 		if err != nil {
 			log.Warnf("file: failed to init GCS storage: %s\n", err.Error())
 		}

--- a/server/internal/infrastructure/gcs/file.go
+++ b/server/internal/infrastructure/gcs/file.go
@@ -18,6 +18,7 @@ import (
 	"github.com/reearth/reearth/server/internal/usecase/gateway"
 	"github.com/reearth/reearth/server/pkg/file"
 	"github.com/reearth/reearth/server/pkg/id"
+	"github.com/reearth/reearth/server/pkg/visualizer"
 	"github.com/reearth/reearthx/log"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/spf13/afero"
@@ -33,14 +34,14 @@ const (
 )
 
 type fileRepo struct {
-	isTest          bool
+	isFake          bool
 	bucketName      string
 	base            *url.URL
 	cacheControl    string
 	baseFileStorage *infrastructure.BaseFileStorage
 }
 
-func NewFile(isTest bool, bucketName, base string, cacheControl string) (gateway.File, error) {
+func NewFile(isFake bool, bucketName, base string, cacheControl string) (gateway.File, error) {
 	if bucketName == "" {
 		return nil, errors.New("bucket name is empty")
 	}
@@ -57,7 +58,7 @@ func NewFile(isTest bool, bucketName, base string, cacheControl string) (gateway
 	}
 
 	return &fileRepo{
-		isTest:       isTest,
+		isFake:       isFake,
 		bucketName:   bucketName,
 		base:         u,
 		cacheControl: cacheControl,
@@ -301,7 +302,7 @@ func (f *fileRepo) bucket(ctx context.Context) (*storage.BucketHandle, error) {
 	var client *storage.Client
 	var err error
 
-	if f.isTest {
+	if f.isFake {
 		testGCS, err := testutil.NewGCSForTesting()
 		if err != nil {
 			return nil, err
@@ -326,13 +327,45 @@ func (f *fileRepo) bucket(ctx context.Context) (*storage.BucketHandle, error) {
 
 func (f *fileRepo) read(ctx context.Context, filename string) (io.ReadCloser, error) {
 	if filename == "" {
+		visualizer.WarnWithCallerLogging(ctx, "gcs: read filename is empty")
 		return nil, rerror.ErrNotFound
 	}
 
 	bucket, err := f.bucket(ctx)
 	if err != nil {
-		log.Errorfc(ctx, "gcs: read bucket err: %+v\n", err)
-		return nil, rerror.ErrInternalByWithContext(ctx, err)
+		return nil, visualizer.ErrorWithCallerLogging(ctx, "gcs: read bucket err", rerror.ErrInternalByWithContext(ctx, err))
+	}
+
+	_, err = bucket.Object(filename).Attrs(ctx)
+	if err != nil && errors.Is(err, storage.ErrObjectNotExist) {
+		visualizer.WarnWithCallerLogging(ctx, "gcs: read attrs err")
+		return nil, rerror.ErrNotFound
+	}
+
+	if err != nil {
+		return nil, visualizer.ErrorWithCallerLogging(ctx, "gcs: read attrs err", rerror.ErrInternalByWithContext(ctx, err))
+	}
+
+	// Note:
+	// fsouza/fake-gcs-server can't read object by Reader.
+	// so we need to download it from the server directly.
+	if f.isFake {
+		u := fmt.Sprintf("http://%s/download/storage/v1/b/%s/o/%s?alt=media",
+			strings.TrimRight("localhost:4443", "/"),
+			url.PathEscape(bucket.BucketName()),
+			url.PathEscape(filename),
+		)
+
+		resp, err := http.Get(u)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			return nil, visualizer.ErrorWithCallerLogging(ctx, "gcs: read fake object err", fmt.Errorf("emu GET failed: status=%d body=%s", resp.StatusCode, string(body)))
+		}
+		return resp.Body, nil
 	}
 
 	reader, err := bucket.Object(filename).NewReader(ctx)
@@ -340,8 +373,7 @@ func (f *fileRepo) read(ctx context.Context, filename string) (io.ReadCloser, er
 		if errors.Is(err, storage.ErrObjectNotExist) {
 			return nil, rerror.ErrNotFound
 		}
-		log.Errorfc(ctx, "gcs: read err: %+v\n", err)
-		return nil, rerror.ErrInternalByWithContext(ctx, err)
+		return nil, visualizer.ErrorWithCallerLogging(ctx, "gcs: read object err", rerror.ErrInternalByWithContext(ctx, err))
 	}
 
 	return reader, nil

--- a/server/internal/usecase/interactor/published.go
+++ b/server/internal/usecase/interactor/published.go
@@ -109,7 +109,7 @@ func (i *Published) Data(ctx context.Context, name string) (io.Reader, error) {
 		return r, nil
 	}
 
-	return nil, visualizer.ErrorWithCallerLogging(ctx, "published: read built scene file", rerror.ErrNotFound)
+	return nil, visualizer.ErrorWithCallerLogging(ctx, "published: no data file found", rerror.ErrNotFound)
 }
 
 func (i *Published) Index(ctx context.Context, name string, u *url.URL) (string, error) {

--- a/server/internal/usecase/interactor/published.go
+++ b/server/internal/usecase/interactor/published.go
@@ -16,6 +16,7 @@ import (
 	"github.com/reearth/reearth/server/internal/usecase/gateway"
 	"github.com/reearth/reearth/server/internal/usecase/interfaces"
 	"github.com/reearth/reearth/server/internal/usecase/repo"
+	"github.com/reearth/reearth/server/pkg/visualizer"
 	"github.com/reearth/reearthx/log"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/reearth/reearthx/util"
@@ -73,6 +74,7 @@ func NewPublishedWithURL(project repo.Project, storytelling repo.Storytelling, f
 func (i *Published) Metadata(ctx context.Context, name string) (interfaces.PublishedMetadata, error) {
 	prj, err := i.project.FindByPublicName(ctx, name)
 	if err != nil && !errors.Is(err, rerror.ErrNotFound) {
+		log.Warnfc(ctx, "published metadata: find by public name err: %s", err)
 		return interfaces.PublishedMetadata{}, err
 	}
 
@@ -93,7 +95,7 @@ func (i *Published) Metadata(ctx context.Context, name string) (interfaces.Publi
 func (i *Published) Data(ctx context.Context, name string) (io.Reader, error) {
 	r, err := i.file.ReadBuiltSceneFile(ctx, name)
 	if err != nil && err != rerror.ErrNotFound {
-		return nil, err
+		return nil, visualizer.ErrorWithCallerLogging(ctx, "published: read built scene file", err)
 	}
 	if r != nil {
 		return r, nil
@@ -101,12 +103,13 @@ func (i *Published) Data(ctx context.Context, name string) (io.Reader, error) {
 
 	r, err = i.file.ReadStoryFile(ctx, name)
 	if err != nil && err != rerror.ErrNotFound {
-		return nil, err
+		return nil, visualizer.ErrorWithCallerLogging(ctx, "published: read story file", err)
 	}
 	if r != nil {
 		return r, nil
 	}
-	return nil, rerror.ErrNotFound
+
+	return nil, visualizer.ErrorWithCallerLogging(ctx, "published: read built scene file", rerror.ErrNotFound)
 }
 
 func (i *Published) Index(ctx context.Context, name string, u *url.URL) (string, error) {


### PR DESCRIPTION
# Overview
- allow origin empty case because html img tag can't read image.
   - we can fix front end to read img with origin by adding [attr](https://developer.mozilla.org/ja/docs/Web/HTML/Reference/Elements/img#crossorigin)  
- use `visualizer.WarnWithCallerLogging` to clear error cause.
- fix `file/gcs.go` to works fine to read file on fake-gcs
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
