### PR TITLE
fix(web): incorrect time limit check on story timeline block

### DIFF
--- a/web/src/app/features/Visualizer/Crust/StoryPanel/Block/builtin/Timeline/hook.ts
+++ b/web/src/app/features/Visualizer/Crust/StoryPanel/Block/builtin/Timeline/hook.ts
@@ -355,12 +355,8 @@ export default ({
 
   useEffect(() => {
     if (
-      (range &&
-        isPlaying &&
-        JSON.stringify(currentTime) >= JSON.stringify(range?.end)) ||
-      (range &&
-        isPlayingReversed &&
-        JSON.stringify(currentTime) <= JSON.stringify(range.start))
+      (range && isPlaying && currentTime >= range.end) ||
+      (range && isPlayingReversed && currentTime <= range.start)
     ) {
       if (playMode === "loop") {
         return handleOnResetAndPlay();

--- a/web/src/app/features/Visualizer/shared/hooks/useFieldComponent.tsx
+++ b/web/src/app/features/Visualizer/shared/hooks/useFieldComponent.tsx
@@ -226,9 +226,17 @@ export const FieldComponent = ({
         description={field.description}
         options={
           field?.choices?.map(
-            ({ key, label }: { key: string; label: string }) => ({
+            ({
+              key,
+              label,
+              title
+            }: {
+              key: string;
+              label: string;
+              title?: string;
+            }) => ({
               value: key,
-              label: label
+              label: label ?? title ?? key
             })
           ) || []
         }


### PR DESCRIPTION
# Overview

- Using string compare for timestamp is incorrect.
- Also fixes the missing option label on timeline block edit panel.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
