### PR TITLE
refactor(web): hide user photo when loading failed

### DIFF
--- a/web/src/app/features/Dashboard/LeftSidePanel/profile.tsx
+++ b/web/src/app/features/Dashboard/LeftSidePanel/profile.tsx
@@ -32,7 +32,7 @@ type ProfileProp = {
 export const Profile: FC<ProfileProp> = ({
   currentUser,
   isPersonal,
-  userPhotoUrl = "/123",
+  userPhotoUrl,
   workspaces,
   currentWorkspace,
   onWorkspaceChange,


### PR DESCRIPTION
# Overview

Hide user photo when loading failed to avoid display a broken image.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
