### PR TITLE
fix(web): correct google_roadmap typo in tilesMigration cesium ion fallback map

### DIFF
--- a/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
@@ -91,7 +91,7 @@ describe("tilesMigration", () => {
       expect(result?.tiles).toEqual([
         { id: "1", type: "google_satellite", cesiumIonAssetId: 2 },
         { id: "2", type: "google_satellite", cesiumIonAssetId: 3 },
-        { id: "3", type: "google_road", cesiumIonAssetId: 4 },
+        { id: "3", type: "google_roadmap", cesiumIonAssetId: 4 },
         { id: "4", type: "nasa_black_marble", cesiumIonAssetId: 3812 }
       ]);
     });
@@ -601,7 +601,7 @@ describe("tilesMigration", () => {
       expect(CESIUM_ION_ASSET_ID_FALLBACK_MAP).toEqual({
         "2": "google_satellite",
         "3": "google_satellite",
-        "4": "google_road",
+        "4": "google_roadmap",
         "3812": "nasa_black_marble"
       });
     });

--- a/web/src/app/features/Visualizer/utils/tilesMigration.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.ts
@@ -35,7 +35,7 @@ const TILE_TYPE_MIGRATION_MAP: Record<string, string> = {
 const CESIUM_ION_ASSET_ID_FALLBACK_MAP: Record<string, string> = {
   "2": "google_satellite",
   "3": "google_satellite",
-  "4": "google_road",
+  "4": "google_roadmap",
   "3812": "nasa_black_marble"
 };
 


### PR DESCRIPTION
## Summary

Fixes a typo in `CESIUM_ION_ASSET_ID_FALLBACK_MAP` in `tilesMigration.ts` where Ion asset ID `"4"` (Bing Road Map / `default_road`) was mapping to `"google_road"` instead of `"google_roadmap"`.

## Test plan

- [x] Unit tests pass
- [x] Verified manually — `cesium_ion` tile with asset ID 4 now falls back to `google_roadmap` in EE mode without an Ion token