### PR TITLE
fix(server): add WarnErrorWithCallerLogging and use it at known-benign sites

### DIFF
--- a/server/internal/usecase/interactor/nlslayer.go
+++ b/server/internal/usecase/interactor/nlslayer.go
@@ -119,7 +119,7 @@ func (i *NLSLayer) AddLayerSimple(ctx context.Context, inp interfaces.AddNLSLaye
 	}()
 
 	if err := i.CanWriteScene(inp.SceneID, operator); err != nil {
-		return nil, visualizer.ErrorWithCallerLogging(ctx, fmt.Sprintf("nlslayer: validateGeoJSONFeatureCollection err: %v", interfaces.ErrOperationDenied), interfaces.ErrOperationDenied)
+		return nil, visualizer.WarnErrorWithCallerLogging(ctx, fmt.Sprintf("nlslayer: validateGeoJSONFeatureCollection err: %v", interfaces.ErrOperationDenied), interfaces.ErrOperationDenied)
 	}
 
 	builder := nlslayer.NewNLSLayerSimple().

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -491,7 +491,7 @@ func (i *Project) Update(ctx context.Context, p interfaces.UpdateProjectParam, o
 
 	prj, err := i.projectRepo.FindByID(ctx, p.ID)
 	if err != nil {
-		return nil, visualizer.ErrorWithCallerLogging(ctx, "failed to find project", err)
+		return nil, visualizer.WarnErrorWithCallerLogging(ctx, "failed to find project", err)
 	}
 
 	operationAllowed, err := i.policyChecker.CheckPolicy(ctx, gateway.CreateGeneralOperationAllowedCheckRequest(prj.Workspace()))

--- a/server/internal/usecase/interactor/published.go
+++ b/server/internal/usecase/interactor/published.go
@@ -109,7 +109,7 @@ func (i *Published) Data(ctx context.Context, name string) (io.Reader, error) {
 		return r, nil
 	}
 
-	return nil, visualizer.ErrorWithCallerLogging(ctx, "published: no data file found", rerror.ErrNotFound)
+	return nil, visualizer.WarnErrorWithCallerLogging(ctx, "published: no data file found", rerror.ErrNotFound)
 }
 
 func (i *Published) Index(ctx context.Context, name string, u *url.URL) (string, error) {

--- a/server/internal/usecase/interactor/storytelling.go
+++ b/server/internal/usecase/interactor/storytelling.go
@@ -961,7 +961,7 @@ func (i *Storytelling) CreateBlock(ctx context.Context, inp interfaces.CreateBlo
 
 	story, err := i.storytellingRepo.FindByID(ctx, inp.StoryID)
 	if err != nil {
-		return nil, nil, nil, -1, visualizer.ErrorWithCallerLogging(ctx, "failed to find story", err)
+		return nil, nil, nil, -1, visualizer.WarnErrorWithCallerLogging(ctx, "failed to find story", err)
 	}
 	if err := i.CanWriteScene(story.Scene(), op); err != nil {
 		return nil, nil, nil, -1, visualizer.ErrorWithCallerLogging(ctx, "failed to check scene", err)

--- a/server/pkg/visualizer/visualizer.go
+++ b/server/pkg/visualizer/visualizer.go
@@ -14,9 +14,21 @@ const (
 	VisualizerCesiumBeta Visualizer = "cesium-beta"
 )
 
+// ErrorWithCallerLogging logs err at ERROR with caller info and returns it unchanged.
+// Use for unexpected failures. For expected user-facing failures (not found, permission
+// denied, invalid input), prefer WarnErrorWithCallerLogging to keep ERROR-level metrics
+// meaningful.
 func ErrorWithCallerLogging(ctx context.Context, msg string, err error) error {
 	_, file, line, _ := runtime.Caller(1)
 	log.Errorfc(ctx, "[Error] error with caller logging: %s at %s:%d %+v", msg, file, line, err)
+	return err
+}
+
+// WarnErrorWithCallerLogging is the WARN-level counterpart of ErrorWithCallerLogging.
+// Use for expected user-facing failures that should not pollute ERROR-level metrics.
+func WarnErrorWithCallerLogging(ctx context.Context, msg string, err error) error {
+	_, file, line, _ := runtime.Caller(1)
+	log.Warnfc(ctx, "[Warn] error with caller logging: %s at %s:%d %+v", msg, file, line, err)
 	return err
 }
 


### PR DESCRIPTION
## Why

`ErrorWithCallerLogging` unconditionally logs at severity=ERROR. Because it's used at expected user-facing failures too (`failed to find project`, `failed to find story`, `no data file found`, `validateGeoJSONFeatureCollection … operation denied`), every 404/permission-denied response was counted against the `reearth_visualizer_api_errors` log-based metric and drove the recent **"Visualizer API error spike (50+ errors in 30 min)"** alert on `reearth-development`. The window contained ~54 expected validation errors from automated traffic hitting negative paths — no real outage.

## Approach

Severity is a property of the log site, not the error value — the caller knows whether the failure is expected. So instead of guessing from the error type inside the helper, add an explicit WARN sibling and let the callsite pick:

- `ErrorWithCallerLogging(ctx, msg, err) error` — unexpected failures (unchanged).
- `WarnErrorWithCallerLogging(ctx, msg, err) error` — expected user-facing failures. Same shape, WARN level, returns the error unchanged.

Then migrate the four paths the alert flagged.

## Changes

- `server/pkg/visualizer/visualizer.go`: add `WarnErrorWithCallerLogging`.
- `server/internal/usecase/interactor/project.go:494` — `failed to find project` (returns `rerror.ErrNotFound`).
- `server/internal/usecase/interactor/storytelling.go:964` — `failed to find story` (returns `rerror.ErrNotFound`).
- `server/internal/usecase/interactor/published.go:112` — `published: no data file found` (returns `rerror.ErrNotFound`).
- `server/internal/usecase/interactor/nlslayer.go:122` — `validateGeoJSONFeatureCollection … operation denied` (returns `interfaces.ErrOperationDenied`).

Other `ErrorWithCallerLogging` callsites are left unchanged pending a per-site audit — they'll be migrated in follow-ups as they're reviewed.

## Follow-ups

- Audit remaining `ErrorWithCallerLogging` callers in `interactor/project.go`, `interactor/storytelling.go`, `interactor/nlslayer.go`, `infrastructure/mongo/project.go`, `internal/adapter/gql/resolver_user.go`, `internal/adapter/internalapi/server.go` and migrate the ones producing expected user-facing failures.
- The accounts client (`reearth-accounts`) has an equivalent always-ERROR helper — same fix should land there so validation errors from that path stop hitting ERROR.
- Interim: tighten the `reearth_visualizer_api_errors` metric filter to exclude common validation strings while the migration progresses.

## Test plan

- [x] `go build ./pkg/visualizer/ ./internal/usecase/interactor/`
- [x] `go vet ./pkg/visualizer/ ./internal/usecase/interactor/`
- [ ] After merge: confirm the metric drops on `reearth-development` and the alert stops firing on synthetic/e2e traffic.