### PR TITLE
fix(web): prevent infinite plugin re-initialization loop in plugin playground

### DIFF
--- a/web/src/app/features/PluginPlayground/Viewer/hooks.ts
+++ b/web/src/app/features/PluginPlayground/Viewer/hooks.ts
@@ -44,7 +44,7 @@ export default ({
       tiles: [
         {
           id: "default",
-          type: "default"
+          type: "google_satellite"
         }
       ]
     }),

--- a/web/src/app/features/PluginPlayground/Viewer/hooks.ts
+++ b/web/src/app/features/PluginPlayground/Viewer/hooks.ts
@@ -1,6 +1,7 @@
 import { ViewerProperty } from "@reearth/app/features/Editor/Visualizer/type";
 import { Camera } from "@reearth/app/utils/value";
 import { MapRef } from "@reearth/core";
+import { config } from "@reearth/services/config";
 import {
   MutableRefObject,
   useCallback,
@@ -39,16 +40,22 @@ export default ({
     []
   );
 
+  const isEE = useMemo(() => config()?.featureCollection === "ee", []);
+  const defaultTileType = useMemo(
+    () => (isEE ? "google_satellite" : "open_street_map"),
+    [isEE]
+  );
+
   const viewerProperty: ViewerProperty = useMemo(
     () => ({
       tiles: [
         {
           id: "default",
-          type: "google_satellite"
+          type: defaultTileType
         }
       ]
     }),
-    []
+    [defaultTileType]
   );
 
   useEffect(() => {

--- a/web/src/app/features/Visualizer/Crust/Plugins/hooks/useLayers.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/hooks/useLayers.ts
@@ -37,16 +37,17 @@ export default ({
   // Extract only the specific token value rather than depending on the whole viewerProperty
   // reference, which changes on every overrideViewerProperty call even when the token hasn't changed.
   const globalIonToken = viewerProperty?.assets?.cesium?.global?.ionAccessToken;
+  const engineToken = engineMeta?.cesiumIonAccessToken;
   const migrationConfig = useMemo(() => {
     const configData = config();
     const isEE = configData?.featureCollection === "ee";
-    const engineToken = engineMeta?.cesiumIonAccessToken;
     const hasAccessToken = !!(
-      (typeof globalIonToken === "string" && globalIonToken.trim().length > 0) ||
+      (typeof globalIonToken === "string" &&
+        globalIonToken.trim().length > 0) ||
       (typeof engineToken === "string" && engineToken.trim().length > 0)
     );
     return { isEE, hasAccessToken };
-  }, [engineMeta, globalIonToken]);
+  }, [engineToken, globalIonToken]);
 
   const hideLayer = useCallback(
     (...args: string[]) => {
@@ -66,7 +67,10 @@ export default ({
     (layer: NaiveLayer) => {
       // Apply migration/fallback logic before adding layer
       // This ensures osm-buildings falls back to reearth-buildings when token is missing
-      const migratedLayer = migrateLayer(layer as Layer, migrationConfig) as NaiveLayer;
+      const migratedLayer = migrateLayer(
+        layer as Layer,
+        migrationConfig
+      ) as NaiveLayer;
       const layerId = layersRef?.add(migratedLayer)?.id;
       // TODO: handle infobox
       return layerId;

--- a/web/src/app/features/Visualizer/Crust/Plugins/hooks/useLayers.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/hooks/useLayers.ts
@@ -34,18 +34,19 @@ export default ({
   const getLayers = useGet(layersRef);
 
   // Migration config for applying fallback logic to plugin-added layers
+  // Extract only the specific token value rather than depending on the whole viewerProperty
+  // reference, which changes on every overrideViewerProperty call even when the token hasn't changed.
+  const globalIonToken = viewerProperty?.assets?.cesium?.global?.ionAccessToken;
   const migrationConfig = useMemo(() => {
     const configData = config();
     const isEE = configData?.featureCollection === "ee";
-    // Check both global token override and engineMeta token
-    const globalIonToken = viewerProperty?.assets?.cesium?.global?.ionAccessToken;
     const engineToken = engineMeta?.cesiumIonAccessToken;
     const hasAccessToken = !!(
       (typeof globalIonToken === "string" && globalIonToken.trim().length > 0) ||
       (typeof engineToken === "string" && engineToken.trim().length > 0)
     );
     return { isEE, hasAccessToken };
-  }, [engineMeta, viewerProperty]);
+  }, [engineMeta, globalIonToken]);
 
   const hideLayer = useCallback(
     (...args: string[]) => {


### PR DESCRIPTION
## Summary

- Change deprecated tile type `\"default\"` to `\"google_satellite\"` in the plugin playground viewer, eliminating migration warnings on every render.
- Fix infinite QuickJS VM restart loop triggered whenever a plugin calls `reearth.viewer.overrideProperty()`.

## Root cause

`useLayers.migrationConfig` depended on the whole `viewerProperty` object. Because `useOverriddenProperty` uses `cloneDeep + mergeWith`, every `overrideProperty()` call from a plugin produced a new `viewerProperty` reference — even when the Ion token hadn't changed. This cascaded:

```
overrideProperty()
  → viewerProperty = new ref
  → migrationConfig recomputes → addLayer = new fn
  → context value recomputes → ctx.reearth = new ref
  → staticExposed recomputes → exposed prop changes
  → PluginFrame useEffect re-runs
  → QuickJS VM disposed + recreated
  → plugin runs overrideProperty() again → ∞
```

## Fix

Extract `viewerProperty?.assets?.cesium?.global?.ionAccessToken` (the only field `migrationConfig` reads from `viewerProperty`) as a scalar dep. `migrationConfig` now only recomputes when the user's Cesium Ion token actually changes.

## Test plan

- [x] Open plugin playground with camera-rotation preset, click Run — no infinite loop / React #185 error
- [x] Globe renders with google_satellite tiles
- [x] Camera rotation button works
- [x] Changing a Cesium Ion token in scene settings still updates layer fallback behaviour