### PR TITLE
fix(web): correct google_roadmap typo in cesium ion asset fallback map

### DIFF
--- a/web/src/app/features/Visualizer/hooks.ts
+++ b/web/src/app/features/Visualizer/hooks.ts
@@ -59,7 +59,7 @@ export default function useHooks({
     const cesiumIonAssetIdFallbackMap: Record<string, string> = {
       "2": "google_satellite",
       "3": "google_satellite",
-      "4": "google_road",
+      "4": "google_roadmap",
       "3812": "nasa_black_marble"
     };
 


### PR DESCRIPTION
Might be a potential typo in the fallback tile

- [x] checked existing code to see if there is any match for the given tile
