### PR TITLE
test(web): skip flaky e2e test suites temporarily

### DIFF
--- a/.github/workflows/playwright_api_tests.yml
+++ b/.github/workflows/playwright_api_tests.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - "server/**"
+      - "server/**/*.go"
+      - "server/go.mod"
+      - "server/go.sum"
       - "e2e/api/**"
       - "e2e/playwright.config.ts"
       - "e2e/package.json"

--- a/e2e/tests/layerDeletionReorder.spec.ts
+++ b/e2e/tests/layerDeletionReorder.spec.ts
@@ -27,7 +27,7 @@ const layerNames = [
 
 test.describe.configure({ mode: "serial" });
 
-test.describe("Layer Deletion & Reordering", () => {
+test.describe.skip("Layer Deletion & Reordering", () => {
   let context: BrowserContext;
   let page: Page;
   let dashBoardPage: DashBoardPage;

--- a/e2e/tests/page-refresh-on-mutation.spec.ts
+++ b/e2e/tests/page-refresh-on-mutation.spec.ts
@@ -23,7 +23,7 @@ const layerName = faker.string.alpha(8);
 
 test.describe.configure({ mode: "serial" });
 
-test.describe("Page refresh on mutation actions", () => {
+test.describe.skip("Page refresh on mutation actions", () => {
   let context: BrowserContext;
   let page: Page;
   let dashBoardPage: DashBoardPage;


### PR DESCRIPTION
## Summary

- Skip `Layer Deletion & Reordering` and `Page Refresh on Mutation` e2e suites — both were flaky due to a race condition where `dblclick()` is called before the project grid card is rendered
- Narrow the Playwright API test trigger from `server/**` to `server/**/*.go`, `server/go.mod`, `server/go.sum` — prevents non-code changes (README, Makefile, .env files) from triggering the workflow

## Follow-up

Will unskip the tests once the cause of flakiness is found and fixed.