### PR TITLE
perf(server): metadata-first aggregation for most_starred sort

### DIFF
--- a/server/internal/infrastructure/mongo/migration/260518143901_add_project_visibility_and_topics_indexes.go
+++ b/server/internal/infrastructure/mongo/migration/260518143901_add_project_visibility_and_topics_indexes.go
@@ -39,14 +39,16 @@ var projectQueryCollation = &options.Collation{
 	Alternate: "shifted",
 }
 
+const addProjectVisibilityAndTopicsIndexesName = "AddProjectVisibilityAndTopicsIndexes"
+
 func AddProjectVisibilityAndTopicsIndexes(ctx context.Context, c DBClient) error {
-	if err := createNonUniqueIndex(ctx, c, "project", "project_visibility_deleted", bson.D{
+	if err := createNonUniqueIndex(ctx, c, addProjectVisibilityAndTopicsIndexesName, "project", "project_visibility_deleted", bson.D{
 		{Key: "visibility", Value: 1},
 		{Key: "deleted", Value: 1},
 	}, projectQueryCollation); err != nil {
 		return err
 	}
-	if err := createNonUniqueIndex(ctx, c, "projectmetadata", "projectmetadata_topics", bson.D{
+	if err := createNonUniqueIndex(ctx, c, addProjectVisibilityAndTopicsIndexesName, "projectmetadata", "projectmetadata_topics", bson.D{
 		{Key: "topics", Value: 1},
 	}, nil); err != nil {
 		return err
@@ -54,15 +56,19 @@ func AddProjectVisibilityAndTopicsIndexes(ctx context.Context, c DBClient) error
 	return nil
 }
 
-func createNonUniqueIndex(ctx context.Context, c DBClient, collectionName, indexName string, keys bson.D, collation *options.Collation) error {
+// createNonUniqueIndex is shared between index-adding migrations. The
+// migrationName parameter is used as a prefix in log lines and wrapped
+// errors so that deploy-time failures clearly identify which migration
+// they originated from.
+func createNonUniqueIndex(ctx context.Context, c DBClient, migrationName, collectionName, indexName string, keys bson.D, collation *options.Collation) error {
 	collection := c.Database().Collection(collectionName)
 
 	exists, existingName, err := indexWithKeysExists(ctx, collection, keys, collation)
 	if err != nil {
-		return fmt.Errorf("migration: AddProjectVisibilityAndTopicsIndexes: failed to list indexes on %s: %w", collectionName, err)
+		return fmt.Errorf("migration: %s: failed to list indexes on %s: %w", migrationName, collectionName, err)
 	}
 	if exists {
-		log.Infofc(ctx, "migration: AddProjectVisibilityAndTopicsIndexes: index already exists on %s as %q, skipping", collectionName, existingName)
+		log.Infofc(ctx, "migration: %s: index already exists on %s as %q, skipping", migrationName, collectionName, existingName)
 		return nil
 	}
 
@@ -75,9 +81,9 @@ func createNonUniqueIndex(ctx context.Context, c DBClient, collectionName, index
 		Options: idxOpts,
 	})
 	if err != nil {
-		return fmt.Errorf("migration: AddProjectVisibilityAndTopicsIndexes: failed to create index on %s: %w", collectionName, err)
+		return fmt.Errorf("migration: %s: failed to create index on %s: %w", migrationName, collectionName, err)
 	}
-	log.Infofc(ctx, "migration: AddProjectVisibilityAndTopicsIndexes: created index on %s: %s", collectionName, name)
+	log.Infofc(ctx, "migration: %s: created index on %s: %s", migrationName, collectionName, name)
 	return nil
 }
 

--- a/server/internal/infrastructure/mongo/migration/260520220637_add_project_metadata_starcount_index.go
+++ b/server/internal/infrastructure/mongo/migration/260520220637_add_project_metadata_starcount_index.go
@@ -8,8 +8,8 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-// AddProjectmetadataStarcountIndex backfills projectmetadata.starcount and
-// creates a compound (starcount, _id) index that backs the most_starred
+// AddProjectMetadataStarcountIndex backfills projectmetadata.starcount and
+// creates a compound (starcount, project) index that backs the most_starred
 // sort path used by InternalAPI GetAllProjects.
 //
 // Backfill: the original AddProjectMetadata migration did not set
@@ -22,7 +22,7 @@ import (
 // star_count field when it carries a usable number.
 //
 // Index: the aggregation reads metadata in starcount order and joins to
-// project, so an index-backed sort on (starcount, _id) replaces the
+// project, so an index-backed sort on (starcount, project) replaces the
 // previous in-memory sort over every public project. The plan is not
 // index-only (project still has to be read for the $lookup), but the
 // sort no longer needs to buffer the full result set. The same
@@ -30,15 +30,23 @@ import (
 // MongoDB scans the index in the reverse direction when the sort
 // inverts every key uniformly.
 //
+// Tie-break: projectmetadata.project (the project ID) is used instead of
+// the metadata document's _id because metadata _id values are not
+// stable across the legacy backfill path. AddProjectMetadata generated
+// fresh metadata _ids for all pre-existing projects in one pass, so
+// their _id ordering reflects backfill order rather than project
+// creation order. The project ID is a stable per-project identifier
+// that gives deterministic pagination across deployments.
+//
 // Idempotent: the backfill targets only documents without a numeric
 // starcount, and createNonUniqueIndex is itself idempotent.
-func AddProjectmetadataStarcountIndex(ctx context.Context, c DBClient) error {
+func AddProjectMetadataStarcountIndex(ctx context.Context, c DBClient) error {
 	if err := backfillStarcount(ctx, c); err != nil {
 		return err
 	}
-	return createNonUniqueIndex(ctx, c, "projectmetadata", "projectmetadata_starcount_id", bson.D{
+	return createNonUniqueIndex(ctx, c, "projectmetadata", "projectmetadata_starcount_project", bson.D{
 		{Key: "starcount", Value: 1},
-		{Key: "_id", Value: 1},
+		{Key: "project", Value: 1},
 	}, nil)
 }
 
@@ -60,10 +68,10 @@ func backfillStarcount(ctx context.Context, c DBClient) error {
 	}
 	res, err := col.UpdateMany(ctx, filter, update)
 	if err != nil {
-		return fmt.Errorf("migration: AddProjectmetadataStarcountIndex: failed to backfill starcount: %w", err)
+		return fmt.Errorf("migration: AddProjectMetadataStarcountIndex: failed to backfill starcount: %w", err)
 	}
 	if res.ModifiedCount > 0 {
-		log.Infofc(ctx, "migration: AddProjectmetadataStarcountIndex: backfilled starcount on %d projectmetadata documents", res.ModifiedCount)
+		log.Infofc(ctx, "migration: AddProjectMetadataStarcountIndex: backfilled starcount on %d projectmetadata documents", res.ModifiedCount)
 	}
 	return nil
 }

--- a/server/internal/infrastructure/mongo/migration/260520220637_add_project_metadata_starcount_index.go
+++ b/server/internal/infrastructure/mongo/migration/260520220637_add_project_metadata_starcount_index.go
@@ -40,11 +40,13 @@ import (
 //
 // Idempotent: the backfill targets only documents without a numeric
 // starcount, and createNonUniqueIndex is itself idempotent.
+const addProjectMetadataStarcountIndexName = "AddProjectMetadataStarcountIndex"
+
 func AddProjectMetadataStarcountIndex(ctx context.Context, c DBClient) error {
 	if err := backfillStarcount(ctx, c); err != nil {
 		return err
 	}
-	return createNonUniqueIndex(ctx, c, "projectmetadata", "projectmetadata_starcount_project", bson.D{
+	return createNonUniqueIndex(ctx, c, addProjectMetadataStarcountIndexName, "projectmetadata", "projectmetadata_starcount_project", bson.D{
 		{Key: "starcount", Value: 1},
 		{Key: "project", Value: 1},
 	}, nil)
@@ -68,10 +70,10 @@ func backfillStarcount(ctx context.Context, c DBClient) error {
 	}
 	res, err := col.UpdateMany(ctx, filter, update)
 	if err != nil {
-		return fmt.Errorf("migration: AddProjectMetadataStarcountIndex: failed to backfill starcount: %w", err)
+		return fmt.Errorf("migration: %s: failed to backfill starcount: %w", addProjectMetadataStarcountIndexName, err)
 	}
 	if res.ModifiedCount > 0 {
-		log.Infofc(ctx, "migration: AddProjectMetadataStarcountIndex: backfilled starcount on %d projectmetadata documents", res.ModifiedCount)
+		log.Infofc(ctx, "migration: %s: backfilled starcount on %d projectmetadata documents", addProjectMetadataStarcountIndexName, res.ModifiedCount)
 	}
 	return nil
 }

--- a/server/internal/infrastructure/mongo/migration/260520220637_add_project_metadata_starcount_index_test.go
+++ b/server/internal/infrastructure/mongo/migration/260520220637_add_project_metadata_starcount_index_test.go
@@ -1,0 +1,106 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearthx/mongox"
+	"github.com/reearth/reearthx/mongox/mongotest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// TestAddProjectMetadataStarcountIndex_Backfill verifies that the migration
+// coerces any non-numeric starcount to 0, lifting a usable legacy
+// star_count value when present, and leaves already-numeric starcount
+// values untouched. It also confirms that the (starcount, project) index
+// is created after the backfill.
+func TestAddProjectMetadataStarcountIndex_Backfill(t *testing.T) {
+	ctx := context.Background()
+	db := mongotest.Connect(t)(t)
+	client := mongox.NewClientWithDatabase(db)
+	col := client.WithCollection("projectmetadata").Client()
+
+	// Seed the collection with a mix of states that the backfill should
+	// normalize, plus one document with a valid starcount to ensure
+	// untouched documents stay untouched.
+	docs := []interface{}{
+		bson.M{"project": "missing"},                                             // starcount field absent
+		bson.M{"project": "null", "starcount": nil},                              // starcount: null
+		bson.M{"project": "string", "starcount": "not-a-number"},                 // starcount: wrong type
+		bson.M{"project": "legacy", "star_count": int64(7)},                      // only legacy field
+		bson.M{"project": "legacy_with_null", "starcount": nil, "star_count": 3}, // null starcount, legacy present
+		bson.M{"project": "legacy_string", "star_count": "still-not-a-number"},   // legacy field is not numeric
+		bson.M{"project": "untouched", "starcount": int64(42)},                   // already valid, must stay
+	}
+	_, err := col.InsertMany(ctx, docs)
+	require.NoError(t, err)
+
+	require.NoError(t, AddProjectMetadataStarcountIndex(ctx, client))
+
+	type row struct {
+		Project   string `bson:"project"`
+		Starcount int64  `bson:"starcount"`
+	}
+	cur, err := col.Find(ctx, bson.M{})
+	require.NoError(t, err)
+	defer cur.Close(ctx)
+
+	got := map[string]int64{}
+	for cur.Next(ctx) {
+		var r row
+		require.NoError(t, cur.Decode(&r))
+		got[r.Project] = r.Starcount
+	}
+	require.NoError(t, cur.Err())
+
+	assert.Equal(t, int64(0), got["missing"], "missing starcount should backfill to 0")
+	assert.Equal(t, int64(0), got["null"], "null starcount should backfill to 0")
+	assert.Equal(t, int64(0), got["string"], "non-numeric starcount should backfill to 0")
+	assert.Equal(t, int64(7), got["legacy"], "missing starcount should inherit numeric star_count")
+	assert.Equal(t, int64(3), got["legacy_with_null"], "null starcount should inherit numeric star_count")
+	assert.Equal(t, int64(0), got["legacy_string"], "non-numeric star_count should not pollute starcount")
+	assert.Equal(t, int64(42), got["untouched"], "already-numeric starcount must not be overwritten")
+
+	// Verify the (starcount, project) index was created.
+	idxCur, err := col.Indexes().List(ctx)
+	require.NoError(t, err)
+	defer idxCur.Close(ctx)
+
+	var foundIndex bool
+	for idxCur.Next(ctx) {
+		var spec struct {
+			Name string `bson:"name"`
+			Key  bson.D `bson:"key"`
+		}
+		require.NoError(t, idxCur.Decode(&spec))
+		if keysEqual(spec.Key, bson.D{{Key: "starcount", Value: 1}, {Key: "project", Value: 1}}) {
+			foundIndex = true
+			assert.Equal(t, "projectmetadata_starcount_project", spec.Name, "expected stable index name")
+		}
+	}
+	require.NoError(t, idxCur.Err())
+	assert.True(t, foundIndex, "expected (starcount, project) index after migration")
+}
+
+// TestAddProjectMetadataStarcountIndex_Idempotent ensures that re-running
+// the migration on already-normalized data is a no-op and does not error.
+func TestAddProjectMetadataStarcountIndex_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	db := mongotest.Connect(t)(t)
+	client := mongox.NewClientWithDatabase(db)
+	col := client.WithCollection("projectmetadata").Client()
+
+	_, err := col.InsertOne(ctx, bson.M{"project": "p1", "starcount": int64(5)})
+	require.NoError(t, err)
+
+	require.NoError(t, AddProjectMetadataStarcountIndex(ctx, client))
+	require.NoError(t, AddProjectMetadataStarcountIndex(ctx, client))
+
+	var doc struct {
+		Starcount int64 `bson:"starcount"`
+	}
+	require.NoError(t, col.FindOne(ctx, bson.M{"project": "p1"}).Decode(&doc))
+	assert.Equal(t, int64(5), doc.Starcount, "starcount must remain unchanged across re-runs")
+}

--- a/server/internal/infrastructure/mongo/migration/260520220637_add_projectmetadata_starcount_index.go
+++ b/server/internal/infrastructure/mongo/migration/260520220637_add_projectmetadata_starcount_index.go
@@ -1,0 +1,27 @@
+package migration
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// AddProjectmetadataStarcountIndex creates a compound (starcount, _id) index
+// on the projectmetadata collection to back the most_starred sort path used
+// by InternalAPI GetAllProjects. The aggregation starts from projectmetadata
+// sorted by starcount (with _id as the deterministic tie-break) and only
+// then joins to project, so a covered index scan on (starcount, _id)
+// replaces the previous in-memory sort over every public project.
+//
+// The same ascending compound index serves both DESC and ASC queries
+// because MongoDB scans the index in the reverse direction when the sort
+// inverts every key uniformly.
+//
+// Idempotent: skipped when an equivalent (same key spec) index already
+// exists, regardless of name. Errors are propagated.
+func AddProjectmetadataStarcountIndex(ctx context.Context, c DBClient) error {
+	return createNonUniqueIndex(ctx, c, "projectmetadata", "projectmetadata_starcount_id", bson.D{
+		{Key: "starcount", Value: 1},
+		{Key: "_id", Value: 1},
+	}, nil)
+}

--- a/server/internal/infrastructure/mongo/migration/260520220637_add_projectmetadata_starcount_index.go
+++ b/server/internal/infrastructure/mongo/migration/260520220637_add_projectmetadata_starcount_index.go
@@ -2,29 +2,68 @@ package migration
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/reearth/reearthx/log"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-// AddProjectmetadataStarcountIndex creates a compound (starcount, _id) index
-// on the projectmetadata collection to back the most_starred sort path used
-// by InternalAPI GetAllProjects. The aggregation starts from projectmetadata
-// sorted by starcount (with _id as the deterministic tie-break) and only
-// then joins to project, so an index-backed sort on (starcount, _id)
-// replaces the previous in-memory sort over every public project. The plan
-// is not index-only (the project field still has to be read from each
-// document for the $lookup), but the sort no longer needs to buffer the
-// full result set.
+// AddProjectmetadataStarcountIndex backfills projectmetadata.starcount and
+// creates a compound (starcount, _id) index that backs the most_starred
+// sort path used by InternalAPI GetAllProjects.
 //
-// The same ascending compound index serves both DESC and ASC queries
-// because MongoDB scans the index in the reverse direction when the sort
+// Backfill: the original AddProjectMetadata migration did not set
+// starcount on existing documents, and older fixup migrations wrote a
+// sibling star_count (with underscore) field that the application does
+// not read. Without the backfill, MongoDB would sort missing/null
+// starcount as null, placing those documents at the boundaries of the
+// result and diverging from the previous in-memory $ifNull→0 semantics.
+// We coerce any non-numeric starcount to 0, pulling from the legacy
+// star_count field when it carries a usable number.
+//
+// Index: the aggregation reads metadata in starcount order and joins to
+// project, so an index-backed sort on (starcount, _id) replaces the
+// previous in-memory sort over every public project. The plan is not
+// index-only (project still has to be read for the $lookup), but the
+// sort no longer needs to buffer the full result set. The same
+// ascending compound index serves both DESC and ASC queries because
+// MongoDB scans the index in the reverse direction when the sort
 // inverts every key uniformly.
 //
-// Idempotent: skipped when an equivalent (same key spec) index already
-// exists, regardless of name. Errors are propagated.
+// Idempotent: the backfill targets only documents without a numeric
+// starcount, and createNonUniqueIndex is itself idempotent.
 func AddProjectmetadataStarcountIndex(ctx context.Context, c DBClient) error {
+	if err := backfillStarcount(ctx, c); err != nil {
+		return err
+	}
 	return createNonUniqueIndex(ctx, c, "projectmetadata", "projectmetadata_starcount_id", bson.D{
 		{Key: "starcount", Value: 1},
 		{Key: "_id", Value: 1},
 	}, nil)
+}
+
+func backfillStarcount(ctx context.Context, c DBClient) error {
+	col := c.Database().Collection("projectmetadata")
+	// $set with a pipeline lets us read the legacy star_count value from
+	// the same document when computing the new starcount.
+	filter := bson.M{"starcount": bson.M{"$not": bson.M{"$type": "number"}}}
+	update := bson.A{
+		bson.M{"$set": bson.M{
+			"starcount": bson.M{
+				"$cond": bson.M{
+					"if":   bson.M{"$isNumber": "$star_count"},
+					"then": "$star_count",
+					"else": int64(0),
+				},
+			},
+		}},
+	}
+	res, err := col.UpdateMany(ctx, filter, update)
+	if err != nil {
+		return fmt.Errorf("migration: AddProjectmetadataStarcountIndex: failed to backfill starcount: %w", err)
+	}
+	if res.ModifiedCount > 0 {
+		log.Infofc(ctx, "migration: AddProjectmetadataStarcountIndex: backfilled starcount on %d projectmetadata documents", res.ModifiedCount)
+	}
+	return nil
 }

--- a/server/internal/infrastructure/mongo/migration/260520220637_add_projectmetadata_starcount_index.go
+++ b/server/internal/infrastructure/mongo/migration/260520220637_add_projectmetadata_starcount_index.go
@@ -10,8 +10,11 @@ import (
 // on the projectmetadata collection to back the most_starred sort path used
 // by InternalAPI GetAllProjects. The aggregation starts from projectmetadata
 // sorted by starcount (with _id as the deterministic tie-break) and only
-// then joins to project, so a covered index scan on (starcount, _id)
-// replaces the previous in-memory sort over every public project.
+// then joins to project, so an index-backed sort on (starcount, _id)
+// replaces the previous in-memory sort over every public project. The plan
+// is not index-only (the project field still has to be read from each
+// document for the $lookup), but the sort no longer needs to buffer the
+// full result set.
 //
 // The same ascending compound index serves both DESC and ASC queries
 // because MongoDB scans the index in the reverse direction when the sort

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -43,5 +43,5 @@ var migrations = migration.Migrations[DBClient]{
 	251216142332: RemoveTimeline,
 	251222111114: AddUnifiedCaseInsensitiveAliasIndex,
 	260518143901: AddProjectVisibilityAndTopicsIndexes,
-	260520220637: AddProjectmetadataStarcountIndex,
+	260520220637: AddProjectMetadataStarcountIndex,
 }

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -43,4 +43,5 @@ var migrations = migration.Migrations[DBClient]{
 	251216142332: RemoveTimeline,
 	251222111114: AddUnifiedCaseInsensitiveAliasIndex,
 	260518143901: AddProjectVisibilityAndTopicsIndexes,
+	260520220637: AddProjectmetadataStarcountIndex,
 }

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -1156,16 +1156,19 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 			"from":     "project",
 			"let":      bson.M{"pid": "$project"},
 			"pipeline": []bson.M{{"$match": lookupMatch}},
-			"as":       "project",
+			// "joinedProject" rather than "project" so we don't clobber the
+			// existing projectmetadata.project scalar that the lookup
+			// correlates against — keeps the pipeline easier to extend.
+			"as": "joinedProject",
 		}},
-		{"$match": bson.M{"project.0": bson.M{"$exists": true}}},
+		{"$match": bson.M{"joinedProject.0": bson.M{"$exists": true}}},
 	}
 	if skip > 0 {
 		pipeline = append(pipeline, bson.M{"$skip": skip})
 	}
 	pipeline = append(pipeline,
 		bson.M{"$limit": lim},
-		bson.M{"$replaceRoot": bson.M{"newRoot": bson.M{"$arrayElemAt": bson.A{"$project", 0}}}},
+		bson.M{"$replaceRoot": bson.M{"newRoot": bson.M{"$arrayElemAt": bson.A{"$joinedProject", 0}}}},
 	)
 
 	metadataColl := r.client.Client().Database().Collection("projectmetadata")

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -1097,7 +1097,7 @@ func filterProjects(ids []id.ProjectID, rows []*project.Project) []*project.Proj
 // projects were needed.
 //
 // This implementation starts from projectmetadata and uses its
-// (starcount, _id) index for an index-backed $sort. A pipeline-form
+// (starcount, project) index for an index-backed $sort. A pipeline-form
 // $lookup brings in the matching project with the visibility/deleted/
 // keyword filter applied inline; non-matching metadata (private/deleted
 // projects, projects filtered out by keyword) is dropped via the
@@ -1107,7 +1107,11 @@ func filterProjects(ids []id.ProjectID, rows []*project.Project) []*project.Proj
 //
 // The total count for the response is independent of metadata and is
 // computed by a direct Count on the project collection using the same
-// project filter.
+// project filter. This relies on the 1:1 invariant between project and
+// projectmetadata established by the AddProjectMetadata backfill and
+// createProject; when len(consumer.Result) falls short of the expected
+// page size, we log a warning so that a regression in that invariant is
+// observable in production.
 //
 // Cursor.After/Before are still ignored on this path; First/Last/Limit
 // are clamped via effectiveSkipLimit.
@@ -1139,9 +1143,14 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 	skip, lim := effectiveSkipLimit(pFilter)
 
 	pipeline := []bson.M{
+		// Tie-break by projectmetadata.project (= project.id) for stable
+		// ordering across deployments. The metadata document's _id is
+		// unstable because the legacy AddProjectMetadata backfill
+		// generated _ids in one pass at backfill time rather than at
+		// project creation time.
 		{"$sort": bson.D{
 			{Key: "starcount", Value: sortOrder},
-			{Key: "_id", Value: sortOrder},
+			{Key: "project", Value: sortOrder},
 		}},
 		{"$lookup": bson.M{
 			"from":     "project",
@@ -1174,6 +1183,21 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 	}
 	if err := cursor.Err(); err != nil {
 		return nil, nil, err
+	}
+
+	// Defensive check for the 1:1 project↔projectmetadata invariant.
+	// totalCount comes from the project collection while the result rows
+	// come from the metadata-first aggregation, so a project without a
+	// metadata document would silently disappear here. Surface the gap.
+	expected := lim
+	if remaining := totalCount - skip; remaining < expected {
+		expected = remaining
+	}
+	if expected < 0 {
+		expected = 0
+	}
+	if int64(len(consumer.Result)) < expected {
+		log.Warnfc(ctx, "FindAll: starcount returned %d projects, expected %d (skip=%d, lim=%d, totalCount=%d); some projects may be missing projectmetadata documents", len(consumer.Result), expected, skip, lim, totalCount)
 	}
 
 	pageInfo := &usecasex.PageInfo{

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -1090,111 +1090,90 @@ func filterProjects(ids []id.ProjectID, rows []*project.Project) []*project.Proj
 	return res
 }
 
+// findAllWithStarcountSort runs the FindAll path that orders by starcount.
+// The previous implementation matched projects first, $lookup'd every
+// metadata, computed sort_star_count, and sorted in memory — so the work
+// scaled with the size of the public project set even when only the top N
+// projects were needed.
+//
+// This implementation starts from projectmetadata and uses its
+// (starcount, _id) index for an index-backed $sort. A pipeline-form
+// $lookup brings in the matching project with the visibility/deleted/
+// keyword filter applied inline; non-matching metadata (private/deleted
+// projects, projects filtered out by keyword) is dropped via the
+// post-lookup $match. MongoDB can stream the index-ordered scan and stop
+// once $limit is satisfied, so realistic top-N queries only touch the
+// metadata entries near the top of the ordering.
+//
+// The total count for the response is independent of metadata and is
+// computed by a direct Count on the project collection using the same
+// project filter.
+//
+// Cursor.After/Before are still ignored on this path; First/Last/Limit
+// are clamped via effectiveSkipLimit.
 func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.ProjectFilter, filter bson.M) ([]*project.Project, *usecasex.PageInfo, error) {
 	warnIfUnsupportedCursor(ctx, "starcount", pFilter.Pagination)
-	matchStage := bson.M{"$match": filter}
 
-	lookupStage := bson.M{
-		"$lookup": bson.M{
-			"from":         "projectmetadata",
-			"localField":   "id",
-			"foreignField": "project",
-			"as":           "metadata",
-		},
+	totalCount, err := r.client.Count(ctx, filter)
+	if err != nil {
+		return nil, nil, visualizer.ErrorWithCallerLogging(ctx, "FindAll: starcount count error", err)
 	}
-
-	// Project-side sort key derived from metadata.starcount, defaulting to 0
-	// when no metadata exists. Missing-metadata projects therefore sort to
-	// the bottom for DESC and to the top for ASC, matching the semantics of
-	// treating an absent star count as zero.
-	addFieldsStage := bson.M{
-		"$addFields": bson.M{
-			"sort_star_count": bson.M{
-				"$cond": bson.M{
-					"if": bson.M{"$gt": bson.A{bson.M{"$size": "$metadata"}, 0}},
-					"then": bson.M{
-						"$toInt": bson.M{
-							"$ifNull": bson.A{
-								bson.M{"$arrayElemAt": bson.A{"$metadata.starcount", 0}},
-								0,
-							},
-						},
-					},
-					"else": 0,
-				},
-			},
-		},
+	if totalCount == 0 {
+		return []*project.Project{}, usecasex.EmptyPageInfo(), nil
 	}
 
 	sortOrder := 1
-	if pFilter.Sort.Desc {
+	if pFilter.Sort != nil && pFilter.Sort.Desc {
 		sortOrder = -1
 	}
-	sortStage := bson.M{
-		"$sort": bson.D{
-			{Key: "sort_star_count", Value: sortOrder},
-			{Key: "_id", Value: sortOrder},
-		},
+
+	// Build the $lookup sub-pipeline: correlate metadata.project with
+	// project.id and apply the same project filter (visibility, deleted,
+	// optional keyword) inline so private/deleted/non-matching projects
+	// are dropped before they reach the post-lookup $match.
+	lookupMatch := bson.M{"$expr": bson.M{"$eq": bson.A{"$id", "$$pid"}}}
+	for k, v := range filter {
+		lookupMatch[k] = v
 	}
 
-	// metadata is only needed to compute sort_star_count, so drop it
-	// immediately after $addFields. The smaller documents reduce sort
-	// buffer/spill cost. sort_star_count is dropped after sorting since
-	// neither field is consumed downstream.
 	skip, lim := effectiveSkipLimit(pFilter)
-	dataPipeline := []bson.M{lookupStage, addFieldsStage, {"$unset": "metadata"}, sortStage}
+
+	pipeline := []bson.M{
+		{"$sort": bson.D{
+			{Key: "starcount", Value: sortOrder},
+			{Key: "_id", Value: sortOrder},
+		}},
+		{"$lookup": bson.M{
+			"from":     "project",
+			"let":      bson.M{"pid": "$project"},
+			"pipeline": []bson.M{{"$match": lookupMatch}},
+			"as":       "project",
+		}},
+		{"$match": bson.M{"project.0": bson.M{"$exists": true}}},
+	}
 	if skip > 0 {
-		dataPipeline = append(dataPipeline, bson.M{"$skip": skip})
+		pipeline = append(pipeline, bson.M{"$skip": skip})
 	}
-	dataPipeline = append(dataPipeline, bson.M{"$limit": lim}, bson.M{"$unset": "sort_star_count"})
+	pipeline = append(pipeline,
+		bson.M{"$limit": lim},
+		bson.M{"$replaceRoot": bson.M{"newRoot": bson.M{"$arrayElemAt": bson.A{"$project", 0}}}},
+	)
 
-	// $facet runs count and paginated data in a single pipeline pass. The
-	// total count for this path is determined solely by the project filter,
-	// so $lookup/$addFields/$sort/$skip/$limit live only in the `data`
-	// sub-pipeline; the `count` sub-pipeline reads the post-$match stream
-	// directly to avoid materializing metadata it does not need.
-	facetStage := bson.M{
-		"$facet": bson.M{
-			"data":  dataPipeline,
-			"count": []bson.M{{"$count": "total"}},
-		},
-	}
-
-	pipeline := []bson.M{matchStage, facetStage}
-
-	cursor, err := r.client.Client().Aggregate(ctx, pipeline)
+	metadataColl := r.client.Client().Database().Collection("projectmetadata")
+	cursor, err := metadataColl.Aggregate(ctx, pipeline)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, visualizer.ErrorWithCallerLogging(ctx, "FindAll: starcount aggregate error", err)
 	}
 	defer cursor.Close(ctx)
 
-	var totalCount int64 = 0
 	consumer := mongodoc.NewProjectConsumer(nil)
-	if cursor.Next(ctx) {
-		var result struct {
-			Data  []bson.Raw `bson:"data"`
-			Count []struct {
-				Total int64 `bson:"total"`
-			} `bson:"count"`
-		}
-		if err := cursor.Decode(&result); err != nil {
+	for cursor.Next(ctx) {
+		if err := consumer.Consume(cursor.Current); err != nil {
 			return nil, nil, err
-		}
-		if len(result.Count) > 0 {
-			totalCount = result.Count[0].Total
-		}
-		for _, raw := range result.Data {
-			if err := consumer.Consume(raw); err != nil {
-				return nil, nil, err
-			}
 		}
 	}
 	if err := cursor.Err(); err != nil {
 		return nil, nil, err
-	}
-
-	if totalCount == 0 {
-		return []*project.Project{}, usecasex.EmptyPageInfo(), nil
 	}
 
 	pageInfo := &usecasex.PageInfo{

--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -1126,6 +1126,20 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 		return []*project.Project{}, usecasex.EmptyPageInfo(), nil
 	}
 
+	skip, lim := effectiveSkipLimit(pFilter)
+
+	// Skip is already beyond the matched set, so the page is empty by
+	// construction. Return a fully-populated PageInfo without running the
+	// metadata-first aggregation; this saves a sort/lookup over the whole
+	// collection for out-of-range pagination requests.
+	if skip >= totalCount {
+		return []*project.Project{}, &usecasex.PageInfo{
+			TotalCount:      totalCount,
+			HasNextPage:     false,
+			HasPreviousPage: skip > 0,
+		}, nil
+	}
+
 	sortOrder := 1
 	if pFilter.Sort != nil && pFilter.Sort.Desc {
 		sortOrder = -1
@@ -1139,8 +1153,6 @@ func (r *Project) findAllWithStarcountSort(ctx context.Context, pFilter repo.Pro
 	for k, v := range filter {
 		lookupMatch[k] = v
 	}
-
-	skip, lim := effectiveSkipLimit(pFilter)
 
 	pipeline := []bson.M{
 		// Tie-break by projectmetadata.project (= project.id) for stable


### PR DESCRIPTION
# Overview

Follow-up to #2202. Optimize the `most_starred` (`sort=STARCOUNT`, direction=`DESC`) path of `InternalAPI.GetAllProjects`. After #2202 the path still scaled with the size of the public project set rather than with the requested page size, because the aggregation matched every public project, `$lookup`'d its metadata, computed a synthetic sort key, and sorted the entire intermediate set in memory before paging.

## What I've done

- **Add migration `AddProjectMetadataStarcountIndex`** (`server/internal/infrastructure/mongo/migration/260520220637_*.go`) that backfills `projectmetadata.starcount` (coercing any non-numeric value to `0`, pulling from the legacy `star_count` field when usable) and creates a compound `(starcount, project)` index on `projectmetadata`. The tie-break field is `project` (= `project.id`, a stable per-project identifier) rather than the metadata document's `_id`, since the legacy `AddProjectMetadata` backfill assigned metadata `_id`s in one pass at backfill time and they do not reflect project creation order. The same ascending compound serves both `DESC` and `ASC` queries because MongoDB reverses the scan when the sort inverts every key uniformly. The migration reuses the idempotent `createNonUniqueIndex` helper, so it is safe to re-run and skips when an equivalent index already exists.
- **Rewrite `findAllWithStarcountSort` to start from `projectmetadata`** rather than from `project`. The new aggregation:
  1. `$sort` on `projectmetadata.(starcount, project)` (index-backed, no in-memory sort).
  2. Pipeline-form `$lookup` that correlates `projectmetadata.project` with `project.id` and applies the visibility/deleted/keyword filter inline, so private/deleted/non-matching projects are filtered inside the lookup.
  3. `$match` `project.0` exists, then `$skip` / `$limit`, then `$replaceRoot` with the joined project document.

  MongoDB can stream the index-ordered scan and stop once `$limit` is satisfied, so realistic top-N queries only touch the metadata entries near the top of the ordering. The previous code touched every public project even when the page size was 10.
- **Compute total count directly on the project collection.** Since the count is independent of metadata, `r.client.Count(ctx, filter)` against `project` is used instead of a `$facet`/`$count` over the joined pipeline. The new path therefore issues two queries (one fast indexed Count + one streaming aggregation) instead of one heavier `$facet` aggregation.

## Why metadata-first is safe

`projectmetadata` and `project` are 1:1:

- `createProject` in the project interactor saves a metadata document for every new project (`server/internal/usecase/interactor/project.go`).
- Existing projects without metadata were backfilled by the `AddProjectMetadata` migration (`server/internal/infrastructure/mongo/migration/250530154721_add_project_metadata.go`).

So starting the aggregation from `projectmetadata` does not drop any project; every public/non-deleted project that the previous code returned is still reachable through the join.

## What I haven't done

- The `findAllWithTopicsFilter` path (`topics` + `starcount` sort) still uses the project-first aggregation. The merged change in #2202 already pushes the topics predicate into the lookup, so the gap is smaller; switching it to a metadata-first layout is a follow-up if the topics+starcount queries also turn out to be hot.
- Relay-style cursor positioning (`After`/`Before`) on the aggregation paths is still not implemented (warning preserved). `First`/`Last`/`Limit` continue to be clamped to `aggregationFacetCap`.

## Defensive instrumentation

A warning is logged when the metadata-first aggregation returns fewer rows than the expected page size (computed from `totalCount - skip`, capped by `lim`). Under the 1:1 invariant this can never fire; if a future code path creates a `project` without a `projectmetadata` document, the warning makes the regression visible in production logs instead of letting rows disappear silently while `PageInfo.TotalCount` still reports them.

## How I tested

- `go build ./...` clean.
- `go vet ./...` clean.
- `gofmt -s -l` clean on touched files.
- `go test ./internal/infrastructure/mongo/...` passes against a local MongoDB. `TestProject_FindAll/FindAll_with_sort_by_starcount` (DESC) and `FindAll_with_sort_by_starcount_ASC` both still pass with the new pipeline. No test files were modified.

## Which point I want you to review particularly

- **1:1 invariant.** The new path depends on every project having a corresponding `projectmetadata` document. The two known creation sites (`createProject` and the backfill migration `AddProjectMetadata`) are noted above. Please confirm there is no other code path that creates a `project` without saving a `projectmetadata`. If one is added in the future, the defensive log will fire when `len(rows) < expected`; results would still be incomplete though.
- **Index direction.** The new index is `{starcount: 1, project: 1}` and is used in both directions by MongoDB. Please confirm this is acceptable; if the workload is heavily DESC-skewed and an index-only scan plan benefits from a same-direction compound, a `{starcount: -1, project: -1}` index can be a follow-up.
- **Lookup filter inheritance.** The `$lookup` sub-pipeline is `{"$expr": {"$eq": ["$id", "$$pid"]}}` merged with the project filter (`visibility`, `deleted`, optional `name` regex from the keyword). The merge happens via a map copy, so any future field added to the project filter automatically propagates into the lookup match.

## Memo

- Related context: #2202 introduced the indexes for the base path, the `$facet` count/data split, and the topics filter rewrite. This PR builds on that work, in particular the migration helpers (`createNonUniqueIndex`, `indexWithKeysExists`) introduced there.

## Checklist

- [x] Verified backward compatibility related to feature modifications.
- [x] Confirmed backward compatibility for migrations. *(Index addition is additive; existing queries continue to work without it, just slower.)*
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)