### PR TITLE
fix(web): clean up iss param

### DIFF
--- a/web/src/services/auth/useAuth.ts
+++ b/web/src/services/auth/useAuth.ts
@@ -28,6 +28,7 @@ export function useCleanUrl(): [string | undefined, boolean] {
 
     params.delete("code");
     params.delete("state");
+    params.delete("iss");
     params.delete(errorKey);
 
     const queries = params.toString();


### PR DESCRIPTION
# Overview

iss stands for Issuer, and it’s a standard OpenID Connect (OIDC) claim that identifies which identity provider (tenant/domain) issued a token or performed an action.

When Auth0 sends users back to app after certain out-of-band flows (like password reset, email verification, or magic link login), it sometimes includes ?iss=https://YOUR_DOMAIN.auth0.com/ just as informational context.
It’s not part of the normal OAuth2 redirect (which would include ?code and ?state).

- The SDK detects code and state, calls handleRedirectCallback(), exchanges them for tokens, and logs the user in.
- The iss parameter is not used at any step in this process.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
