### PR TITLE
feat(web): support reload page on plugin API [VIZ-DEV-24]

### DIFF
--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/commonReearth.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/commonReearth.ts
@@ -2,7 +2,7 @@ import { LazyLayer, MapRef } from "@reearth/core";
 
 import { REEATH_PLUGIN_API_VERSION } from "./constaint";
 import { GlobalThis, Reearth } from "./types";
-import { openUrlInNewTab } from "./utils";
+import { openUrlInNewTab, reloadCurrentWebPage } from "./utils";
 
 export type CommonReearth = Omit<
   Reearth,
@@ -215,6 +215,7 @@ export function commonReearth({
       },
       capture: captureScreen,
       open: openUrlInNewTab,
+      reload: reloadCurrentWebPage,
       tools: {
         getLocationFromScreenCoordinate,
         getScreenCoordinateFromPosition,

--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/types/viewer.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/types/viewer.ts
@@ -54,6 +54,7 @@ export declare type Viewer = {
     encoderOptions?: number
   ) => string | undefined;
   readonly open: (url: string) => void;
+  readonly reload: () => void;
   readonly on: ViewerEvents["on"];
   readonly off: ViewerEvents["off"];
 };

--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/utils.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/utils.ts
@@ -1,2 +1,6 @@
 // Re-export from the shared utils location for backward compatibility
-export { openUrlInNewTab, isSafeHttpUrl } from "@reearth/app/utils/url";
+export {
+  openUrlInNewTab,
+  isSafeHttpUrl,
+  reloadCurrentWebPage
+} from "@reearth/app/utils/url";

--- a/web/src/app/features/Visualizer/Crust/Plugins/storybook.tsx
+++ b/web/src/app/features/Visualizer/Crust/Plugins/storybook.tsx
@@ -5,7 +5,7 @@ import { PluginProvider } from "./context";
 import type { Context } from "./types";
 
 // Mock function for actions
- 
+
 const fn =
   () =>
   (..._args: any[]) => {};
@@ -119,6 +119,7 @@ export const context: Context = {
       },
       capture: act("captureScreen"),
       open: act("open"),
+      reload: act("reload"),
       tools: {
         getLocationFromScreenCoordinate: act("getLocationFromScreenCoordinate"),
         getScreenCoordinateFromPosition: act("getScreenCoordinateFromPosition"),

--- a/web/src/app/utils/url.test.ts
+++ b/web/src/app/utils/url.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { isValidUrl, isSafeHttpUrl, openUrlInNewTab } from "./url";
+import { isValidUrl, isSafeHttpUrl, openUrlInNewTab, reloadCurrentWebPage } from "./url";
 
 describe("isValidUrl", () => {
   it("should return true for valid HTTP URLs", () => {
@@ -268,5 +268,41 @@ describe("openUrlInNewTab", () => {
         expect.any(String)
       );
     });
+  });
+});
+
+describe("reloadCurrentWebPage", () => {
+  let reloadMock: ReturnType<typeof vi.fn>;
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    // Save original location
+    originalLocation = window.location;
+
+    // Create mock reload function
+    reloadMock = vi.fn();
+
+    // Replace window.location with a mock that includes our reload mock
+    delete (window as { location?: Location }).location;
+    (window as { location: Location }).location = {
+      ...originalLocation,
+      reload: reloadMock
+    } as Location;
+  });
+
+  afterEach(() => {
+    // Restore original location
+    (window as { location: Location }).location = originalLocation;
+    vi.clearAllMocks();
+  });
+
+  it("should call window.location.reload", () => {
+    reloadCurrentWebPage();
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call window.location.reload without arguments", () => {
+    reloadCurrentWebPage();
+    expect(reloadMock).toHaveBeenCalledWith();
   });
 });

--- a/web/src/app/utils/url.ts
+++ b/web/src/app/utils/url.ts
@@ -24,3 +24,7 @@ export const openUrlInNewTab = (url: string): void => {
   }
   window.open(url, "_blank", "noopener");
 };
+
+export const reloadCurrentWebPage = (): void => {
+  window.location.reload();
+};


### PR DESCRIPTION
# Overview

We got the requirement that user might want to reload page through plugin API.

This PR added `reearth.viewer.reload()` to meet this requirment.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
