### PR TITLE
fix(server): update reearth-accounts-api image to latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - reearth
 
   reearth-accounts-api:
-    image: reearth/reearth-accounts-api:v1.0.0
+    image: reearth/reearth-accounts-api:latest
     hostname: reearth-accounts-dev
     profiles:
       - accounts

--- a/server/README.md
+++ b/server/README.md
@@ -149,7 +149,7 @@ graph TB
 
     subgraph docker["Docker Network: reearth"]
         Visualizer["reearth-visualizer-dev<br/>(Go + Air hot reload)<br/>:8080"]
-        Accounts["reearth-accounts-api<br/>(reearth/reearth-accounts-api:v1.0.0)<br/>:8090"]
+        Accounts["reearth-accounts-api<br/>(reearth/reearth-accounts-api:latest)<br/>:8090"]
         Cerbos["reearth-cerbos<br/>(cerbos/cerbos:0.40.0)<br/>:3593"]
         Mongo["reearth-mongo<br/>(mongo:7)<br/>:27017"]
         GCS["reearth-gcs<br/>(fake-gcs-server:1.52.1)<br/>:4443"]
@@ -166,7 +166,7 @@ graph TB
 | Container | Image | Port | Description |
 | --- | --- | --- | --- |
 | reearth-visualizer-dev | (local build) | 8080 | Visualizer API server with hot reload |
-| reearth-accounts-api | reearth/reearth-accounts-api:v1.0.0 | 8090 | User/workspace management API |
+| reearth-accounts-api | reearth/reearth-accounts-api:latest | 8090 | User/workspace management API |
 | reearth-cerbos | cerbos/cerbos:0.40.0 | 3593 | Authorization policy engine |
 | reearth-mongo | mongo:7 | 27017 | MongoDB (shared by visualizer and accounts) |
 | reearth-gcs | fsouza/fake-gcs-server:1.52.1 | 4443 | Fake GCS for local asset storage |
@@ -185,7 +185,7 @@ make d-run
 
 This brings up all required containers with their dependencies: **visualizer** + **accounts API** + **Cerbos** + **MongoDB** + **GCS**
 
-This method uses the public image `reearth/reearth-accounts-api:v1.0.0` from Docker Hub.
+This method uses the public image `reearth/reearth-accounts-api:latest` from Docker Hub.
 
 To stop all services:
 


### PR DESCRIPTION
## Summary

- `v1.0.0` was missing `latestLogoutAt` on the `Me` GraphQL type, causing a schema mismatch with the visualizer's accounts Go module (which requires it since `v1.5.0`)
- Using `latest` keeps the image in sync with the accounts API version the visualizer depends on

## Test plan

- [x] `make d-run` on a clean install
- [x] `make setup-dev` — mock user created successfully
- [x] `curl http://localhost:8080/api/graphql` returns `{"data":{"__typename":"Query"}}`