### PR TITLE
fix(web): tile without type should apply default tile type

### DIFF
--- a/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
@@ -36,7 +36,7 @@ describe("tilesMigration", () => {
       expect(result).toBe(viewerProperty);
     });
 
-    it("should NOT migrate tiles without type (use schema defaults)", () => {
+    it("should apply defaultTileType to tiles without type when defaultTileType is provided", () => {
       const viewerProperty = {
         tiles: [
           { id: "1" },
@@ -46,6 +46,23 @@ describe("tilesMigration", () => {
       const result = migrateViewerPropertyTiles(viewerProperty, {
         isEE: false,
         defaultTileType: "open_street_map",
+        hasAccessToken: false
+      });
+      expect(result?.tiles).toEqual([
+        { id: "1", type: "open_street_map" },
+        { id: "2", type: "open_street_map" }
+      ]);
+    });
+
+    it("should NOT apply type to tiles without type when defaultTileType is not provided", () => {
+      const viewerProperty = {
+        tiles: [
+          { id: "1" },
+          { id: "2", type: undefined }
+        ]
+      };
+      const result = migrateViewerPropertyTiles(viewerProperty, {
+        isEE: false,
         hasAccessToken: false
       });
       expect(result).toBe(viewerProperty); // No migration, returns original
@@ -124,7 +141,7 @@ describe("tilesMigration", () => {
       const viewerProperty = {
         tiles: [
           { id: "1", type: "open_street_map" }, // No migration
-          { id: "2" }, // No migration (undefined uses schema default)
+          { id: "2" }, // Needs default application
           { id: "3", type: "default" }, // Needs EE migration
           { id: "4", type: "cesium_ion", cesiumIonAssetId: 2 }, // Needs fallback
           { id: "5", type: "google_satellite" } // No migration
@@ -137,7 +154,7 @@ describe("tilesMigration", () => {
       });
       expect(result?.tiles).toEqual([
         { id: "1", type: "open_street_map" },
-        { id: "2" }, // Unchanged
+        { id: "2", type: "open_street_map" }, // Default applied
         { id: "3", type: "google_satellite" },
         { id: "4", type: "google_satellite", cesiumIonAssetId: 2 },
         { id: "5", type: "google_satellite" }
@@ -283,7 +300,15 @@ describe("tilesMigration", () => {
   });
 
   describe("needsTileMigration", () => {
-    it("should return false for tiles without type (use schema defaults)", () => {
+    it("should return true for tiles without type when defaultTileType is provided", () => {
+      const result = needsTileMigration(
+        { type: undefined },
+        { isEE: false, defaultTileType: "open_street_map", hasAccessToken: false }
+      );
+      expect(result).toBe(true);
+    });
+
+    it("should return false for tiles without type when defaultTileType is not provided", () => {
       const result = needsTileMigration(
         { type: undefined },
         { isEE: false, hasAccessToken: false }
@@ -349,11 +374,24 @@ describe("tilesMigration", () => {
   });
 
   describe("migrateTile", () => {
-    it("should NOT migrate when type is missing (use schema defaults)", () => {
+    it("should apply defaultTileType when type is missing", () => {
       const tile = { id: "1", type: undefined, opacity: 0.8 };
       const result = migrateTile(tile, {
         isEE: false,
         defaultTileType: "open_street_map",
+        hasAccessToken: false
+      });
+      expect(result).toEqual({
+        id: "1",
+        type: "open_street_map",
+        opacity: 0.8
+      });
+    });
+
+    it("should NOT apply type when type is missing and defaultTileType is not provided", () => {
+      const tile = { id: "1", type: undefined, opacity: 0.8 };
+      const result = migrateTile(tile, {
+        isEE: false,
         hasAccessToken: false
       });
       expect(result).toBe(tile); // Returns original unchanged

--- a/web/src/app/features/Visualizer/utils/tilesMigration.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.ts
@@ -46,6 +46,9 @@ function needsTileMigration(
   tile: { type?: string; cesiumIonAssetId?: number | string },
   config: TilesMigrationConfig
 ): boolean {
+  // Check if tile needs default type application
+  if (!tile.type && config.defaultTileType) return true;
+
   // Skip tiles without type - they will use schema defaults
   if (!tile.type) return false;
 
@@ -68,12 +71,21 @@ function needsTileMigration(
 
 /**
  * Applies migration and fallback to a single tile
+ * - Default Application: Apply defaultTileType when no type is set
  * - Migration: Migrate deprecated types (backward compatibility, EE only)
  * - Fallback: Use alternatives when Cesium Ion requires token but it's missing (EE only)
  */
 function migrateTile<
   T extends { type?: string; cesiumIonAssetId?: number | string }
 >(tile: T, config: TilesMigrationConfig): T {
+  // Apply default tile type when no type is set
+  if (!tile.type && config.defaultTileType) {
+    return {
+      ...tile,
+      type: config.defaultTileType
+    };
+  }
+
   // Skip tiles without type - they will use schema defaults
   if (!tile.type) return tile;
 
@@ -139,17 +151,20 @@ function migrateTerrain<T extends { type?: string; enabled?: boolean }>(
 /**
  * Applies migration (backward compatibility) and fallback logic to viewer property
  *
+ * Default Application:
+ * 1. Apply defaultTileType to tiles without explicit type
+ *
  * Migration (backward compatibility):
- * 1. Migrate deprecated tile types to new types (EE only)
+ * 2. Migrate deprecated tile types to new types (EE only)
  *
  * Fallback (when requirements not met):
- * 2. Fallback Cesium Ion tiles to alternatives when token missing (EE only)
- * 3. Fallback Cesium terrain to reearth_terrain when token missing
+ * 3. Fallback Cesium Ion tiles to alternatives when token missing (EE only)
+ * 4. Fallback Cesium terrain to reearth_terrain when token missing
  *
- * Note: Tiles/terrain without explicit type will use schema defaults (no migration needed)
+ * Note: Tiles without type and without defaultTileType config will use schema defaults
  *
  * @param viewerProperty - The viewer property containing tiles and terrain
- * @param config - Migration and fallback configuration
+ * @param config - Migration and fallback configuration (includes defaultTileType)
  * @returns Processed viewer property or original if no processing needed
  */
 export function migrateViewerPropertyTiles(


### PR DESCRIPTION
# Overview

It should use default tile based on env. when no tile type been provided.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
