### PR TITLE
fix(web): remove terrain workarounds made obsolete by core fix[VIZ-DEV-85]

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -131,7 +131,7 @@
     "@popperjs/core": "2.11.8",
     "@radix-ui/react-select": "2.2.6",
     "@radix-ui/react-slot": "1.2.4",
-    "@reearth/core": "0.0.7-alpha.70",
+    "@reearth/core": "0.0.7-alpha.71",
     "@reearth/sentinel": "0.1.2",
     "@rot1024/use-transition": "1.0.0",
     "@sentry/browser": "7.77.0",

--- a/web/src/app/features/Editor/Visualizer/hooks.ts
+++ b/web/src/app/features/Editor/Visualizer/hooks.ts
@@ -93,17 +93,6 @@ export default ({
   );
   const isInitialized = useRef(false);
 
-  // Workaround: Temporarily disable terrain when terrain is enabled
-  // We don't know the root cause yet, but it seems that terrain is not loaded properly when terrain is enabled on Editor
-  const [tempDisableTerrain, setTempDisableTerrain] = useState(true);
-
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      setTempDisableTerrain(false);
-    }, 0);
-
-    return () => clearTimeout(timeoutId);
-  }, []);
 
   const prevFOV = useRef<number | undefined>(undefined);
   const fovTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -147,20 +136,11 @@ export default ({
         ) as ViewerProperty)
       : undefined;
 
-    if (
-      viewerProperty &&
-      tempDisableTerrain &&
-      viewerProperty.terrain &&
-      viewerProperty.terrain.enabled
-    ) {
-      viewerProperty.terrain.enabled = false;
-    }
-
     return {
       viewerProperty,
       cesiumIonAccessToken
     };
-  }, [scene?.property, tempDisableTerrain, setCurrentCamera]);
+  }, [scene?.property, setCurrentCamera]);
 
   // Cleanup fovTimeoutRef on unmount
   useEffect(() => {

--- a/web/src/app/features/Visualizer/hooks.ts
+++ b/web/src/app/features/Visualizer/hooks.ts
@@ -65,13 +65,14 @@ export default function useHooks({
       (typeof engineToken === "string" && engineToken.trim().length > 0)
     );
 
-    return migrateViewerPropertyTiles(overriddenViewerProperty, {
+    const migrated = migrateViewerPropertyTiles(overriddenViewerProperty, {
       isEE,
       defaultTileType,
       defaultTerrainType: "reearth_terrain",
       hasAccessToken,
       widgets
     });
+    return migrated;
   }, [overriddenViewerProperty, engineMeta, widgets]);
 
   const storyWrapperRef = useRef<HTMLDivElement>(null);

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5412,9 +5412,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reearth/core@npm:0.0.7-alpha.70":
-  version: 0.0.7-alpha.70
-  resolution: "@reearth/core@npm:0.0.7-alpha.70"
+"@reearth/core@npm:0.0.7-alpha.71":
+  version: 0.0.7-alpha.71
+  resolution: "@reearth/core@npm:0.0.7-alpha.71"
   dependencies:
     "@radix-ui/react-checkbox": "npm:^1.3.3"
     "@radix-ui/react-dialog": "npm:^1.1.15"
@@ -5468,7 +5468,7 @@ __metadata:
     cesium: 1.118.x
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/479511171ec319d571724b2abd712aa3dd6a0ab52cc2ec52eb830d57f58b1d1b5f2dfa700ec93e678c2d3f0e5dd0446b9a60dbcb772806e739a26744457ef889
+  checksum: 10c0/f80cff9c3649cfba132cd21bebd673c1f565c0de970e3b9297b29fee91b17d29fbfde62252e33aa8ea79ca75b3af1015f367a9708e105e887d0f07e3f89a72ad
   languageName: node
   linkType: hard
 
@@ -5530,7 +5530,7 @@ __metadata:
     "@popperjs/core": "npm:2.11.8"
     "@radix-ui/react-select": "npm:2.2.6"
     "@radix-ui/react-slot": "npm:1.2.4"
-    "@reearth/core": "npm:0.0.7-alpha.70"
+    "@reearth/core": "npm:0.0.7-alpha.71"
     "@reearth/sentinel": "npm:0.1.2"
     "@rollup/plugin-yaml": "npm:4.1.2"
     "@rot1024/use-transition": "npm:1.0.0"


### PR DESCRIPTION
# Overview
  ### Problem

  When terrain was enabled in a scene, navigating away from the Editor (e.g. to Project Settings or Plugins) and returning caused terrain to disappear from the map. A full page refresh was required to restore it.

  ### Root Cause

  Resium's `Globe` component skips its `update()` function on initial mount due to an internal flag timing issue: the flag is set by a passive `useEffect`, but the initializer runs in a `useLayoutEffect` microtask that fires first.

  A `tempDisableTerrain` workaround compensated by forcing terrain disabled → enabled via `setTimeout(0)`, producing a prop change that hit `Globe.update()` after the flag was ready. On navigation-back, Apollo serves cached scene data synchronously, so `setTimeout(0)` fires before the Cesium Viewer has recreated its scene and before `Globe` has mounted. Globe then mounts with terrain already enabled, no prop change ever occurs, and `globe.terrainProvider` is never applied.

## What I've done
  The root cause is fixed upstream in `@reearth/core`: `Globe/index.tsx` now directly sets `globe.terrainProvider` via a `CesiumComponentRef` after the provider Promise resolves, bypassing Resium's timing entirely.

  With that fix in place this PR removes the compensating workarounds:
  
  - **`Editor/Visualizer/hooks.ts`** — remove `tempDisableTerrain` state, the `useEffect` with `setTimeout(0)`, and the `viewerProperty.terrain.enabled` mutation; simplify `useMemo` dependency array
  - **`Editor/Visualizer/index.tsx`** — remove debug `useEffect`, `prevTerrainRef`, and unused `useEffect`/`useRef` React imports
  - **`Visualizer/hooks.ts`** — remove debug logs
  - **`Visualizer/index.tsx`** — remove the 100 ms polling `requestRender` interval workaround, debug logs, and unused `useEffect` React import

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
