### PR TITLE
chore(web): bump version to 1.0.0-beta.16.1

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reearth/visualizer",
-  "version": "1.0.0-beta.16.0",
+  "version": "1.0.0-beta.16.1",
   "repository": "https://github.com/reearth/reearth-visualizer.git",
   "author": "Re:Earth contributors <community@reearth.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- Bump web package version from 1.0.0-beta.16.0 to 1.0.0-beta.16.1