### PR TITLE
chore(web): bump version to 1.0.0-beta.15.9

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reearth/visualizer",
-  "version": "1.0.0-beta.15.8",
+  "version": "1.0.0-beta.15.9",
   "repository": "https://github.com/reearth/reearth-visualizer.git",
   "author": "Re:Earth contributors <community@reearth.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Overview

## What I've done
- Bumped web version from `1.0.0-beta.15.8` to `1.0.0-beta.15.9`

## What I haven't done
- N/A

## How I tested
- Version string change only, no functional impact

## Which point I want you to review particularly
- N/A

## Memo
- N/A

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)