### PR TITLE
fix(server): prevent panic during project import with plugin schema field types

### DIFF
--- a/server/internal/adapter/gql/gqlmodel/convert_value.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_value.go
@@ -232,6 +232,14 @@ func ToPropertyValueType(t string) property.ValueType {
 		return property.ValueTypeRect
 	case ValueTypeArray.String():
 		return property.ValueTypeArray
+	case ValueTypeCamera.String():
+		return property.ValueTypeCamera
+	case ValueTypeTypography.String():
+		return property.ValueTypeTypography
+	case ValueTypeSpacing.String():
+		return property.ValueTypeSpacing
+	case ValueTypeTimeline.String():
+		return property.ValueTypeTimeline
 	default:
 		return property.ValueTypeUnknown
 	}

--- a/server/internal/adapter/gql/gqlmodel/convert_value_test.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_value_test.go
@@ -3,6 +3,7 @@ package gqlmodel
 import (
 	"testing"
 
+	"github.com/reearth/reearth/server/pkg/property"
 	"github.com/reearth/reearth/server/pkg/value"
 	"github.com/stretchr/testify/assert"
 )
@@ -10,4 +11,35 @@ import (
 func Test_FromValueType(t *testing.T) {
 	assert.Equal(t, value.TypeString, FromValueType(ValueTypeString))
 	assert.Equal(t, value.TypeNumber, FromValueType(ValueTypeNumber))
+}
+
+func Test_ToPropertyValueType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  property.ValueType
+	}{
+		{ValueTypeBool.String(), property.ValueTypeBool},
+		{ValueTypeNumber.String(), property.ValueTypeNumber},
+		{ValueTypeString.String(), property.ValueTypeString},
+		{ValueTypeRef.String(), property.ValueTypeRef},
+		{ValueTypeURL.String(), property.ValueTypeURL},
+		{ValueTypeLatlng.String(), property.ValueTypeLatLng},
+		{ValueTypeLatlngheight.String(), property.ValueTypeLatLngHeight},
+		{ValueTypeCoordinates.String(), property.ValueTypeCoordinates},
+		{ValueTypePolygon.String(), property.ValueTypePolygon},
+		{ValueTypeRect.String(), property.ValueTypeRect},
+		{ValueTypeArray.String(), property.ValueTypeArray},
+		{ValueTypeCamera.String(), property.ValueTypeCamera},
+		{ValueTypeTypography.String(), property.ValueTypeTypography},
+		{ValueTypeSpacing.String(), property.ValueTypeSpacing},
+		{ValueTypeTimeline.String(), property.ValueTypeTimeline},
+		{"UNKNOWN", property.ValueTypeUnknown},
+		{"", property.ValueTypeUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, ToPropertyValueType(tt.input))
+		})
+	}
 }

