### PR TITLE
ci: add explicit permissions to fix startup_failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     branches: [main, release/*, release]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -130,6 +133,9 @@ jobs:
 
   deploy-web:
     needs: build-web
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/deploy_web_nightly.yml
     secrets: inherit
 
@@ -161,15 +167,24 @@ jobs:
 
   deploy-server:
     needs: build-server
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/deploy_server_nightly.yml
     secrets: inherit
   playwright-tests:
     needs: deploy-web
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/playwright_ui_tests.yml
     secrets: inherit
 
   playwright-tests-pr:
     needs: deploy-web-pr
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/playwright_ui_tests.yml
     with:
       url: ${{ needs.deploy-web-pr.outputs.preview_url }}
@@ -178,5 +193,8 @@ jobs:
   playwright-tests-e2e-only:
     needs: prepare
     if: needs.prepare.outputs.e2e == 'true' && github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/playwright_ui_tests.yml
     secrets: inherit


### PR DESCRIPTION
## Summary

CI has been failing with `startup_failure` (zero jobs executed) since April 23, 2026. The calling workflow needs to explicitly grant `id-token: write` for jobs that call reusable workflows requiring OIDC. Added per-job — not workflow-wide — so `prepare` / `ci-*` jobs handling untrusted PR code can't mint OIDC tokens.

Jobs granted `id-token: write`: `deploy-web`, `deploy-server`, `playwright-tests`, `playwright-tests-pr`, `playwright-tests-e2e-only`. (`deploy-web-pr` already had it.)

Refs: [GitHub OIDC reusable-workflow changelog](https://github.blog/changelog/2023-06-15-github-actions-securing-openid-connect-oidc-token-permissions-in-reusable-workflows/) · same fix in [reearth/reearth-flow#2070](https://github.com/reearth/reearth-flow/pull/2070).

## Test plan

- [x] CI on this PR no longer ends in `startup_failure`
- [x] Deploy and playwright jobs still authenticate to GCP