### PR TITLE
chore(e2e): add 1Password CLI setup for web/e2e commands

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 .env
+.env.op
 test-results.json
 test-results/
 .last-run.json

--- a/e2e/ONBOARDING.md
+++ b/e2e/ONBOARDING.md
@@ -22,6 +22,7 @@ They are both run via `npx playwright test`, just with different `--project` fla
 - **Node.js 24** (matches the CI image; see `.github/workflows/playwright_*.yml`).
 - **npm** (lockfile is committed).
 - **Google Cloud SDK / `gcloud` CLI** — only needed when the target environment is behind Google IAP and you authenticate with Application Default Credentials. Run `gcloud auth application-default login` once.
+- **1Password CLI** (optional) — install from <https://developer.1password.com/docs/cli/get-started/>. Required only if using `test:ui:op` / `test:api:op` instead of a `.env` file.
 - The Playwright WebKit browser binary. Install via `npx playwright install webkit` after `npm install` (the CI image ships browsers preinstalled at `mcr.microsoft.com/playwright:v1.58.2-noble`).
 
 ⚠ Note: `package.json` does not include a `postinstall` step, so `npm install` does **not** automatically download browser binaries — you must run `npx playwright install webkit` yourself on a fresh checkout.
@@ -30,12 +31,27 @@ They are both run via `npx playwright test`, just with different `--project` fla
 
 ## 3. Setup
 
+**Option 1: Traditional `.env` file**
+
 ```bash
 cd e2e
 npm install
 npx playwright install webkit
 cp env.example .env
 # then edit .env
+```
+
+**Option 2: 1Password CLI (skips `.env` entirely)**
+
+Requires access to the `Visualizer` vault in the team 1Password account.
+
+```bash
+cd e2e
+npm install
+npx playwright install webkit
+op signin
+npm run test:ui:op   # UI tests
+npm run test:api:op  # API tests
 ```
 
 ### 3.1 Minimum `.env` values
@@ -230,8 +246,10 @@ All npm scripts (`package.json`):
 | Script | What it does |
 |---|---|
 | `npm run test:ui` | Removes `./out` and runs the `webkit` UI project (this is what CI runs). |
+| `npm run test:ui:op` | Same as `test:ui` but injects secrets from 1Password (no `.env` needed). |
 | `npm run test:local` | Same as above with `REEARTH_WEB_E2E_BASEURL=http://localhost:3000`. |
 | `npm run test:api` | Runs `api-setup` + `api-tests` with `SKIP_STORAGE_STATE=true` (skips browser global setup). |
+| `npm run test:api:op` | Same as `test:api` but injects secrets from 1Password (no `.env` needed). |
 | `npm run test:api:local` | Same as `test:api` but forces `REEARTH_E2E_AUTH_MODE=mock` and `BASEURL=http://localhost:3000` — for running API tests against a local server with debug user header. |
 | `npm run allure:generate` | Generates a static Allure HTML report from `./out/allure-results`. |
 | `npm run allure:serve` | Serves the report on port 8080. |

--- a/e2e/ONBOARDING.md
+++ b/e2e/ONBOARDING.md
@@ -22,7 +22,6 @@ They are both run via `npx playwright test`, just with different `--project` fla
 - **Node.js 24** (matches the CI image; see `.github/workflows/playwright_*.yml`).
 - **npm** (lockfile is committed).
 - **Google Cloud SDK / `gcloud` CLI** — only needed when the target environment is behind Google IAP and you authenticate with Application Default Credentials. Run `gcloud auth application-default login` once.
-- **1Password CLI** (optional) — install from <https://developer.1password.com/docs/cli/get-started/>. Required only if using `test:ui:op` / `test:api:op` instead of a `.env` file.
 - The Playwright WebKit browser binary. Install via `npx playwright install webkit` after `npm install` (the CI image ships browsers preinstalled at `mcr.microsoft.com/playwright:v1.58.2-noble`).
 
 ⚠ Note: `package.json` does not include a `postinstall` step, so `npm install` does **not** automatically download browser binaries — you must run `npx playwright install webkit` yourself on a fresh checkout.
@@ -30,8 +29,6 @@ They are both run via `npx playwright test`, just with different `--project` fla
 ---
 
 ## 3. Setup
-
-**Option 1: Traditional `.env` file**
 
 ```bash
 cd e2e
@@ -41,41 +38,15 @@ cp env.example .env
 # then edit .env
 ```
 
