### PR TITLE
chore(web): bump core version to 0.0.7-alpha.67

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -128,7 +128,7 @@
     "@popperjs/core": "2.11.8",
     "@radix-ui/react-select": "2.2.6",
     "@radix-ui/react-slot": "1.2.4",
-    "@reearth/core": "0.0.7-alpha.66",
+    "@reearth/core": "0.0.7-alpha.67",
     "@reearth/sentinel": "0.1.0",
     "@rot1024/use-transition": "1.0.0",
     "@sentry/browser": "7.77.0",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5412,9 +5412,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reearth/core@npm:0.0.7-alpha.66":
-  version: 0.0.7-alpha.66
-  resolution: "@reearth/core@npm:0.0.7-alpha.66"
+"@reearth/core@npm:0.0.7-alpha.67":
+  version: 0.0.7-alpha.67
+  resolution: "@reearth/core@npm:0.0.7-alpha.67"
   dependencies:
     "@radix-ui/react-checkbox": "npm:^1.3.3"
     "@radix-ui/react-dialog": "npm:^1.1.15"
@@ -5468,7 +5468,7 @@ __metadata:
     cesium: 1.118.x
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/4f14b28f85ef041cec94bdbea89b655fdee574f7ecfe55bf4b057a4e134ff76190f69bef20896c3fa90422141ec9e76af5ff97cf649b4564f47d3da898f676c3
+  checksum: 10c0/782dc38e19f91e5f3353cc027dcaf942bc1ed91344270eb7b2f3987ed47ec463150d465295d3e6fce4940383eaabb45389454fa831eaaf0d2bf8ff416abbf5b9
   languageName: node
   linkType: hard
 
@@ -5530,7 +5530,7 @@ __metadata:
     "@popperjs/core": "npm:2.11.8"
     "@radix-ui/react-select": "npm:2.2.6"
     "@radix-ui/react-slot": "npm:1.2.4"
-    "@reearth/core": "npm:0.0.7-alpha.66"
+    "@reearth/core": "npm:0.0.7-alpha.67"
     "@reearth/sentinel": "npm:0.1.0"
     "@rollup/plugin-yaml": "npm:4.1.2"
     "@rot1024/use-transition": "npm:1.0.0"


### PR DESCRIPTION
# Overview

Apply the fix for stable tiles

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
