### PR TITLE
fix: terrain not rendering on first load in new projects

### DIFF
--- a/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
@@ -274,7 +274,7 @@ describe("tilesMigration", () => {
       expect(result).toBe(viewerProperty); // No migration
     });
 
-    it("should NOT migrate terrain when enabled without type (use schema defaults)", () => {
+    it("should migrate terrain to reearth_terrain when enabled without type and no token", () => {
       const viewerProperty = {
         terrain: { enabled: true }
       };
@@ -282,10 +282,10 @@ describe("tilesMigration", () => {
         isEE: false,
         hasAccessToken: false
       });
-      expect(result).toBe(viewerProperty); // No migration
+      expect(result?.terrain).toEqual({ enabled: true, type: "reearth_terrain" });
     });
 
-    it("should only migrate tiles when terrain has no type (no terrain migration)", () => {
+    it("should migrate both tiles and terrain when terrain has no type and no token", () => {
       const viewerProperty = {
         tiles: [{ id: "1", type: "default" as const }],
         terrain: { enabled: true }
@@ -295,7 +295,7 @@ describe("tilesMigration", () => {
         hasAccessToken: false
       });
       expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite" }]);
-      expect(result?.terrain).toBe(viewerProperty.terrain); // Unchanged
+      expect(result?.terrain).toEqual({ enabled: true, type: "reearth_terrain" });
     });
   });
 
@@ -577,22 +577,35 @@ describe("tilesMigration", () => {
       });
     });
 
-    it("should NOT migrate when enabled without type (use schema defaults)", () => {
+    it("should fallback to reearth_terrain when enabled without type and no token", () => {
+      // undefined type means the user never explicitly set terrainType (manifest defaultValue is a
+      // UI hint only and is not persisted until changed). The core would silently fall back to
+      // "cesium" (Cesium World Terrain) which requires an Ion token — so we must intercept here.
       const terrain = { enabled: true };
       const result = migrateTerrain(terrain, {
         isEE: false,
         hasAccessToken: false
       });
-      expect(result).toBe(terrain); // Returns original unchanged
+      expect(result).toEqual({ enabled: true, type: "reearth_terrain" });
     });
 
-    it("should NOT migrate when enabled with empty type (use schema defaults)", () => {
+    it("should fallback to reearth_terrain when enabled with explicit undefined type and no token", () => {
       const terrain = { enabled: true, type: undefined };
       const result = migrateTerrain(terrain, {
         isEE: false,
         hasAccessToken: false
       });
-      expect(result).toBe(terrain); // Returns original unchanged
+      expect(result).toEqual({ enabled: true, type: "reearth_terrain" });
+    });
+
+    it("should NOT fallback when enabled without type but token is available", () => {
+      // With a token, undefined type should stay undefined and the core will default to "cesium".
+      const terrain = { enabled: true };
+      const result = migrateTerrain(terrain, {
+        isEE: false,
+        hasAccessToken: true
+      });
+      expect(result).toBe(terrain);
     });
 
     it("should NOT fallback when terrain is disabled without type", () => {

--- a/web/src/app/features/Visualizer/utils/tilesMigration.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.ts
@@ -133,11 +133,15 @@ function migrateTerrain<T extends { type?: string; enabled?: boolean }>(
   if (!terrain) return terrain;
 
   // Fallback cesium (Cesium World Terrain) to reearth_terrain when token is missing (FALLBACK)
+  // Also covers undefined type: the manifest defaultValue "reearth_terrain" is only a UI hint and is
+  // never persisted until the user explicitly changes the field, so a brand-new project will have
+  // terrain.type === undefined here, which the core would silently default to "cesium" (requiring a
+  // token). Treating undefined the same as "cesium" closes that gap.
   // Note: cesiumion is intentionally excluded — if the user chose a custom Ion asset
   // and provides no token, terrain simply won't load (expected behaviour).
-  if (terrain.type === "cesium" && !config.hasAccessToken) {
+  if ((!terrain.type || terrain.type === "cesium") && terrain.enabled && !config.hasAccessToken) {
     console.warn(
-      `[Terrain Fallback] Terrain type "cesium" → "reearth_terrain" (Cesium Ion access token required but missing)`
+      `[Terrain Fallback] Terrain type "${terrain.type ?? "undefined (default cesium)"}" → "reearth_terrain" (Cesium Ion access token required but missing)`
     );
     return {
       ...terrain,
@@ -182,8 +186,12 @@ export function migrateViewerPropertyTiles(
     hasTiles && tiles.some((tile) => needsTileMigration(tile, config));
 
   // Check if terrain needs fallback
+  // Also handles undefined type: core defaults undefined to "cesium" (requires token)
   const terrainNeedsFallback =
-    hasTerrain && terrain.type === "cesium" && !config.hasAccessToken;
+    hasTerrain &&
+    (!terrain.type || terrain.type === "cesium") &&
+    !!terrain.enabled &&
+    !config.hasAccessToken;
 
   // Return original if nothing needs processing
   if (!tilesNeedProcessing && !terrainNeedsFallback) {

--- a/web/src/app/types/sceneProperty.ts
+++ b/web/src/app/types/sceneProperty.ts
@@ -4,7 +4,7 @@
 
 type TerrainProperty = {
   terrain?: boolean;
-  terrainType?: "cesium" | "cesiumion"; // default: cesium
+  terrainType?: "cesium" | "cesiumion" | "reearth_terrain"; // default: reearth_terrain
   terrainCesiumIonAsset?: string;
   terrainCesiumIonAccessToken?: string;
   terrainCesiumIonUrl?: string;
@@ -110,7 +110,7 @@ type LegacySceneProperty = {
   }[];
   terrain?: {
     terrain?: boolean;
-    terrainType?: "cesium" | "cesiumion"; // default: cesium
+    terrainType?: "cesium" | "cesiumion" | "reearth_terrain"; // default: reearth_terrain
     terrainExaggeration?: number; // default: 1
     terrainExaggerationRelativeHeight?: number; // default: 0
     depthTestAgainstTerrain?: boolean;


### PR DESCRIPTION
# Overview                                
In a brand-new project, enabling terrain with reearth_terrain had no visible effect. The terrain would only start working after the user manually switched to Cesium World Terrain and then switched back.

Root cause: The manifest.yml defaultValue: reearth_terrain is a UI display hint only — it is never persisted to the database until the user explicitly changes the field. So a new project's terrain object arrives as { enabled: true } with no type field.

In migrateViewerPropertyTiles, the guard that decides whether to call migrateTerrain checked only for terrain.type === "cesium":

```
  const terrainNeedsFallback =
    hasTerrain && terrain.type === "cesium" && !config.hasAccessToken;
```

When terrain.type was undefined, this condition was false and migrateTerrain was never called. The raw { enabled: true } terrain object was passed straight down to the Cesium core, where terrainType ?? "cesium" defaulted to Cesium World Terrain — which requires a Cesium Ion access token. Without one, every terrain tile request returned 401 and nothing rendered.

## What I've done
Updated the terrainNeedsFallback guard to match the logic already inside migrateTerrain itself, treating undefined type the same as "cesium":

```
  const terrainNeedsFallback =
    hasTerrain &&
    (!terrain.type || terrain.type === "cesium") &&
    !!terrain.enabled &&
    !config.hasAccessToken;
```

Now a new project's { enabled: true } terrain correctly falls back to reearth_terrain (which requires no token) before reaching the Cesium core.

Also updated sceneProperty.ts to include reearth_terrain as a valid terrainType value, and updated tests to reflect the corrected behavior.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
