### PR TITLE
refactor(web): support override cesium ion token & correct tile migration map

### DIFF
--- a/web/src/app/features/Editor/Visualizer/type.ts
+++ b/web/src/app/features/Editor/Visualizer/type.ts
@@ -1,9 +1,9 @@
 import { Block } from "@reearth/app/features/Visualizer/Crust";
 import { SceneMode } from "@reearth/app/types";
 import {
-  ImageBasedLighting,
-  LightProperty,
-  ShadowProperty,
+  AssetsProperty as CoreAssetsProperty,
+  AssetsCesiumProperty as CoreAssetsCesiumProperty,
+  SceneProperty as CoreSceneProperty,
   ViewerProperty as CoreViewerProperty
 } from "@reearth/core";
 
@@ -15,15 +15,15 @@ export interface Item {
 
 export type BlockType = Item & Pick<Block, "pluginId" | "extensionId">;
 
-export declare type ViewerProperty = {
-  scene?: {
-    backgroundColor?: string;
+export declare type ViewerProperty = Omit<CoreViewerProperty, "scene" | "assets"> & {
+  scene?: Omit<CoreSceneProperty, "mode"> & {
     mode?: SceneMode;
-    verticalExaggeration?: number;
-    verticalExaggerationRelativeHeight?: number;
-    vr?: boolean;
-    light?: LightProperty;
-    shadow?: ShadowProperty;
-    imageBasedLighting?: ImageBasedLighting;
   };
-} & Omit<CoreViewerProperty, "scene">;
+  assets?: Omit<CoreAssetsProperty, "cesium"> & {
+    cesium?: CoreAssetsCesiumProperty & {
+      global?: {
+        ionAccessToken?: string;
+      };
+    };
+  };
+};

--- a/web/src/app/features/Visualizer/hooks.ts
+++ b/web/src/app/features/Visualizer/hooks.ts
@@ -51,7 +51,11 @@ export default function useHooks({
     const configData = config();
     const isEE = configData?.featureCollection === "ee";
     const defaultTileType = appFeature()?.defaultTileType;
-    const hasAccessToken = !!engineMeta?.cesiumIonAccessToken;
+    // Check both global token override and engineMeta token
+    const hasAccessToken = !!(
+      overriddenViewerProperty?.assets?.cesium?.global?.ionAccessToken ||
+      engineMeta?.cesiumIonAccessToken
+    );
 
     return migrateViewerPropertyTiles(overriddenViewerProperty, {
       isEE,

--- a/web/src/app/features/Visualizer/hooks.ts
+++ b/web/src/app/features/Visualizer/hooks.ts
@@ -51,10 +51,14 @@ export default function useHooks({
     const configData = config();
     const isEE = configData?.featureCollection === "ee";
     const defaultTileType = appFeature()?.defaultTileType;
+
     // Check both global token override and engineMeta token
+    // Validate tokens are non-empty strings
+    const globalToken = overriddenViewerProperty?.assets?.cesium?.global?.ionAccessToken;
+    const engineToken = engineMeta?.cesiumIonAccessToken;
     const hasAccessToken = !!(
-      overriddenViewerProperty?.assets?.cesium?.global?.ionAccessToken ||
-      engineMeta?.cesiumIonAccessToken
+      (typeof globalToken === "string" && globalToken.trim().length > 0) ||
+      (typeof engineToken === "string" && engineToken.trim().length > 0)
     );
 
     return migrateViewerPropertyTiles(overriddenViewerProperty, {

--- a/web/src/app/features/Visualizer/index.tsx
+++ b/web/src/app/features/Visualizer/index.tsx
@@ -243,15 +243,30 @@ const Visualizer: FC<VisualizerProps> = ({
     engineMeta
   });
 
+  // Override engineMeta cesiumIonAccessToken with global token from viewer property if set
+  const overriddenEngineMeta = useMemo(() => {
+    const globalIonToken = overriddenViewerProperty?.assets?.cesium?.global?.ionAccessToken;
+
+    if (globalIonToken && typeof globalIonToken === "string") {
+      return {
+        ...engineMeta,
+        cesiumIonAccessToken: globalIonToken
+      };
+    }
+
+    return engineMeta;
+  }, [overriddenViewerProperty, engineMeta]);
+
   // Apply layers fallback when requirements not met:
   // 1. OSM Buildings: fallback to reearth-buildings when Cesium Ion token missing
   // 2. Google Photorealistic (EE): fallback provider to reearth when token missing or no provider
   const migratedLayers = useMemo(() => {
     const configData = config();
     const isEE = configData?.featureCollection === "ee";
-    const hasAccessToken = !!engineMeta?.cesiumIonAccessToken;
+    // Check both global token override and engineMeta token (overriddenEngineMeta already includes global token)
+    const hasAccessToken = !!overriddenEngineMeta?.cesiumIonAccessToken;
     return migrateLayers(layers, { isEE, hasAccessToken });
-  }, [layers, engineMeta]);
+  }, [layers, overriddenEngineMeta]);
 
   const coreWrapperRef = useRef<HTMLDivElement>(null);
   const { viewport } = useViewport({
@@ -278,7 +293,7 @@ const Visualizer: FC<VisualizerProps> = ({
           zoomedLayerId={zoomedLayerId}
           viewerProperty={overriddenViewerProperty}
           ready={ready}
-          meta={engineMeta}
+          meta={overriddenEngineMeta}
           customProvider={customProviders}
           camera={visualizerCamera}
           interactionMode={interactionMode}

--- a/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
@@ -68,7 +68,7 @@ describe("tilesMigration", () => {
       expect(result).toBe(viewerProperty); // No migration, returns original
     });
 
-    it("should migrate deprecated tile types in EE environment", () => {
+    it("should migrate deprecated tile types in EE environment without token (applies fallback)", () => {
       const viewerProperty = {
         tiles: [
           { id: "1", type: "default" },
@@ -81,11 +81,34 @@ describe("tilesMigration", () => {
         isEE: true,
         hasAccessToken: false
       });
+      // Without token: deprecated → cesium_ion → fallback to google_satellite/etc
       expect(result?.tiles).toEqual([
-        { id: "1", type: "google_satellite" },
-        { id: "2", type: "google_satellite" },
-        { id: "3", type: "google_roadmap" },
-        { id: "4", type: "nasa_black_marble" }
+        { id: "1", type: "google_satellite", cesiumIonAssetId: 3 },
+        { id: "2", type: "google_satellite", cesiumIonAssetId: 3 },
+        { id: "3", type: "google_roadmap", cesiumIonAssetId: 4 },
+        { id: "4", type: "nasa_black_marble", cesiumIonAssetId: 3812 }
+      ]);
+    });
+
+    it("should migrate deprecated tile types to cesium_ion in EE environment with token (no fallback)", () => {
+      const viewerProperty = {
+        tiles: [
+          { id: "1", type: "default" },
+          { id: "2", type: "default_label" },
+          { id: "3", type: "default_road" },
+          { id: "4", type: "black_marble" }
+        ]
+      };
+      const result = migrateViewerPropertyTiles(viewerProperty, {
+        isEE: true,
+        hasAccessToken: true
+      });
+      // With token: deprecated → cesium_ion (stays as cesium_ion, no fallback)
+      expect(result?.tiles).toEqual([
+        { id: "1", type: "cesium_ion", cesiumIonAssetId: 3 },
+        { id: "2", type: "cesium_ion", cesiumIonAssetId: 3 },
+        { id: "3", type: "cesium_ion", cesiumIonAssetId: 4 },
+        { id: "4", type: "cesium_ion", cesiumIonAssetId: 3812 }
       ]);
     });
 
@@ -142,7 +165,7 @@ describe("tilesMigration", () => {
         tiles: [
           { id: "1", type: "open_street_map" }, // No migration
           { id: "2" }, // Needs default application
-          { id: "3", type: "default" }, // Needs EE migration
+          { id: "3", type: "default" }, // Needs EE migration + fallback
           { id: "4", type: "cesium_ion", cesiumIonAssetId: 2 }, // Needs fallback
           { id: "5", type: "google_satellite" } // No migration
         ]
@@ -155,8 +178,8 @@ describe("tilesMigration", () => {
       expect(result?.tiles).toEqual([
         { id: "1", type: "open_street_map" },
         { id: "2", type: "open_street_map" }, // Default applied
-        { id: "3", type: "google_satellite" },
-        { id: "4", type: "google_satellite", cesiumIonAssetId: 2 },
+        { id: "3", type: "google_satellite", cesiumIonAssetId: 3 }, // Migrated + fallback
+        { id: "4", type: "google_satellite", cesiumIonAssetId: 2 }, // Fallback
         { id: "5", type: "google_satellite" }
       ]);
     });
@@ -223,8 +246,8 @@ describe("tilesMigration", () => {
         hasAccessToken: false
       });
       expect(result?.tiles).toEqual([
-        { id: "1", type: "google_satellite" },
-        { id: "2", type: "google_satellite", cesiumIonAssetId: 2 }
+        { id: "1", type: "google_satellite", cesiumIonAssetId: 3 }, // Migrated + fallback
+        { id: "2", type: "google_satellite", cesiumIonAssetId: 2 } // Fallback
       ]);
       expect(result?.terrain).toEqual({
         type: "reearth_terrain",
@@ -241,7 +264,7 @@ describe("tilesMigration", () => {
         isEE: true,
         hasAccessToken: false
       });
-      expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite" }]);
+      expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite", cesiumIonAssetId: 3 }]); // Migrated + fallback
       expect(result?.terrain).toEqual({ type: "reearth_terrain", enabled: true });
     });
 
@@ -310,7 +333,7 @@ describe("tilesMigration", () => {
         defaultTerrainType: "reearth_terrain",
         hasAccessToken: false
       });
-      expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite" }]);
+      expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite", cesiumIonAssetId: 3 }]); // Migrated + fallback
       expect(result?.terrain).toEqual({
         enabled: true,
         type: "reearth_terrain"
@@ -326,7 +349,7 @@ describe("tilesMigration", () => {
         isEE: true,
         hasAccessToken: false
       });
-      expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite" }]);
+      expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite", cesiumIonAssetId: 3 }]); // Migrated + fallback
       expect(result?.terrain).toBe(viewerProperty.terrain); // Unchanged
     });
   });
@@ -439,15 +462,31 @@ describe("tilesMigration", () => {
       expect(result).toBe(tile); // Returns original unchanged
     });
 
-    it("should migrate deprecated types in EE environment", () => {
+    it("should migrate deprecated types in EE environment without token (applies fallback)", () => {
       const tile = { id: "1", type: "default" };
       const result = migrateTile(tile, {
         isEE: true,
         hasAccessToken: false
       });
+      // Without token: deprecated → cesium_ion → fallback to google_satellite
       expect(result).toEqual({
         id: "1",
-        type: "google_satellite"
+        type: "google_satellite",
+        cesiumIonAssetId: 3
+      });
+    });
+
+    it("should migrate deprecated types to cesium_ion in EE environment with token (no fallback)", () => {
+      const tile = { id: "1", type: "default" };
+      const result = migrateTile(tile, {
+        isEE: true,
+        hasAccessToken: true
+      });
+      // With token: deprecated → cesium_ion (stays as cesium_ion)
+      expect(result).toEqual({
+        id: "1",
+        type: "cesium_ion",
+        cesiumIonAssetId: 3
       });
     });
 
@@ -519,6 +558,7 @@ describe("tilesMigration", () => {
       expect(result).toEqual({
         id: "1",
         type: "google_satellite",
+        cesiumIonAssetId: 3,
         opacity: 0.5,
         zoomLevel: [1, 10],
         customProp: "value"
@@ -672,10 +712,10 @@ describe("tilesMigration", () => {
   describe("Migration maps", () => {
     it("should have correct tile type migration map", () => {
       expect(TILE_TYPE_MIGRATION_MAP).toEqual({
-        default: "google_satellite",
-        default_label: "google_satellite",
-        default_road: "google_roadmap",
-        black_marble: "nasa_black_marble"
+        default: { type: "cesium_ion", cesiumIonAssetId: 3 },
+        default_label: { type: "cesium_ion", cesiumIonAssetId: 3 },
+        default_road: { type: "cesium_ion", cesiumIonAssetId: 4 },
+        black_marble: { type: "cesium_ion", cesiumIonAssetId: 3812 }
       });
     });
 

--- a/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
@@ -83,7 +83,7 @@ describe("tilesMigration", () => {
       });
       // Without token: deprecated → cesium_ion → fallback to google_satellite/etc
       expect(result?.tiles).toEqual([
-        { id: "1", type: "google_satellite", cesiumIonAssetId: 3 },
+        { id: "1", type: "google_satellite", cesiumIonAssetId: 2 },
         { id: "2", type: "google_satellite", cesiumIonAssetId: 3 },
         { id: "3", type: "google_roadmap", cesiumIonAssetId: 4 },
         { id: "4", type: "nasa_black_marble", cesiumIonAssetId: 3812 }
@@ -105,7 +105,7 @@ describe("tilesMigration", () => {
       });
       // With token: deprecated → cesium_ion (stays as cesium_ion, no fallback)
       expect(result?.tiles).toEqual([
-        { id: "1", type: "cesium_ion", cesiumIonAssetId: 3 },
+        { id: "1", type: "cesium_ion", cesiumIonAssetId: 2 },
         { id: "2", type: "cesium_ion", cesiumIonAssetId: 3 },
         { id: "3", type: "cesium_ion", cesiumIonAssetId: 4 },
         { id: "4", type: "cesium_ion", cesiumIonAssetId: 3812 }
@@ -178,7 +178,7 @@ describe("tilesMigration", () => {
       expect(result?.tiles).toEqual([
         { id: "1", type: "open_street_map" },
         { id: "2", type: "open_street_map" }, // Default applied
-        { id: "3", type: "google_satellite", cesiumIonAssetId: 3 }, // Migrated + fallback
+        { id: "3", type: "google_satellite", cesiumIonAssetId: 2 }, // Migrated + fallback
         { id: "4", type: "google_satellite", cesiumIonAssetId: 2 }, // Fallback
         { id: "5", type: "google_satellite" }
       ]);
@@ -246,7 +246,7 @@ describe("tilesMigration", () => {
         hasAccessToken: false
       });
       expect(result?.tiles).toEqual([
-        { id: "1", type: "google_satellite", cesiumIonAssetId: 3 }, // Migrated + fallback
+        { id: "1", type: "google_satellite", cesiumIonAssetId: 2 }, // Migrated + fallback
         { id: "2", type: "google_satellite", cesiumIonAssetId: 2 } // Fallback
       ]);
       expect(result?.terrain).toEqual({
@@ -264,7 +264,7 @@ describe("tilesMigration", () => {
         isEE: true,
         hasAccessToken: false
       });
-      expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite", cesiumIonAssetId: 3 }]); // Migrated + fallback
+      expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite", cesiumIonAssetId: 2 }]); // Migrated + fallback
       expect(result?.terrain).toEqual({ type: "reearth_terrain", enabled: true });
     });
 
@@ -333,7 +333,7 @@ describe("tilesMigration", () => {
         defaultTerrainType: "reearth_terrain",
         hasAccessToken: false
       });
-      expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite", cesiumIonAssetId: 3 }]); // Migrated + fallback
+      expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite", cesiumIonAssetId: 2 }]); // Migrated + fallback
       expect(result?.terrain).toEqual({
         enabled: true,
         type: "reearth_terrain"
@@ -349,7 +349,7 @@ describe("tilesMigration", () => {
         isEE: true,
         hasAccessToken: false
       });
-      expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite", cesiumIonAssetId: 3 }]); // Migrated + fallback
+      expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite", cesiumIonAssetId: 2 }]); // Migrated + fallback
       expect(result?.terrain).toBe(viewerProperty.terrain); // Unchanged
     });
   });
@@ -472,7 +472,7 @@ describe("tilesMigration", () => {
       expect(result).toEqual({
         id: "1",
         type: "google_satellite",
-        cesiumIonAssetId: 3
+        cesiumIonAssetId: 2
       });
     });
 
@@ -486,7 +486,7 @@ describe("tilesMigration", () => {
       expect(result).toEqual({
         id: "1",
         type: "cesium_ion",
-        cesiumIonAssetId: 3
+        cesiumIonAssetId: 2
       });
     });
 
@@ -558,7 +558,7 @@ describe("tilesMigration", () => {
       expect(result).toEqual({
         id: "1",
         type: "google_satellite",
-        cesiumIonAssetId: 3,
+        cesiumIonAssetId: 2,
         opacity: 0.5,
         zoomLevel: [1, 10],
         customProp: "value"
@@ -712,7 +712,7 @@ describe("tilesMigration", () => {
   describe("Migration maps", () => {
     it("should have correct tile type migration map", () => {
       expect(TILE_TYPE_MIGRATION_MAP).toEqual({
-        default: { type: "cesium_ion", cesiumIonAssetId: 3 },
+        default: { type: "cesium_ion", cesiumIonAssetId: 2 },
         default_label: { type: "cesium_ion", cesiumIonAssetId: 3 },
         default_road: { type: "cesium_ion", cesiumIonAssetId: 4 },
         black_marble: { type: "cesium_ion", cesiumIonAssetId: 3812 }

--- a/web/src/app/features/Visualizer/utils/tilesMigration.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.ts
@@ -24,13 +24,16 @@ export type TilesMigrationConfig = {
 };
 
 /**
- * Mapping of deprecated tile types to EE tile types
+ * Mapping of deprecated tile types to cesium_ion with asset IDs
  */
-const TILE_TYPE_MIGRATION_MAP: Record<string, string> = {
-  default: "google_satellite",
-  default_label: "google_satellite",
-  default_road: "google_roadmap",
-  black_marble: "nasa_black_marble"
+const TILE_TYPE_MIGRATION_MAP: Record<
+  string,
+  { type: "cesium_ion"; cesiumIonAssetId: number }
+> = {
+  default: { type: "cesium_ion", cesiumIonAssetId: 3 },
+  default_label: { type: "cesium_ion", cesiumIonAssetId: 3 },
+  default_road: { type: "cesium_ion", cesiumIonAssetId: 4 },
+  black_marble: { type: "cesium_ion", cesiumIonAssetId: 3812 }
 };
 
 /**
@@ -76,8 +79,8 @@ function needsTileMigration(
 /**
  * Applies migration and fallback to a single tile
  * - Default Application: Apply defaultTileType when no type is set
- * - Migration: Migrate deprecated types (backward compatibility, EE only)
- * - Fallback: Use alternatives when Cesium Ion requires token but it's missing (EE only)
+ * - Migration: Migrate deprecated types to cesium_ion with proper asset IDs (backward compatibility, EE only)
+ * - Fallback: If no token available, fallback cesium_ion tiles to alternative EE types (EE only)
  */
 function migrateTile<
   T extends { type?: string; cesiumIonAssetId?: number | string }
@@ -96,34 +99,37 @@ function migrateTile<
   // EE-specific migrations only apply when featureCollection is 'ee'
   if (!config.isEE) return tile;
 
-  // Migrate deprecated tile types (MIGRATION - backward compatibility)
+  let processedTile = tile;
+
+  // Step 1: Migrate deprecated tile types to cesium_ion (MIGRATION - backward compatibility)
   if (tile.type in TILE_TYPE_MIGRATION_MAP) {
-    const newType = TILE_TYPE_MIGRATION_MAP[tile.type];
+    const migration = TILE_TYPE_MIGRATION_MAP[tile.type];
     console.warn(
-      `[Tiles Migration] Migrating deprecated tile type "${tile.type}" to "${newType}" (backward compatibility, EE environment)`
+      `[Tiles Migration] Migrating deprecated tile type "${tile.type}" to "${migration.type}" with asset ID ${migration.cesiumIonAssetId} (backward compatibility, EE environment)`
     );
-    return {
+    processedTile = {
       ...tile,
-      type: newType
+      type: migration.type,
+      cesiumIonAssetId: migration.cesiumIonAssetId
     };
   }
 
-  // Fallback cesium_ion tiles to EE types when token is missing (FALLBACK)
-  if (tile.type === "cesium_ion" && !config.hasAccessToken) {
-    const assetId = tile.cesiumIonAssetId;
+  // Step 2: Fallback cesium_ion tiles to EE types when token is missing (FALLBACK)
+  if (processedTile.type === "cesium_ion" && !config.hasAccessToken) {
+    const assetId = processedTile.cesiumIonAssetId;
     if (assetId && String(assetId) in CESIUM_ION_ASSET_ID_FALLBACK_MAP) {
       const newType = CESIUM_ION_ASSET_ID_FALLBACK_MAP[String(assetId)];
       console.warn(
         `[Tiles Fallback] Cesium Ion tile (asset ID: ${assetId}) → "${newType}" (Cesium Ion access token required but missing)`
       );
       return {
-        ...tile,
+        ...processedTile,
         type: newType
       };
     }
   }
 
-  return tile;
+  return processedTile;
 }
 
 /**
@@ -171,11 +177,12 @@ function migrateTerrain<T extends { type?: string; enabled?: boolean }>(
  * 1. Apply defaultTileType to tiles without explicit type
  * 2. Apply defaultTerrainType to terrain without explicit type
  *
- * Migration (backward compatibility):
- * 3. Migrate deprecated tile types to new types (EE only)
+ * Migration (backward compatibility, EE only):
+ * 3. Migrate deprecated tile types (default, default_label, default_road, black_marble)
+ *    to cesium_ion with proper asset IDs
  *
  * Fallback (when requirements not met):
- * 4. Fallback Cesium Ion tiles to alternatives when token missing (EE only)
+ * 4. If no Cesium Ion token available, fallback cesium_ion tiles to alternative EE types (EE only)
  * 5. Fallback Cesium terrain to reearth_terrain when token missing
  *
  * Note: Tiles/terrain without type and without default config will use schema defaults

--- a/web/src/app/features/Visualizer/utils/tilesMigration.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.ts
@@ -30,7 +30,7 @@ const TILE_TYPE_MIGRATION_MAP: Record<
   string,
   { type: "cesium_ion"; cesiumIonAssetId: number }
 > = {
-  default: { type: "cesium_ion", cesiumIonAssetId: 3 },
+  default: { type: "cesium_ion", cesiumIonAssetId: 2 },
   default_label: { type: "cesium_ion", cesiumIonAssetId: 3 },
   default_road: { type: "cesium_ion", cesiumIonAssetId: 4 },
   black_marble: { type: "cesium_ion", cesiumIonAssetId: 3812 }

--- a/web/src/app/features/Visualizer/utils/tilesMigration.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.ts
@@ -102,7 +102,7 @@ function migrateTile<
   let processedTile = tile;
 
   // Step 1: Migrate deprecated tile types to cesium_ion (MIGRATION - backward compatibility)
-  if (tile.type in TILE_TYPE_MIGRATION_MAP) {
+  if (tile.type && Object.hasOwn(TILE_TYPE_MIGRATION_MAP, tile.type)) {
     const migration = TILE_TYPE_MIGRATION_MAP[tile.type];
     console.warn(
       `[Tiles Migration] Migrating deprecated tile type "${tile.type}" to "${migration.type}" with asset ID ${migration.cesiumIonAssetId} (backward compatibility, EE environment)`
@@ -117,7 +117,7 @@ function migrateTile<
   // Step 2: Fallback cesium_ion tiles to EE types when token is missing (FALLBACK)
   if (processedTile.type === "cesium_ion" && !config.hasAccessToken) {
     const assetId = processedTile.cesiumIonAssetId;
-    if (assetId && String(assetId) in CESIUM_ION_ASSET_ID_FALLBACK_MAP) {
+    if (assetId && Object.hasOwn(CESIUM_ION_ASSET_ID_FALLBACK_MAP, String(assetId))) {
       const newType = CESIUM_ION_ASSET_ID_FALLBACK_MAP[String(assetId)];
       console.warn(
         `[Tiles Fallback] Cesium Ion tile (asset ID: ${assetId}) → "${newType}" (Cesium Ion access token required but missing)`


### PR DESCRIPTION
# Overview

- Update the interface of plugin API viewerProperty, support override cesium ion token (globally)
- Fix the incorrect FE migration map, it should be migrate to cesium_ion first and then go fallback process.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
