### PR TITLE
perf(server): optimize InternalAPI GetAllProjects query path

### DIFF
--- a/server/internal/infrastructure/mongo/migration/260518143901_add_project_visibility_and_topics_indexes.go
+++ b/server/internal/infrastructure/mongo/migration/260518143901_add_project_visibility_and_topics_indexes.go
@@ -25,25 +25,39 @@ import (
 // propagated so the migration framework can mark this migration as
 // unapplied and retry on a future run instead of silently leaving the
 // database without the intended indexes.
+// projectQueryCollation mirrors the collation used by Project.FindAll's
+// non-aggregation Find path. MongoDB only picks an index for a collationed
+// query when the index's collation matches the query's, so the
+// (visibility, deleted) project index must be created with the same
+// collation to be usable from that path. The topics index lives on
+// projectmetadata, which the aggregation pipeline reads without collation,
+// so it stays on the default collation.
+var projectQueryCollation = &options.Collation{
+	Locale:    "en",
+	Strength:  3,
+	CaseLevel: true,
+	Alternate: "shifted",
+}
+
 func AddProjectVisibilityAndTopicsIndexes(ctx context.Context, c DBClient) error {
 	if err := createNonUniqueIndex(ctx, c, "project", "project_visibility_deleted", bson.D{
 		{Key: "visibility", Value: 1},
 		{Key: "deleted", Value: 1},
-	}); err != nil {
+	}, projectQueryCollation); err != nil {
 		return err
 	}
 	if err := createNonUniqueIndex(ctx, c, "projectmetadata", "projectmetadata_topics", bson.D{
 		{Key: "topics", Value: 1},
-	}); err != nil {
+	}, nil); err != nil {
 		return err
 	}
 	return nil
 }
 
