### PR TITLE
test(e2e): skip moveStory tests until server-side implemented

### DIFF
--- a/e2e/api/tests/move-story.api.spec.ts
+++ b/e2e/api/tests/move-story.api.spec.ts
@@ -55,8 +55,8 @@ test.describe("Move story via API", () => {
     storyId = s.createStory.story.id;
   });
 
-  test.fixme("Move story to index 0", async ({ gqlClient }) => {
-    // Server returns "not implemented" for moveStory mutation
+  test.skip("Move story to index 0", async ({ gqlClient }) => {
+    // Skipped: server returns "not implemented" for moveStory mutation
     const { status, data } = await gqlClient.mutate<{
       moveStory: {
         storyId: string;

--- a/e2e/api/tests/move-story.api.spec.ts
+++ b/e2e/api/tests/move-story.api.spec.ts
@@ -73,8 +73,8 @@ test.describe("Move story via API", () => {
   });
 });
 
-// Negative scenarios
-test.describe("Move story negative scenarios", () => {
+// Negative scenarios — skipped until moveStory is implemented server-side
+test.describe.skip("Move story negative scenarios", () => {
   test("Cannot move a non-existent story", async ({ gqlClient }) => {
     const fakeSceneId = generateFakeId();
     const fakeStoryId = generateFakeId();


### PR DESCRIPTION
## Summary

- `moveStory` returns `ErrNotImplemented` on the server for any input, causing every test call to log an ERROR and trigger alerts on `reearth-oss`
- The positive test was already marked `test.fixme` but the negative scenario describe block was still running and hitting the mutation
- This PR skips the negative scenario block with `test.describe.skip` for the same reason

## Related

- Notion task: https://app.notion.com/p/38016e0fb165811886e7f7651e4a50bd

## Test plan

- [x] `moveStory` negative scenario no longer runs in CI
- [x] `moveStory not implemented` errors will stop appearing in GCP logs