### PR TITLE
fix(ci): add contents: write permission to release jobs

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -23,6 +23,8 @@ jobs:
     name: Build and release server
     runs-on: ubuntu-latest
     if: inputs.name || inputs.new_tag
+    permissions:
+      contents: write
     env:
       ARTIFACTS: server/dist/reearth_*.*
     steps:

--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -162,6 +162,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: ${{ inputs.new_tag != '' }}
+    permissions:
+      contents: write
     env:
       ARTIFACT: reearth-web_${{ inputs.new_tag }}.tar.gz
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,6 @@ jobs:
 
   build-web:
     needs: [ci-web, build-prepare]
-    permissions:
-      contents: write
     uses: ./.github/workflows/build_web.yml
     with:
       sha_short: ${{ needs.build-prepare.outputs.sha_short }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,8 @@ jobs:
 
   build-web:
     needs: [ci-web, build-prepare]
+    permissions:
+      contents: write
     uses: ./.github/workflows/build_web.yml
     with:
       sha_short: ${{ needs.build-prepare.outputs.sha_short }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   prepare:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/release'
+    permissions:
+      contents: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1


### PR DESCRIPTION
## Summary

Release jobs were failing with 403 errors because they inherited `contents: read` from the top-level `ci.yml`, but creating GitHub releases and pushing tags requires write access.

- `build_web.yml` — `release` job couldn't create a GitHub release
- `build_release.yml` — same issue
- `release.yml` — couldn't push tags/branch

The `build_server` 404s were a knock-on effect: the server build fetches the web artifact to embed it, but since the web release was never created, the artifact didn't exist.

Fix: add `permissions: contents: write` at the job level on each affected job, same pattern as [reearth-flow](https://github.com/reearth/reearth-flow/commit/8ba0fe73408d8df5a36fb384d6e3a8016b3f9945).

## Test plan

- [x] Verify `build-web / release` and `build-server / Build` pass on the next release branch CI run