### PR TITLE
refactor(web): prevent infinite scroll from getting stuck after fetchMore error[VIZ-DEV-84]

### DIFF
--- a/web/src/app/features/Dashboard/ContentsContainer/Projects/hooks.test.ts
+++ b/web/src/app/features/Dashboard/ContentsContainer/Projects/hooks.test.ts
@@ -1,0 +1,302 @@
+import { renderHook, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import useHooks from "./hooks";
+
+const fetchMore = vi.fn();
+const fetchMoreStarred = vi.fn();
+const refetch = vi.fn();
+const navigate = vi.fn();
+
+let capturedLoadMoreHandlers: (() => Promise<void> | void)[] = [];
+
+vi.mock("react-router", () => ({
+  useNavigate: () => navigate
+}));
+
+vi.mock("@apollo/client/react", () => ({
+  useApolloClient: () => ({
+    cache: {
+      identify: vi.fn(),
+      evict: vi.fn(),
+      gc: vi.fn()
+    }
+  })
+}));
+
+vi.mock("@reearth/app/hooks/useLoadMore", () => ({
+  default: vi.fn(({ onLoadMore }) => {
+    capturedLoadMoreHandlers.push(onLoadMore);
+    return {
+      wrapperRef: { current: null },
+      contentRef: { current: null }
+    };
+  })
+}));
+
+vi.mock("@reearth/services/config/appFeatureConfig", () => ({
+  appFeature: () => ({ projectVisibility: true })
+}));
+
+vi.mock("@reearth/services/api/utils", () => ({
+  toPublishmentStatus: vi.fn((status: string) => status?.toLowerCase())
+}));
+
+vi.mock("@reearth/services/gql", () => ({
+  ProjectSortField: {
+    Createdat: "CREATED_AT",
+    Updatedat: "UPDATED_AT",
+    Name: "NAME"
+  },
+  SortDirection: {
+    Asc: "ASC",
+    Desc: "DESC"
+  },
+  Visualizer: {
+    Cesium: "CESIUM"
+  }
+}));
+
+vi.mock("@reearth/services/api/project", () => ({
+  useProjectMutations: () => ({
+    updateProject: vi.fn(),
+    createProject: vi.fn(),
+    updateProjectRecycleBin: vi.fn(),
+    publishProject: vi.fn()
+  }),
+  useProjects: () => ({
+    projects: [],
+    loading: false,
+    isRefetching: false,
+    hasMoreProjects: true,
+    endCursor: "project-end-cursor",
+    fetchMore,
+    refetch
+  }),
+  useStarredProjects: () => ({
+    starredProjects: [],
+    hasMoreStarredProjects: true,
+    endCursor: "starred-end-cursor",
+    fetchMore: fetchMoreStarred
+  })
+}));
+
+vi.mock("./useProjectImport", () => ({
+  default: () => ({
+    importStatus: undefined,
+    handleProjectImport: vi.fn(),
+    handleProjectImportErrorDownload: vi.fn(),
+    handleProjectImportErrorClose: vi.fn()
+  })
+}));
+
+describe("dashboard project hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedLoadMoreHandlers = [];
+    localStorage.clear();
+  });
+
+  it("fetches more projects with the current end cursor", async () => {
+    fetchMore.mockResolvedValueOnce({});
+
+    renderHook(() => useHooks("workspace-id"));
+
+    // First useLoadMore call is for normal projects; second is for starred projects.
+    const loadMoreProjects = capturedLoadMoreHandlers[0];
+
+    await act(async () => {
+      await loadMoreProjects();
+    });
+
+    expect(fetchMore).toHaveBeenCalledTimes(1);
+    expect(fetchMore).toHaveBeenCalledWith({
+      variables: {
+        pagination: {
+          after: "project-end-cursor",
+          first: 16
+        }
+      }
+    });
+  });
+
+  it("does not call fetchMore again while a fetch is already in progress", async () => {
+    let resolveFetchMore: (value?: unknown) => void = () => undefined;
+    fetchMore.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetchMore = resolve;
+        })
+    );
+
+    renderHook(() => useHooks("workspace-id"));
+    const loadMoreProjects = capturedLoadMoreHandlers[0];
+
+    const firstCall = act(async () => {
+      await loadMoreProjects();
+    });
+
+    await act(async () => {
+      await loadMoreProjects();
+    });
+
+    expect(fetchMore).toHaveBeenCalledTimes(1);
+
+    resolveFetchMore({});
+    await firstCall;
+  });
+
+  
+  it("resets the fetching guard after fetchMore succeeds so a subsequent call can run", async () => {
+    fetchMore
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+
+    renderHook(() => useHooks("workspace-id"));
+    const loadMoreProjects = capturedLoadMoreHandlers[0];
+
+    await act(async () => {
+      await loadMoreProjects();
+    });
+
+    await act(async () => {
+      await loadMoreProjects();
+    });
+
+    expect(fetchMore).toHaveBeenCalledTimes(2);
+  });
+
+  it("resets the fetching guard after fetchMore fails so a later retry can run", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    fetchMore
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockResolvedValueOnce({});
+
+    renderHook(() => useHooks("workspace-id"));
+    const loadMoreProjects = capturedLoadMoreHandlers[0];
+
+    await act(async () => {
+      await loadMoreProjects();
+    });
+
+    await act(async () => {
+      await loadMoreProjects();
+    });
+
+    expect(fetchMore).toHaveBeenCalledTimes(2);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to fetch more projects:",
+      expect.any(Error)
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});
+
+describe("dashboard starred projects hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedLoadMoreHandlers = [];
+    localStorage.clear();
+  });
+
+  it("fetches more starred projects with the current end cursor", async () => {
+    fetchMoreStarred.mockResolvedValueOnce({});
+
+    renderHook(() => useHooks("workspace-id"));
+
+    // Second useLoadMore call is for starred projects.
+    const loadMoreStarred = capturedLoadMoreHandlers[1];
+
+    await act(async () => {
+      await loadMoreStarred();
+    });
+
+    expect(fetchMoreStarred).toHaveBeenCalledTimes(1);
+    expect(fetchMoreStarred).toHaveBeenCalledWith({
+      variables: {
+        pagination: {
+          after: "starred-end-cursor",
+          first: 12
+        }
+      }
+    });
+  });
+
+  it("does not call fetchMoreStarred again while a fetch is already in progress", async () => {
+    let resolveFetchMoreStarred: (value?: unknown) => void = () => undefined;
+    fetchMoreStarred.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetchMoreStarred = resolve;
+        })
+    );
+
+    renderHook(() => useHooks("workspace-id"));
+    const loadMoreStarred = capturedLoadMoreHandlers[1];
+
+    const firstCall = act(async () => {
+      await loadMoreStarred();
+    });
+
+    await act(async () => {
+      await loadMoreStarred();
+    });
+
+    expect(fetchMoreStarred).toHaveBeenCalledTimes(1);
+
+    resolveFetchMoreStarred({});
+    await firstCall;
+  });
+
+  it("resets the fetching guard after fetchMoreStarred succeeds so a subsequent call can run", async () => {
+    fetchMoreStarred
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+
+    renderHook(() => useHooks("workspace-id"));
+    const loadMoreStarred = capturedLoadMoreHandlers[1];
+
+    await act(async () => {
+      await loadMoreStarred();
+    });
+
+    await act(async () => {
+      await loadMoreStarred();
+    });
+
+    expect(fetchMoreStarred).toHaveBeenCalledTimes(2);
+  });
+
+  it("resets the fetching guard after fetchMoreStarred fails so a later retry can run", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    fetchMoreStarred
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockResolvedValueOnce({});
+
+    renderHook(() => useHooks("workspace-id"));
+    const loadMoreStarred = capturedLoadMoreHandlers[1];
+
+    await act(async () => {
+      await loadMoreStarred();
+    });
+
+    await act(async () => {
+      await loadMoreStarred();
+    });
+
+    expect(fetchMoreStarred).toHaveBeenCalledTimes(2);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to fetch more starred projects:",
+      expect.any(Error)
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/web/src/app/features/Dashboard/ContentsContainer/Projects/hooks.ts
+++ b/web/src/app/features/Dashboard/ContentsContainer/Projects/hooks.ts
@@ -125,6 +125,8 @@ export default (workspaceId?: string) => {
             }
           }
         });
