### PR TITLE
fix(server): require auth on export download endpoint (SEC-02)

### DIFF
--- a/server/e2e/gql_plugin_widget_test.go
+++ b/server/e2e/gql_plugin_widget_test.go
@@ -287,6 +287,8 @@ func fetchAndParseExport(t *testing.T, e *httpexpect.Expect, projectDataPath str
 	t.Helper()
 
 	resp := e.GET(projectDataPath).
+		WithHeader("authorization", "Bearer test").
+		WithHeader("X-Reearth-Debug-User", uID.String()).
 		Expect().
 		Status(200)
 

--- a/server/e2e/gql_project_export_test.go
+++ b/server/e2e/gql_project_export_test.go
@@ -32,6 +32,8 @@ func TestProjectExport(t *testing.T) {
 	projectDataPath := Export(t, e, projectId)
 
 	resp := e.GET(projectDataPath).
+		WithHeader("authorization", "Bearer test").
+		WithHeader("X-Reearth-Debug-User", uID.String()).
 		Expect().
 		Status(200)
 

--- a/server/e2e/gql_project_import_signature_test.go
+++ b/server/e2e/gql_project_import_signature_test.go
@@ -44,6 +44,8 @@ func GenProjectZipFile(t *testing.T, e *httpexpect.Expect) (projectZipFilePath s
 	projectId := SetupProject(t, e)
 	projectDataPath := Export(t, e, projectId)
 	resp := e.GET(projectDataPath).
+		WithHeader("authorization", "Bearer test").
+		WithHeader("X-Reearth-Debug-User", uID.String()).
 		Expect().
 		Status(200)
 	resp.Header("Content-Type").Contains("application/zip")

--- a/server/e2e/proto_project_export_test.go
+++ b/server/e2e/proto_project_export_test.go
@@ -64,6 +64,8 @@ func TestInternalAPI_export(t *testing.T) {
 
 		// Try download
 		resp := e.GET(exp.ProjectDataPath).
+			WithHeader("authorization", "Bearer test").
+			WithHeader("X-Reearth-Debug-User", uID.String()).
 			Expect().
 			Status(200)
 
@@ -84,15 +86,10 @@ func TestInternalAPI_export(t *testing.T) {
 		assert.NotNil(t, exp.ProjectDataPath)
 		assert.Nil(t, err)
 
-		// Try download
-		resp := e.GET(exp.ProjectDataPath).
+		// Download requires auth — visitor (unauthenticated) should get 401
+		e.GET(exp.ProjectDataPath).
 			Expect().
-			Status(200)
-
-		resp.Header("Content-Type").Contains("application/zip")
-		body := resp.Body().Raw()
-		assert.Greater(t, len(body), 4)
-		assert.Equal(t, "PK\x03\x04", string(body[:4])) // check zip file hedder
+			Status(401)
 
 		// private => Error!
 		exp, err = client.ExportProject(ctx, &pb.ExportProjectRequest{
@@ -130,6 +127,8 @@ func TestInternalAPI_export(t *testing.T) {
 
 		// Try download
 		resp := e.GET(exp.ProjectDataPath).
+			WithHeader("authorization", "Bearer test").
+			WithHeader("X-Reearth-Debug-User", uID3.String()).
 			Expect().
 			Status(200)
 

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -148,6 +148,8 @@ func initEcho(
 	apiRoot.GET("/mockuser", MockUser())
 
 	// Asset API for handling GCP files
+	serveFiles(e, cfg, allowedOrigins(cfg), cfg.Gateways.DomainChecker, cfg.Gateways.File)
+
 	apiPrivateRoute := apiRoot.Group("", privateCache)
 	if cfg.Config.UseMockAuth() {
 		apiPrivateRoute.Use(attachOpMiddlewareMockUser(cfg))
@@ -155,8 +157,6 @@ func initEcho(
 		apiPrivateRoute.Use(attachOpMiddlewareReearthAccounts(cfg))
 	}
 	apiPrivateRoute.Use(LatestLogoutAtHeader)
-
-	serveFiles(e, cfg, allowedOrigins(cfg), cfg.Gateways.DomainChecker, cfg.Gateways.File)
 
 	// Main backend API
 	apiPrivateRoute.POST("/graphql", GraphqlAPI(cfg.Config.GraphQL, cfg.AccountsAPIClient, gqldev))

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -148,8 +148,6 @@ func initEcho(
 	apiRoot.GET("/mockuser", MockUser())
 
 	// Asset API for handling GCP files
-	serveFiles(e, allowedOrigins(cfg), cfg.Gateways.DomainChecker, cfg.Gateways.File)
-
 	apiPrivateRoute := apiRoot.Group("", privateCache)
 	if cfg.Config.UseMockAuth() {
 		apiPrivateRoute.Use(attachOpMiddlewareMockUser(cfg))
@@ -157,6 +155,8 @@ func initEcho(
 		apiPrivateRoute.Use(attachOpMiddlewareReearthAccounts(cfg))
 	}
 	apiPrivateRoute.Use(LatestLogoutAtHeader)
+
+	serveFiles(e, cfg, allowedOrigins(cfg), cfg.Gateways.DomainChecker, cfg.Gateways.File)
 
 	// Main backend API
 	apiPrivateRoute.POST("/graphql", GraphqlAPI(cfg.Config.GraphQL, cfg.AccountsAPIClient, gqldev))

--- a/server/internal/app/file.go
+++ b/server/internal/app/file.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth/server/internal/adapter"
 	"github.com/reearth/reearth/server/internal/adapter/middleware"
 	"github.com/reearth/reearth/server/internal/usecase/gateway"
 	"github.com/reearth/reearth/server/pkg/id"
@@ -73,6 +74,10 @@ func serveFiles(
 	ec.GET(
 		"/export/:filename",
 		fileHandler(func(ctx echo.Context) (io.Reader, string, error) {
+			if adapter.Operator(ctx.Request().Context()) == nil {
+				return nil, "", echo.ErrUnauthorized
+			}
+
 			filename := ctx.Param("filename")
 
 			r, err := fileGateway.ReadExportProjectZip(ctx.Request().Context(), filename)
@@ -85,7 +90,9 @@ func serveFiles(
 			go func() {
 				// download and then delete
 				time.Sleep(3 * time.Second)
-				err := fileGateway.RemoveExportProjectZip(context.Background(), filename)
+				deleteCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				err := fileGateway.RemoveExportProjectZip(deleteCtx, filename)
 				if err != nil {
 					fmt.Printf("[export] !!!! delete err: %s \n", err.Error())
 				} else {

--- a/server/internal/app/file.go
+++ b/server/internal/app/file.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"mime"
@@ -17,6 +18,7 @@ import (
 
 func serveFiles(
 	ec *echo.Echo,
+	cfg *ServerConfig,
 	allowedOrigins []string,
 	domainChecker gateway.DomainChecker,
 	fileGateway gateway.File,
@@ -61,6 +63,13 @@ func serveFiles(
 		middleware.FilesCORSMiddleware(domainChecker, allowedOrigins),
 	)
 
+	var exportAuthMiddleware echo.MiddlewareFunc
+	if cfg.Config.UseMockAuth() {
+		exportAuthMiddleware = attachOpMiddlewareMockUser(cfg)
+	} else {
+		exportAuthMiddleware = attachOpMiddlewareReearthAccounts(cfg)
+	}
+
 	ec.GET(
 		"/export/:filename",
 		fileHandler(func(ctx echo.Context) (io.Reader, string, error) {
@@ -73,12 +82,10 @@ func serveFiles(
 			}
 			fmt.Printf("[export] download file: %s \n", filename)
 
-			rctx := ctx.Request().Context()
-
 			go func() {
 				// download and then delete
 				time.Sleep(3 * time.Second)
-				err := fileGateway.RemoveExportProjectZip(rctx, filename)
+				err := fileGateway.RemoveExportProjectZip(context.Background(), filename)
 				if err != nil {
 					fmt.Printf("[export] !!!! delete err: %s \n", err.Error())
 				} else {
@@ -87,6 +94,7 @@ func serveFiles(
 			}()
 			return r, filename, nil
 		}),
+		exportAuthMiddleware,
 		middleware.FilesCORSMiddleware(domainChecker, allowedOrigins),
 	)
 


### PR DESCRIPTION
## Summary

- Add auth middleware to `/export/:filename` — previously unauthenticated, allowing anyone who knew the project ID to download private project exports
- Fix the delete-after-download goroutine to use `context.Background()` instead of the request context, which was already cancelled by the time the goroutine ran