### PR TITLE
fix(web): use project's workspace for custom domain policy check

### DIFF
--- a/web/src/app/features/ProjectSettings/index.tsx
+++ b/web/src/app/features/ProjectSettings/index.tsx
@@ -211,6 +211,7 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({
             <PublicSettings
               data-testid="project-settings-public"
               project={project}
+              workspaceId={workspaceId || ""}
               sceneId={sceneId}
               isStory={!!subId}
               currentStory={currentStory}

--- a/web/src/app/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
+++ b/web/src/app/features/ProjectSettings/innerPages/PublicSettings/PublicSettingsDetail.tsx
@@ -17,8 +17,7 @@ import { useLang, useT } from "@reearth/services/i18n/hooks";
 import {
   NotificationType,
   useCurrentTheme,
-  useNotification,
-  useWorkspace
+  useNotification
 } from "@reearth/services/state";
 import { useTheme } from "@reearth/services/styled";
 import { styled } from "@reearth/services/theme";
@@ -46,6 +45,7 @@ export type StoryWithTypename = Story & WithTypename;
 
 type Props = {
   settingsItem: (SettingsProject | Story) & WithTypename;
+  workspaceId: string;
   sceneId?: string;
   isStory?: boolean;
   onUpdate: (settings: PublicSettingsType) => void;
@@ -63,6 +63,7 @@ type ExtensionComponentProps = (
 
 const PublicSettingsDetail: FC<Props> = ({
   settingsItem,
+  workspaceId,
   sceneId,
   isStory,
   onUpdate,
@@ -186,10 +187,7 @@ const PublicSettingsDetail: FC<Props> = ({
     [settingsItem.publishmentStatus]
   );
 
-  const [workspace] = useWorkspace();
-  const workspacePolicyCheckResultData = useWorkspacePolicyCheck(
-    workspace?.id ?? ""
-  );
+  const workspacePolicyCheckResultData = useWorkspacePolicyCheck(workspaceId);
   const enableCustomDomainExtension =
     !!workspacePolicyCheckResultData?.workspacePolicyCheck
       ?.enableCustomDomainCreation;

--- a/web/src/app/features/ProjectSettings/innerPages/PublicSettings/index.tsx
+++ b/web/src/app/features/ProjectSettings/innerPages/PublicSettings/index.tsx
@@ -55,6 +55,7 @@ export type SettingsProject = {
 
 type Props = {
   project: SettingsProject;
+  workspaceId: string;
   sceneId?: string;
   isStory: boolean;
   currentStory?: Story;
@@ -68,6 +69,7 @@ type Props = {
 
 const PublicSettings: FC<Props> = ({
   project,
+  workspaceId,
   sceneId,
   isStory,
   currentStory,
@@ -98,6 +100,7 @@ const PublicSettings: FC<Props> = ({
             key={currentStory?.id}
             isStory
             settingsItem={storySettingsItem}
+            workspaceId={workspaceId}
             onUpdate={onUpdateStory}
             onUpdateBasicAuth={onUpdateStory}
             onUpdateAlias={onUpdateStoryAlias}
@@ -107,6 +110,7 @@ const PublicSettings: FC<Props> = ({
           <PublicSettingsDetail
             key="map"
             settingsItem={projectSettingsItem}
+            workspaceId={workspaceId}
             sceneId={sceneId}
             onUpdate={onUpdateProject}
             onUpdateBasicAuth={onUpdateProjectBasicAuth}


### PR DESCRIPTION
## What I've done

- Pass `workspaceId` from the project's scene down through `ProjectSettings` → `PublicSettings` → `PublicSettingsDetail` as a prop.
- Replace the `useWorkspace()` state hook (which returns the globally selected workspace) with the passed prop when calling `useWorkspacePolicyCheck`.

## What I haven't done

- No server-side changes; the policy check API itself is unchanged.
- No changes to other components that still rely on `useWorkspace()` from state.

## How I tested

- Manually verified that the Custom Domain section in Public Settings now reads the policy of the workspace that owns the project, not the user's currently selected workspace.
- `useWorkspacePolicyCheck` already skips when `workspaceId` is empty, so the empty-string fallback is safe.

## Which point I want you to review particularly

- The prop drilling of `workspaceId` through `ProjectSettings` → `PublicSettings` → `PublicSettingsDetail`.
- Whether the empty-string fallback (`workspaceId || ""`) is acceptable, given that the underlying hook skips on falsy input.

## Memo

Previously, `PublicSettingsDetail` used `useWorkspace()` from `@reearth/services/state`, which returns the currently selected workspace (often the personal workspace). This caused the custom domain policy check to evaluate against the wrong workspace when the project belongs to a different workspace than the one currently selected in the UI.

## Checklist

- [x] Verified backward compatibility related to feature modifications
- [x] Confirmed backward compatibility for migrations
- [x] Verified that no personally identifiable information (PII) is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)