+      } catch (_err) {
+        console.error("Failed to fetch more projects:", _err);
       } finally {
         isFetchingMore.current = false;
       }
@@ -328,6 +330,8 @@ export default (workspaceId?: string) => {
             }
           }
         });
+      } catch (_err) {
+        console.error("Failed to fetch more starred projects:", _err);
       } finally {
         isFetchingMoreStarred.current = false;
       }

--- a/web/src/app/features/Dashboard/ContentsContainer/Projects/hooks.ts
+++ b/web/src/app/features/Dashboard/ContentsContainer/Projects/hooks.ts
@@ -116,15 +116,18 @@ export default (workspaceId?: string) => {
     if (isFetchingMore.current) return;
     if (hasMoreProjects) {
       isFetchingMore.current = true;
-      await fetchMore({
-        variables: {
-          pagination: {
-            after: endCursor,
-            first: PROJECTS_PER_PAGE
+      try {
+        await fetchMore({
+          variables: {
+            pagination: {
+              after: endCursor,
+              first: PROJECTS_PER_PAGE
+            }
           }
-        }
-      });
-      isFetchingMore.current = false;
+        });
+      } finally {
+        isFetchingMore.current = false;
+      }
     }
   }, [hasMoreProjects, fetchMore, endCursor]);
 