--- a/server/internal/usecase/interactor/plugin.go
+++ b/server/internal/usecase/interactor/plugin.go
@@ -279,7 +279,10 @@ func parsePropertySchemaField(fieldMap map[string]interface{}) (*property.Schema
 	if choices, ok := fieldMap["choices"].([]interface{}); ok {
 
 		for _, choice := range choices {
-			choiceMap := choice.(map[string]interface{})
+			choiceMap, ok := choice.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("parsePropertySchemaField: unexpected choice entry type %T", choice)
+			}
 
 			chBuilder := property.NewSchemaFieldChoice()
 			if v, ok := choiceMap["key"].(string); ok {
@@ -292,10 +295,17 @@ func parsePropertySchemaField(fieldMap map[string]interface{}) (*property.Schema
 				chBuilder = chBuilder.Icon(v)
 			}
 
-			chs = append(chs, *chBuilder.MustBuild())
+			ch, err := chBuilder.Build()
+			if err != nil {
+				return nil, fmt.Errorf("parsePropertySchemaField: failed to build choice: %w", err)
+			}
+			chs = append(chs, *ch)
 		}
 	}
-	fieldId := fieldMap["fieldId"].(string)
+	fieldId, ok := fieldMap["fieldId"].(string)
+	if !ok {
+		return nil, fmt.Errorf("parsePropertySchemaField: missing or invalid fieldId")
+	}
 	fid := id.PropertyFieldIDFromRef(&fieldId)
 	fiBuilder := property.NewSchemaField().ID(*fid)
 	if len(chs) > 0 {
@@ -322,8 +332,9 @@ func parsePropertySchemaField(fieldMap map[string]interface{}) (*property.Schema
 		fiBuilder = fiBuilder.Suffix(v)
 	}
 	if v, ok := fieldMap["ui"].(string); ok {
-		ui := gqlmodel.FromPropertySchemaFieldUI(&v)
-		fiBuilder = fiBuilder.UI(*ui)
+		if ui := gqlmodel.FromPropertySchemaFieldUI(&v); ui != nil {
+			fiBuilder = fiBuilder.UI(*ui)
+		}
 	}
 	if v, ok := fieldMap["min"].(float64); ok {
 		fiBuilder = fiBuilder.Min(v)
@@ -370,10 +381,16 @@ func parsePropertySchema(psid id.PropertySchemaID, schemaMap map[string]any) (*p
 		fil := make([]*property.SchemaField, 0)
 		if fields, ok := groupMap["fields"].([]any); ok {
 			for _, field := range fields {
-				fieldMap := field.(map[string]any)
+				fieldMap, ok := field.(map[string]any)
+				if !ok {
+					return nil, fmt.Errorf("failed to parse schema field: unexpected field entry type %T", field)
+				}
+				schemaGroupID, _ := groupMap["schemaGroupId"].(string)
+				fieldID, _ := fieldMap["fieldId"].(string)
+				rawType, _ := fieldMap["type"].(string)
 				fi, err := parsePropertySchemaField(fieldMap)
 				if err != nil {
-					return nil, fmt.Errorf("failed to parse schema field: %w", err)
+					return nil, fmt.Errorf("failed to parse schema field (schemaGroupId=%q, fieldId=%q, type=%q): %w", schemaGroupID, fieldID, rawType, err)
 				}
 				fil = append(fil, fi)
 			}

--- a/server/internal/usecase/interactor/plugin.go
+++ b/server/internal/usecase/interactor/plugin.go
@@ -272,7 +272,7 @@ func (i *Plugin) uploadPluginFile(ctx context.Context, plugins map[string]*zip.F
 	return nil
 }
 
-func parsePropertySchemaField(fieldMap map[string]interface{}) *property.SchemaField {
+func parsePropertySchemaField(fieldMap map[string]interface{}) (*property.SchemaField, error) {
 
 	// SchemaFieldChoice -------------
 	chs := make([]property.SchemaFieldChoice, 0)
@@ -305,7 +305,7 @@ func parsePropertySchemaField(fieldMap map[string]interface{}) *property.SchemaF
 	if v, ok := fieldMap["type"].(string); ok {
 		t := gqlmodel.ToPropertyValueType(v)
 		fiBuilder = fiBuilder.Type(t)
-		if dv, ok := fieldMap["defaultValue"]; ok {
+		if dv, ok := fieldMap["defaultValue"]; ok && dv != nil {
 			fiBuilder = fiBuilder.DefaultValue(property.ValueType(t).ValueFrom(dv))
 		}
 	}
@@ -334,7 +334,7 @@ func parsePropertySchemaField(fieldMap map[string]interface{}) *property.SchemaF
 	if v, ok := fieldMap["isAvailableIf"].(map[string]interface{}); ok {
 		fiBuilder = fiBuilder.IsAvailableIf(parseIsAvailableIf(v))
 	}
-	return fiBuilder.MustBuild()
+	return fiBuilder.Build()
 }
 
 func parseIsAvailableIf(conditionMap map[string]any) *property.Condition {
@@ -371,7 +371,10 @@ func parsePropertySchema(psid id.PropertySchemaID, schemaMap map[string]any) (*p
 		if fields, ok := groupMap["fields"].([]any); ok {
 			for _, field := range fields {
 				fieldMap := field.(map[string]any)
-				fi := parsePropertySchemaField(fieldMap)
+				fi, err := parsePropertySchemaField(fieldMap)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse schema field: %w", err)
+				}
 				fil = append(fil, fi)
 			}
 		}


### PR DESCRIPTION
## Summary

- `ToPropertyValueType` was missing cases for `CAMERA`, `TYPOGRAPHY`, `SPACING`, and `TIMELINE` value types, causing it to return `ValueTypeUnknown` for those fields
- When `parsePropertySchemaField` then called `MustBuild()`, it panicked with `"invalid value type"`, crashing the import goroutine mid-flight and leaving the project stuck in `PROCESSING` state indefinitely
- Changed `parsePropertySchemaField` to return `(*property.SchemaField, error)` using `Build()` instead of `MustBuild()` so errors surface cleanly rather than panicking
- Added nil guard on `defaultValue` to skip JSON null values passed into `ValueFrom`

## Root cause

Plugins using any of the 4 missing field types (e.g. the navigation/legend panel plugin which uses `CAMERA` type fields) would always cause a server panic during project import. All 15 GraphQL `ValueType` enum values are now covered.

## Test plan

- [x] Import a project that contains a plugin with `CAMERA`, `TYPOGRAPHY`, `SPACING`, or `TIMELINE` schema fields — import should complete successfully
- [x] Verify no panic in server logs during import

🤖 Generated with [Claude Code](https://claude.com/claude-code)