### PR TITLE
refactor(e2e): parallelize playwright suite, split tests into feature folders

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 1,
-  workers: 1,
+  workers: 3,
   reporter: [
     [
       "allure-playwright",

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 1,
-  workers: 3,
+  workers: 2,
   reporter: [
     [
       "allure-playwright",

--- a/e2e/tests/account/accountWorkspaceSettings.spec.ts
+++ b/e2e/tests/account/accountWorkspaceSettings.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect, BrowserContext, Page } from "@playwright/test";
 
-import { STORAGE_STATE } from "../global-setup";
-import { AccountSettingsPage } from "../pages/accountSettingsPage";
-import { DashBoardPage } from "../pages/dashBoardPage";
-import { WorkspaceSettingsPage } from "../pages/workspaceSettingsPage";
-import { createIAPContext } from "../utils/iap-auth";
+import { STORAGE_STATE } from "../../global-setup";
+import { AccountSettingsPage } from "../../pages/accountSettingsPage";
+import { DashBoardPage } from "../../pages/dashBoardPage";
+import { WorkspaceSettingsPage } from "../../pages/workspaceSettingsPage";
+import { createIAPContext } from "../../utils/iap-auth";
 
 const REEARTH_WEB_E2E_BASEURL = process.env.REEARTH_WEB_E2E_BASEURL;
 if (!REEARTH_WEB_E2E_BASEURL) {

--- a/e2e/tests/account/members.spec.ts
+++ b/e2e/tests/account/members.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect, BrowserContext, Page } from "@playwright/test";
 
-import { STORAGE_STATE } from "../global-setup";
-import { DashBoardPage } from "../pages/dashBoardPage";
-import { MembersPage } from "../pages/membersPage";
-import { createIAPContext } from "../utils/iap-auth";
+import { STORAGE_STATE } from "../../global-setup";
+import { DashBoardPage } from "../../pages/dashBoardPage";
+import { MembersPage } from "../../pages/membersPage";
+import { createIAPContext } from "../../utils/iap-auth";
 
 const REEARTH_WEB_E2E_BASEURL = process.env.REEARTH_WEB_E2E_BASEURL;
 if (!REEARTH_WEB_E2E_BASEURL) {

--- a/e2e/tests/auth/login.spec.ts.Skip
+++ b/e2e/tests/auth/login.spec.ts.Skip
@@ -1,8 +1,8 @@
 import { faker } from "@faker-js/faker";
 import { test, expect, BrowserContext, Page } from "@playwright/test";
 
-import { DashBoardPage } from "../pages/dashBoardPage";
-import { LoginPage } from "../pages/loginPage";
+import { DashBoardPage } from "../../pages/dashBoardPage";
+import { LoginPage } from "../../pages/loginPage";
 
 const REEARTH_E2E_EMAIL = process.env.REEARTH_E2E_EMAIL;
 const REEARTH_E2E_PASSWORD = process.env.REEARTH_E2E_PASSWORD;

--- a/e2e/tests/dashboard/dashboard.spec.ts
+++ b/e2e/tests/dashboard/dashboard.spec.ts
@@ -3,12 +3,12 @@ import path from "path";
 import { faker } from "@faker-js/faker";
 import { test, expect, BrowserContext, Page } from "@playwright/test";
 
-import { STORAGE_STATE } from "../global-setup";
-import { DashBoardPage } from "../pages/dashBoardPage";
-import { ProjectScreenPage } from "../pages/projectScreenPage";
-import { ProjectsPage } from "../pages/projectsPage";
-import { RecycleBinPage } from "../pages/recycleBinPage";
-import { createIAPContext } from "../utils/iap-auth";
+import { STORAGE_STATE } from "../../global-setup";
+import { DashBoardPage } from "../../pages/dashBoardPage";
+import { ProjectScreenPage } from "../../pages/projectScreenPage";
+import { ProjectsPage } from "../../pages/projectsPage";
+import { RecycleBinPage } from "../../pages/recycleBinPage";
+import { createIAPContext } from "../../utils/iap-auth";
 
 const REEARTH_E2E_EMAIL = process.env.REEARTH_E2E_EMAIL;
 const REEARTH_E2E_PASSWORD = process.env.REEARTH_E2E_PASSWORD;
@@ -22,7 +22,7 @@ const specialProjectName = "e2e-" + faker.lorem.words(2) + "!@#$%^&*()_+";
 const projectAlias = faker.string.alphanumeric(15);
 
 const fileName = "Test_Asset_migration.zip";
-const docPath = path.resolve(__dirname, "../test-data", fileName);
+const docPath = path.resolve(__dirname, "../../test-data", fileName);
 test.describe.configure({ mode: "serial" });
 
 test.describe("DASHBOARD - Test cases", () => {

--- a/e2e/tests/dashboard/dashboardFeatures.spec.ts
+++ b/e2e/tests/dashboard/dashboardFeatures.spec.ts
@@ -1,11 +1,11 @@
 import { faker } from "@faker-js/faker";
 import { test, expect, BrowserContext, Page } from "@playwright/test";
 
-import { STORAGE_STATE } from "../global-setup";
-import { DashBoardPage } from "../pages/dashBoardPage";
-import { ProjectsPage } from "../pages/projectsPage";
-import { RecycleBinPage } from "../pages/recycleBinPage";
-import { createIAPContext } from "../utils/iap-auth";
+import { STORAGE_STATE } from "../../global-setup";
+import { DashBoardPage } from "../../pages/dashBoardPage";
+import { ProjectsPage } from "../../pages/projectsPage";
+import { RecycleBinPage } from "../../pages/recycleBinPage";
+import { createIAPContext } from "../../utils/iap-auth";
 
 const REEARTH_WEB_E2E_BASEURL = process.env.REEARTH_WEB_E2E_BASEURL;
 if (!REEARTH_WEB_E2E_BASEURL) {

--- a/e2e/tests/layer/externalLayers.spec.ts
+++ b/e2e/tests/layer/externalLayers.spec.ts
@@ -1,14 +1,14 @@
 import { faker } from "@faker-js/faker";
 import { test, expect, BrowserContext, Page } from "@playwright/test";
 
-import { STORAGE_STATE } from "../global-setup";
-import { CesiumViewerPage } from "../pages/cesiumViewerPage";
-import { DashBoardPage } from "../pages/dashBoardPage";
-import { DataSourceManagerPage } from "../pages/dataSourceManagerPage";
-import { ProjectScreenPage } from "../pages/projectScreenPage";
-import { ProjectsPage } from "../pages/projectsPage";
-import { createIAPContext } from "../utils/iap-auth";
-import { deleteProjectByName } from "../utils/project-cleanup";
+import { STORAGE_STATE } from "../../global-setup";
+import { CesiumViewerPage } from "../../pages/cesiumViewerPage";
+import { DashBoardPage } from "../../pages/dashBoardPage";
+import { DataSourceManagerPage } from "../../pages/dataSourceManagerPage";
+import { ProjectScreenPage } from "../../pages/projectScreenPage";
+import { ProjectsPage } from "../../pages/projectsPage";
+import { createIAPContext } from "../../utils/iap-auth";
+import { deleteProjectByName } from "../../utils/project-cleanup";
 
 const REEARTH_E2E_EMAIL = process.env.REEARTH_E2E_EMAIL;
 const REEARTH_E2E_PASSWORD = process.env.REEARTH_E2E_PASSWORD;

--- a/e2e/tests/layer/layerDeletionReorder.spec.ts
+++ b/e2e/tests/layer/layerDeletionReorder.spec.ts
@@ -1,13 +1,13 @@
 import { faker } from "@faker-js/faker";
 import { test, expect, BrowserContext, Page } from "@playwright/test";
 
-import { STORAGE_STATE } from "../global-setup";
-import { CesiumViewerPage } from "../pages/cesiumViewerPage";
-import { DashBoardPage } from "../pages/dashBoardPage";
-import { ProjectScreenPage } from "../pages/projectScreenPage";
-import { ProjectsPage } from "../pages/projectsPage";
-import { createIAPContext } from "../utils/iap-auth";
-import { deleteProjectByName } from "../utils/project-cleanup";
+import { STORAGE_STATE } from "../../global-setup";
+import { CesiumViewerPage } from "../../pages/cesiumViewerPage";
+import { DashBoardPage } from "../../pages/dashBoardPage";
+import { ProjectScreenPage } from "../../pages/projectScreenPage";
+import { ProjectsPage } from "../../pages/projectsPage";
+import { createIAPContext } from "../../utils/iap-auth";
+import { deleteProjectByName } from "../../utils/project-cleanup";
 
 const REEARTH_E2E_EMAIL = process.env.REEARTH_E2E_EMAIL;
 const REEARTH_E2E_PASSWORD = process.env.REEARTH_E2E_PASSWORD;

--- a/e2e/tests/layer/multipleStyles.spec.ts
+++ b/e2e/tests/layer/multipleStyles.spec.ts
@@ -1,14 +1,14 @@
 import { faker } from "@faker-js/faker";
 import { test, expect, BrowserContext, Page } from "@playwright/test";
 
-import { STORAGE_STATE } from "../global-setup";
-import { CesiumViewerPage } from "../pages/cesiumViewerPage";
-import { DashBoardPage } from "../pages/dashBoardPage";
-import { LayerStylePanelPage } from "../pages/layerStylePanelPage";
-import { ProjectScreenPage } from "../pages/projectScreenPage";
-import { ProjectsPage } from "../pages/projectsPage";
-import { createIAPContext } from "../utils/iap-auth";
-import { deleteProjectByName } from "../utils/project-cleanup";
+import { STORAGE_STATE } from "../../global-setup";
+import { CesiumViewerPage } from "../../pages/cesiumViewerPage";
+import { DashBoardPage } from "../../pages/dashBoardPage";
+import { LayerStylePanelPage } from "../../pages/layerStylePanelPage";
+import { ProjectScreenPage } from "../../pages/projectScreenPage";
+import { ProjectsPage } from "../../pages/projectsPage";
+import { createIAPContext } from "../../utils/iap-auth";
+import { deleteProjectByName } from "../../utils/project-cleanup";
 
 const REEARTH_E2E_EMAIL = process.env.REEARTH_E2E_EMAIL;
 const REEARTH_E2E_PASSWORD = process.env.REEARTH_E2E_PASSWORD;

--- a/e2e/tests/layer/page-refresh-on-mutation.spec.ts
+++ b/e2e/tests/layer/page-refresh-on-mutation.spec.ts
@@ -1,13 +1,13 @@
 import { faker } from "@faker-js/faker";
 import { test, expect, BrowserContext, Page } from "@playwright/test";
 
-import { STORAGE_STATE } from "../global-setup";
-import { CesiumViewerPage } from "../pages/cesiumViewerPage";
-import { DashBoardPage } from "../pages/dashBoardPage";
-import { ProjectScreenPage } from "../pages/projectScreenPage";
-import { ProjectsPage } from "../pages/projectsPage";
-import { createIAPContext } from "../utils/iap-auth";
-import { deleteProjectByName } from "../utils/project-cleanup";
+import { STORAGE_STATE } from "../../global-setup";
+import { CesiumViewerPage } from "../../pages/cesiumViewerPage";
+import { DashBoardPage } from "../../pages/dashBoardPage";
+import { ProjectScreenPage } from "../../pages/projectScreenPage";
+import { ProjectsPage } from "../../pages/projectsPage";
+import { createIAPContext } from "../../utils/iap-auth";
+import { deleteProjectByName } from "../../utils/project-cleanup";
 
 const REEARTH_E2E_EMAIL = process.env.REEARTH_E2E_EMAIL;
 const REEARTH_E2E_PASSWORD = process.env.REEARTH_E2E_PASSWORD;

--- a/e2e/tests/layer/photoOverlay.spec.ts
+++ b/e2e/tests/layer/photoOverlay.spec.ts
@@ -3,13 +3,13 @@ import path from "path";
 import { faker } from "@faker-js/faker";
 import { test, expect, BrowserContext, Page } from "@playwright/test";
 
-import { STORAGE_STATE } from "../global-setup";
-import { DashBoardPage } from "../pages/dashBoardPage";
-import { PhotoOverlayPage } from "../pages/photoOverlayPage";
-import { ProjectScreenPage } from "../pages/projectScreenPage";
-import { ProjectsPage } from "../pages/projectsPage";
-import { createIAPContext } from "../utils/iap-auth";
-import { deleteProjectByName } from "../utils/project-cleanup";
+import { STORAGE_STATE } from "../../global-setup";
+import { DashBoardPage } from "../../pages/dashBoardPage";
+import { PhotoOverlayPage } from "../../pages/photoOverlayPage";
+import { ProjectScreenPage } from "../../pages/projectScreenPage";
+import { ProjectsPage } from "../../pages/projectsPage";
+import { createIAPContext } from "../../utils/iap-auth";
+import { deleteProjectByName } from "../../utils/project-cleanup";
 
 const REEARTH_E2E_EMAIL = process.env.REEARTH_E2E_EMAIL;
 const REEARTH_E2E_PASSWORD = process.env.REEARTH_E2E_PASSWORD;
@@ -169,7 +169,7 @@ test.describe("Photo Overlay Feature", () => {
 
   test("Upload an image and submit the Photo Overlay", async () => {
     test.setTimeout(90000);
-    const testImagePath = path.resolve(__dirname, "../test-data/testimage.jpg");
+    const testImagePath = path.resolve(__dirname, "../../test-data/testimage.jpg");
     await photoOverlay.uploadAsset(testImagePath);
     await expect(photoOverlay.editorPanel).toBeVisible();
     await photoOverlay.verifyNoCrash();
@@ -250,7 +250,7 @@ test.describe("Photo Overlay Feature", () => {
     await expect(photoOverlay.editorPanel).toBeVisible();
 
     // Upload an image and add description
-    const testImagePath = path.resolve(__dirname, "../test-data/testimage.jpg");
+    const testImagePath = path.resolve(__dirname, "../../test-data/testimage.jpg");
     await photoOverlay.uploadAsset(testImagePath);
     await photoOverlay.photoDescriptionTextarea.fill("Should not be saved");
     await page.waitForTimeout(500);

--- a/e2e/tests/project/projectSettings.spec.ts
+++ b/e2e/tests/project/projectSettings.spec.ts
@@ -1,11 +1,11 @@
 import { faker } from "@faker-js/faker";
 import { test, expect, BrowserContext, Page } from "@playwright/test";
 
-import { STORAGE_STATE } from "../global-setup";
-import { DashBoardPage } from "../pages/dashBoardPage";
-import { ProjectSettingsPage } from "../pages/projectSettingsPage";
-import { ProjectsPage } from "../pages/projectsPage";
-import { createIAPContext } from "../utils/iap-auth";
+import { STORAGE_STATE } from "../../global-setup";
+import { DashBoardPage } from "../../pages/dashBoardPage";
+import { ProjectSettingsPage } from "../../pages/projectSettingsPage";
+import { ProjectsPage } from "../../pages/projectsPage";
+import { createIAPContext } from "../../utils/iap-auth";
 
 const REEARTH_WEB_E2E_BASEURL = process.env.REEARTH_WEB_E2E_BASEURL;
 if (!REEARTH_WEB_E2E_BASEURL) {

--- a/e2e/tests/project/projects.spec.ts
+++ b/e2e/tests/project/projects.spec.ts
@@ -1,12 +1,12 @@
 import { faker } from "@faker-js/faker";
 import { test, expect, BrowserContext, Page } from "@playwright/test";
 
-import { STORAGE_STATE } from "../../global-setup";
-import { DashBoardPage } from "../../pages/dashBoardPage";
-import { ProjectScreenPage } from "../../pages/projectScreenPage";
-import { ProjectsPage } from "../../pages/projectsPage";
-import { createIAPContext } from "../../utils/iap-auth";
-import { deleteProjectByName } from "../../utils/project-cleanup";
+import { STORAGE_STATE } from "@/global-setup";
+import { DashBoardPage } from "@pages/dashBoardPage";
+import { ProjectScreenPage } from "@pages/projectScreenPage";
+import { ProjectsPage } from "@pages/projectsPage";
+import { createIAPContext } from "@utils/iap-auth";
+import { deleteProjectByName } from "@utils/project-cleanup";
 
 const REEARTH_E2E_EMAIL = process.env.REEARTH_E2E_EMAIL;
 const REEARTH_E2E_PASSWORD = process.env.REEARTH_E2E_PASSWORD;

--- a/e2e/tests/project/projects.spec.ts
+++ b/e2e/tests/project/projects.spec.ts
@@ -1,12 +1,12 @@
 import { faker } from "@faker-js/faker";
 import { test, expect, BrowserContext, Page } from "@playwright/test";
 
-import { STORAGE_STATE } from "../global-setup";
-import { DashBoardPage } from "../pages/dashBoardPage";
-import { ProjectScreenPage } from "../pages/projectScreenPage";
-import { ProjectsPage } from "../pages/projectsPage";
-import { createIAPContext } from "../utils/iap-auth";
-import { deleteProjectByName } from "../utils/project-cleanup";
+import { STORAGE_STATE } from "../../global-setup";
+import { DashBoardPage } from "../../pages/dashBoardPage";
+import { ProjectScreenPage } from "../../pages/projectScreenPage";
+import { ProjectsPage } from "../../pages/projectsPage";
+import { createIAPContext } from "../../utils/iap-auth";
+import { deleteProjectByName } from "../../utils/project-cleanup";
 
 const REEARTH_E2E_EMAIL = process.env.REEARTH_E2E_EMAIL;
 const REEARTH_E2E_PASSWORD = process.env.REEARTH_E2E_PASSWORD;

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -2,6 +2,12 @@
   "compilerOptions": {
     "strict": true,
     "strictPropertyInitialization": false,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "@pages/*": ["pages/*"],
+      "@utils/*": ["utils/*"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `workers: 1 -> 2` in `e2e/playwright.config.ts`
- Split flat `e2e/tests/` into `account/`, `auth/`, `dashboard/`, `layer/`, `project/` (rename-only, import paths fixed)

## Why
Every spec file uses per-test unique faker names + name-scoped locators, so cross-file concurrency is safe. `fullyParallel` left `false` — all files use serial-mode describe blocks, so the speedup comes purely from `workers` scheduling different files concurrently.

## Validation
- Local: UI suite 9.7min -> 2.4-2.7min, API suite 13.1s -> 5.8-6.6s, identical results
- Real CI (manual dispatch): `workers:3` hit 1 failure (`externalLayers.spec.ts` 3D Tiles test, missing a `test.skip(CI)` guard its siblings already have). Dialed to `workers:2`, reran clean: 84 passed, 1 flaky (same known test, recovered), 65 skipped, 7.4min

## Known pre-existing issues (not caused by this PR)
- Missing CI-skip guard on the 3D Tiles test above
- Intermittent dashboard recycle-bin delete flakiness

## Test plan
- [x] Local full-suite validation
- [x] Real CI validation via manual dispatch
- [x] CI run on this PR