### PR TITLE
chore: limit renovate auto-rebase to conflicted branches only

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,5 @@
   "extends": [
     "github>reearth/renovate-config"
   ],
-  "rebaseWhen": "never"
+  "rebaseWhen": "conflicted"
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>reearth/renovate-config"
-  ]
+  ],
+  "rebaseWhen": "never"
 }


### PR DESCRIPTION
## Problem

Every push to `main` triggers Renovate to rebase all open PRs, even when there are no merge conflicts. With 8+ open Renovate PRs, this creates a cascade effect:

- Each merge to `main` causes Renovate to rebase all its open PRs simultaneously
- Each rebase fires a `pull_request: synchronize` event, triggering a full CI run per PR
- Today alone, Renovate rebased all PRs **3 times** (at 04:43, 06:23, and 07:41 UTC), each wave triggered by a push to `main`
- This wastes CI runner minutes on PRs that were already passing and had no relevant changes

## Fix

Set `rebaseWhen: "conflicted"` in the local `renovate.json`. Renovate will now only rebase a PR when it has an actual merge conflict — not just because it's behind `main`.

This overrides the default `"auto"` behaviour from the shared `github>reearth/renovate-config` without touching that shared config (which is used across other reearth repos).

## Why not `"never"`?

`"never"` stops all rebases including conflict resolution, which means PRs can get stuck in an unresolvable state. `"conflicted"` is the safer middle ground — it eliminates the CI flood while still keeping PRs mergeable.