### PR TITLE
refactor(web): integrate workspace policy check to manage custom domain extension availability [VIZ-2268]

### DIFF
--- a/web/src/app/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
+++ b/web/src/app/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
@@ -181,8 +181,8 @@ const PublicSettingsDetail: FC<Props> = ({
   const workspacePolicyCheckResultData = useWorkspacePolicyCheck(
     workspace?.id ?? ""
   );
-  const disableCustomDomainExtension =
-    !workspacePolicyCheckResultData?.workspacePolicyCheck
+  const enableCustomDomainExtension =
+    !!workspacePolicyCheckResultData?.workspacePolicyCheck
       ?.enableToCreatePrivateProject;
 
   return (
@@ -275,7 +275,7 @@ const PublicSettingsDetail: FC<Props> = ({
       </SettingsFields>
       {extensions &&
         extensions.filter((ext) => ext.type === "publication").length > 0 &&
-        !disableCustomDomainExtension &&
+        enableCustomDomainExtension &&
         accessToken && (
           <SettingsFields>
             <TitleWrapper size="body" weight="bold">


### PR DESCRIPTION
# Overview

Show custom domain extension only when workspacePolicyCheck?.enableToCreatePrivateProject is true

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
