### PR TITLE
fix(server): remap legacy tile types on project import

### DIFF
--- a/server/internal/app/file_import_common.go
+++ b/server/internal/app/file_import_common.go
@@ -247,6 +247,60 @@ func UpdateImportStatus(
 	}
 }
 
+var legacyTileTypeMap = map[string]string{
+	"default":       "google_satellite",
+	"default_label": "google_satellite",
+	"default_road":  "google_roadmap",
+	"black_marble":  "nasa_black_marble",
+}
+
+func migrateLegacyTileTypes(data *[]byte) error {
+	var d map[string]any
+	if err := json.Unmarshal(*data, &d); err != nil {
+		return err
+	}
+
+	scene, ok := d["scene"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	property, ok := scene["property"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	tiles, ok := property["tiles"].([]any)
+	if !ok {
+		return nil
+	}
+
+	for _, t := range tiles {
+		tile, ok := t.(map[string]any)
+		if !ok {
+			continue
+		}
+		// tile_type is stored as {"type": "string", "value": "<tile_type>"}
+		tileTypeObj, ok := tile["tile_type"].(map[string]any)
+		if !ok {
+			continue
+		}
+		tileType, ok := tileTypeObj["value"].(string)
+		if !ok {
+			continue
+		}
+		if mapped, exists := legacyTileTypeMap[tileType]; exists {
+			log.Infof("[Import] migrating legacy tile_type %q -> %q", tileType, mapped)
+			tileTypeObj["value"] = mapped
+		}
+	}
+
+	b, err := json.Marshal(d)
+	if err != nil {
+		return err
+	}
+	*data = b
+	return nil
+}
+
 func ImportProject(
 	ctx context.Context,
 	usecases *interfaces.Container,
@@ -259,6 +313,10 @@ func ImportProject(
 	result map[string]any,
 	version *string,
 ) bool {
+
+	if err := migrateLegacyTileTypes(importData); err != nil {
+		log.Warnf("[Import] failed to migrate legacy tile types: %v", err)
+	}
 
 	// project ----------
 	newProject, err := usecases.Project.ImportProjectData(ctx, wsId.String(), pid.Ref().StringRef(), importData, op)

--- a/server/internal/app/file_import_common_test.go
+++ b/server/internal/app/file_import_common_test.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func tileField(v string) map[string]any {
+	return map[string]any{"type": "string", "value": v}
+}
+
+func buildImportData(t *testing.T, tiles []map[string]any) *[]byte {
+	t.Helper()
+	d := map[string]any{
+		"scene": map[string]any{
+			"property": map[string]any{
+				"tiles": tiles,
+			},
+		},
+	}
+	b, err := json.Marshal(d)
+	require.NoError(t, err)
+	return &b
+}
+
+func getTileTypeValue(t *testing.T, data *[]byte, index int) string {
+	t.Helper()
+	var d map[string]any
+	require.NoError(t, json.Unmarshal(*data, &d))
+	raw := d["scene"].(map[string]any)["property"].(map[string]any)["tiles"].([]any)
+	tile := raw[index].(map[string]any)
+	return tile["tile_type"].(map[string]any)["value"].(string)
+}
+
+func TestMigrateLegacyTileTypes(t *testing.T) {
+	t.Run("legacy types are remapped", func(t *testing.T) {
+		data := buildImportData(t, []map[string]any{
+			{"tile_type": tileField("default")},
+			{"tile_type": tileField("default_label")},
+			{"tile_type": tileField("default_road")},
+			{"tile_type": tileField("black_marble")},
+		})
+
+		require.NoError(t, migrateLegacyTileTypes(data))
+
+		assert.Equal(t, "google_satellite", getTileTypeValue(t, data, 0))
+		assert.Equal(t, "google_satellite", getTileTypeValue(t, data, 1))
+		assert.Equal(t, "google_roadmap", getTileTypeValue(t, data, 2))
+		assert.Equal(t, "nasa_black_marble", getTileTypeValue(t, data, 3))
+	})
+
+	t.Run("non-legacy types are left alone", func(t *testing.T) {
+		data := buildImportData(t, []map[string]any{
+			{"tile_type": tileField("open_street_map")},
+			{"tile_type": tileField("url"), "tile_url": "https://example.com/{z}/{x}/{y}.png"},
+			{"tile_type": tileField("google_satellite")},
+		})
+
+		require.NoError(t, migrateLegacyTileTypes(data))
+
+		assert.Equal(t, "open_street_map", getTileTypeValue(t, data, 0))
+		assert.Equal(t, "url", getTileTypeValue(t, data, 1))
+		assert.Equal(t, "google_satellite", getTileTypeValue(t, data, 2))
+	})
+
+	t.Run("tile with no tile_type field is untouched", func(t *testing.T) {
+		data := buildImportData(t, []map[string]any{
+			{"tile_opacity": 1},
+		})
+
+		require.NoError(t, migrateLegacyTileTypes(data))
+
+		var d map[string]any
+		require.NoError(t, json.Unmarshal(*data, &d))
+		raw := d["scene"].(map[string]any)["property"].(map[string]any)["tiles"].([]any)
+		tile := raw[0].(map[string]any)
+		_, hasType := tile["tile_type"]
+		assert.False(t, hasType)
+	})
+
+	t.Run("no tiles in scene returns nil", func(t *testing.T) {
+		d := map[string]any{
+			"scene": map[string]any{
+				"property": map[string]any{},
+			},
+		}
+		b, err := json.Marshal(d)
+		require.NoError(t, err)
+		assert.NoError(t, migrateLegacyTileTypes(&b))
+	})
+
+	t.Run("malformed json returns error", func(t *testing.T) {
+		b := []byte(`not valid json`)
+		assert.Error(t, migrateLegacyTileTypes(&b))
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `migrateLegacyTileTypes` to `file_import_common.go` that rewrites Ion-backed tile types in the import JSON before any data is written to the DB
- Projects exported before the Terravista migration (containing `default`, `default_label`, `default_road`, `black_marble`) will have those types remapped to `google_satellite`, `google_satellite`, `google_roadmap`, `nasa_black_marble` respectively on import
- Non-legacy types (`open_street_map`, `url`, `japan_gsi_standard`, `cesium_ion`, etc.) pass through unchanged
- Both the direct GCS trigger path and the chunked upload path go through `ImportProject`, so both are covered

## Test plan

- [x] Import a project exported before the migration and verify tile types are remapped in the DB
- [x] Import a project with non-legacy tile types and verify they are unchanged
- [x] Unit tests pass: `go test ./internal/app/ -run TestMigrateLegacyTileTypes`