### PR TITLE
chore: add unpinned dependency check script and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,13 @@ jobs:
             e2e/
             .github/workflows/playwright_ui_tests.yml
 
+  check-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Check for unpinned dependencies
+        run: bash script/check-unpinned-deps.sh
+
   ci-web:
     needs: prepare
     if: needs.prepare.outputs.web == 'true'
@@ -60,6 +67,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     needs:
+      - check-deps
       - ci-web
       - ci-server
     if: ${{ !failure() }}

--- a/script/check-unpinned-deps.sh
+++ b/script/check-unpinned-deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Check for unpinned dependencies in web/e2e package.json files
-# Unpinned = uses range operators (^, ~, *, >=, >, <, <=) instead of exact versions
+# Unpinned = uses range operators (^, ~, *, >=, >, <, <=), x/X wildcards, || ranges, or dist-tags (latest, next, canary) instead of exact versions
 
 set -euo pipefail
 
@@ -11,35 +11,44 @@ EXIT_CODE=0
 if [ -t 1 ]; then
   RED='\033[0;31m'
   GREEN='\033[0;32m'
-  YELLOW='\033[0;33m'
   BOLD='\033[1m'
   NC='\033[0m'
 else
-  RED='' GREEN='' YELLOW='' BOLD='' NC=''
+  RED='' GREEN='' BOLD='' NC=''
 fi
 
 header() { echo -e "\n${BOLD}=== $1 ===${NC}"; }
 ok() { echo -e "  ${GREEN}✓${NC}  $1"; }
 fail() { echo -e "  ${RED}✗${NC}  $1"; }
-warn() { echo -e "  ${YELLOW}⚠${NC}  $1"; }
 
 check_package_json() {
   local pkg="$1"
   local label="$2"
 
   if [ ! -f "$pkg" ]; then
-    warn "$label: $pkg not found, skipping"
+    fail "$label: $pkg not found"
+    EXIT_CODE=1
     return
   fi
 
   header "$label"
 
+  if ! command -v jq >/dev/null 2>&1; then
+    fail "$label: 'jq' command not found; cannot check $pkg"
+    EXIT_CODE=1
+    return
+  fi
+
   local unpinned
-  unpinned=$(jq -r '
+  if ! unpinned=$(jq -r '
     ["dependencies","devDependencies","peerDependencies","optionalDependencies"] as $sections |
-    [ $sections[] as $s | .[$s] // {} | to_entries[] | select(.value | test("[\\^~*xX]|>=|<=|>[^=]|<[^=]|\\|\\||^(latest|next|canary)$")) | "\($s)\t\(.key)\t\(.value)" ] |
+    [ $sections[] as $s | .[$s] // {} | to_entries[] | select(.value | test("[\\^~*]|>=|<=|>[^=]|<[^=]|\\|\\||^[0-9]+\\.[xX]|^(latest|next|canary)$")) | "\($s)\t\(.key)\t\(.value)" ] |
     sort[] // empty
-  ' "$pkg" 2>/dev/null || true)
+  ' "$pkg"); then
+    fail "$label: Failed to parse $pkg with jq"
+    EXIT_CODE=1
+    return
+  fi
 
   if [ -n "$unpinned" ]; then
     local count

--- a/script/check-unpinned-deps.sh
+++ b/script/check-unpinned-deps.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Check for unpinned dependencies in web/e2e package.json files
+# Unpinned = uses range operators (^, ~, *, >=, >, <, <=) instead of exact versions
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+EXIT_CODE=0
+
+# Colors (disabled if not a terminal)
+if [ -t 1 ]; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[0;33m'
+  BOLD='\033[1m'
+  NC='\033[0m'
+else
+  RED='' GREEN='' YELLOW='' BOLD='' NC=''
+fi
+
+header() { echo -e "\n${BOLD}=== $1 ===${NC}"; }
+ok() { echo -e "  ${GREEN}✓${NC}  $1"; }
+fail() { echo -e "  ${RED}✗${NC}  $1"; }
+warn() { echo -e "  ${YELLOW}⚠${NC}  $1"; }
+
+check_package_json() {
+  local pkg="$1"
+  local label="$2"
+
+  if [ ! -f "$pkg" ]; then
+    warn "$label: $pkg not found, skipping"
+    return
+  fi
+
+  header "$label"
+
+  local unpinned
+  unpinned=$(jq -r '
+    ["dependencies","devDependencies","peerDependencies","optionalDependencies"] as $sections |
+    [ $sections[] as $s | .[$s] // {} | to_entries[] | select(.value | test("[\\^~*xX]|>=|<=|>[^=]|<[^=]|\\|\\||^(latest|next|canary)$")) | "\($s)\t\(.key)\t\(.value)" ] |
+    sort[] // empty
+  ' "$pkg" 2>/dev/null || true)
+
+  if [ -n "$unpinned" ]; then
+    local count
+    count=$(echo "$unpinned" | wc -l | tr -d ' ')
+    (echo -e "SECTION\tPACKAGE\tVERSION"; echo "$unpinned") | column -t -s $'\t' | sed 's/^/  /'
+    fail "$count unpinned dependency(ies) found"
+    EXIT_CODE=1
+  else
+    ok "All dependencies pinned to exact versions"
+  fi
+}
+
+# --- Run checks ---
+echo -e "${BOLD}Dependency Pin Check${NC}"
+echo "Scanning for unpinned or unstable dependencies..."
+
+check_package_json "${REPO_ROOT}/web/package.json" "Web (web/package.json)"
+check_package_json "${REPO_ROOT}/e2e/package.json" "E2E (e2e/package.json)"
+
+echo ""
+if [ "$EXIT_CODE" -eq 0 ]; then
+  echo -e "${GREEN}${BOLD}All checks passed!${NC}"
+else
+  echo -e "${RED}${BOLD}Unpinned dependencies found. Pin them to exact versions for reproducible builds.${NC}"
+fi
+
+exit "$EXIT_CODE"


### PR DESCRIPTION
## What
Adds `script/check-unpinned-deps.sh` — a pure bash script that detects unpinned dependencies (`^`, `~`, range operators) in `web/package.json` and `e2e/package.json`. Embeds a `check-deps` job in `ci.yml` that runs on every push/PR and blocks merge via the `ci` gate.

## Why
Prevents range-versioned deps from sneaking in and breaking reproducible builds. Caught `e2e/package.json` having 21 unpinned deps (fixed in #2140).

## Changed
- `script/check-unpinned-deps.sh` — new script; uses `jq` (pre-installed on ubuntu-latest) to parse deps, `column` for aligned output
- `.github/workflows/ci.yml` — adds `check-deps` job + gates `ci` on it