### PR TITLE
fix(web): fallback cesium terrain to reearth_terrain when Ion token missing

### DIFF
--- a/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
@@ -160,6 +160,20 @@ describe("tilesMigration", () => {
       expect(result).toBe(viewerProperty); // Unknown asset ID, no fallback available
     });
 
+    it("should migrate terrain when type is cesium and no token provided", () => {
+      const viewerProperty = {
+        terrain: { type: "cesium" as const, enabled: true }
+      };
+      const result = migrateViewerPropertyTiles(viewerProperty, {
+        isEE: false,
+        hasAccessToken: false
+      });
+      expect(result?.terrain).toEqual({
+        type: "reearth_terrain",
+        enabled: true
+      });
+    });
+
     it("should migrate terrain when type is cesiumion and no token provided", () => {
       const viewerProperty = {
         terrain: { type: "cesiumion" as const, enabled: true }
@@ -207,7 +221,7 @@ describe("tilesMigration", () => {
       });
     });
 
-    it("should only migrate tiles when terrain doesn't need migration", () => {
+    it("should migrate both tiles and cesium terrain when no token", () => {
       const viewerProperty = {
         tiles: [{ id: "1", type: "default" as const }],
         terrain: { type: "cesium" as const, enabled: true }
@@ -217,7 +231,7 @@ describe("tilesMigration", () => {
         hasAccessToken: false
       });
       expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite" }]);
-      expect(result?.terrain).toBe(viewerProperty.terrain); // Unchanged
+      expect(result?.terrain).toEqual({ type: "reearth_terrain", enabled: true });
     });
 
     it("should only migrate terrain when tiles don't need migration", () => {
@@ -239,7 +253,7 @@ describe("tilesMigration", () => {
     it("should return original viewerProperty when neither tiles nor terrain need migration", () => {
       const viewerProperty = {
         tiles: [{ id: "1", type: "open_street_map" as const }],
-        terrain: { type: "cesium" as const, enabled: true }
+        terrain: { type: "reearth_terrain" as const, enabled: true }
       };
       const result = migrateViewerPropertyTiles(viewerProperty, {
         isEE: false,
@@ -500,19 +514,31 @@ describe("tilesMigration", () => {
     });
 
     it("should NOT modify terrain with other types", () => {
-      const terrain1 = { type: "cesium", enabled: true };
-      const result1 = migrateTerrain(terrain1, {
+      // reearth_terrain should never be remapped
+      const terrain = { type: "reearth_terrain", enabled: true };
+      const result = migrateTerrain(terrain, {
         isEE: false,
         hasAccessToken: false
       });
-      expect(result1).toBe(terrain1);
+      expect(result).toBe(terrain);
+    });
 
-      const terrain2 = { type: "reearth_terrain", enabled: true };
-      const result2 = migrateTerrain(terrain2, {
+    it("should fallback cesium terrain to reearth_terrain when no token", () => {
+      const terrain = { type: "cesium", enabled: true };
+      const result = migrateTerrain(terrain, {
         isEE: false,
         hasAccessToken: false
       });
-      expect(result2).toBe(terrain2);
+      expect(result).toEqual({ type: "reearth_terrain", enabled: true });
+    });
+
+    it("should NOT fallback cesium terrain when token is available", () => {
+      const terrain = { type: "cesium", enabled: true };
+      const result = migrateTerrain(terrain, {
+        isEE: false,
+        hasAccessToken: true
+      });
+      expect(result).toBe(terrain);
     });
 
     it("should preserve all terrain properties during migration", () => {

--- a/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
@@ -174,7 +174,7 @@ describe("tilesMigration", () => {
       });
     });
 
-    it("should migrate terrain when type is cesiumion and no token provided", () => {
+    it("should NOT migrate cesiumion terrain when no token (user's explicit choice)", () => {
       const viewerProperty = {
         terrain: { type: "cesiumion" as const, enabled: true }
       };
@@ -182,10 +182,7 @@ describe("tilesMigration", () => {
         isEE: false,
         hasAccessToken: false
       });
-      expect(result?.terrain).toEqual({
-        type: "reearth_terrain",
-        enabled: true
-      });
+      expect(result).toBe(viewerProperty); // No migration — cesiumion without token is expected to fail
     });
 
     it("should NOT migrate terrain when token is available", () => {
@@ -205,7 +202,7 @@ describe("tilesMigration", () => {
           { id: "1", type: "default" as const },
           { id: "2", type: "cesium_ion" as const, cesiumIonAssetId: 2 }
         ],
-        terrain: { type: "cesiumion" as const, enabled: true }
+        terrain: { type: "cesium" as const, enabled: true }
       };
       const result = migrateViewerPropertyTiles(viewerProperty, {
         isEE: true,
@@ -237,7 +234,7 @@ describe("tilesMigration", () => {
     it("should only migrate terrain when tiles don't need migration", () => {
       const viewerProperty = {
         tiles: [{ id: "1", type: "open_street_map" as const }],
-        terrain: { type: "cesiumion" as const, enabled: true }
+        terrain: { type: "cesium" as const, enabled: true }
       };
       const result = migrateViewerPropertyTiles(viewerProperty, {
         isEE: false,
@@ -492,26 +489,21 @@ describe("tilesMigration", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should fallback cesiumion terrain to reearth_terrain when no token", () => {
+    it("should NOT fallback cesiumion terrain when no token (user's explicit choice)", () => {
       const terrain = { type: "cesiumion", enabled: true, normal: true };
       const result = migrateTerrain(terrain, {
         isEE: false,
         hasAccessToken: false
       });
-      expect(result).toEqual({
-        type: "reearth_terrain",
-        enabled: true,
-        normal: true
-      });
+      expect(result).toBe(terrain); // No migration
     });
 
-    it("should NOT fallback cesiumion terrain when token is available", () => {
-      const terrain = { type: "cesiumion", enabled: true };
-      const result = migrateTerrain(terrain, {
-        isEE: false,
-        hasAccessToken: true
-      });
-      expect(result).toBe(terrain); // Returns original unchanged
+    it("should NOT fallback cesiumion terrain regardless of token (user's explicit choice)", () => {
+      const terrainNoToken = { type: "cesiumion", enabled: true };
+      expect(migrateTerrain(terrainNoToken, { isEE: false, hasAccessToken: false })).toBe(terrainNoToken);
+
+      const terrainWithToken = { type: "cesiumion", enabled: true };
+      expect(migrateTerrain(terrainWithToken, { isEE: false, hasAccessToken: true })).toBe(terrainWithToken);
     });
 
     it("should NOT modify terrain with other types", () => {
@@ -542,9 +534,9 @@ describe("tilesMigration", () => {
       expect(result).toBe(terrain);
     });
 
-    it("should preserve all terrain properties during migration", () => {
+    it("should preserve all terrain properties during cesium migration", () => {
       const terrain = {
-        type: "cesiumion" as const,
+        type: "cesium" as const,
         enabled: true,
         url: "https://example.com/terrain",
         normal: true,

--- a/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
@@ -253,7 +253,8 @@ describe("tilesMigration", () => {
     it("should return original viewerProperty when neither tiles nor terrain need migration", () => {
       const viewerProperty = {
         tiles: [{ id: "1", type: "open_street_map" as const }],
-        terrain: { type: "reearth_terrain" as const, enabled: true }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        terrain: { type: "reearth_terrain" as any, enabled: true }
       };
       const result = migrateViewerPropertyTiles(viewerProperty, {
         isEE: false,

--- a/web/src/app/features/Visualizer/utils/tilesMigration.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.ts
@@ -129,13 +129,12 @@ function migrateTerrain<T extends { type?: string; enabled?: boolean }>(
 ): T | undefined {
   if (!terrain) return terrain;
 
-  // Fallback Ion-backed terrain types to reearth_terrain when token is missing (FALLBACK)
-  if (
-    (terrain.type === "cesiumion" || terrain.type === "cesium") &&
-    !config.hasAccessToken
-  ) {
+  // Fallback cesium (Cesium World Terrain) to reearth_terrain when token is missing (FALLBACK)
+  // Note: cesiumion is intentionally excluded — if the user chose a custom Ion asset
+  // and provides no token, terrain simply won't load (expected behaviour).
+  if (terrain.type === "cesium" && !config.hasAccessToken) {
     console.warn(
-      `[Terrain Fallback] Terrain type "${terrain.type}" → "reearth_terrain" (Cesium Ion access token required but missing)`
+      `[Terrain Fallback] Terrain type "cesium" → "reearth_terrain" (Cesium Ion access token required but missing)`
     );
     return {
       ...terrain,
@@ -185,14 +184,12 @@ export function migrateViewerPropertyTiles(
 
   // Check if tiles need migration
   const tilesNeedProcessing =
-    hasTiles &&
-    tiles.some((tile) => needsTileMigration(tile, config));
+    hasTiles && tiles.some((tile) => needsTileMigration(tile, config));
 
   // Check if terrain needs migration
   const terrainNeedsMigration =
     hasTerrain &&
-    (((terrain.type === "cesiumion" || terrain.type === "cesium") &&
-      !config.hasAccessToken) ||
+    ((terrain.type === "cesium" && !config.hasAccessToken) ||
       (terrain.enabled && !terrain.type));
 
   // Return original if nothing needs migration

--- a/web/src/app/features/Visualizer/utils/tilesMigration.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.ts
@@ -129,10 +129,13 @@ function migrateTerrain<T extends { type?: string; enabled?: boolean }>(
 ): T | undefined {
   if (!terrain) return terrain;
 
-  // Fallback cesiumion terrain when token is missing (FALLBACK)
-  if (terrain.type === "cesiumion" && !config.hasAccessToken) {
+  // Fallback Ion-backed terrain types to reearth_terrain when token is missing (FALLBACK)
+  if (
+    (terrain.type === "cesiumion" || terrain.type === "cesium") &&
+    !config.hasAccessToken
+  ) {
     console.warn(
-      '[Terrain Fallback] Terrain type "cesiumion" → "reearth_terrain" (Cesium Ion access token required but missing)'
+      `[Terrain Fallback] Terrain type "${terrain.type}" → "reearth_terrain" (Cesium Ion access token required but missing)`
     );
     return {
       ...terrain,
@@ -188,7 +191,8 @@ export function migrateViewerPropertyTiles(
   // Check if terrain needs migration
   const terrainNeedsMigration =
     hasTerrain &&
-    ((terrain.type === "cesiumion" && !config.hasAccessToken) ||
+    (((terrain.type === "cesiumion" || terrain.type === "cesium") &&
+      !config.hasAccessToken) ||
       (terrain.enabled && !terrain.type));
 
   // Return original if nothing needs migration


### PR DESCRIPTION
## Summary

Adds a fallback in `tilesMigration.ts` for **Cesium World Terrain** (`type: "cesium"`) when no Ion access token is provided — it falls back to **Re:Earth Terrain** instead of silently failing with a flat globe.

**Why only `cesium` and not `cesiumion`?**
- `cesium` = Cesium World Terrain (built-in default) — reasonable to fall back automatically
- `cesiumion` = user's explicit custom Ion asset — if no token is provided, terrain not loading is the expected behaviour

## Test plan

- [x] Tested manually — selecting Cesium World Terrain without an Ion token falls back to Re:Earth Terrain
- [x] Unit tests pass