### PR TITLE
chore(server): upgrade Go from 1.26.1 to 1.26.4

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.4"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         # TODO: fix error=archive named dist/reearth_0.0.0-SNAPSHOT-xxxxxxxx.tar.gz already exists. Check your archive name template

--- a/go.work
+++ b/go.work
@@ -1,3 +1,3 @@
-go 1.26.1
+go 1.26.4
 
 use ./server

--- a/server/.tool-versions
+++ b/server/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.1
+golang 1.26.4

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine AS build
+FROM golang:1.26.4-alpine AS build
 ARG TAG=release
 ARG VERSION
 

--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine
+FROM golang:1.26.4-alpine
 
 RUN apk add --update --no-cache git ca-certificates build-base curl binutils-gold
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -233,4 +233,4 @@ require (
 	moul.io/http2curl/v2 v2.3.0 // indirect
 )
 
-go 1.26.1
+go 1.26.4


### PR DESCRIPTION
## Summary

- Bumps Go from 1.26.1 to 1.26.4 across all relevant files
- Updates `server/go.mod`, `go.work`, `server/Dockerfile`, `server/Dockerfile.dev`, `server/.tool-versions`, and `.github/workflows/build_release.yml`

## Test plan

- [x] `go mod tidy` runs cleanly with no changes to `go.sum`
- [x] Local dev build passes: `docker compose -f ../docker-compose.yml --profile accounts up reearth-visualizer-dev` (requires `docker pull golang:1.26.4-alpine` on first run)
- [x] CI passes on merge

## Note for reviewers

When pulling this branch locally, run `docker pull golang:1.26.4-alpine` before rebuilding the dev container to avoid a cache hit on the old base image.