### PR TITLE
ci: grant pull-requests:write to reviewer lottery workflow

### DIFF
--- a/.github/workflows/reviewer_lottery.yml
+++ b/.github/workflows/reviewer_lottery.yml
@@ -5,6 +5,10 @@ on:
         - web/**
     types: [opened, ready_for_review, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Overview

## What I've done

- Added an explicit `permissions:` block to `.github/workflows/reviewer_lottery.yml` granting `contents: read` and `pull-requests: write` so the `uesteibar/reviewer-lottery@v4` action can call the request-reviewers API.

## What I haven't done

- Did not change the lottery configuration (`.github/reviewer-lottery.yml`) or any other workflow.

## How I tested

- Verified that the workflow currently fails with `HttpError: Resource not accessible by integration` on the request-reviewers call (e.g. #2191 run).
- The failure shape matches GitHub's documented behavior when `GITHUB_TOKEN` lacks `pull-requests: write`, and the workflow had no `permissions:` block, so it inherited the (now read-only) repository default. Declaring the required scope explicitly is the standard fix and will be exercised on the next `pull_request_target` run.

## Which point I want you to review particularly

- Whether `contents: read` + `pull-requests: write` is the right minimal scope, or if you'd prefer to scope it tighter / wider.
- Whether we want to pin `uesteibar/reviewer-lottery` to a SHA while we're here (left as `@v4` to keep this PR minimal).

## Memo

- Lottery started failing 2026-04-24, after succeeding through 2026-04-22 — consistent with a repo/org default-permissions tightening rather than a code change.
- Related failing run: https://github.com/reearth/reearth-visualizer/pull/2191

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)