### PR TITLE
fix(web): missing initialize step for sentinel on published page

### DIFF
--- a/web/src/published.tsx
+++ b/web/src/published.tsx
@@ -6,15 +6,20 @@ import { createRoot } from "react-dom/client";
 
 import App from "./publishedapp";
 import loadConfig from "./services/config";
+import { initializeSentinel } from "./services/sentinel";
 import "./wdyr";
 import "@reearth-widget-ui/styles/globals.css";
 
 window.React = React;
 window.ReactDOM = ReactDOM;
 
-loadConfig().finally(() => {
+loadConfig().finally(async () => {
   const element = document.getElementById("root");
   if (!element) throw new Error("root element is not found");
+
+  // Initialize Sentinel for protected tile server authentication
+  await initializeSentinel();
+
   const root = createRoot(element);
   root.render(<App />);
 });


### PR DESCRIPTION
# Overview

There're separated entrance, missing initialize of sentinel on published.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