@@ -316,15 +319,18 @@ export default (workspaceId?: string) => {
     if (isFetchingMoreStarred.current) return;
     if (hasMoreStarredProjects) {
       isFetchingMoreStarred.current = true;
-      await fetchMoreStarred({
-        variables: {
-          pagination: {
-            after: starredEndCursor,
-            first: STARRED_PROJECTS_PER_PAGE
+      try {
+        await fetchMoreStarred({
+          variables: {
+            pagination: {
+              after: starredEndCursor,
+              first: STARRED_PROJECTS_PER_PAGE
+            }
           }
-        }
-      });
-      isFetchingMoreStarred.current = false;
+        });
+      } finally {
+        isFetchingMoreStarred.current = false;
+      }
     }
   }, [hasMoreStarredProjects, fetchMoreStarred, starredEndCursor]);
 

--- a/web/src/app/features/Dashboard/ContentsContainer/RecycleBin/hooks.test.ts
+++ b/web/src/app/features/Dashboard/ContentsContainer/RecycleBin/hooks.test.ts
@@ -1,0 +1,147 @@
+import { renderHook, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import useHooks from "./hooks";
+
+const fetchMoreDeleted = vi.fn();
+const refetch = vi.fn();
+
+let capturedLoadMoreHandlers: (() => Promise<void> | void)[] = [];
+
+vi.mock("@apollo/client/react", () => ({
+  useApolloClient: () => ({
+    cache: {
+      identify: vi.fn(),
+      evict: vi.fn(),
+      gc: vi.fn()
+    }
+  })
+}));
+
+vi.mock("@reearth/app/hooks/useLoadMore", () => ({
+  default: vi.fn(({ onLoadMore }) => {
+    capturedLoadMoreHandlers.push(onLoadMore);
+    return {
+      wrapperRef: { current: null },
+      contentRef: { current: null }
+    };
+  })
+}));
+
+vi.mock("@reearth/services/api/project", () => ({
+  useProjectMutations: () => ({
+    updateProjectRecycleBin: vi.fn(),
+    deleteProject: vi.fn()
+  }),
+  useDeletedProjects: () => ({
+    deletedProjects: [],
+    hasMoreDeletedProjects: true,
+    loading: false,
+    refetch,
+    endCursor: "deleted-end-cursor",
+    fetchMore: fetchMoreDeleted
+  })
+}));
+
+describe("recycle bin hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedLoadMoreHandlers = [];
+  });
+
+  it("fetches more deleted projects with the current end cursor", async () => {
+    fetchMoreDeleted.mockResolvedValueOnce({});
+
+    renderHook(() => useHooks("workspace-id"));
+
+    const loadMoreDeleted = capturedLoadMoreHandlers[0];
+
+    await act(async () => {
+      await loadMoreDeleted();
+    });
+
+    expect(fetchMoreDeleted).toHaveBeenCalledTimes(1);
+    expect(fetchMoreDeleted).toHaveBeenCalledWith({
+      variables: {
+        pagination: {
+          after: "deleted-end-cursor",
+          first: 16
+        }
+      }
+    });
+  });
+
+  it("does not call fetchMoreDeleted again while a fetch is already in progress", async () => {
+    let resolveFetchMoreDeleted: (value?: unknown) => void = () => undefined;
+    fetchMoreDeleted.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetchMoreDeleted = resolve;
+        })
+    );
+
+    renderHook(() => useHooks("workspace-id"));
+    const loadMoreDeleted = capturedLoadMoreHandlers[0];
+
+    const firstCall = act(async () => {
+      await loadMoreDeleted();
+    });
+
+    await act(async () => {
+      await loadMoreDeleted();
+    });
+
+    expect(fetchMoreDeleted).toHaveBeenCalledTimes(1);
+
+    resolveFetchMoreDeleted({});
+    await firstCall;
+  });
+
+  it("resets the fetching guard after fetchMoreDeleted succeeds so a subsequent call can run", async () => {
+    fetchMoreDeleted
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+
+    renderHook(() => useHooks("workspace-id"));
+    const loadMoreDeleted = capturedLoadMoreHandlers[0];
+
+    await act(async () => {
+      await loadMoreDeleted();
+    });
+
+    await act(async () => {
+      await loadMoreDeleted();
+    });
+
+    expect(fetchMoreDeleted).toHaveBeenCalledTimes(2);
+  });
+
+  it("resets the fetching guard after fetchMoreDeleted fails so a later retry can run", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    fetchMoreDeleted
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockResolvedValueOnce({});
+
+    renderHook(() => useHooks("workspace-id"));
+    const loadMoreDeleted = capturedLoadMoreHandlers[0];
+
+    await act(async () => {
+      await loadMoreDeleted();
+    });
+
+    await act(async () => {
+      await loadMoreDeleted();
+    });
+
+    expect(fetchMoreDeleted).toHaveBeenCalledTimes(2);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to fetch more deleted projects:",
+      expect.any(Error)
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/web/src/app/features/Dashboard/ContentsContainer/RecycleBin/hooks.ts
+++ b/web/src/app/features/Dashboard/ContentsContainer/RecycleBin/hooks.ts
@@ -40,15 +40,18 @@ export default (workspaceId?: string) => {
     if (isFetchingMore.current) return;
     if (hasMoreDeletedProjects) {
       isFetchingMore.current = true;
-      await fetchMoreDeleted({
-        variables: {
-          pagination: {
-            after: deletedEndCursor,
-            first: DELETED_PROJECTS_PER_PAGE
+      try {
+        await fetchMoreDeleted({
+          variables: {
+            pagination: {
+              after: deletedEndCursor,
+              first: DELETED_PROJECTS_PER_PAGE
+            }
           }
-        }
-      });
-      isFetchingMore.current = false;
+        });
+      } finally {
+        isFetchingMore.current = false;
+      }
     }
   }, [hasMoreDeletedProjects, fetchMoreDeleted, deletedEndCursor]);
 

--- a/web/src/app/features/Dashboard/ContentsContainer/RecycleBin/hooks.ts
+++ b/web/src/app/features/Dashboard/ContentsContainer/RecycleBin/hooks.ts
@@ -49,6 +49,8 @@ export default (workspaceId?: string) => {
             }
           }
         });
+      } catch (_err) {
+        console.error("Failed to fetch more deleted projects:", _err);
       } finally {
         isFetchingMore.current = false;
       }


### PR DESCRIPTION
# Overview
This PR fixes an AI Scan issue where infinite scrolling could become permanently blocked when a `fetchMore` request failed. The loading guard is now always reset, preventing pagination from getting stuck after transient network or GraphQL errors.

The fix has been applied to the following project lists:

- Projects
- Starred Projects
- Recycle Bin Projects

As a result, users can continue loading additional items even after a failed pagination request, without needing to refresh the page.


## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
