### PR TITLE
fix(server): restore scene permission checks on Style and NLSLayer mutations [VIZ-DEV-98][VIZ-DEV-99]

### DIFF
--- a/server/internal/usecase/interactor/nlslayer.go
+++ b/server/internal/usecase/interactor/nlslayer.go
@@ -982,6 +982,11 @@ func (i *NLSLayer) RemoveCustomProperty(ctx context.Context, inp interfaces.AddO
 	if err != nil {
 		return nil, err
 	}
+
+	if err := i.CanWriteScene(layer.Scene(), operator); err != nil {
+		return nil, err
+	}
+
 	if layer.Sketch() == nil || layer.Sketch().FeatureCollection() == nil {
 		return nil, ErrSketchNotFound
 	}
@@ -1040,6 +1045,10 @@ func (i *NLSLayer) AddGeoJSONFeature(ctx context.Context, inp interfaces.AddNLSL
 
 	layer, err := i.nlslayerRepo.FindByID(ctx, inp.LayerID)
 	if err != nil {
+		return nlslayer.Feature{}, err
+	}
+
+	if err := i.CanWriteScene(layer.Scene(), operator); err != nil {
 		return nlslayer.Feature{}, err
 	}
 
@@ -1110,6 +1119,10 @@ func (i *NLSLayer) UpdateGeoJSONFeature(ctx context.Context, inp interfaces.Upda
 		return nlslayer.Feature{}, err
 	}
 
+	if err := i.CanWriteScene(layer.Scene(), operator); err != nil {
+		return nlslayer.Feature{}, err
+	}
+
 	if layer.Sketch() == nil || layer.Sketch().FeatureCollection() == nil || layer.Sketch().FeatureCollection().Features() == nil || len(layer.Sketch().FeatureCollection().Features()) == 0 {
 		return nlslayer.Feature{}, interfaces.ErrFeatureNotFound
 	}
@@ -1164,6 +1177,10 @@ func (i *NLSLayer) DeleteGeoJSONFeature(ctx context.Context, inp interfaces.Dele
 
 	layer, err := i.nlslayerRepo.FindByID(ctx, inp.LayerID)
 	if err != nil {
+		return id.FeatureID{}, err
+	}
+
+	if err := i.CanWriteScene(layer.Scene(), operator); err != nil {
 		return id.FeatureID{}, err
 	}
 

--- a/server/internal/usecase/interactor/nlslayer_test.go
+++ b/server/internal/usecase/interactor/nlslayer_test.go
@@ -486,3 +486,86 @@ func TestDeleteGeoJSONFeature(t *testing.T) {
 	assert.NotNil(t, featureCollection)
 	assert.Equal(t, 0, len(featureCollection.Features()))
 }
+
+// TestNLSLayer_GeoJSONFeature_CrossTenantIDOR is a regression test for
+// SEC-02 (eukarya-inc/compliance#50): AddGeoJSONFeature/
+// UpdateGeoJSONFeature/DeleteGeoJSONFeature/RemoveCustomProperty must
+// reject an operator with no write access to the layer's scene. Before
+// the fix these methods never called CanWriteScene at all, so any
+// authenticated operator could mutate sketch geometry/properties on a
+// layer belonging to a workspace they had no role in.
+func TestNLSLayer_GeoJSONFeature_CrossTenantIDOR(t *testing.T) {
+	ctx := context.Background()
+	db := memory.New()
+
+	prj, _ := project.New().NewID().Build()
+	_ = db.Project.Save(ctx, prj)
+	victimScene, _ := scene.New().NewID().Workspace(accountsID.NewWorkspaceID()).Project(prj.ID()).Build()
+	_ = db.Scene.Save(ctx, victimScene)
+
+	il := NewNLSLayer(db, &gateway.Container{
+		File: lo.Must(fs.NewFile(afero.NewMemMapFs(), "https://example.com")),
+	})
+
+	victimLayer, _ := nlslayer.NewNLSLayerSimple().NewID().Scene(victimScene.ID()).Build()
+	_ = db.NLSLayer.Save(ctx, victimLayer)
+
+	attacker := &usecase.Operator{
+		WritableScenes: []id.SceneID{id.NewSceneID()}, // some other scene, not victimScene
+	}
+	owner := &usecase.Operator{
+		WritableScenes: []id.SceneID{victimScene.ID()},
+	}
+
+	t.Run("AddGeoJSONFeature denies an operator with no write access to the layer's scene", func(t *testing.T) {
+		f, err := il.AddGeoJSONFeature(ctx, interfaces.AddNLSLayerGeoJSONFeatureParams{
+			LayerID:  victimLayer.ID(),
+			Type:     "Feature",
+			Geometry: map[string]any{"type": "Point", "coordinates": []any{0.0, 0.0}},
+		}, attacker)
+		assert.ErrorIs(t, err, interfaces.ErrOperationDenied)
+		assert.Equal(t, nlslayer.Feature{}, f)
+	})
+
+	// Seed a legitimate feature in the victim's layer for the remaining cases.
+	feature, err := il.AddGeoJSONFeature(ctx, interfaces.AddNLSLayerGeoJSONFeatureParams{
+		LayerID:  victimLayer.ID(),
+		Type:     "Feature",
+		Geometry: map[string]any{"type": "Point", "coordinates": []any{0.0, 0.0}},
+	}, owner)
+	assert.NoError(t, err)
+
+	t.Run("UpdateGeoJSONFeature denies an operator with no write access to the layer's scene", func(t *testing.T) {
+		props := map[string]any{"owner": "attacker"}
+		_, err := il.UpdateGeoJSONFeature(ctx, interfaces.UpdateNLSLayerGeoJSONFeatureParams{
+			LayerID:    victimLayer.ID(),
+			FeatureID:  feature.ID(),
+			Properties: &props,
+		}, attacker)
+		assert.ErrorIs(t, err, interfaces.ErrOperationDenied)
+	})
+
+	t.Run("RemoveCustomProperty denies an operator with no write access to the layer's scene", func(t *testing.T) {
+		_, err := il.RemoveCustomProperty(ctx, interfaces.AddOrUpdateCustomPropertiesInput{
+			LayerID: victimLayer.ID(),
+			Schema:  map[string]any{},
+		}, "some-title", attacker)
+		assert.ErrorIs(t, err, interfaces.ErrOperationDenied)
+	})
+
+	t.Run("DeleteGeoJSONFeature denies an operator with no write access to the layer's scene", func(t *testing.T) {
+		_, err := il.DeleteGeoJSONFeature(ctx, interfaces.DeleteNLSLayerGeoJSONFeatureParams{
+			LayerID:   victimLayer.ID(),
+			FeatureID: feature.ID(),
+		}, attacker)
+		assert.ErrorIs(t, err, interfaces.ErrOperationDenied)
+	})
+
+	t.Run("the legitimate owner can still write", func(t *testing.T) {
+		_, err := il.DeleteGeoJSONFeature(ctx, interfaces.DeleteNLSLayerGeoJSONFeatureParams{
+			LayerID:   victimLayer.ID(),
+			FeatureID: feature.ID(),
+		}, owner)
+		assert.NoError(t, err)
+	})
+}

--- a/server/internal/usecase/interactor/style.go
+++ b/server/internal/usecase/interactor/style.go
@@ -57,9 +57,9 @@ func (i *Style) AddStyle(ctx context.Context, param interfaces.AddStyleInput, op
 		}
 	}()
 
-	// if err := i.CanWriteScene(param.SceneID, operator); err != nil {
-	// 	return nil, interfaces.ErrOperationDenied
-	// }
+	if err := i.CanWriteScene(param.SceneID, operator); err != nil {
+		return nil, err
+	}
 
 	style, err := scene.NewStyle().
 		NewID().
@@ -104,6 +104,10 @@ func (i *Style) UpdateStyle(ctx context.Context, param interfaces.UpdateStyleInp
 		return nil, err
 	}
 
+	if err := i.CanWriteScene(style.Scene(), operator); err != nil {
+		return nil, err
+	}
+
 	if param.Name != nil {
 		style.Rename(*param.Name)
 	}
@@ -143,9 +147,9 @@ func (i *Style) RemoveStyle(ctx context.Context, styleID id.StyleID, operator *u
 		return styleID, err
 	}
 
-	// if err := i.CanWriteScene(s.Scene(), operator); err != nil {
-	// 	return styleID, err
-	// }
+	if err := i.CanWriteScene(s.Scene(), operator); err != nil {
+		return styleID, err
+	}
 
 	if err := i.CheckSceneLock(ctx, s.Scene()); err != nil {
 		return styleID, err
@@ -183,9 +187,9 @@ func (i *Style) DuplicateStyle(ctx context.Context, styleID id.StyleID, operator
 		return nil, err
 	}
 
-	// if err := i.CanWriteScene(s.Scene(), operator); err != nil {
-	// 	return nil, err
-	// }
+	if err := i.CanWriteScene(style.Scene(), operator); err != nil {
+		return nil, err
+	}
 
 	duplicatedStyle := style.Duplicate()
 

--- a/server/internal/usecase/interactor/style_test.go
+++ b/server/internal/usecase/interactor/style_test.go
@@ -1,0 +1,88 @@
+package interactor
+
+import (
+	"context"
+	"testing"
+
+	accountsID "github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth/server/internal/infrastructure/memory"
+	"github.com/reearth/reearth/server/internal/usecase"
+	"github.com/reearth/reearth/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth/server/pkg/id"
+	"github.com/reearth/reearth/server/pkg/project"
+	"github.com/reearth/reearth/server/pkg/scene"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStyle_CrossTenantIDOR is a regression test for SEC-01
+// (eukarya-inc/compliance#50): AddStyle/UpdateStyle/RemoveStyle/
+// DuplicateStyle must reject an operator that has no write access to the
+// style's scene, even though the scene/style ID came straight from the
+// client. Before the fix, the CanWriteScene check was commented out (or,
+// for UpdateStyle, missing entirely), so any authenticated operator could
+// mutate a style belonging to a scene/workspace they had no role in.
+func TestStyle_CrossTenantIDOR(t *testing.T) {
+	ctx := context.Background()
+	db := memory.New()
+
+	prj, _ := project.New().NewID().Build()
+	_ = db.Project.Save(ctx, prj)
+	victimScene, _ := scene.New().NewID().Workspace(accountsID.NewWorkspaceID()).Project(prj.ID()).Build()
+	_ = db.Scene.Save(ctx, victimScene)
+
+	uc := NewStyle(db)
+
+	attacker := &usecase.Operator{
+		WritableScenes: id.SceneIDList{id.NewSceneID()}, // some other scene, not victimScene
+	}
+	owner := &usecase.Operator{
+		WritableScenes: id.SceneIDList{victimScene.ID()},
+	}
+
+	t.Run("AddStyle denies an operator with no write access to the target scene", func(t *testing.T) {
+		s, err := uc.AddStyle(ctx, interfaces.AddStyleInput{
+			SceneID: victimScene.ID(),
+			Name:    "attacker style",
+		}, attacker)
+		assert.ErrorIs(t, err, interfaces.ErrOperationDenied)
+		assert.Nil(t, s)
+	})
+
+	// Seed a legitimate style in the victim's scene for the remaining cases.
+	victimStyle, err := uc.AddStyle(ctx, interfaces.AddStyleInput{
+		SceneID: victimScene.ID(),
+		Name:    "victim style",
+	}, owner)
+	assert.NoError(t, err)
+
+	t.Run("UpdateStyle denies an operator with no write access to the style's scene", func(t *testing.T) {
+		newName := "renamed by attacker"
+		s, err := uc.UpdateStyle(ctx, interfaces.UpdateStyleInput{
+			StyleID: victimStyle.ID(),
+			Name:    &newName,
+		}, attacker)
+		assert.ErrorIs(t, err, interfaces.ErrOperationDenied)
+		assert.Nil(t, s)
+	})
+
+	t.Run("DuplicateStyle denies an operator with no write access to the style's scene", func(t *testing.T) {
+		s, err := uc.DuplicateStyle(ctx, victimStyle.ID(), attacker)
+		assert.ErrorIs(t, err, interfaces.ErrOperationDenied)
+		assert.Nil(t, s)
+	})
+
+	t.Run("RemoveStyle denies an operator with no write access to the style's scene", func(t *testing.T) {
+		_, err := uc.RemoveStyle(ctx, victimStyle.ID(), attacker)
+		assert.ErrorIs(t, err, interfaces.ErrOperationDenied)
+	})
+
+	t.Run("the legitimate owner can still write", func(t *testing.T) {
+		newName := "renamed by owner"
+		s, err := uc.UpdateStyle(ctx, interfaces.UpdateStyleInput{
+			StyleID: victimStyle.ID(),
+			Name:    &newName,
+		}, owner)
+		assert.NoError(t, err)
+		assert.Equal(t, newName, s.Name())
+	})
+}


### PR DESCRIPTION
## Summary
Fixes SEC-01 and SEC-02: Style and NLSLayer mutations were missing or had commented out the scene permission check, letting any authenticated operator mutate or delete another tenant's style or layer given only its ID. Confirmed both live against two real local tenants before writing the fix.

## Test plan
- Added regression tests for all eight call sites: denied without scene access, still works with it
- Tested manually that functions are being called correctly from the UI 
- go build, go vet, full go test pass
- Existing e2e tests for these mutations still pass