### PR TITLE
fix(web): set default terrain type as reearth_terrain

### DIFF
--- a/web/src/app/features/Visualizer/hooks.ts
+++ b/web/src/app/features/Visualizer/hooks.ts
@@ -56,6 +56,7 @@ export default function useHooks({
     return migrateViewerPropertyTiles(overriddenViewerProperty, {
       isEE,
       defaultTileType,
+      defaultTerrainType: "reearth_terrain",
       hasAccessToken
     });
   }, [overriddenViewerProperty, engineMeta]);

--- a/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
@@ -274,7 +274,22 @@ describe("tilesMigration", () => {
       expect(result).toBe(viewerProperty); // No migration
     });
 
-    it("should NOT migrate terrain when enabled without type (use schema defaults)", () => {
+    it("should apply defaultTerrainType to terrain without type when defaultTerrainType is provided", () => {
+      const viewerProperty = {
+        terrain: { enabled: true }
+      };
+      const result = migrateViewerPropertyTiles(viewerProperty, {
+        isEE: false,
+        defaultTerrainType: "reearth_terrain",
+        hasAccessToken: false
+      });
+      expect(result?.terrain).toEqual({
+        enabled: true,
+        type: "reearth_terrain"
+      });
+    });
+
+    it("should NOT apply type to terrain without type when defaultTerrainType is not provided", () => {
       const viewerProperty = {
         terrain: { enabled: true }
       };
@@ -285,7 +300,24 @@ describe("tilesMigration", () => {
       expect(result).toBe(viewerProperty); // No migration
     });
 
-    it("should only migrate tiles when terrain has no type (no terrain migration)", () => {
+    it("should migrate tiles and apply defaultTerrainType when both need processing", () => {
+      const viewerProperty = {
+        tiles: [{ id: "1", type: "default" as const }],
+        terrain: { enabled: true }
+      };
+      const result = migrateViewerPropertyTiles(viewerProperty, {
+        isEE: true,
+        defaultTerrainType: "reearth_terrain",
+        hasAccessToken: false
+      });
+      expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite" }]);
+      expect(result?.terrain).toEqual({
+        enabled: true,
+        type: "reearth_terrain"
+      });
+    });
+
+    it("should only migrate tiles when terrain has no type and no defaultTerrainType", () => {
       const viewerProperty = {
         tiles: [{ id: "1", type: "default" as const }],
         terrain: { enabled: true }
@@ -586,10 +618,33 @@ describe("tilesMigration", () => {
       expect(result).toBe(terrain); // Returns original unchanged
     });
 
-    it("should NOT migrate when enabled with empty type (use schema defaults)", () => {
+    it("should apply defaultTerrainType when type is undefined", () => {
       const terrain = { enabled: true, type: undefined };
       const result = migrateTerrain(terrain, {
         isEE: false,
+        defaultTerrainType: "reearth_terrain",
+        hasAccessToken: false
+      });
+      expect(result).toEqual({
+        enabled: true,
+        type: "reearth_terrain"
+      });
+    });
+
+    it("should NOT apply type when type is undefined and defaultTerrainType is not provided", () => {
+      const terrain = { enabled: true, type: undefined };
+      const result = migrateTerrain(terrain, {
+        isEE: false,
+        hasAccessToken: false
+      });
+      expect(result).toBe(terrain); // Returns original unchanged
+    });
+
+    it("should NOT apply defaultTerrainType when terrain already has a type", () => {
+      const terrain = { enabled: true, type: "cesiumion" };
+      const result = migrateTerrain(terrain, {
+        isEE: false,
+        defaultTerrainType: "reearth_terrain",
         hasAccessToken: false
       });
       expect(result).toBe(terrain); // Returns original unchanged

--- a/web/src/app/features/Visualizer/utils/tilesMigration.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.ts
@@ -9,9 +9,13 @@ export type TilesMigrationConfig = {
    */
   isEE: boolean;
   /**
-   * Default tile type (used for UI display only, not for migration)
+   * Default tile type (applied when tile has no type)
    */
   defaultTileType?: string;
+  /**
+   * Default terrain type (applied when terrain has no type)
+   */
+  defaultTerrainType?: string;
   /**
    * Whether Cesium Ion access token is available
    * Used for tiles and terrain fallback when token is required but missing
@@ -123,7 +127,8 @@ function migrateTile<
 }
 
 /**
- * Applies fallback to terrain property
+ * Applies default and fallback to terrain property
+ * - Default Application: Apply defaultTerrainType when no type is set
  * - Fallback: Use reearth_terrain when cesium requires token but it's missing
  */
 function migrateTerrain<T extends { type?: string; enabled?: boolean }>(
@@ -131,6 +136,17 @@ function migrateTerrain<T extends { type?: string; enabled?: boolean }>(
   config: TilesMigrationConfig
 ): T | undefined {
   if (!terrain) return terrain;
+
+  // Apply default terrain type when no type is set
+  if (!terrain.type && config.defaultTerrainType) {
+    return {
+      ...terrain,
+      type: config.defaultTerrainType
+    };
+  }
+
+  // Skip if still no type after default application
+  if (!terrain.type) return terrain;
 
   // Fallback cesium (Cesium World Terrain) to reearth_terrain when token is missing (FALLBACK)
   // Note: cesiumion is intentionally excluded — if the user chose a custom Ion asset
@@ -153,18 +169,19 @@ function migrateTerrain<T extends { type?: string; enabled?: boolean }>(
  *
  * Default Application:
  * 1. Apply defaultTileType to tiles without explicit type
+ * 2. Apply defaultTerrainType to terrain without explicit type
  *
  * Migration (backward compatibility):
- * 2. Migrate deprecated tile types to new types (EE only)
+ * 3. Migrate deprecated tile types to new types (EE only)
  *
  * Fallback (when requirements not met):
- * 3. Fallback Cesium Ion tiles to alternatives when token missing (EE only)
- * 4. Fallback Cesium terrain to reearth_terrain when token missing
+ * 4. Fallback Cesium Ion tiles to alternatives when token missing (EE only)
+ * 5. Fallback Cesium terrain to reearth_terrain when token missing
  *
- * Note: Tiles without type and without defaultTileType config will use schema defaults
+ * Note: Tiles/terrain without type and without default config will use schema defaults
  *
  * @param viewerProperty - The viewer property containing tiles and terrain
- * @param config - Migration and fallback configuration (includes defaultTileType)
+ * @param config - Migration and fallback configuration (includes defaultTileType and defaultTerrainType)
  * @returns Processed viewer property or original if no processing needed
  */
 export function migrateViewerPropertyTiles(
@@ -181,12 +198,14 @@ export function migrateViewerPropertyTiles(
   const tilesNeedProcessing =
     hasTiles && tiles.some((tile) => needsTileMigration(tile, config));
 
-  // Check if terrain needs fallback
-  const terrainNeedsFallback =
-    hasTerrain && terrain.type === "cesium" && !config.hasAccessToken;
+  // Check if terrain needs default application or fallback
+  const terrainNeedsProcessing =
+    hasTerrain &&
+    ((!terrain.type && config.defaultTerrainType) ||
+      (terrain.type === "cesium" && !config.hasAccessToken));
 
   // Return original if nothing needs processing
-  if (!tilesNeedProcessing && !terrainNeedsFallback) {
+  if (!tilesNeedProcessing && !terrainNeedsProcessing) {
     return viewerProperty;
   }
 
@@ -197,8 +216,8 @@ export function migrateViewerPropertyTiles(
     result.tiles = tiles.map((tile) => migrateTile(tile, config));
   }
 
-  // Apply terrain fallback if needed
-  if (terrainNeedsFallback) {
+  // Apply terrain default or fallback if needed
+  if (terrainNeedsProcessing) {
     result.terrain = migrateTerrain(terrain, config);
   }
 


### PR DESCRIPTION
# Overview

From earlier clean up of migration we removed the default settings as well, this PR added the default setup back.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
