### PR TITLE
chore(web): disable sentinel debug logging to reduce excessive logs in production

### DIFF
--- a/web/src/services/sentinel/index.ts
+++ b/web/src/services/sentinel/index.ts
@@ -48,7 +48,9 @@ export async function initializeSentinel(): Promise<void> {
         memoryCacheTTL: 300_000, // 5 min
         refreshThreshold: 60_000 // refresh 1 min before expiry
       },
-      debug: import.meta.env.DEV,
+      //TODO: disable debug temporarily due to verbose logging in some environments that may cause performance issues. Can be re-enabled when the underlying issue is resolved.
+      // debug: import.meta.env.DEV,
+      debug: false,
       onTokenExpired: async () => {
         try {
           const res = await fetch("/reearth_config.json", {
@@ -62,10 +64,14 @@ export async function initializeSentinel(): Promise<void> {
               expiresAt: Date.now() + 24 * 60 * 60 * 1000
             });
             if (!refreshed) {
-              console.warn("[Sentinel] Token refresh succeeded but SW did not acknowledge — protected requests may fail");
+              console.warn(
+                "[Sentinel] Token refresh succeeded but SW did not acknowledge — protected requests may fail"
+              );
             }
           } else {
-            console.warn("[Sentinel] Token expired and no new token found in config");
+            console.warn(
+              "[Sentinel] Token expired and no new token found in config"
+            );
           }
         } catch (err) {
           console.error("[Sentinel] Token refresh failed:", err);
@@ -79,7 +85,9 @@ export async function initializeSentinel(): Promise<void> {
     });
 
     if (!tokenStored) {
-      console.error("[Sentinel] SW did not acknowledge token — initialization aborted, tiles may return 401");
+      console.error(
+        "[Sentinel] SW did not acknowledge token — initialization aborted, tiles may return 401"
+      );
       return;
     }
 

--- a/web/src/services/sentinel/index.ts
+++ b/web/src/services/sentinel/index.ts
@@ -48,8 +48,8 @@ export async function initializeSentinel(): Promise<void> {
         memoryCacheTTL: 300_000, // 5 min
         refreshThreshold: 60_000 // refresh 1 min before expiry
       },
-      //TODO: disable debug temporarily due to verbose logging in some environments that may cause performance issues. Can be re-enabled when the underlying issue is resolved.
-      // debug: import.meta.env.DEV,
+      // TODO: Debug logging is temporarily disabled due to verbose logging in some environments that
+      // may cause performance issues. Re-enable once the underlying issue is resolved.
       debug: false,
       onTokenExpired: async () => {
         try {


### PR DESCRIPTION
# Overview
This PR disables Sentinel debug mode to prevent excessive logging in production-like environments.

## What I've done
Set Sentinel debug option to false (was previously enabled in development mode).
Added a TODO comment to document that debug logging is temporarily disabled due to verbose logs and potential performance impact.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
