### PR TITLE
refactor(web): enable normal for reearth terrain

### DIFF
--- a/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.test.ts
@@ -207,7 +207,8 @@ describe("tilesMigration", () => {
       });
       expect(result?.terrain).toEqual({
         type: "reearth_terrain",
-        enabled: true
+        enabled: true,
+        normal: true
       });
     });
 
@@ -251,7 +252,8 @@ describe("tilesMigration", () => {
       ]);
       expect(result?.terrain).toEqual({
         type: "reearth_terrain",
-        enabled: true
+        enabled: true,
+        normal: true
       });
     });
 
@@ -265,7 +267,7 @@ describe("tilesMigration", () => {
         hasAccessToken: false
       });
       expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite", cesiumIonAssetId: 2 }]); // Migrated + fallback
-      expect(result?.terrain).toEqual({ type: "reearth_terrain", enabled: true });
+      expect(result?.terrain).toEqual({ type: "reearth_terrain", enabled: true, normal: true });
     });
 
     it("should only migrate terrain when tiles don't need migration", () => {
@@ -280,7 +282,8 @@ describe("tilesMigration", () => {
       expect(result?.tiles).toBe(viewerProperty.tiles); // Unchanged
       expect(result?.terrain).toEqual({
         type: "reearth_terrain",
-        enabled: true
+        enabled: true,
+        normal: true
       });
     });
 
@@ -288,7 +291,7 @@ describe("tilesMigration", () => {
       const viewerProperty = {
         tiles: [{ id: "1", type: "open_street_map" as const }],
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        terrain: { type: "reearth_terrain" as any, enabled: true }
+        terrain: { type: "reearth_terrain" as any, enabled: true, normal: true }
       };
       const result = migrateViewerPropertyTiles(viewerProperty, {
         isEE: false,
@@ -308,7 +311,8 @@ describe("tilesMigration", () => {
       });
       expect(result?.terrain).toEqual({
         enabled: true,
-        type: "reearth_terrain"
+        type: "reearth_terrain",
+        normal: true
       });
     });
 
@@ -321,6 +325,69 @@ describe("tilesMigration", () => {
         hasAccessToken: false
       });
       expect(result).toBe(viewerProperty); // No migration
+    });
+
+    it("should set normal=true for reearth_terrain when enabled", () => {
+      const viewerProperty = {
+        terrain: { type: "reearth_terrain" as const, enabled: true }
+      };
+      const result = migrateViewerPropertyTiles(viewerProperty, {
+        isEE: false,
+        hasAccessToken: false
+      });
+      expect(result?.terrain).toEqual({
+        type: "reearth_terrain",
+        enabled: true,
+        normal: true
+      });
+    });
+
+    it("should NOT set normal=true for reearth_terrain when disabled", () => {
+      const viewerProperty = {
+        terrain: { type: "reearth_terrain" as const, enabled: false }
+      };
+      const result = migrateViewerPropertyTiles(viewerProperty, {
+        isEE: false,
+        hasAccessToken: false
+      });
+      expect(result).toBe(viewerProperty); // No change for disabled terrain
+    });
+
+    it("should NOT override normal if already set to true", () => {
+      const viewerProperty = {
+        terrain: { type: "reearth_terrain" as const, enabled: true, normal: true }
+      };
+      const result = migrateViewerPropertyTiles(viewerProperty, {
+        isEE: false,
+        hasAccessToken: false
+      });
+      expect(result).toBe(viewerProperty); // No change needed
+    });
+
+    it("should set normal=true even if it was explicitly false", () => {
+      const viewerProperty = {
+        terrain: { type: "reearth_terrain" as const, enabled: true, normal: false }
+      };
+      const result = migrateViewerPropertyTiles(viewerProperty, {
+        isEE: false,
+        hasAccessToken: false
+      });
+      expect(result?.terrain).toEqual({
+        type: "reearth_terrain",
+        enabled: true,
+        normal: true
+      });
+    });
+
+    it("should NOT set normal for non-reearth_terrain types", () => {
+      const viewerProperty = {
+        terrain: { type: "cesium" as const, enabled: true }
+      };
+      const result = migrateViewerPropertyTiles(viewerProperty, {
+        isEE: false,
+        hasAccessToken: true // Token available, no fallback
+      });
+      expect(result).toBe(viewerProperty); // No change for other terrain types
     });
 
     it("should migrate tiles and apply defaultTerrainType when both need processing", () => {
@@ -336,7 +403,8 @@ describe("tilesMigration", () => {
       expect(result?.tiles).toEqual([{ id: "1", type: "google_satellite", cesiumIonAssetId: 2 }]); // Migrated + fallback
       expect(result?.terrain).toEqual({
         enabled: true,
-        type: "reearth_terrain"
+        type: "reearth_terrain",
+        normal: true
       });
     });
 

--- a/web/src/app/features/Visualizer/utils/tilesMigration.ts
+++ b/web/src/app/features/Visualizer/utils/tilesMigration.ts
@@ -211,8 +211,15 @@ export function migrateViewerPropertyTiles(
     ((!terrain.type && config.defaultTerrainType) ||
       (terrain.type === "cesium" && !config.hasAccessToken));
 
+  // Check if terrain needs normal map setting for reearth_terrain
+  const terrainNeedsNormalMap =
+    hasTerrain &&
+    terrain.enabled !== false &&
+    terrain.type === "reearth_terrain" &&
+    terrain.normal !== true;
+
   // Return original if nothing needs processing
-  if (!tilesNeedProcessing && !terrainNeedsProcessing) {
+  if (!tilesNeedProcessing && !terrainNeedsProcessing && !terrainNeedsNormalMap) {
     return viewerProperty;
   }
 
@@ -226,6 +233,20 @@ export function migrateViewerPropertyTiles(
   // Apply terrain default or fallback if needed
   if (terrainNeedsProcessing) {
     result.terrain = migrateTerrain(terrain, config);
+  }
+
+  // Set normal map for reearth_terrain when enabled (if not already set)
+  const finalTerrain = result.terrain || terrain;
+  if (
+    finalTerrain &&
+    finalTerrain.enabled !== false &&
+    finalTerrain.type === "reearth_terrain" &&
+    finalTerrain.normal !== true
+  ) {
+    result.terrain = {
+      ...finalTerrain,
+      normal: true
+    };
   }
 
   return result;


### PR DESCRIPTION
# Overview

Always enable normal for reearth terrain.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