-**Option 2: 1Password CLI (skips `.env` entirely)**
-
-Requires access to the `Visualizer` vault in the team 1Password account.
-
-```bash
-cd e2e
-npm install
-npx playwright install webkit
-op signin
-```
-
-Create a local `.env.op` file (not tracked in git) with `op://` references for each variable in `env.example`:
-
-```dotenv
-REEARTH_E2E_EMAIL="op://YourVault/YourItem/REEARTH_E2E_EMAIL"
-REEARTH_E2E_PASSWORD="op://YourVault/YourItem/REEARTH_E2E_PASSWORD"
-# ... one line per variable
-```
-
-Then run:
-
-```bash
-npm run test:ui:op   # UI tests
-npm run test:api:op  # API tests
-```
-
 ### 3.1 Minimum `.env` values
 
 From `env.example` and the code that reads it (`global-setup.ts`, `api/config/env.ts`, `api/tests/auth-utils.ts`, `utils/iap-auth.ts`):
 
 ```dotenv
-# Required for everything
-REEARTH_WEB_E2E_BASEURL=https://visualizer.dev.reearth.io/
-REEARTH_E2E_EMAIL=your_test_account
-REEARTH_E2E_PASSWORD=your_test_password
+# Required. Credentials are stored in 1Password
+REEARTH_WEB_E2E_BASEURL=
+REEARTH_E2E_EMAIL=
+REEARTH_E2E_PASSWORD=
 ```
 
 ### 3.2 IAP (Google Identity-Aware Proxy)
@@ -101,12 +72,13 @@ Auto-detection rules (`utils/iap-auth.ts` → `createIAPContext`):
 ### 3.3 Extra `.env` values for the API stack
 
 ```dotenv
+# Required. Credentials are stored in 1Password
 REEARTH_E2E_AUTH_MODE=auth0      # auth0 | mock
 
 # auth0 mode (this is what CI uses)
-REEARTH_E2E_AUTH0_DOMAIN=reearth-dev.auth0.com
-REEARTH_E2E_AUTH0_AUDIENCE=https://api.dev.reearth.io
-REEARTH_E2E_AUTH0_CLIENT_ID=<auth0-spa-client-id>
+REEARTH_E2E_AUTH0_DOMAIN=
+REEARTH_E2E_AUTH0_AUDIENCE=
+REEARTH_E2E_AUTH0_CLIENT_ID=
 
 # mock mode (used by `npm run test:api:local`)
 REEARTH_E2E_MOCK_USER_ID=<server-side debug user id>
@@ -115,7 +87,7 @@ REEARTH_E2E_MOCK_USER_ID=<server-side debug user id>
 REEARTH_E2E_SECOND_USER_EMAIL=...
 
 # Optional override of GraphQL endpoint; otherwise derived from BASEURL
-REEARTH_E2E_API_URL=https://api.dev.reearth.io
+REEARTH_E2E_API_URL=
 ```
 
 ⚠ Note: `auth0` mode uses Resource Owner Password Credentials (`grant_type=password`) — your Auth0 tenant and client must permit this grant, and the test user must not require MFA.
@@ -259,10 +231,8 @@ All npm scripts (`package.json`):
 | Script | What it does |
 |---|---|
 | `npm run test:ui` | Removes `./out` and runs the `webkit` UI project (this is what CI runs). |
-| `npm run test:ui:op` | Same as `test:ui` but injects secrets from 1Password (no `.env` needed). |
 | `npm run test:local` | Same as above with `REEARTH_WEB_E2E_BASEURL=http://localhost:3000`. |
 | `npm run test:api` | Runs `api-setup` + `api-tests` with `SKIP_STORAGE_STATE=true` (skips browser global setup). |
-| `npm run test:api:op` | Same as `test:api` but injects secrets from 1Password (no `.env` needed). |
 | `npm run test:api:local` | Same as `test:api` but forces `REEARTH_E2E_AUTH_MODE=mock` and `BASEURL=http://localhost:3000` — for running API tests against a local server with debug user header. |
 | `npm run allure:generate` | Generates a static Allure HTML report from `./out/allure-results`. |
 | `npm run allure:serve` | Serves the report on port 8080. |

--- a/e2e/ONBOARDING.md
+++ b/e2e/ONBOARDING.md
@@ -50,6 +50,19 @@ cd e2e
 npm install
 npx playwright install webkit
 op signin
+```
+
+Create a local `.env.op` file (not tracked in git) with `op://` references for each variable in `env.example`:
+
+```dotenv
+REEARTH_E2E_EMAIL="op://YourVault/YourItem/REEARTH_E2E_EMAIL"
+REEARTH_E2E_PASSWORD="op://YourVault/YourItem/REEARTH_E2E_PASSWORD"
+# ... one line per variable
+```
+
+Then run:
+
+```bash
 npm run test:ui:op   # UI tests
 npm run test:api:op  # API tests
 ```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -40,15 +40,26 @@ This project is a Playwright framework setup that follows the Page Object Design
    npm install
    ```
 
-3. **Set up the `.env` file:**
+3. **Set up environment variables:**
 
-   Create a `.env` file in the root of the `e2e` folder and add the following variables:
+   **Option 1: Traditional `.env` file**
 
+   ```bash
+   cp env.example .env
+   # Fill in values — consult the team for credentials
    ```
-   REEARTH_WEB_E2E_BASEURL=http://localhost:3000 OR DEV URL
-   REEARTH_WEB_E2E_ACCOUNT=your_visualizer_account
-   REEARTH_WEB_E2E_ACCOUNT_PASSWORD=your_visualizer_password
+
+   **Option 2: 1Password CLI (Recommended)**
+
+   ```bash
+   # One-time setup — requires access to the Visualizer vault
+   op signin
+   # Then run tests directly with:
+   npm run test:ui:op
+   npm run test:api:op
    ```
+
+   See [ONBOARDING.md](ONBOARDING.md) for full setup details.
 
 4. **Run tests:**
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -54,6 +54,8 @@ This project is a Playwright framework setup that follows the Page Object Design
    ```bash
    # One-time setup — requires access to the Visualizer vault
    op signin
