### PR TITLE
feat(server): Allow access from storage trigger [VIZ-2232]

### DIFF
--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -153,8 +153,8 @@ func initEcho(ctx context.Context, cfg *ServerConfig) *echo.Echo {
 
 	serveFiles(e, allowedOrigins(cfg), cfg.Gateways.DomainChecker, cfg.Gateways.File)
 
-	servSplitUploadFiles(e, cfg.Gateways.File)
-	servSignatureUploadFiles(e, cfg.Gateways.File)
+	servSplitUploadFiles(e, cfg)
+	servSignatureUploadFiles(e, cfg)
 
 	(&WebHandler{
 		Disabled:    cfg.Config.Web_Disabled,

--- a/server/internal/app/file_import_common.go
+++ b/server/internal/app/file_import_common.go
@@ -60,19 +60,19 @@ func SplitFilename(objectPath string) (string, *accountdomain.WorkspaceID, *id.P
 	workspaceID := parts[0]
 	wid, err := accountdomain.WorkspaceIDFrom(workspaceID)
 	if err != nil {
-		return base, nil, nil, nil, fmt.Errorf("Invalid workspace id: %v", err)
+		return base, nil, nil, nil, fmt.Errorf("invalid workspace id: %v", err)
 	}
 
 	projectID := parts[1]
 	pid, err := id.ProjectIDFrom(projectID)
 	if err != nil {
-		return base, nil, nil, nil, fmt.Errorf("Invalid project id: %v", err)
+		return base, nil, nil, nil, fmt.Errorf("invalid project id: %v", err)
 	}
 
 	userID := parts[2]
 	uid, err := accountdomain.UserIDFrom(userID)
 	if err != nil {
-		return base, nil, nil, nil, fmt.Errorf("Invalid user id: %v", err)
+		return base, nil, nil, nil, fmt.Errorf("invalid user id: %v", err)
 	}
 	return base, &wid, &pid, &uid, nil
 }

--- a/server/internal/usecase/interactor/common.go
+++ b/server/internal/usecase/interactor/common.go
@@ -3,7 +3,6 @@ package interactor
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/url"
 	"strings"
 
@@ -86,10 +85,6 @@ func (i common) CanWriteWorkspace(t accountdomain.WorkspaceID, op *usecase.Opera
 		return err
 	}
 	if !op.IsWritableWorkspace(t) {
-		fmt.Println("-----------------------2-1 ", t.String())
-		for _, v := range op.AllWritableWorkspaces() {
-			fmt.Println("-----------------------2-2 ", v.String())
-		}
 		return interfaces.ErrOperationDenied
 	}
 	return nil

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -1228,7 +1228,6 @@ var (
 
 func (i *Project) createProject(ctx context.Context, input createProjectInput, operator *usecase.Operator) (_ *project.Project, err error) {
 	if err := i.CanWriteWorkspace(input.WorkspaceID, operator); err != nil {
-		fmt.Println("----------------------- ")
 		return nil, err
 	}
 


### PR DESCRIPTION
# Overview

# Allow access from storage trigger

## What I've done

### Since access from the storage trigger does not include a token, the user cannot be identified.
### Therefore, I made the following changes:

###  1.Modified the format used when saving files received from the FE:
## {workspaceID}-{projectID}-{userID}.zip
```go
func GenFileName(workspaceID accountdomain.WorkspaceID, projectID id.ProjectID, userID accountdomain.UserID) string {
	return fmt.Sprintf("%s-%s-%s.zip", workspaceID.String(), projectID.String(), userID.String())
}
```

### 2.When access comes from the storage trigger, the operator is supplemented:
```go
return func(c echo.Context) error {
    req := c.Request()
    ctx := req.Context()
    ...
    if req.Method == "POST" && req.URL.Path == "/api/import-project" {
        _, _, _, userID, err := SplitFilename(n.CloudEventData.Name)
        ...
        u, err := cfg.AccountRepos.User.FindByID(ctx, *userID)
        ...
        op, err := generateOperator(ctx, cfg, u)
        ...
        ctx = adapter.AttachOperator(ctx, op)
```

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
