### PR TITLE
chore(web): bump @reearth/core to 0.0.7-alpha.75 for scene.backgroundColor and skyBox fix

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -131,7 +131,7 @@
     "@popperjs/core": "2.11.8",
     "@radix-ui/react-select": "2.2.6",
     "@radix-ui/react-slot": "1.2.4",
-    "@reearth/core": "0.0.7-alpha.72",
+    "@reearth/core": "0.0.7-alpha.75",
     "@reearth/sentinel": "0.1.2",
     "@rot1024/use-transition": "1.0.0",
     "@sentry/browser": "7.77.0",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5920,9 +5920,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reearth/core@npm:0.0.7-alpha.72":
-  version: 0.0.7-alpha.72
-  resolution: "@reearth/core@npm:0.0.7-alpha.72"
+"@reearth/core@npm:0.0.7-alpha.75":
+  version: 0.0.7-alpha.75
+  resolution: "@reearth/core@npm:0.0.7-alpha.75"
   dependencies:
     "@radix-ui/react-checkbox": "npm:^1.3.3"
     "@radix-ui/react-dialog": "npm:^1.1.15"
@@ -5976,7 +5976,7 @@ __metadata:
     cesium: 1.118.x
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/f9edbe823ae129e1c5497ad5cf3ed834eb1ae811a15f5f347eab86dc5e098da65ddf20e9053004d4621263285c3146f905b91b38359816923b0d0bb611fd6471
+  checksum: 10c0/e2a61a13ea330ce298208251c6531ea9997ce53db66b9318d8549120b790d59d24038b6dfe81c0f34a8e7d74b2cdcb2536d080af3b71f7805b5a8f87e03200a2
   languageName: node
   linkType: hard
 
@@ -6038,7 +6038,7 @@ __metadata:
     "@popperjs/core": "npm:2.11.8"
     "@radix-ui/react-select": "npm:2.2.6"
     "@radix-ui/react-slot": "npm:1.2.4"
-    "@reearth/core": "npm:0.0.7-alpha.72"
+    "@reearth/core": "npm:0.0.7-alpha.75"
     "@reearth/sentinel": "npm:0.1.2"
     "@rollup/plugin-yaml": "npm:4.1.2"
     "@rot1024/use-transition": "npm:1.0.0"


### PR DESCRIPTION
## Overview

Bumps \`@reearth/core\` from \`0.0.7-alpha.72\` to \`0.0.7-alpha.75\` to pick up the fix for \`scene.backgroundColor\` and \`sky.skyBox.show\` not applying correctly in Cesium 1.139.

## What I've done

- Updated \`@reearth/core\` dependency to \`0.0.7-alpha.75\`.

## What I haven't done

- No changes to visualizer code — this fix lives entirely in core.

## How I tested

> The following test uses reearth-visualizer to exercise the core fix. Run in the script console:

```js
reearth.viewer.overrideProperty({
  sky: {
    skyBox: { show: false },
    skyAtmosphere: { show: false }
  },
  scene: { backgroundColor: '#99ff00' }
})
```

Expected: background turns yellow-green, no stars visible.

## Memo

Depends on the companion core PR: https://github.com/reearth/core/pull/145

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.