### PR TITLE
fix(server): fix gofmt formatting in migration comment

### DIFF
--- a/server/internal/infrastructure/mongo/migration/260522120000_migrate_tiles_and_terrain_to_cesium.go
+++ b/server/internal/infrastructure/mongo/migration/260522120000_migrate_tiles_and_terrain_to_cesium.go
@@ -21,9 +21,9 @@ var tileTypeToCesiumIonAsset = map[string]string{
 // and adds default terrain type for enabled terrain without explicit type.
 //
 // This migration performs two operations:
-// 1. Tiles: Converts legacy tile types (default, default_label, default_road, black_marble)
-//    to cesium_ion with appropriate asset IDs
-// 2. Terrain: Adds terrainType="cesium" when terrain is enabled but no type is specified
+//  1. Tiles: Converts legacy tile types (default, default_label, default_road, black_marble)
+//     to cesium_ion with appropriate asset IDs
+//  2. Terrain: Adds terrainType="cesium" when terrain is enabled but no type is specified
 func MigrateTilesAndTerrainToCesium(ctx context.Context, c DBClient) error {
 	col := c.WithCollection("property")
 


### PR DESCRIPTION
## Summary

- Fixes gofmt lint error in `260522120000_migrate_tiles_and_terrain_to_cesium.go`
- The godoc numbered list comment style requires an extra indent (`//  1.` not `// 1.`)

## Test plan

- [x] `gofmt -l` reports no issues on the file