### PR TITLE
chore(web): bump version to 1.0.0-beta.16.2

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reearth/visualizer",
-  "version": "1.0.0-beta.16.1",
+  "version": "1.0.0-beta.16.2",
   "repository": "https://github.com/reearth/reearth-visualizer.git",
   "author": "Re:Earth contributors <community@reearth.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Overview

## What I've done

- Bump web package version from `1.0.0-beta.16.1` to `1.0.0-beta.16.2`.

## What I haven't done

- No code or dependency changes.

## How I tested

- Version field updated in `web/package.json`; no functional changes to test.

## Which point I want you to review particularly

- N/A

## Memo

- Routine version bump following the existing `1.0.0-beta.16.x` cadence.

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)