### PR TITLE
chore(server): bump version to 1.0.0-beta.16.4

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reearth/visualizer",
-  "version": "1.0.0-beta.16.3",
+  "version": "1.0.0-beta.16.4",
   "repository": "https://github.com/reearth/reearth-visualizer.git",
   "author": "Re:Earth contributors <community@reearth.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Overview

Bump version to 1.0.0-beta.16.4 to ship the InternalAPI `GetAllProjects` performance work landed in #2202 and #2206:

- #2202 — collapse duplicate Count calls, restructure topics filtering via pipeline-form `$lookup`, fold count/data into a single `$facet`, add `(visibility, deleted)` and `topics` indexes via migration.
- #2206 — metadata-first aggregation for `most_starred` sort (`$sort` on the new `(starcount, project)` index, `$lookup` to project with the visibility/keyword filter pushed down, $facet-free streaming aggregation), plus a backfill of `projectmetadata.starcount` for legacy documents.

## What I've done

- Bumped `web/package.json` from `1.0.0-beta.16.3` to `1.0.0-beta.16.4`.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)