### PR TITLE
chore(web): missing write permission on release-nightly-rc

### DIFF
--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -157,6 +157,7 @@ jobs:
           tag: ${{ inputs.name }}
           body: ${{ inputs.sha }}
           prerelease: true
+          token: ${{ steps.app-token.outputs.token }}
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Overview

We have `Error 403: Resource not accessible by integration ` on Release step, there's one step called app-token but the output is not been used.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