+   # Create .env.op with op:// references for each variable in env.example
+   # (see ONBOARDING.md for the exact format)
    # Then run tests directly with:
    npm run test:ui:op
    npm run test:api:op

--- a/e2e/env.example
+++ b/e2e/env.example
@@ -43,3 +43,8 @@ IAP_AUTH_METHOD=adc
 IAP_TARGET_AUDIENCE=
 # Google Service Account JSON (required for 'service-account' method)
 GOOGLE_SERVICE_ACCOUNT_JSON=
+# Pre-fetched ID token (required for 'id-token' method)
+IAP_ID_TOKEN=
+
+# Optional override of the GraphQL/REST API base URL (derived from REEARTH_WEB_E2E_BASEURL if not set)
+REEARTH_E2E_API_URL=

--- a/e2e/env.example
+++ b/e2e/env.example
@@ -1,6 +1,37 @@
+# ============================================================================
+# Re:Earth Visualizer E2E — Environment Variables Template
+# ============================================================================
+#
+# USAGE:
+#
+# Option 1: Traditional .env file
+#   cp env.example .env
+#   Fill in the values and run: npm run test:ui / npm run test:api
+#
+# Option 2: 1Password CLI (Recommended)
+#   Create a 1Password item with fields matching the variable names below.
+#   Then create a local .env.op file (not tracked) with secret references:
+#
+#     REEARTH_E2E_EMAIL="op://YourVault/YourItem/REEARTH_E2E_EMAIL"
+#     REEARTH_E2E_PASSWORD="op://YourVault/YourItem/REEARTH_E2E_PASSWORD"
+#     ... (one line per variable)
+#
+#   Then run: npm run test:ui:op / npm run test:api:op
+#   See ONBOARDING.md for full setup instructions.
+#
+# ============================================================================
+
 REEARTH_WEB_E2E_BASEURL=
 REEARTH_E2E_EMAIL=
 REEARTH_E2E_PASSWORD=
+
+# API Test Auth Config
+REEARTH_E2E_AUTH_MODE=
+REEARTH_E2E_AUTH0_DOMAIN=
+REEARTH_E2E_AUTH0_AUDIENCE=
+REEARTH_E2E_AUTH0_CLIENT_ID=
+REEARTH_E2E_SECOND_USER_EMAIL=
+REEARTH_E2E_MOCK_USER_ID=
 
 # Google IAP Authentication (optional)
 # Set USE_IAP_AUTH=true to enable IAP authentication for protected environments

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test:ui": "rm -rf ./out && npx playwright test --config=playwright.config.ts --project=webkit",
+    "test:ui:op": "op run --env-file=.env.op -- npm run test:ui",
     "test:api": "SKIP_STORAGE_STATE=true npx playwright test --config=playwright.config.ts --project=api-setup --project=api-tests",
+    "test:api:op": "op run --env-file=.env.op -- npm run test:api",
     "test:api:local": "SKIP_STORAGE_STATE=true REEARTH_E2E_AUTH_MODE=mock REEARTH_WEB_E2E_BASEURL=http://localhost:3000 npx playwright test --config=playwright.config.ts --project=api-setup --project=api-tests",
     "allure:generate": "rm -rf ./out/allure-report && npx allure generate ./out/allure-results --output ./out/allure-report",
     "allure:serve": "npx allure serve --port 8080 ./out/allure-results",


### PR DESCRIPTION
## Summary

- Adds `test:ui:op` and `test:api:op` scripts to `e2e/package.json` that inject secrets via `op run --env-file=.env.op` — no `.env` file needed
- Creates a `Visualizer e2e secrets OSS` item in the team 1Password Visualizer vault with all required env vars
- Adds `.env.op` to `e2e/.gitignore` (not tracked — users create their own locally)
- Updates `e2e/env.example` with missing API auth vars (`REEARTH_E2E_AUTH_MODE`, `REEARTH_E2E_AUTH0_*`, `REEARTH_E2E_SECOND_USER_EMAIL`, `REEARTH_E2E_MOCK_USER_ID`) and a comment block explaining both `.env` and 1Password setup options
- Updates `e2e/README.md` and `e2e/ONBOARDING.md` with 1Password setup instructions and new script references

## Test plan

- [x] Verified `op run --env-file=.env.op` resolves all 11 env vars from the Visualizer vault
- [x] `npm run test:api:op` runs successfully (223 API tests execute with secrets injected from 1Password)
- [x] `npm run test:ui:op` launches correctly (IAP ADC failure is a local gcloud credential issue, unrelated to this change)