-func createNonUniqueIndex(ctx context.Context, c DBClient, collectionName, indexName string, keys bson.D) error {
+func createNonUniqueIndex(ctx context.Context, c DBClient, collectionName, indexName string, keys bson.D, collation *options.Collation) error {
 	collection := c.Database().Collection(collectionName)
 
-	exists, existingName, err := indexWithKeysExists(ctx, collection, keys)
+	exists, existingName, err := indexWithKeysExists(ctx, collection, keys, collation)
 	if err != nil {
 		return fmt.Errorf("migration: AddProjectVisibilityAndTopicsIndexes: failed to list indexes on %s: %w", collectionName, err)
 	}
@@ -52,9 +66,13 @@ func createNonUniqueIndex(ctx context.Context, c DBClient, collectionName, index
 		return nil
 	}
 
+	idxOpts := options.Index().SetName(indexName)
+	if collation != nil {
+		idxOpts = idxOpts.SetCollation(collation)
+	}
 	name, err := collection.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys:    keys,
-		Options: options.Index().SetName(indexName),
+		Options: idxOpts,
 	})
 	if err != nil {
 		return fmt.Errorf("migration: AddProjectVisibilityAndTopicsIndexes: failed to create index on %s: %w", collectionName, err)
@@ -65,11 +83,13 @@ func createNonUniqueIndex(ctx context.Context, c DBClient, collectionName, index
 
 // indexWithKeysExists returns the name of any existing index on col whose
 // key specification matches keys (same field names in the same order with the
-// same direction values). MongoDB enforces that only one index can exist per
-// key spec, so a positive match here means CreateOne would either succeed as
-// a no-op or fail with a conflict; we skip in either case.
+// same direction values) AND whose collation matches the requested one.
+// MongoDB allows two indexes with the same key spec to coexist as long as
+// they have different collations (because the query planner picks them
+// based on the query's collation), so we treat collation as part of
+// identity here.
 //
-// Note: the match is strict on field order. A pre-existing index that
+// Note: the key match is strict on field order. A pre-existing index that
 // reverses the order — for example {deleted: 1, visibility: 1} when this
 // migration wants {visibility: 1, deleted: 1} — is treated as a different
 // index and the migration will still create its declared index. This is
@@ -78,7 +98,7 @@ func createNonUniqueIndex(ctx context.Context, c DBClient, collectionName, index
 // leave the workload on a less-effective index. Operators pre-building
 // these indexes manually must use the field order declared in
 // AddProjectVisibilityAndTopicsIndexes.
-func indexWithKeysExists(ctx context.Context, col *mongo.Collection, keys bson.D) (bool, string, error) {
+func indexWithKeysExists(ctx context.Context, col *mongo.Collection, keys bson.D, collation *options.Collation) (bool, string, error) {
 	cursor, err := col.Indexes().List(ctx)
 	if err != nil {
 		return false, "", err
@@ -87,17 +107,54 @@ func indexWithKeysExists(ctx context.Context, col *mongo.Collection, keys bson.D
 
 	for cursor.Next(ctx) {
 		var spec struct {
-			Name string `bson:"name"`
-			Key  bson.D `bson:"key"`
+			Name      string `bson:"name"`
+			Key       bson.D `bson:"key"`
+			Collation bson.M `bson:"collation,omitempty"`
 		}
 		if err := cursor.Decode(&spec); err != nil {
 			return false, "", err
 		}
-		if keysEqual(spec.Key, keys) {
+		if keysEqual(spec.Key, keys) && collationsEqual(spec.Collation, collation) {
 			return true, spec.Name, nil
 		}
 	}
 	return false, "", cursor.Err()
+}
+
+// collationsEqual reports whether a stored index collation (as decoded from
+// MongoDB's indexes listing) matches a requested options.Collation. Both
+// nil/missing means "default collation"; otherwise we compare the fields we
+// set on the requested side, which is enough for the small set of options
+// this migration uses.
+func collationsEqual(stored bson.M, requested *options.Collation) bool {
+	if requested == nil {
+		return len(stored) == 0
+	}
+	if len(stored) == 0 {
+		return false
+	}
+	if s, _ := stored["locale"].(string); s != requested.Locale {
+		return false
+	}
+	if requested.Strength != 0 {
+		si, ok := toInt64(stored["strength"])
+		if !ok || si != int64(requested.Strength) {
+			return false
+		}
+	}
+	if requested.CaseLevel {
+		cl, _ := stored["caseLevel"].(bool)
+		if !cl {
+			return false
+		}
+	}
+	if requested.Alternate != "" {
+		alt, _ := stored["alternate"].(string)
+		if alt != requested.Alternate {
+			return false
+		}
+	}
+	return true
 }
 
 func keysEqual(a, b bson.D) bool {

--- a/server/internal/infrastructure/mongo/migration/260518143901_add_project_visibility_and_topics_indexes.go
+++ b/server/internal/infrastructure/mongo/migration/260518143901_add_project_visibility_and_topics_indexes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/reearth/reearthx/log"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // AddProjectVisibilityAndTopicsIndexes creates indexes that back the public
@@ -24,13 +25,13 @@ import (
 // can mark this migration as unapplied and retry on a future run instead of
 // silently leaving the database without the intended indexes.
 func AddProjectVisibilityAndTopicsIndexes(ctx context.Context, c DBClient) error {
-	if err := createNonUniqueIndex(ctx, c, "project", bson.D{
+	if err := createNonUniqueIndex(ctx, c, "project", "project_visibility_deleted", bson.D{
 		{Key: "visibility", Value: 1},
 		{Key: "deleted", Value: 1},
 	}); err != nil {
 		return err
 	}
-	if err := createNonUniqueIndex(ctx, c, "projectmetadata", bson.D{
+	if err := createNonUniqueIndex(ctx, c, "projectmetadata", "projectmetadata_topics", bson.D{
 		{Key: "topics", Value: 1},
 	}); err != nil {
 		return err
@@ -38,10 +39,11 @@ func AddProjectVisibilityAndTopicsIndexes(ctx context.Context, c DBClient) error
 	return nil
 }
 
-func createNonUniqueIndex(ctx context.Context, c DBClient, collectionName string, keys bson.D) error {
+func createNonUniqueIndex(ctx context.Context, c DBClient, collectionName, indexName string, keys bson.D) error {
 	collection := c.Database().Collection(collectionName)
 	name, err := collection.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: keys,
+		Keys:    keys,
+		Options: options.Index().SetName(indexName),
 	})
 	if err != nil {
 		return fmt.Errorf("migration: AddProjectVisibilityAndTopicsIndexes: failed to create index on %s: %w", collectionName, err)

--- a/server/internal/infrastructure/mongo/migration/260518143901_add_project_visibility_and_topics_indexes.go
+++ b/server/internal/infrastructure/mongo/migration/260518143901_add_project_visibility_and_topics_indexes.go
@@ -20,10 +20,11 @@ import (
 //     $lookup whose sub-pipeline matches metadata by the topics array, so
 //     the topics field needs an index for the $all match to be selective.
 //
-// Index creation is idempotent; CreateOne against an equivalent existing
-// index is a no-op. Other errors are propagated so the migration framework
-// can mark this migration as unapplied and retry on a future run instead of
-// silently leaving the database without the intended indexes.
+// The migration is idempotent: if an index with the same key spec already
+// exists (regardless of its name), creation is skipped. Other errors are
+// propagated so the migration framework can mark this migration as
+// unapplied and retry on a future run instead of silently leaving the
+// database without the intended indexes.
 func AddProjectVisibilityAndTopicsIndexes(ctx context.Context, c DBClient) error {
 	if err := createNonUniqueIndex(ctx, c, "project", "project_visibility_deleted", bson.D{
 		{Key: "visibility", Value: 1},
@@ -41,6 +42,16 @@ func AddProjectVisibilityAndTopicsIndexes(ctx context.Context, c DBClient) error
 
 func createNonUniqueIndex(ctx context.Context, c DBClient, collectionName, indexName string, keys bson.D) error {
 	collection := c.Database().Collection(collectionName)
+
+	exists, existingName, err := indexWithKeysExists(ctx, collection, keys)
+	if err != nil {
+		return fmt.Errorf("migration: AddProjectVisibilityAndTopicsIndexes: failed to list indexes on %s: %w", collectionName, err)
+	}
+	if exists {
+		log.Infofc(ctx, "migration: AddProjectVisibilityAndTopicsIndexes: index already exists on %s as %q, skipping", collectionName, existingName)
+		return nil
+	}
+
 	name, err := collection.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys:    keys,
 		Options: options.Index().SetName(indexName),
@@ -50,4 +61,62 @@ func createNonUniqueIndex(ctx context.Context, c DBClient, collectionName, index
 	}
 	log.Infofc(ctx, "migration: AddProjectVisibilityAndTopicsIndexes: created index on %s: %s", collectionName, name)
 	return nil
+}
+
+// indexWithKeysExists returns the name of any existing index on col whose
+// key specification matches keys (same field names in the same order with the
+// same direction values). MongoDB enforces that only one index can exist per
+// key spec, so a positive match here means CreateOne would either succeed as
+// a no-op or fail with a conflict; we skip in either case.
+func indexWithKeysExists(ctx context.Context, col *mongo.Collection, keys bson.D) (bool, string, error) {
+	cursor, err := col.Indexes().List(ctx)
+	if err != nil {
+		return false, "", err
+	}
+	defer cursor.Close(ctx)
+
+	for cursor.Next(ctx) {
+		var spec struct {
+			Name string `bson:"name"`
+			Key  bson.D `bson:"key"`
+		}
+		if err := cursor.Decode(&spec); err != nil {
+			return false, "", err
+		}
+		if keysEqual(spec.Key, keys) {
+			return true, spec.Name, nil
+		}
+	}
+	return false, "", cursor.Err()
+}
+
+func keysEqual(a, b bson.D) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Key != b[i].Key {
+			return false
+		}
+		// Index direction is stored as int32 on disk but may decode as int32 or int64;
+		// compare numerically when both sides are integers.
+		ai, aok := toInt64(a[i].Value)
+		bi, bok := toInt64(b[i].Value)
+		if !aok || !bok || ai != bi {
+			return false
+		}
+	}
+	return true
+}
+
+func toInt64(v any) (int64, bool) {
+	switch x := v.(type) {
+	case int:
+		return int64(x), true
+	case int32:
+		return int64(x), true
+	case int64:
+		return x, true
+	}
+	return 0, false
 }

--- a/server/internal/infrastructure/mongo/migration/260518143901_add_project_visibility_and_topics_indexes.go
+++ b/server/internal/infrastructure/mongo/migration/260518143901_add_project_visibility_and_topics_indexes.go
@@ -2,6 +2,7 @@ package migration
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/reearth/reearthx/log"
 	"go.mongodb.org/mongo-driver/bson"
@@ -14,31 +15,37 @@ import (
 //   - project: (visibility, deleted) — the default FindAll filter selects
 //     by visibility and the not-deleted flag, so the composite index turns
 //     a collection scan into an index range scan.
-//   - projectmetadata: topics — topics filtering pre-queries projectmetadata
-//     for matching project IDs before fanning out to project, and the topics
-//     array needs an index for the $all match to be selective.
+//   - projectmetadata: topics — topics filtering runs a pipeline-form
+//     $lookup whose sub-pipeline matches metadata by the topics array, so
+//     the topics field needs an index for the $all match to be selective.
 //
-// Index creation is idempotent; if the index already exists CreateOne returns
-// without error.
+// Index creation is idempotent; CreateOne against an equivalent existing
+// index is a no-op. Other errors are propagated so the migration framework
+// can mark this migration as unapplied and retry on a future run instead of
+// silently leaving the database without the intended indexes.
 func AddProjectVisibilityAndTopicsIndexes(ctx context.Context, c DBClient) error {
-	createNonUniqueIndex(ctx, c, "project", bson.D{
+	if err := createNonUniqueIndex(ctx, c, "project", bson.D{
 		{Key: "visibility", Value: 1},
 		{Key: "deleted", Value: 1},
-	})
-	createNonUniqueIndex(ctx, c, "projectmetadata", bson.D{
+	}); err != nil {
+		return err
+	}
+	if err := createNonUniqueIndex(ctx, c, "projectmetadata", bson.D{
 		{Key: "topics", Value: 1},
-	})
+	}); err != nil {
+		return err
+	}
 	return nil
 }
 
-func createNonUniqueIndex(ctx context.Context, c DBClient, collectionName string, keys bson.D) {
+func createNonUniqueIndex(ctx context.Context, c DBClient, collectionName string, keys bson.D) error {
 	collection := c.Database().Collection(collectionName)
 	name, err := collection.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys: keys,
 	})
 	if err != nil {
-		log.Warnfc(ctx, "migration: AddProjectVisibilityAndTopicsIndexes: failed to create index on %s: %v", collectionName, err)
-		return
+		return fmt.Errorf("migration: AddProjectVisibilityAndTopicsIndexes: failed to create index on %s: %w", collectionName, err)
 	}
 	log.Infofc(ctx, "migration: AddProjectVisibilityAndTopicsIndexes: created index on %s: %s", collectionName, name)
+	return nil
 }

--- a/server/internal/infrastructure/mongo/migration/260518143901_add_project_visibility_and_topics_indexes.go
+++ b/server/internal/infrastructure/mongo/migration/260518143901_add_project_visibility_and_topics_indexes.go
@@ -68,6 +68,16 @@ func createNonUniqueIndex(ctx context.Context, c DBClient, collectionName, index
 // same direction values). MongoDB enforces that only one index can exist per
 // key spec, so a positive match here means CreateOne would either succeed as
 // a no-op or fail with a conflict; we skip in either case.
+//
+// Note: the match is strict on field order. A pre-existing index that
+// reverses the order — for example {deleted: 1, visibility: 1} when this
+// migration wants {visibility: 1, deleted: 1} — is treated as a different
+// index and the migration will still create its declared index. This is
+// intentional: MongoDB compound indexes are order-sensitive (prefix-match
+// rules differ), so silently treating reversed orders as equivalent could
+// leave the workload on a less-effective index. Operators pre-building
+// these indexes manually must use the field order declared in
+// AddProjectVisibilityAndTopicsIndexes.
 func indexWithKeysExists(ctx context.Context, col *mongo.Collection, keys bson.D) (bool, string, error) {
 	cursor, err := col.Indexes().List(ctx)
 	if err != nil {

--- a/server/internal/infrastructure/mongo/migration/260518143901_add_project_visibility_and_topics_indexes.go
+++ b/server/internal/infrastructure/mongo/migration/260518143901_add_project_visibility_and_topics_indexes.go
@@ -1,0 +1,44 @@
+package migration
+
+import (
+	"context"
+
+	"github.com/reearth/reearthx/log"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// AddProjectVisibilityAndTopicsIndexes creates indexes that back the public
+// project listing path used by InternalAPI GetAllProjects.
+//
+//   - project: (visibility, deleted) — the default FindAll filter selects
+//     by visibility and the not-deleted flag, so the composite index turns
+//     a collection scan into an index range scan.
+//   - projectmetadata: topics — topics filtering pre-queries projectmetadata
+//     for matching project IDs before fanning out to project, and the topics
+//     array needs an index for the $all match to be selective.
+//
+// Index creation is idempotent; if the index already exists CreateOne returns
+// without error.
+func AddProjectVisibilityAndTopicsIndexes(ctx context.Context, c DBClient) error {
+	createNonUniqueIndex(ctx, c, "project", bson.D{
+		{Key: "visibility", Value: 1},
+		{Key: "deleted", Value: 1},
+	})
+	createNonUniqueIndex(ctx, c, "projectmetadata", bson.D{
+		{Key: "topics", Value: 1},
+	})
+	return nil
+}
+
+func createNonUniqueIndex(ctx context.Context, c DBClient, collectionName string, keys bson.D) {
+	collection := c.Database().Collection(collectionName)
+	name, err := collection.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: keys,
+	})
+	if err != nil {
+		log.Warnfc(ctx, "migration: AddProjectVisibilityAndTopicsIndexes: failed to create index on %s: %v", collectionName, err)
+		return
+	}
+	log.Infofc(ctx, "migration: AddProjectVisibilityAndTopicsIndexes: created index on %s: %s", collectionName, name)
+}

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -42,4 +42,5 @@ var migrations = migration.Migrations[DBClient]{
 	251113173239: GcschangeEsriToDefault,
 	251216142332: RemoveTimeline,
 	251222111114: AddUnifiedCaseInsensitiveAliasIndex,
+	260518143901: AddProjectVisibilityAndTopicsIndexes,
 }

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -663,25 +663,30 @@ const aggregationFacetCap int64 = 1000
 
 // effectiveSkipLimit derives an effective ($skip, $limit) pair for the
 // aggregation paths. Precedence: explicit pFilter.Limit/Offset → Pagination
-// Offset → Pagination Cursor First/Last → the hard cap.
+// Offset → Pagination Cursor First/Last → the hard cap. The returned limit
+// is always clamped to (0, aggregationFacetCap] regardless of caller input,
+// since unauthenticated GetAllProjects reaches these paths and the $facet
+// "data" array must stay well below MongoDB's 16MB document limit.
 func effectiveSkipLimit(pFilter repo.ProjectFilter) (skip, lim int64) {
-	if pFilter.Limit != nil && pFilter.Offset != nil {
-		return *pFilter.Offset, *pFilter.Limit
+	switch {
+	case pFilter.Limit != nil && pFilter.Offset != nil:
+		skip, lim = *pFilter.Offset, *pFilter.Limit
+	case pFilter.Pagination != nil && pFilter.Pagination.Offset != nil:
+		skip, lim = pFilter.Pagination.Offset.Offset, pFilter.Pagination.Offset.Limit
+	case pFilter.Pagination != nil && pFilter.Pagination.Cursor != nil && pFilter.Pagination.Cursor.First != nil:
+		lim = *pFilter.Pagination.Cursor.First
+	case pFilter.Pagination != nil && pFilter.Pagination.Cursor != nil && pFilter.Pagination.Cursor.Last != nil:
+		lim = *pFilter.Pagination.Cursor.Last
+	default:
+		lim = aggregationFacetCap
 	}
-	if pFilter.Pagination != nil {
-		if pFilter.Pagination.Offset != nil {
-			return pFilter.Pagination.Offset.Offset, pFilter.Pagination.Offset.Limit
-		}
-		if pFilter.Pagination.Cursor != nil {
-			if pFilter.Pagination.Cursor.First != nil && *pFilter.Pagination.Cursor.First > 0 {
-				return 0, *pFilter.Pagination.Cursor.First
-			}
-			if pFilter.Pagination.Cursor.Last != nil && *pFilter.Pagination.Cursor.Last > 0 {
-				return 0, *pFilter.Pagination.Cursor.Last
-			}
-		}
+	if skip < 0 {
+		skip = 0
 	}
-	return 0, aggregationFacetCap
+	if lim <= 0 || lim > aggregationFacetCap {
+		lim = aggregationFacetCap
+	}
+	return skip, lim
 }
 
 // findAllWithTopicsFilter runs the FindAll aggregation when a topics filter is
@@ -741,7 +746,10 @@ func (r *Project) findAllWithTopicsFilter(ctx context.Context, pFilter repo.Proj
 	if skip > 0 {
 		dataPipeline = append(dataPipeline, bson.M{"$skip": skip})
 	}
-	dataPipeline = append(dataPipeline, bson.M{"$limit": lim})
+	// Drop the joined metadata array before materializing into the facet.
+	// The project consumer ignores it, and keeping it would bloat the single
+	// facet result document toward MongoDB's 16MB limit.
+	dataPipeline = append(dataPipeline, bson.M{"$limit": lim}, bson.M{"$unset": "metadata"})
 
 	facetStage := bson.M{
 		"$facet": bson.M{
@@ -1063,7 +1071,9 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 	}
 
 	// Project-side sort key derived from metadata.starcount, defaulting to 0
-	// when no metadata exists, so projects without metadata sort to the end.
+	// when no metadata exists. Missing-metadata projects therefore sort to
+	// the bottom for DESC and to the top for ASC, matching the semantics of
+	// treating an absent star count as zero.
 	addFieldsStage := bson.M{
 		"$addFields": bson.M{
 			"sort_star_count": bson.M{
@@ -1099,7 +1109,11 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 	if skip > 0 {
 		dataPipeline = append(dataPipeline, bson.M{"$skip": skip})
 	}
-	dataPipeline = append(dataPipeline, bson.M{"$limit": lim})
+	// Drop the joined metadata array and the temporary sort key before
+	// materializing into the facet. Neither field is consumed downstream and
+	// keeping them would bloat the single facet result document toward
+	// MongoDB's 16MB limit.
+	dataPipeline = append(dataPipeline, bson.M{"$limit": lim}, bson.M{"$unset": []string{"metadata", "sort_star_count"}})
 
 	// $facet runs count and paginated data in a single pipeline pass. The
 	// total count for this path is determined solely by the project filter,

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -577,20 +577,13 @@ func (r *Project) FindAll(ctx context.Context, pFilter repo.ProjectFilter) ([]*p
 		}
 	}
 
-	// Topics filter requires joining with projectmetadata. Pre-fetch matching
-	// project IDs to avoid a per-document $lookup over all public projects.
+	// Topics filter or starcount sort needs to join projectmetadata. The
+	// topics path keeps the join entirely server-side via a pipeline-form
+	// $lookup that filters on the projectmetadata.topics index, which avoids
+	// transferring potentially large ID sets through the client.
 	if len(pFilter.Topics) > 0 {
-		ids, err := r.findProjectIDsByTopics(ctx, pFilter.Topics)
-		if err != nil {
-			return nil, nil, visualizer.ErrorWithCallerLogging(ctx, "FindAll: topics pre-query error", err)
-		}
-		if len(ids) == 0 {
-			return []*project.Project{}, usecasex.EmptyPageInfo(), nil
-		}
-		filter["id"] = bson.M{"$in": ids}
+		return r.findAllWithTopicsFilter(ctx, pFilter, filter)
 	}
-
-	// Sort by starcount needs metadata join via aggregation
 	if pFilter.Sort != nil && pFilter.Sort.Key == "starcount" {
 		return r.findAllWithStarcountSort(ctx, pFilter, filter)
 	}
@@ -662,35 +655,115 @@ func (r *Project) findAllWithFilter(ctx context.Context, pFilter repo.ProjectFil
 	return projects, pageInfo, nil
 }
 
-// findProjectIDsByTopics returns the list of project IDs whose metadata
-// matches all provided topics. Pre-fetching IDs is much faster than a
-// $lookup-then-$match aggregation across the project collection.
-func (r *Project) findProjectIDsByTopics(ctx context.Context, topics []string) ([]string, error) {
-	metadataColl := r.client.Client().Database().Collection("projectmetadata")
-	cursor, err := metadataColl.Find(ctx, bson.M{
-		"topics": bson.M{"$all": topics},
-	}, options.Find().SetProjection(bson.M{"project": 1, "_id": 0}))
+// findAllWithTopicsFilter runs the FindAll aggregation when a topics filter is
+// active. It uses a pipeline-form $lookup so the topics match runs inside the
+// projectmetadata sub-pipeline (using both the project and topics indexes),
+// avoiding the per-document $lookup-then-$match the previous implementation
+// did and without transferring matching IDs through the client.
+//
+// When no explicit sort is given, ordering defaults to metadata.starcount
+// descending, matching the previous topics path's behavior.
+func (r *Project) findAllWithTopicsFilter(ctx context.Context, pFilter repo.ProjectFilter, filter bson.M) ([]*project.Project, *usecasex.PageInfo, error) {
+	matchStage := bson.M{"$match": filter}
+
+	lookupStage := bson.M{
+		"$lookup": bson.M{
+			"from": "projectmetadata",
+			"let":  bson.M{"pid": "$id"},
+			"pipeline": []bson.M{
+				{"$match": bson.M{
+					"$expr":  bson.M{"$eq": bson.A{"$project", "$$pid"}},
+					"topics": bson.M{"$all": pFilter.Topics},
+				}},
+			},
+			"as": "metadata",
+		},
+	}
+
+	matchHasMetadata := bson.M{
+		"$match": bson.M{"metadata.0": bson.M{"$exists": true}},
+	}
+
+	sortKey := "metadata.starcount"
+	sortOrder := -1
+	if pFilter.Sort != nil {
+		if pFilter.Sort.Key == "starcount" {
+			sortKey = "metadata.starcount"
+		} else {
+			sortKey = pFilter.Sort.Key
+		}
+		if pFilter.Sort.Desc {
+			sortOrder = -1
+		} else {
+			sortOrder = 1
+		}
+	}
+	sortStage := bson.M{
+		"$sort": bson.D{
+			{Key: sortKey, Value: sortOrder},
+			{Key: "_id", Value: sortOrder},
+		},
+	}
+
+	dataPipeline := []bson.M{sortStage}
+	if pFilter.Limit != nil && pFilter.Offset != nil {
+		dataPipeline = append(dataPipeline, bson.M{"$skip": *pFilter.Offset})
+		dataPipeline = append(dataPipeline, bson.M{"$limit": *pFilter.Limit})
+	}
+
+	facetStage := bson.M{
+		"$facet": bson.M{
+			"data":  dataPipeline,
+			"count": []bson.M{{"$count": "total"}},
+		},
+	}
+
+	pipeline := []bson.M{matchStage, lookupStage, matchHasMetadata, facetStage}
+
+	cursor, err := r.client.Client().Aggregate(ctx, pipeline)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer cursor.Close(ctx)
 
-	var ids []string
-	for cursor.Next(ctx) {
-		var doc struct {
-			Project string `bson:"project"`
+	var totalCount int64 = 0
+	consumer := mongodoc.NewProjectConsumer(nil)
+	if cursor.Next(ctx) {
+		var result struct {
+			Data  []bson.Raw `bson:"data"`
+			Count []struct {
+				Total int64 `bson:"total"`
+			} `bson:"count"`
 		}
-		if err := cursor.Decode(&doc); err != nil {
-			return nil, err
+		if err := cursor.Decode(&result); err != nil {
+			return nil, nil, err
 		}
-		if doc.Project != "" {
-			ids = append(ids, doc.Project)
+		if len(result.Count) > 0 {
+			totalCount = result.Count[0].Total
+		}
+		for _, raw := range result.Data {
+			if err := consumer.Consume(raw); err != nil {
+				return nil, nil, err
+			}
 		}
 	}
 	if err := cursor.Err(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return ids, nil
+
+	var hasNextPage, hasPreviousPage bool
+	if pFilter.Limit != nil && pFilter.Offset != nil {
+		hasNextPage = *pFilter.Offset+*pFilter.Limit < totalCount
+		hasPreviousPage = *pFilter.Offset > 0
+	}
+
+	pageInfo := &usecasex.PageInfo{
+		TotalCount:      totalCount,
+		HasNextPage:     hasNextPage,
+		HasPreviousPage: hasPreviousPage,
+	}
+
+	return consumer.Result, pageInfo, nil
 }
 
 func (r *Project) CheckProjectAliasUnique(ctx context.Context, ws accountsID.WorkspaceID, newAlias string, excludeSelfProjectID *id.ProjectID) error {

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -783,6 +783,10 @@ func (r *Project) findAllWithTopicsFilter(ctx context.Context, pFilter repo.Proj
 		return nil, nil, err
 	}
 
+	if totalCount == 0 {
+		return []*project.Project{}, usecasex.EmptyPageInfo(), nil
+	}
+
 	pageInfo := &usecasex.PageInfo{
 		TotalCount:      totalCount,
 		HasNextPage:     skip+lim < totalCount,
@@ -1091,14 +1095,17 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 	}
 
 	skip, lim := effectiveSkipLimit(pFilter)
-	dataPipeline := []bson.M{sortStage}
+	dataPipeline := []bson.M{lookupStage, addFieldsStage, sortStage}
 	if skip > 0 {
 		dataPipeline = append(dataPipeline, bson.M{"$skip": skip})
 	}
 	dataPipeline = append(dataPipeline, bson.M{"$limit": lim})
 
-	// $facet runs count and paginated data in a single pipeline pass,
-	// avoiding the duplicate $lookup/$addFields the previous code required.
+	// $facet runs count and paginated data in a single pipeline pass. The
+	// total count for this path is determined solely by the project filter,
+	// so $lookup/$addFields/$sort/$skip/$limit live only in the `data`
+	// sub-pipeline; the `count` sub-pipeline reads the post-$match stream
+	// directly to avoid materializing metadata it does not need.
 	facetStage := bson.M{
 		"$facet": bson.M{
 			"data":  dataPipeline,
@@ -1106,7 +1113,7 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 		},
 	}
 
-	pipeline := []bson.M{matchStage, lookupStage, addFieldsStage, facetStage}
+	pipeline := []bson.M{matchStage, facetStage}
 
 	cursor, err := r.client.Client().Aggregate(ctx, pipeline)
 	if err != nil {
@@ -1137,6 +1144,10 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 	}
 	if err := cursor.Err(); err != nil {
 		return nil, nil, err
+	}
+
+	if totalCount == 0 {
+		return []*project.Project{}, usecasex.EmptyPageInfo(), nil
 	}
 
 	pageInfo := &usecasex.PageInfo{

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -1120,7 +1120,7 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 	// buffer/spill cost. sort_star_count is dropped after sorting since
 	// neither field is consumed downstream.
 	skip, lim := effectiveSkipLimit(pFilter)
-	dataPipeline := []bson.M{lookupStage, addFieldsStage, bson.M{"$unset": "metadata"}, sortStage}
+	dataPipeline := []bson.M{lookupStage, addFieldsStage, {"$unset": "metadata"}, sortStage}
 	if skip > 0 {
 		dataPipeline = append(dataPipeline, bson.M{"$skip": skip})
 	}

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	projectIndexes       = []string{"alias", "alias,publishmentstatus", "workspace", "visibility,deleted"}
+	projectIndexes       = []string{"alias", "alias,publishmentstatus", "workspace"}
 	projectUniqueIndexes = []string{"id"}
 )
 

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -742,15 +742,25 @@ func (r *Project) findAllWithTopicsFilter(ctx context.Context, pFilter repo.Proj
 		},
 	}
 
+	// When ordering does not depend on the joined metadata (e.g. by
+	// updatedat on the project itself), drop the metadata array before
+	// $sort to reduce sort buffer/spill cost. When sorting by
+	// metadata.starcount the array must survive until after $sort and is
+	// dropped once $limit has reduced the row count.
 	skip, lim := effectiveSkipLimit(pFilter)
-	dataPipeline := []bson.M{sortStage}
+	sortNeedsMetadata := strings.HasPrefix(sortKey, "metadata.")
+	dataPipeline := make([]bson.M, 0, 6)
+	if !sortNeedsMetadata {
+		dataPipeline = append(dataPipeline, bson.M{"$unset": "metadata"})
+	}
+	dataPipeline = append(dataPipeline, sortStage)
 	if skip > 0 {
 		dataPipeline = append(dataPipeline, bson.M{"$skip": skip})
 	}
-	// Drop the joined metadata array before materializing into the facet.
-	// The project consumer ignores it, and keeping it would bloat the single
-	// facet result document toward MongoDB's 16MB limit.
-	dataPipeline = append(dataPipeline, bson.M{"$limit": lim}, bson.M{"$unset": "metadata"})
+	dataPipeline = append(dataPipeline, bson.M{"$limit": lim})
+	if sortNeedsMetadata {
+		dataPipeline = append(dataPipeline, bson.M{"$unset": "metadata"})
+	}
 
 	facetStage := bson.M{
 		"$facet": bson.M{
@@ -1105,16 +1115,16 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 		},
 	}
 
+	// metadata is only needed to compute sort_star_count, so drop it
+	// immediately after $addFields. The smaller documents reduce sort
+	// buffer/spill cost. sort_star_count is dropped after sorting since
+	// neither field is consumed downstream.
 	skip, lim := effectiveSkipLimit(pFilter)
-	dataPipeline := []bson.M{lookupStage, addFieldsStage, sortStage}
+	dataPipeline := []bson.M{lookupStage, addFieldsStage, bson.M{"$unset": "metadata"}, sortStage}
 	if skip > 0 {
 		dataPipeline = append(dataPipeline, bson.M{"$skip": skip})
 	}
-	// Drop the joined metadata array and the temporary sort key before
-	// materializing into the facet. Neither field is consumed downstream and
-	// keeping them would bloat the single facet result document toward
-	// MongoDB's 16MB limit.
-	dataPipeline = append(dataPipeline, bson.M{"$limit": lim}, bson.M{"$unset": []string{"metadata", "sort_star_count"}})
+	dataPipeline = append(dataPipeline, bson.M{"$limit": lim}, bson.M{"$unset": "sort_star_count"})
 
 	// $facet runs count and paginated data in a single pipeline pass. The
 	// total count for this path is determined solely by the project filter,

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -649,17 +649,33 @@ func (r *Project) findAllWithFilter(ctx context.Context, pFilter repo.ProjectFil
 
 	projects, pageInfo, err := r.paginateWithoutWorkspaceFilter(ctx, filter, pFilter.Sort, pFilter.Pagination)
 	if err != nil {
-		log.Warnf("FindAll: Error in pagination: %v", err)
-		return []*project.Project{}, usecasex.EmptyPageInfo(), nil
+		return nil, nil, visualizer.ErrorWithCallerLogging(ctx, "FindAll: pagination error", err)
 	}
 	return projects, pageInfo, nil
 }
 
 // aggregationFacetCap is the hard upper bound on documents materialized into
 // the $facet "data" sub-pipeline. The cap prevents a single facet result from
-// approaching MongoDB's 16MB document limit when no explicit pagination is
-// supplied.
+// approaching MongoDB's 16MB document limit when callers provide no
+// pagination (or request more than the cap). When the cap actually
+// truncates results, warnFacetTruncation surfaces the event in logs so
+// operators can spot the case and ask the caller to paginate explicitly.
 const aggregationFacetCap int64 = 1000
+
+// warnFacetTruncation emits a warning when the aggregation $facet path
+// returned fewer documents than the total match count strictly because the
+// hard cap kicked in. The caller-provided skip/lim are reported so it is
+// clear whether the truncation came from an explicit large limit or from
+// the fallback default.
+func warnFacetTruncation(ctx context.Context, path string, skip, lim, totalCount int64) {
+	if lim != aggregationFacetCap {
+		return
+	}
+	if skip+lim >= totalCount {
+		return
+	}
+	log.Warnfc(ctx, "FindAll: %s truncated to aggregationFacetCap=%d (skip=%d, totalCount=%d); caller should paginate", path, aggregationFacetCap, skip, totalCount)
+}
 
 // effectiveSkipLimit derives an effective ($skip, $limit) pair for the
 // aggregation paths. Precedence: explicit pFilter.Limit/Offset → Pagination
@@ -794,6 +810,8 @@ func (r *Project) findAllWithTopicsFilter(ctx context.Context, pFilter repo.Proj
 	if totalCount == 0 {
 		return []*project.Project{}, usecasex.EmptyPageInfo(), nil
 	}
+
+	warnFacetTruncation(ctx, "topics", skip, lim, totalCount)
 
 	pageInfo := &usecasex.PageInfo{
 		TotalCount:      totalCount,
@@ -1163,6 +1181,8 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 	if totalCount == 0 {
 		return []*project.Project{}, usecasex.EmptyPageInfo(), nil
 	}
+
+	warnFacetTruncation(ctx, "starcount", skip, lim, totalCount)
 
 	pageInfo := &usecasex.PageInfo{
 		TotalCount:      totalCount,

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	projectIndexes       = []string{"alias", "alias,publishmentstatus", "workspace"}
+	projectIndexes       = []string{"alias", "alias,publishmentstatus", "workspace", "visibility,deleted"}
 	projectUniqueIndexes = []string{"id"}
 )
 
@@ -563,24 +563,12 @@ func (r *Project) FindAll(ctx context.Context, pFilter repo.ProjectFilter) ([]*p
 		visibility = *pFilter.Visibility
 	}
 
-	// Check if we need to filter by topics (which requires joining with projectmetadata)
-	if len(pFilter.Topics) > 0 {
-		return r.findAllWithTopicsFilter(ctx, pFilter, visibility)
-	}
-
-	// Check if we need to sort by starcount (which requires joining with projectmetadata)
-	if pFilter.Sort != nil && pFilter.Sort.Key == "starcount" {
-		return r.findAllWithStarcountSort(ctx, pFilter, visibility)
-	}
-
-	// Original implementation for non-topics search
 	filter := bson.M{
 		"visibility": visibility,
 		"deleted":    false,
 	}
 
 	if pFilter.Keyword != nil {
-		// Add name regex search directly to the filter
 		filter["name"] = bson.M{
 			"$regex": primitive.Regex{
 				Pattern: fmt.Sprintf(".*%s.*", regexp.QuoteMeta(*pFilter.Keyword)),
@@ -589,30 +577,35 @@ func (r *Project) FindAll(ctx context.Context, pFilter repo.ProjectFilter) ([]*p
 		}
 	}
 
-	count, err := r.client.Count(ctx, filter)
-	if err != nil {
-		log.Errorf("FindAll: Error counting public projects: %v", err)
-	} else {
-		// If count is 0, do a broader search just to verify projects exist
-		if count == 0 {
-			// Check if there are any projects at all
-			totalCount, err := r.client.Count(ctx, bson.M{})
-			if err != nil {
-				log.Errorf("FindAll: Error counting all projects: %v", err)
-			} else {
-				log.Infof("FindAll: Total projects in MongoDB: %d", totalCount)
-			}
-
-			log.Warnf("FindAll: No public projects found, returning empty list")
+	// Topics filter requires joining with projectmetadata. Pre-fetch matching
+	// project IDs to avoid a per-document $lookup over all public projects.
+	if len(pFilter.Topics) > 0 {
+		ids, err := r.findProjectIDsByTopics(ctx, pFilter.Topics)
+		if err != nil {
+			return nil, nil, visualizer.ErrorWithCallerLogging(ctx, "FindAll: topics pre-query error", err)
+		}
+		if len(ids) == 0 {
 			return []*project.Project{}, usecasex.EmptyPageInfo(), nil
 		}
+		filter["id"] = bson.M{"$in": ids}
 	}
 
+	// Sort by starcount needs metadata join via aggregation
+	if pFilter.Sort != nil && pFilter.Sort.Key == "starcount" {
+		return r.findAllWithStarcountSort(ctx, pFilter, filter)
+	}
+
+	return r.findAllWithFilter(ctx, pFilter, filter)
+}
+
+func (r *Project) findAllWithFilter(ctx context.Context, pFilter repo.ProjectFilter, filter bson.M) ([]*project.Project, *usecasex.PageInfo, error) {
 	if pFilter.Limit != nil && pFilter.Offset != nil {
 		totalCount, err := r.client.Count(ctx, filter)
 		if err != nil {
-			log.Errorf("FindAll: Count error: %v", err)
 			return nil, nil, visualizer.ErrorWithCallerLogging(ctx, "FindAll: Count error:", err)
+		}
+		if totalCount == 0 {
+			return []*project.Project{}, usecasex.EmptyPageInfo(), nil
 		}
 
 		var sortDoc bson.D
@@ -645,8 +638,7 @@ func (r *Project) FindAll(ctx context.Context, pFilter repo.ProjectFilter) ([]*p
 
 		c := mongodoc.NewProjectConsumer(nil)
 		if err := r.client.Find(ctx, filter, c, findOptions); err != nil {
-			log.Errorf("FindAll: Find error: %v", err)
-			return nil, nil, visualizer.ErrorWithCallerLogging(ctx, "FindAll: Count error:", err)
+			return nil, nil, visualizer.ErrorWithCallerLogging(ctx, "FindAll: Find error:", err)
 		}
 
 		pageInfo := &usecasex.PageInfo{
@@ -663,13 +655,42 @@ func (r *Project) FindAll(ctx context.Context, pFilter repo.ProjectFilter) ([]*p
 	}
 
 	projects, pageInfo, err := r.paginateWithoutWorkspaceFilter(ctx, filter, pFilter.Sort, pFilter.Pagination)
-	if err == nil {
-		log.Infof("FindAll: Filter succeeded, found %d projects", len(projects))
-		return projects, pageInfo, nil
-	} else {
-		log.Warnf("FindAll: Error in pagination: %v, trying simplified query", err)
+	if err != nil {
+		log.Warnf("FindAll: Error in pagination: %v", err)
 		return []*project.Project{}, usecasex.EmptyPageInfo(), nil
 	}
+	return projects, pageInfo, nil
+}
+
+// findProjectIDsByTopics returns the list of project IDs whose metadata
+// matches all provided topics. Pre-fetching IDs is much faster than a
+// $lookup-then-$match aggregation across the project collection.
+func (r *Project) findProjectIDsByTopics(ctx context.Context, topics []string) ([]string, error) {
+	metadataColl := r.client.Client().Database().Collection("projectmetadata")
+	cursor, err := metadataColl.Find(ctx, bson.M{
+		"topics": bson.M{"$all": topics},
+	}, options.Find().SetProjection(bson.M{"project": 1, "_id": 0}))
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var ids []string
+	for cursor.Next(ctx) {
+		var doc struct {
+			Project string `bson:"project"`
+		}
+		if err := cursor.Decode(&doc); err != nil {
+			return nil, err
+		}
+		if doc.Project != "" {
+			ids = append(ids, doc.Project)
+		}
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, err
+	}
+	return ids, nil
 }
 
 func (r *Project) CheckProjectAliasUnique(ctx context.Context, ws accountsID.WorkspaceID, newAlias string, excludeSelfProjectID *id.ProjectID) error {
@@ -926,24 +947,8 @@ func filterProjects(ids []id.ProjectID, rows []*project.Project) []*project.Proj
 	return res
 }
 
-func (r *Project) findAllWithTopicsFilter(ctx context.Context, pFilter repo.ProjectFilter, visibility string) ([]*project.Project, *usecasex.PageInfo, error) {
-	// Build aggregation pipeline
-	matchStage := bson.M{
-		"$match": bson.M{
-			"visibility": visibility,
-			"deleted":    false,
-		},
-	}
-
-	// Add keyword search for name if provided
-	if pFilter.Keyword != nil {
-		matchStage["$match"].(bson.M)["name"] = bson.M{
-			"$regex": primitive.Regex{
-				Pattern: fmt.Sprintf(".*%s.*", regexp.QuoteMeta(*pFilter.Keyword)),
-				Options: "i",
-			},
-		}
-	}
+func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.ProjectFilter, filter bson.M) ([]*project.Project, *usecasex.PageInfo, error) {
+	matchStage := bson.M{"$match": filter}
 
 	lookupStage := bson.M{
 		"$lookup": bson.M{
@@ -954,128 +959,8 @@ func (r *Project) findAllWithTopicsFilter(ctx context.Context, pFilter repo.Proj
 		},
 	}
 
-	// Build topics match condition
-	topicsMatchStage := bson.M{
-		"$match": bson.M{
-			"metadata.topics": bson.M{"$all": pFilter.Topics},
-		},
-	}
-
-	pipeline := []bson.M{matchStage, lookupStage, topicsMatchStage}
-
-	// Handle sorting
-	sortOrder := 1
-	if pFilter.Sort != nil {
-		sortKey := pFilter.Sort.Key
-		if sortKey == "starcount" {
-			sortKey = "metadata.starcount"
-		}
-		if pFilter.Sort.Desc {
-			sortOrder = -1
-		}
-		sortStage := bson.M{
-			"$sort": bson.D{{Key: sortKey, Value: sortOrder}, {Key: "_id", Value: sortOrder}},
-		}
-		pipeline = append(pipeline, sortStage)
-	} else {
-		// Default sort by starcount descending
-		sortStage := bson.M{
-			"$sort": bson.D{{Key: "metadata.starcount", Value: -1}, {Key: "_id", Value: -1}},
-		}
-		pipeline = append(pipeline, sortStage)
-	}
-
-	// Count total documents with aggregation
-	countPipeline := make([]bson.M, len(pipeline))
-	copy(countPipeline, pipeline)
-	countPipeline = append(countPipeline, bson.M{"$count": "total"})
-
-	countCursor, err := r.client.Client().Aggregate(ctx, countPipeline)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer countCursor.Close(ctx)
-
-	var totalCount int64 = 0
-	if countCursor.Next(ctx) {
-		var result struct {
-			Total int64 `bson:"total"`
-		}
-		if err := countCursor.Decode(&result); err == nil {
-			totalCount = result.Total
-		}
-	}
-
-	// Handle pagination
-	if pFilter.Limit != nil && pFilter.Offset != nil {
-		pipeline = append(pipeline, bson.M{"$skip": *pFilter.Offset})
-		pipeline = append(pipeline, bson.M{"$limit": *pFilter.Limit})
-	}
-
-	// Execute aggregation
-	cursor, err := r.client.Client().Aggregate(ctx, pipeline)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer cursor.Close(ctx)
-
-	consumer := mongodoc.NewProjectConsumer(nil)
-	for cursor.Next(ctx) {
-		raw := cursor.Current
-		if err := consumer.Consume(raw); err != nil {
-			return nil, nil, err
-		}
-	}
-	if err := cursor.Err(); err != nil {
-		return nil, nil, err
-	}
-
-	var hasNextPage, hasPreviousPage bool
-	if pFilter.Limit != nil && pFilter.Offset != nil {
-		hasNextPage = *pFilter.Offset+*pFilter.Limit < totalCount
-		hasPreviousPage = *pFilter.Offset > 0
-	}
-
-	pageInfo := &usecasex.PageInfo{
-		TotalCount:      totalCount,
-		HasNextPage:     hasNextPage,
-		HasPreviousPage: hasPreviousPage,
-	}
-
-	return consumer.Result, pageInfo, nil
-}
-
-func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.ProjectFilter, visibility string) ([]*project.Project, *usecasex.PageInfo, error) {
-	// Build aggregation pipeline
-	matchStage := bson.M{
-		"$match": bson.M{
-			"visibility": visibility,
-			"deleted":    false,
-		},
-	}
-
-	// Add keyword search for name if provided
-	if pFilter.Keyword != nil {
-		matchStage["$match"].(bson.M)["name"] = bson.M{
-			"$regex": primitive.Regex{
-				Pattern: fmt.Sprintf(".*%s.*", regexp.QuoteMeta(*pFilter.Keyword)),
-				Options: "i",
-			},
-		}
-	}
-
-	lookupStage := bson.M{
-		"$lookup": bson.M{
-			"from":         "projectmetadata",
-			"localField":   "id",
-			"foreignField": "project",
-			"as":           "metadata",
-		},
-	}
-
-	// Handle sorting by starcount
-	// For projects without metadata, we need to handle them specially
-	// Add a field for sorting that handles missing metadata
+	// Project-side sort key derived from metadata.starcount, defaulting to 0
+	// when no metadata exists, so projects without metadata sort to the end.
 	addFieldsStage := bson.M{
 		"$addFields": bson.M{
 			"sort_star_count": bson.M{
@@ -1089,7 +974,7 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 							},
 						},
 					},
-					"else": 0, // Projects without metadata get 0 for sorting
+					"else": 0,
 				},
 			},
 		},
@@ -1106,47 +991,48 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 		},
 	}
 
-	pipeline := []bson.M{matchStage, lookupStage, addFieldsStage, sortStage}
-
-	// Count total documents with aggregation
-	countPipeline := make([]bson.M, len(pipeline))
-	copy(countPipeline, pipeline)
-	countPipeline = append(countPipeline, bson.M{"$count": "total"})
-
-	countCursor, err := r.client.Client().Aggregate(ctx, countPipeline)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer countCursor.Close(ctx)
-
-	var totalCount int64 = 0
-	if countCursor.Next(ctx) {
-		var result struct {
-			Total int64 `bson:"total"`
-		}
-		if err := countCursor.Decode(&result); err == nil {
-			totalCount = result.Total
-		}
-	}
-
-	// Handle pagination
+	dataPipeline := []bson.M{sortStage}
 	if pFilter.Limit != nil && pFilter.Offset != nil {
-		pipeline = append(pipeline, bson.M{"$skip": *pFilter.Offset})
-		pipeline = append(pipeline, bson.M{"$limit": *pFilter.Limit})
+		dataPipeline = append(dataPipeline, bson.M{"$skip": *pFilter.Offset})
+		dataPipeline = append(dataPipeline, bson.M{"$limit": *pFilter.Limit})
 	}
 
-	// Execute aggregation
+	// $facet runs count and paginated data in a single pipeline pass,
+	// avoiding the duplicate $lookup/$addFields the previous code required.
+	facetStage := bson.M{
+		"$facet": bson.M{
+			"data":  dataPipeline,
+			"count": []bson.M{{"$count": "total"}},
+		},
+	}
+
+	pipeline := []bson.M{matchStage, lookupStage, addFieldsStage, facetStage}
+
 	cursor, err := r.client.Client().Aggregate(ctx, pipeline)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer cursor.Close(ctx)
 
+	var totalCount int64 = 0
 	consumer := mongodoc.NewProjectConsumer(nil)
-	for cursor.Next(ctx) {
-		raw := cursor.Current
-		if err := consumer.Consume(raw); err != nil {
+	if cursor.Next(ctx) {
+		var result struct {
+			Data  []bson.Raw `bson:"data"`
+			Count []struct {
+				Total int64 `bson:"total"`
+			} `bson:"count"`
+		}
+		if err := cursor.Decode(&result); err != nil {
 			return nil, nil, err
+		}
+		if len(result.Count) > 0 {
+			totalCount = result.Count[0].Total
+		}
+		for _, raw := range result.Data {
+			if err := consumer.Consume(raw); err != nil {
+				return nil, nil, err
+			}
 		}
 	}
 	if err := cursor.Err(); err != nil {

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -655,27 +655,12 @@ func (r *Project) findAllWithFilter(ctx context.Context, pFilter repo.ProjectFil
 }
 
 // aggregationFacetCap is the hard upper bound on documents materialized into
-// the $facet "data" sub-pipeline. The cap prevents a single facet result from
-// approaching MongoDB's 16MB document limit when callers provide no
+// the $facet "data" sub-pipeline. The cap keeps the single facet result
+// document well below MongoDB's 16MB limit when callers provide no
 // pagination (or request more than the cap). When the cap actually
-// truncates results, warnFacetTruncation surfaces the event in logs so
-// operators can spot the case and ask the caller to paginate explicitly.
+// truncates a result set, callers can detect it by comparing the returned
+// project count against PageInfo.TotalCount.
 const aggregationFacetCap int64 = 1000
-
-// warnFacetTruncation emits a warning when the aggregation $facet path
-// returned fewer documents than the total match count strictly because the
-// hard cap kicked in. The caller-provided skip/lim are reported so it is
-// clear whether the truncation came from an explicit large limit or from
-// the fallback default.
-func warnFacetTruncation(ctx context.Context, path string, skip, lim, totalCount int64) {
-	if lim != aggregationFacetCap {
-		return
-	}
-	if skip+lim >= totalCount {
-		return
-	}
-	log.Warnfc(ctx, "FindAll: %s truncated to aggregationFacetCap=%d (skip=%d, totalCount=%d); caller should paginate", path, aggregationFacetCap, skip, totalCount)
-}
 
 // effectiveSkipLimit derives an effective ($skip, $limit) pair for the
 // aggregation paths. Precedence: explicit pFilter.Limit/Offset → Pagination
@@ -810,8 +795,6 @@ func (r *Project) findAllWithTopicsFilter(ctx context.Context, pFilter repo.Proj
 	if totalCount == 0 {
 		return []*project.Project{}, usecasex.EmptyPageInfo(), nil
 	}
-
-	warnFacetTruncation(ctx, "topics", skip, lim, totalCount)
 
 	pageInfo := &usecasex.PageInfo{
 		TotalCount:      totalCount,
@@ -1181,8 +1164,6 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 	if totalCount == 0 {
 		return []*project.Project{}, usecasex.EmptyPageInfo(), nil
 	}
-
-	warnFacetTruncation(ctx, "starcount", skip, lim, totalCount)
 
 	pageInfo := &usecasex.PageInfo{
 		TotalCount:      totalCount,

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -662,12 +662,32 @@ func (r *Project) findAllWithFilter(ctx context.Context, pFilter repo.ProjectFil
 // project count against PageInfo.TotalCount.
 const aggregationFacetCap int64 = 1000
 
+// warnIfUnsupportedCursor surfaces a warning when callers request Relay-style
+// cursor positioning (After/Before) on the aggregation paths. These paths do
+// not implement cursor-position $match — they only honor First/Last as a
+// bounded $limit — so After/Before are silently ignored, which matches the
+// pre-existing behavior of the topics aggregation prior to this PR. The
+// warning lets operators spot mis-paginated calls.
+func warnIfUnsupportedCursor(ctx context.Context, path string, pagination *usecasex.Pagination) {
+	if pagination == nil || pagination.Cursor == nil {
+		return
+	}
+	if pagination.Cursor.After == nil && pagination.Cursor.Before == nil {
+		return
+	}
+	log.Warnfc(ctx, "FindAll: %s ignored cursor positioning (After/Before); aggregation paths only honor First/Last as $limit", path)
+}
+
 // effectiveSkipLimit derives an effective ($skip, $limit) pair for the
 // aggregation paths. Precedence: explicit pFilter.Limit/Offset → Pagination
 // Offset → Pagination Cursor First/Last → the hard cap. The returned limit
 // is always clamped to (0, aggregationFacetCap] regardless of caller input,
 // since unauthenticated GetAllProjects reaches these paths and the $facet
 // "data" array must stay well below MongoDB's 16MB document limit.
+//
+// Relay-style cursor positioning (Cursor.After / Cursor.Before) is not
+// implemented on the aggregation paths and is therefore ignored here; see
+// warnIfUnsupportedCursor.
 func effectiveSkipLimit(pFilter repo.ProjectFilter) (skip, lim int64) {
 	switch {
 	case pFilter.Limit != nil && pFilter.Offset != nil:
@@ -701,6 +721,7 @@ func effectiveSkipLimit(pFilter repo.ProjectFilter) (skip, lim int64) {
 // When no explicit sort is given, ordering defaults to metadata.starcount
 // descending, matching the previous topics path's behavior.
 func (r *Project) findAllWithTopicsFilter(ctx context.Context, pFilter repo.ProjectFilter, filter bson.M) ([]*project.Project, *usecasex.PageInfo, error) {
+	warnIfUnsupportedCursor(ctx, "topics", pFilter.Pagination)
 	matchStage := bson.M{"$match": filter}
 
 	lookupStage := bson.M{
@@ -1070,6 +1091,7 @@ func filterProjects(ids []id.ProjectID, rows []*project.Project) []*project.Proj
 }
 
 func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.ProjectFilter, filter bson.M) ([]*project.Project, *usecasex.PageInfo, error) {
+	warnIfUnsupportedCursor(ctx, "starcount", pFilter.Pagination)
 	matchStage := bson.M{"$match": filter}
 
 	lookupStage := bson.M{

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -655,11 +655,42 @@ func (r *Project) findAllWithFilter(ctx context.Context, pFilter repo.ProjectFil
 	return projects, pageInfo, nil
 }
 
+// aggregationFacetCap is the hard upper bound on documents materialized into
+// the $facet "data" sub-pipeline. The cap prevents a single facet result from
+// approaching MongoDB's 16MB document limit when no explicit pagination is
+// supplied.
+const aggregationFacetCap int64 = 1000
+
+// effectiveSkipLimit derives an effective ($skip, $limit) pair for the
+// aggregation paths. Precedence: explicit pFilter.Limit/Offset → Pagination
+// Offset → Pagination Cursor First/Last → the hard cap.
+func effectiveSkipLimit(pFilter repo.ProjectFilter) (skip, lim int64) {
+	if pFilter.Limit != nil && pFilter.Offset != nil {
+		return *pFilter.Offset, *pFilter.Limit
+	}
+	if pFilter.Pagination != nil {
+		if pFilter.Pagination.Offset != nil {
+			return pFilter.Pagination.Offset.Offset, pFilter.Pagination.Offset.Limit
+		}
+		if pFilter.Pagination.Cursor != nil {
+			if pFilter.Pagination.Cursor.First != nil && *pFilter.Pagination.Cursor.First > 0 {
+				return 0, *pFilter.Pagination.Cursor.First
+			}
+			if pFilter.Pagination.Cursor.Last != nil && *pFilter.Pagination.Cursor.Last > 0 {
+				return 0, *pFilter.Pagination.Cursor.Last
+			}
+		}
+	}
+	return 0, aggregationFacetCap
+}
+
 // findAllWithTopicsFilter runs the FindAll aggregation when a topics filter is
-// active. It uses a pipeline-form $lookup so the topics match runs inside the
-// projectmetadata sub-pipeline (using both the project and topics indexes),
-// avoiding the per-document $lookup-then-$match the previous implementation
-// did and without transferring matching IDs through the client.
+// active. The topics match is pushed into the $lookup sub-pipeline so only
+// metadata matching the requested topics is joined (predicate pushdown,
+// exercising both the projectmetadata.project and projectmetadata.topics
+// indexes). The lookup itself still runs per input project document — the
+// improvement is reduced joined payload and an early non-empty-array check
+// in place of the previous post-lookup `metadata.topics: $all` scan.
 //
 // When no explicit sort is given, ordering defaults to metadata.starcount
 // descending, matching the previous topics path's behavior.
@@ -705,11 +736,12 @@ func (r *Project) findAllWithTopicsFilter(ctx context.Context, pFilter repo.Proj
 		},
 	}
 
+	skip, lim := effectiveSkipLimit(pFilter)
 	dataPipeline := []bson.M{sortStage}
-	if pFilter.Limit != nil && pFilter.Offset != nil {
-		dataPipeline = append(dataPipeline, bson.M{"$skip": *pFilter.Offset})
-		dataPipeline = append(dataPipeline, bson.M{"$limit": *pFilter.Limit})
+	if skip > 0 {
+		dataPipeline = append(dataPipeline, bson.M{"$skip": skip})
 	}
+	dataPipeline = append(dataPipeline, bson.M{"$limit": lim})
 
 	facetStage := bson.M{
 		"$facet": bson.M{
@@ -751,16 +783,10 @@ func (r *Project) findAllWithTopicsFilter(ctx context.Context, pFilter repo.Proj
 		return nil, nil, err
 	}
 
-	var hasNextPage, hasPreviousPage bool
-	if pFilter.Limit != nil && pFilter.Offset != nil {
-		hasNextPage = *pFilter.Offset+*pFilter.Limit < totalCount
-		hasPreviousPage = *pFilter.Offset > 0
-	}
-
 	pageInfo := &usecasex.PageInfo{
 		TotalCount:      totalCount,
-		HasNextPage:     hasNextPage,
-		HasPreviousPage: hasPreviousPage,
+		HasNextPage:     skip+lim < totalCount,
+		HasPreviousPage: skip > 0,
 	}
 
 	return consumer.Result, pageInfo, nil
@@ -1064,11 +1090,12 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 		},
 	}
 
+	skip, lim := effectiveSkipLimit(pFilter)
 	dataPipeline := []bson.M{sortStage}
-	if pFilter.Limit != nil && pFilter.Offset != nil {
-		dataPipeline = append(dataPipeline, bson.M{"$skip": *pFilter.Offset})
-		dataPipeline = append(dataPipeline, bson.M{"$limit": *pFilter.Limit})
+	if skip > 0 {
+		dataPipeline = append(dataPipeline, bson.M{"$skip": skip})
 	}
+	dataPipeline = append(dataPipeline, bson.M{"$limit": lim})
 
 	// $facet runs count and paginated data in a single pipeline pass,
 	// avoiding the duplicate $lookup/$addFields the previous code required.
@@ -1112,16 +1139,10 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 		return nil, nil, err
 	}
 
-	var hasNextPage, hasPreviousPage bool
-	if pFilter.Limit != nil && pFilter.Offset != nil {
-		hasNextPage = *pFilter.Offset+*pFilter.Limit < totalCount
-		hasPreviousPage = *pFilter.Offset > 0
-	}
-
 	pageInfo := &usecasex.PageInfo{
 		TotalCount:      totalCount,
-		HasNextPage:     hasNextPage,
-		HasPreviousPage: hasPreviousPage,
+		HasNextPage:     skip+lim < totalCount,
+		HasPreviousPage: skip > 0,
 	}
 
 	return consumer.Result, pageInfo, nil

--- a/server/internal/infrastructure/mongo/project_metadata.go
+++ b/server/internal/infrastructure/mongo/project_metadata.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	projectmetadataIndexes       = []string{"project"}
+	projectmetadataIndexes       = []string{"project", "topics"}
 	projectmetadataUniqueIndexes = []string{"id"}
 )
 

--- a/server/internal/infrastructure/mongo/project_metadata.go
+++ b/server/internal/infrastructure/mongo/project_metadata.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	projectmetadataIndexes       = []string{"project", "topics"}
+	projectmetadataIndexes       = []string{"project"}
 	projectmetadataUniqueIndexes = []string{"id"}
 )
 


### PR DESCRIPTION
# Overview

Optimize hot-path performance of the InternalAPI `GetAllProjects` flow, which currently does redundant work in `Project.FindAll` (`server/internal/infrastructure/mongo/project.go`) and lacks MongoDB indexes for the filters it issues.

## What I've done

- **Add MongoDB indexes via a new migration `AddProjectVisibilityAndTopicsIndexes`** (`server/internal/infrastructure/mongo/migration/260518143901_*.go`). The migration creates `project.(visibility, deleted)` and `projectmetadata.topics`. The project index is created with the same `{Locale: "en", Strength: 3, CaseLevel: true, Alternate: "shifted"}` collation that `findAllWithFilter` uses, so it is usable from that path; the projectmetadata index stays on the default collation (the aggregation paths read it without collation). Both are non-unique and created idempotently — the migration lists existing indexes and skips when an equivalent (same key spec **and** collation) one is already present, regardless of name. Errors from index creation are propagated so the migration framework retries instead of marking it applied with missing indexes.
- **Collapse duplicate `Count` calls in `FindAll`.** The previous implementation could issue up to three `Count` queries per request (an initial filter count, a diagnostic full-collection count when the result was zero, and a re-count for the `offset+limit` path). The diagnostic count is removed and the offset+limit path keeps a single count.
- **Restructure topics filtering with a pipeline-form `$lookup`.** The previous code ran an aggregation `$match → $lookup → $match(topics)` on every public project, so the join always materialized the full metadata array before the topics condition was applied. Replaced with a pipeline-form `$lookup` whose sub-pipeline filters `projectmetadata` by both `project` and `topics` inline (predicate pushdown). The lookup still runs per input project document, but it now uses the new `topics` index, returns an empty array for non-matching projects, and the post-lookup `$match` reduces to a cheap "metadata array non-empty" check. Everything stays server-side — no intermediate ID list is transferred through the client. When no explicit sort is given, ordering defaults to `metadata.starcount` descending, matching the previous behavior.
- **`$facet` the starcount-sort and topics aggregations.** Previously each aggregation ran the `$match → $lookup → $addFields → $sort` (or equivalent) stages twice — once for a `$count` pipeline and once for the data pipeline. Now a single pipeline runs the stages once and fans out to `count` and `data` sub-pipelines via `$facet`. The starcount path puts the `$lookup`/`$addFields`/`$sort`/pagination stages entirely inside the `data` sub-pipeline (the count branch reads the post-`$match` stream directly), and both paths drop the joined `metadata` array (and `sort_star_count`) via `$unset` before `$limit` so the facet result document stays well below MongoDB's 16MB limit.
- **Bound the `$facet` `data` sub-pipeline.** The helper `effectiveSkipLimit` derives `(skip, limit)` from `pFilter.Limit/Offset` → `Pagination.Offset` → `Pagination.Cursor.First/Last` → a hard cap (`aggregationFacetCap = 1000`). **All** input values — including `Cursor.First/Last` — are clamped to `(0, 1000]` so callers cannot push the facet output toward 16MB. When the cap actually truncates a result set, callers can detect it by comparing the returned project count against `PageInfo.TotalCount`. Relay-style cursor positioning (`Cursor.After` / `Cursor.Before`) is **not** implemented on the aggregation paths and is ignored — this matches the pre-existing behavior of the old topics aggregation. A warning is logged when such a request reaches an aggregation path so operators can spot mis-paginated callers.

## What I haven't done

Several issues identified during analysis are out of scope for this PR:

- The keyword search uses a leading-wildcard regex (`.*kw.*`), which cannot use an index. Switching to a text index or anchored prefix is a separate decision.
- The default sort key for non-topics, non-starcount queries when no sort is provided is still `starcount` (a field that does not exist on `project` documents). Behavior is preserved as-is for that path.
- The `maxLimit` clamp in `GetAllProjects` (API layer) only clamps `Limit`; `First`/`Last` are still unbounded at the API layer. The aggregation paths additionally clamp `First`/`Last` to `aggregationFacetCap` defensively.
- Full Relay-style cursor positioning (`Before`/`After`) on the aggregation paths is still not implemented. Callers that pass these values get the first page back and a warning in logs. The non-aggregation `findAllWithFilter` path still uses `paginateWithoutWorkspaceFilter` which supports cursor positioning.
- `getMetadata` in the project interactor uses a nested O(N×M) loop. Effect is minor at the default page size of 100.

## How I tested

- `go build ./...` clean.
- `go vet ./...` clean.
- `gofmt -s -l` clean on touched files.
- `go test ./internal/infrastructure/mongo/...` passes against a local MongoDB. All `TestProject_FindAll` subtests (no-filter, keyword, single/multiple topics, keyword+topics, non-matching topic, private visibility, pagination, starcount sort DESC/ASC, updatedat DESC/ASC) pass on both `origin/main` and this branch with identical results — no test files are modified in this PR.
- `go test ./internal/infrastructure/mongo/migration/...` passes.

The optimizations preserve the existing API surface and result semantics of `Project.FindAll` for the only caller (`GetAllProjects`). Two intentional changes to internal behavior are worth calling out so future callers are not surprised:

- **Error handling is stricter.** When `paginateWithoutWorkspaceFilter` fails, `findAllWithFilter` now propagates the error instead of logging it and returning an empty list with `nil` error. The previous behavior could hide DB failures behind an apparently-empty success response; the new behavior surfaces them to the caller. This change was made in response to earlier review feedback (Copilot thread Nc6DZZJH) and is intentional.
- **Aggregation paths cap the result set.** `findAllWithTopicsFilter` and `findAllWithStarcountSort` always apply `$skip`/`$limit` derived from `effectiveSkipLimit`, including the `aggregationFacetCap = 1000` fallback when no pagination is supplied. The pre-existing aggregation code returned the full match set in that case. The only caller (`GetAllProjects`) always supplies pagination (default `First = 100`), so this is not user-visible; the cap is a hard safety bound against the `$facet` 16MB document limit and is observable to callers via `PageInfo.TotalCount > len(Projects)`.

## Which point I want you to review particularly

- **Index migration cost on deploy.** The new indexes are created by migration `260518143901_add_project_visibility_and_topics_indexes.go`, which runs as part of the regular migration flow. On a large `project` / `projectmetadata` collection the initial build can take time and momentarily affect write throughput. MongoDB 4.2+ uses a hybrid index build that does not hold an exclusive lock for the full duration, but for very large collections we recommend pre-building these indexes manually ahead of the application rollout. The indexes are intentionally **not** added to `projectIndexes` / `projectmetadataIndexes` so the server startup path (`Init`) does not race the migration to build them. Indexes are created with stable names (`project_visibility_deleted` and `projectmetadata_topics`) and the project index uses the same query collation `findAllWithFilter` issues, so manual pre-builds and the migration recognize each other.
- **Topics `$lookup` correlation key.** The pipeline-form `$lookup` correlates `project.id` (string) with `projectmetadata.project` (string) via `$expr: {$eq: ["$project", "$$pid"]}`. Please confirm the field mapping is correct.
- **`$facet` and pagination bounds.** All inputs to `effectiveSkipLimit` are clamped to `(0, aggregationFacetCap]`. The cap (`1000`) is intentionally well above the API's default `First=100` so realistic callers are unaffected. `Cursor.After`/`Before` are not honored on the aggregation paths (logged as a warning) — please confirm this is acceptable as a documented limitation.

## Memo

- Related context: `server/CLAUDE.md` documents the InternalAPI selective-auth implementation; this PR does not change auth behavior.

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations. *(Index additions are additive; existing queries continue to work without the indexes, just slower.)*
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)