### PR TITLE
fix(web): support object values in PropertyList block custom fields

### DIFF
--- a/web/src/app/features/Visualizer/Crust/Infobox/Block/builtin/PropertyList/CustomFields/index.tsx
+++ b/web/src/app/features/Visualizer/Crust/Infobox/Block/builtin/PropertyList/CustomFields/index.tsx
@@ -7,6 +7,19 @@ import ListItem from "../ListItem";
 
 import useEvaluateProperties from "./useEvaluateProperties";
 
+function toDisplayString(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (Array.isArray(value)) return value.join(", ");
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "[object]";
+    }
+  }
+  return String(value);
+}
+
 type Props = {
   extensionId?: string;
   selectedFeature?: ComputedFeature;
@@ -26,8 +39,13 @@ const CustomFields: FC<Props> = ({
   return (
     <>
       {evaluatedProperties && evaluatedProperties.length > 0 ? (
-        evaluatedProperties.map((ep) => (
-          <ListItem key={ep.id} keyValue={ep.key} value={ep.value} />
+        evaluatedProperties.map((ep, idx) => (
+          <ListItem
+            key={ep.id}
+            index={idx}
+            keyValue={ep.key}
+            value={toDisplayString(ep.value)}
+          />
         ))
       ) : (
         <Template icon={extensionId} height={120} />

--- a/web/src/app/features/Visualizer/Crust/Infobox/Block/builtin/PropertyList/CustomFields/index.tsx
+++ b/web/src/app/features/Visualizer/Crust/Infobox/Block/builtin/PropertyList/CustomFields/index.tsx
@@ -9,7 +9,7 @@ import useEvaluateProperties from "./useEvaluateProperties";
 
 function toDisplayString(value: unknown): string {
   if (value === null || value === undefined) return "";
-  if (Array.isArray(value)) return value.join(", ");
+  if (Array.isArray(value)) return value.map(toDisplayString).join(", ");
   if (typeof value === "object") {
     try {
       return JSON.stringify(value);

--- a/web/src/app/features/Visualizer/Crust/Infobox/Block/builtin/PropertyList/CustomFields/useEvaluateProperties.ts
+++ b/web/src/app/features/Visualizer/Crust/Infobox/Block/builtin/PropertyList/CustomFields/useEvaluateProperties.ts
@@ -53,7 +53,7 @@ export default ({ properties, selectedFeature }: Props) => {
         );
 
         return ev !== undefined && ev !== null
-          ? ({ ...v, value: ev } as EvaluatedPropertyListItem)
+          ? { ...v, value: ev }
           : undefined;
       });
       const filtered = es?.filter(

--- a/web/src/app/features/Visualizer/Crust/Infobox/Block/builtin/PropertyList/CustomFields/useEvaluateProperties.ts
+++ b/web/src/app/features/Visualizer/Crust/Infobox/Block/builtin/PropertyList/CustomFields/useEvaluateProperties.ts
@@ -4,6 +4,10 @@ import { useEffect, useState } from "react";
 
 import { PropertyListItem } from "../ListEditor";
 
+export type EvaluatedPropertyListItem = Omit<PropertyListItem, "value"> & {
+  value: unknown;
+};
+
 type Props = {
   selectedFeature?: ComputedFeature;
   properties?: PropertyListItem[];
@@ -15,7 +19,7 @@ export default ({ properties, selectedFeature }: Props) => {
   >(properties);
 
   const [evaluatedProperties, setEvaluatedResult] = useState<
-    PropertyListItem[] | undefined
+    EvaluatedPropertyListItem[] | undefined
   >(undefined);
 
   // We want the useEffect to be called on each render to make sure evaluatedProperties is up to date
@@ -48,18 +52,18 @@ export default ({ properties, selectedFeature }: Props) => {
           simpleFeature
         );
 
-        return ev
-          ? {
-              ...v,
-              value: ev
-            }
+        return ev !== undefined && ev !== null
+          ? ({ ...v, value: ev } as EvaluatedPropertyListItem)
           : undefined;
       });
-      if (!isEqual(es, evaluatedProperties)) {
-        setEvaluatedResult(es as PropertyListItem[]);
+      const filtered = es?.filter(
+        (e): e is EvaluatedPropertyListItem => e !== undefined
+      );
+      if (!isEqual(filtered, evaluatedProperties)) {
+        setEvaluatedResult(filtered);
       }
     }
   }, [isReady, currentValue, properties, evaluatedProperties, selectedFeature]);
 
-  return evaluatedProperties?.filter((ep) => ep !== undefined);
+  return evaluatedProperties;
 };

--- a/web/src/app/features/Visualizer/Crust/Infobox/Block/builtin/PropertyList/CustomFields/useEvaluateProperties.ts
+++ b/web/src/app/features/Visualizer/Crust/Infobox/Block/builtin/PropertyList/CustomFields/useEvaluateProperties.ts
@@ -43,19 +43,21 @@ export default ({ properties, selectedFeature }: Props) => {
         metaData: selectedFeature.metaData,
         range: selectedFeature.range
       };
-      const es = currentValue?.map((v) => {
-        const ev = evalExpression(
-          {
-            expression: v.value
-          },
-          undefined,
-          simpleFeature
-        );
+      const es = currentValue?.map(
+        (v): EvaluatedPropertyListItem | undefined => {
+          const ev = evalExpression(
+            {
+              expression: v.value
+            },
+            undefined,
+            simpleFeature
+          );
 
-        return ev !== undefined && ev !== null
-          ? { ...v, value: ev }
-          : undefined;
-      });
+          return ev !== undefined && ev !== null
+            ? { ...v, value: ev }
+            : undefined;
+        }
+      );
       const filtered = es?.filter(
         (e): e is EvaluatedPropertyListItem => e !== undefined
       );


### PR DESCRIPTION
# Overview

The `propertyListBlock` custom fields mode crashed with a React render error when a template expression like `${group}` evaluated to an object value, because the block only handled string values. This PR fixes the crash, prevents an infinite re-render loop introduced in the fix, and makes object/array values display correctly in the existing `ListItem` style.

## What I've done

- **Added `EvaluatedPropertyListItem` type** in `useEvaluateProperties.ts` with `value: unknown` so that the hook accurately types evaluated values that may be objects, arrays, numbers, or booleans — instead of unsafely casting to `PropertyListItem[]` (which requires `value: string`).
- **Fixed infinite re-render loop**: the previous code compared the raw `.map()` result `es` (which may contain `undefined` slots) against the stored `evaluatedProperties` (which is always filtered-dense) via `isEqual`. These two arrays can never be deeply equal when any expression evaluates to `null`/`undefined`, causing `setEvaluatedResult` to fire on every render. Fixed by filtering `es` into `filtered` before the `isEqual` comparison.
- **Added `toDisplayString` helper** in `CustomFields/index.tsx` to safely convert any evaluated value to a display string:
  - Arrays → `join(", ")`
  - Objects → `JSON.stringify` wrapped in `try/catch` (fallback to `"[object]"` for circular or non-serializable values)
  - Primitives → `String(value)`
- **Added `index={idx}` to `ListItem`** so alternating row background colors (#F4F4F4 / #ffffff) work correctly for custom fields rows (previously all rows defaulted to even/grey).

## What I haven't done

- Rows where `evalExpression` returns `null` or `undefined` (e.g. the feature has no matching property key) are still silently omitted from the list. This is pre-existing behavior and a separate concern.
- No deep pretty-printing for nested objects — they render as a flat JSON string, consistent with the existing `ListItem` style.

## How I tested

- Opened an infobox on a GeoJSON point feature, added a `propertyListBlock`, selected "customize" display type, configured a field with value `${group}` where `group` is a nested object — previously crashed, now renders the JSON string in the same `ListItem` row style.
- Verified that `${group.title_group2}` (string value) continues to display correctly.
- Verified TypeScript passes with no errors (`yarn type`).
- <img width="274" height="149" alt="image" src="https://github.com/user-attachments/assets/82d7cf6e-9fa4-4733-b50f-a9aba3214eaf" />


## Which point I want you to review particularly

- The `isEqual(filtered, evaluatedProperties)` guard — whether the effect dependency array is still correct after this change.
- Whether `toDisplayString` handling of arrays (`.join(", ")`) matches the expected display format for multi-value feature properties in this project.

## Memo

The crash was caused by the original code passing an evaluated object value directly as JSX children through `Typography`, which React rejects with "Objects are not valid as a React child." The root cause was a type mismatch: `evalExpression` returns `unknown` but the result was cast to `PropertyListItem[]` (requiring `value: string`) without any runtime check.

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.