### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,32 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: reearth-visualizer
+  namespace: reearth
+  description: 3D WebGIS visualization platform with storytelling, plugin marketplace,
+    and Cesium-based rendering
+  annotations:
+    github.com/project-slug: reearth/reearth-visualizer
+  links:
+  - url: https://github.com/reearth/reearth-visualizer
+    title: GitHub
+    icon: github
+  - url: https://reearth.io
+    title: Production
+    icon: web
+  - url: https://visualizer.developer.reearth.io
+    title: Developer Docs
+    icon: docs
+  - url: https://reearth.io/product/visualizer
+    title: Website
+    icon: web
+  tags:
+  - typescript
+  - go
+  - webgis
+  - cesium
+  - wasm
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/visualizer


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `reearth-visualizer` (namespace `reearth`)
- **Owner:** `reearth/visualizer`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.