### PR TITLE
chore: add env for playwright tests

### DIFF
--- a/.github/workflows/playwright_ui_tests.yml
+++ b/.github/workflows/playwright_ui_tests.yml
@@ -66,6 +66,7 @@ jobs:
           REEARTH_E2E_EMAIL: ${{ secrets.REEARTH_E2E_EMAIL }}
           REEARTH_E2E_PASSWORD: ${{ secrets.REEARTH_E2E_PASSWORD }}
           REEARTH_WEB_E2E_BASEURL: ${{ env.BASE_URL }}
+          REEARTH_E2E_API_URL: ${{ secrets.REEARTH_E2E_API_URL }}
           USE_IAP_AUTH: false
         run: npm run test:ui
 


### PR DESCRIPTION
- Added env for playwright-test-pr to access the right env
- [x] Added `REEARTH_E2E_API_URL` secret to GitHub `dev` environment
- [x] Verify `playwright-tests-pr` passes against Cloud Run PR preview URL