### PR TITLE
fix(e2e): paginate starredProjects and deletedProjects queries to handle stale data

### DIFF
--- a/e2e/api/graphql/queries.ts
+++ b/e2e/api/graphql/queries.ts
@@ -96,18 +96,20 @@ export const CHECK_SCENE_ALIAS = `
 `;
 
 export const GET_STARRED_PROJECTS = `
-  query GetStarredProjects($workspaceId: ID!) {
-    starredProjects(workspaceId: $workspaceId) {
+  query GetStarredProjects($workspaceId: ID!, $pagination: Pagination) {
+    starredProjects(workspaceId: $workspaceId, pagination: $pagination) {
       totalCount
+      pageInfo { hasNextPage endCursor }
       nodes { id name starred }
     }
   }
 `;
 
 export const GET_DELETED_PROJECTS = `
-  query GetDeletedProjects($workspaceId: ID!) {
-    deletedProjects(workspaceId: $workspaceId) {
+  query GetDeletedProjects($workspaceId: ID!, $pagination: Pagination) {
+    deletedProjects(workspaceId: $workspaceId, pagination: $pagination) {
       totalCount
+      pageInfo { hasNextPage endCursor }
       nodes { id name isDeleted }
     }
   }

--- a/e2e/api/tests/project-crud-extended.api.spec.ts
+++ b/e2e/api/tests/project-crud-extended.api.spec.ts
@@ -165,7 +165,7 @@ test.describe("Project starred and deleted queries via API", () => {
         };
       }> = await gqlClient.query(GET_STARRED_PROJECTS, {
         workspaceId,
-        pagination: cursor ? { after: cursor } : undefined
+        pagination: { first: 100, ...(cursor ? { after: cursor } : {}) }
       });
       expect(res.status).toBe(200);
       found = res.data.starredProjects.nodes.find((p) => p.id === projectId);
@@ -201,7 +201,7 @@ test.describe("Project starred and deleted queries via API", () => {
         };
       }> = await gqlClient.query(GET_STARRED_PROJECTS, {
         workspaceId,
-        pagination: cursor ? { after: cursor } : undefined
+        pagination: { first: 100, ...(cursor ? { after: cursor } : {}) }
       });
       expect(res.status).toBe(200);
       found = res.data.starredProjects.nodes.find((p) => p.id === projectId);
@@ -236,7 +236,7 @@ test.describe("Project starred and deleted queries via API", () => {
         };
       }> = await gqlClient.query(GET_DELETED_PROJECTS, {
         workspaceId,
-        pagination: cursor ? { after: cursor } : undefined
+        pagination: { first: 100, ...(cursor ? { after: cursor } : {}) }
       });
       expect(res.status).toBe(200);
       expect(res.data.deletedProjects.totalCount).toBeGreaterThan(0);

--- a/e2e/api/tests/project-crud-extended.api.spec.ts
+++ b/e2e/api/tests/project-crud-extended.api.spec.ts
@@ -171,7 +171,7 @@ test.describe("Project starred and deleted queries via API", () => {
       found = res.data.starredProjects.nodes.find((p) => p.id === projectId);
       hasNextPage = res.data.starredProjects.pageInfo.hasNextPage;
       cursor = res.data.starredProjects.pageInfo.endCursor;
-      if (found) break;
+      if (found || !cursor) break;
     }
     expect(found).toBeDefined();
     expect(found?.starred).toBe(true);
@@ -207,7 +207,7 @@ test.describe("Project starred and deleted queries via API", () => {
       found = res.data.starredProjects.nodes.find((p) => p.id === projectId);
       hasNextPage = res.data.starredProjects.pageInfo.hasNextPage;
       cursor = res.data.starredProjects.pageInfo.endCursor;
-      if (found) break;
+      if (found || !cursor) break;
     }
     expect(found).toBeUndefined();
   });
@@ -243,7 +243,7 @@ test.describe("Project starred and deleted queries via API", () => {
       found = res.data.deletedProjects.nodes.find((p) => p.id === projectId);
       hasNextPage = res.data.deletedProjects.pageInfo.hasNextPage;
       cursor = res.data.deletedProjects.pageInfo.endCursor;
-      if (found) break;
+      if (found || !cursor) break;
     }
     expect(found).toBeDefined();
     expect(found?.isDeleted).toBe(true);

--- a/e2e/api/tests/project-crud-extended.api.spec.ts
+++ b/e2e/api/tests/project-crud-extended.api.spec.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
 
 import { test, expect } from "../fixtures/api-test-fixtures";
+import { GQLResult } from "../graphql/client";
 import {
   CREATE_PROJECT,
   CREATE_SCENE,
@@ -30,8 +31,9 @@ test.describe("Project alias checks via API", () => {
     if (!projectId) return;
     try {
       await gqlClient.mutate(DELETE_PROJECT, { input: { projectId } });
-    } catch {
-      // already deleted
+      console.log(`[afterAll] deleted project ${projectId}`);
+    } catch (e) {
+      console.warn(`[afterAll] failed to delete project ${projectId}:`, e);
     }
   });
 
@@ -116,8 +118,9 @@ test.describe("Project starred and deleted queries via API", () => {
     if (!projectId) return;
     try {
       await gqlClient.mutate(DELETE_PROJECT, { input: { projectId } });
-    } catch {
-      // already deleted
+      console.log(`[afterAll] deleted project ${projectId}`);
+    } catch (e) {
+      console.warn(`[afterAll] failed to delete project ${projectId}:`, e);
     }
   });
 
@@ -150,15 +153,26 @@ test.describe("Project starred and deleted queries via API", () => {
   });
 
   test("starredProjects returns the starred project", async ({ gqlClient }) => {
-    const { status, data } = await gqlClient.query<{
-      starredProjects: {
-        totalCount: number;
-        nodes: { id: string; name: string; starred: boolean }[];
-      };
-    }>(GET_STARRED_PROJECTS, { workspaceId });
-
-    expect(status).toBe(200);
-    const found = data.starredProjects.nodes.find((p) => p.id === projectId);
+    let cursor: string | null = null;
+    let hasNextPage = true;
+    let found: { id: string; name: string; starred: boolean } | undefined;
+    while (hasNextPage) {
+      const res: GQLResult<{
+        starredProjects: {
+          totalCount: number;
+          pageInfo: { hasNextPage: boolean; endCursor: string | null };
+          nodes: { id: string; name: string; starred: boolean }[];
+        };
+      }> = await gqlClient.query(GET_STARRED_PROJECTS, {
+        workspaceId,
+        pagination: cursor ? { after: cursor } : undefined
+      });
+      expect(res.status).toBe(200);
+      found = res.data.starredProjects.nodes.find((p) => p.id === projectId);
+      hasNextPage = res.data.starredProjects.pageInfo.hasNextPage;
+      cursor = res.data.starredProjects.pageInfo.endCursor;
+      if (found) break;
+    }
     expect(found).toBeDefined();
     expect(found?.starred).toBe(true);
   });
@@ -175,15 +189,26 @@ test.describe("Project starred and deleted queries via API", () => {
   test("starredProjects no longer includes the project", async ({
     gqlClient
   }) => {
-    const { status, data } = await gqlClient.query<{
-      starredProjects: {
-        totalCount: number;
-        nodes: { id: string }[];
-      };
-    }>(GET_STARRED_PROJECTS, { workspaceId });
-
-    expect(status).toBe(200);
-    const found = data.starredProjects.nodes.find((p) => p.id === projectId);
+    let cursor: string | null = null;
+    let hasNextPage = true;
+    let found: { id: string } | undefined;
+    while (hasNextPage) {
+      const res: GQLResult<{
+        starredProjects: {
+          totalCount: number;
+          pageInfo: { hasNextPage: boolean; endCursor: string | null };
+          nodes: { id: string }[];
+        };
+      }> = await gqlClient.query(GET_STARRED_PROJECTS, {
+        workspaceId,
+        pagination: cursor ? { after: cursor } : undefined
+      });
+      expect(res.status).toBe(200);
+      found = res.data.starredProjects.nodes.find((p) => p.id === projectId);
+      hasNextPage = res.data.starredProjects.pageInfo.hasNextPage;
+      cursor = res.data.starredProjects.pageInfo.endCursor;
+      if (found) break;
+    }
     expect(found).toBeUndefined();
   });
 
@@ -199,16 +224,27 @@ test.describe("Project starred and deleted queries via API", () => {
   test("deletedProjects returns the soft-deleted project", async ({
     gqlClient
   }) => {
-    const { status, data } = await gqlClient.query<{
-      deletedProjects: {
-        totalCount: number;
-        nodes: { id: string; name: string; isDeleted: boolean }[];
-      };
-    }>(GET_DELETED_PROJECTS, { workspaceId });
-
-    expect(status).toBe(200);
-    expect(data.deletedProjects.totalCount).toBeGreaterThan(0);
-    const found = data.deletedProjects.nodes.find((p) => p.id === projectId);
+    let cursor: string | null = null;
+    let hasNextPage = true;
+    let found: { id: string; name: string; isDeleted: boolean } | undefined;
+    while (hasNextPage) {
+      const res: GQLResult<{
+        deletedProjects: {
+          totalCount: number;
+          pageInfo: { hasNextPage: boolean; endCursor: string | null };
+          nodes: { id: string; name: string; isDeleted: boolean }[];
+        };
+      }> = await gqlClient.query(GET_DELETED_PROJECTS, {
+        workspaceId,
+        pagination: cursor ? { after: cursor } : undefined
+      });
+      expect(res.status).toBe(200);
+      expect(res.data.deletedProjects.totalCount).toBeGreaterThan(0);
+      found = res.data.deletedProjects.nodes.find((p) => p.id === projectId);
+      hasNextPage = res.data.deletedProjects.pageInfo.hasNextPage;
+      cursor = res.data.deletedProjects.pageInfo.endCursor;
+      if (found) break;
+    }
     expect(found).toBeDefined();
     expect(found?.isDeleted).toBe(true);
   });
@@ -221,8 +257,9 @@ test.describe("Project export and metadata via API", () => {
     if (!projectId) return;
     try {
       await gqlClient.mutate(DELETE_PROJECT, { input: { projectId } });
-    } catch {
-      // already deleted
+      console.log(`[afterAll] deleted project ${projectId}`);
+    } catch (e) {
+      console.warn(`[afterAll] failed to delete project ${projectId}:`, e);
     }
   });
 

--- a/e2e/utils/project-cleanup.ts
+++ b/e2e/utils/project-cleanup.ts
@@ -3,7 +3,7 @@ import path from "path";
 
 import { APIRequestContext } from "@playwright/test";
 
-import { GraphQLClient } from "../api/graphql/client";
+import { GraphQLClient, GQLResult } from "../api/graphql/client";
 import { DELETE_PROJECT, UPDATE_PROJECT } from "../api/graphql/mutations";
 import { GET_ME, GET_DELETED_PROJECTS, GET_PROJECTS } from "../api/graphql/queries";
 
@@ -80,18 +80,33 @@ export async function deleteProjectByName(
       (p) => p.name === projectName
     );
 
-    // Also find soft-deleted projects (in recycle bin)
-    const { data: deletedData } = await client
-      .query<{
-        deletedProjects: { nodes: { id: string; name: string }[] };
-      }>(GET_DELETED_PROJECTS, { workspaceId })
-      .catch(() => ({
-        data: { deletedProjects: { nodes: [] } }
-      }));
-
-    const deletedProjects = deletedData.deletedProjects.nodes.filter(
-      (p) => p.name === projectName
-    );
+    // Also find soft-deleted projects (in recycle bin), paginating through all pages
+    const deletedProjects: { id: string; name: string }[] = [];
+    let cursor: string | null = null;
+    let hasNextPage = true;
+    while (hasNextPage) {
+      let res: GQLResult<{
+        deletedProjects: {
+          pageInfo: { hasNextPage: boolean; endCursor: string | null };
+          nodes: { id: string; name: string }[];
+        };
+      }>;
+      try {
+        res = await client.query(GET_DELETED_PROJECTS, {
+          workspaceId,
+          pagination: { first: 100, ...(cursor ? { after: cursor } : {}) }
+        });
+      } catch {
+        break;
+      }
+      const matched = res.data.deletedProjects.nodes.filter(
+        (p) => p.name === projectName
+      );
+      deletedProjects.push(...matched);
+      hasNextPage = res.data.deletedProjects.pageInfo.hasNextPage;
+      cursor = res.data.deletedProjects.pageInfo.endCursor;
+      if (!cursor) break;
+    }
 
     const allProjects = [...activeProjects, ...deletedProjects];
 


### PR DESCRIPTION
## Summary

- `GET_STARRED_PROJECTS` and `GET_DELETED_PROJECTS` queries lacked pagination variables, so they always hit the server's default page cap of 100 results
- After PR #2182 introduced server-side pagination, interrupted CI runs started leaking soft-deleted projects into the dev workspace — once the count exceeded 100, the `deletedProjects returns the soft-deleted project` test could no longer find the project it just created and began failing consistently
- This PR updates both queries to pass `pagination` and fetch `pageInfo { hasNextPage endCursor }`, and updates the tests to walk pages until the target project is found
- Also adds `console.log`/`console.warn` to all `afterAll` cleanup blocks so failures surface in CI logs rather than being silently swallowed

## Root cause

PR #2182 fixed an unbounded MongoDB query security issue (SCA-02) by switching `starredProjects` and `deletedProjects` to paginated queries with a default limit of 100. The e2e tests were never updated to pass pagination args.

## Test plan

- [x] `Project starred and deleted queries via API` describe block passes locally (8/8 tests)
- [x] TypeScript compiles clean (`yarn tsc --noEmit`)
- [x] CI run on this branch