### PR TITLE
chore(web): bump @reearth/core to 0.0.7-alpha.76 for scene.backgroundColor and skyBox fix

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -131,7 +131,7 @@
     "@popperjs/core": "2.11.8",
     "@radix-ui/react-select": "2.2.6",
     "@radix-ui/react-slot": "1.2.4",
-    "@reearth/core": "0.0.7-alpha.75",
+    "@reearth/core": "0.0.7-alpha.76",
     "@reearth/sentinel": "0.1.2",
     "@reearth/zushi": "0.3.0",
     "@rot1024/use-transition": "1.0.0",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5963,9 +5963,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reearth/core@npm:0.0.7-alpha.75":
-  version: 0.0.7-alpha.75
-  resolution: "@reearth/core@npm:0.0.7-alpha.75"
+"@reearth/core@npm:0.0.7-alpha.76":
+  version: 0.0.7-alpha.76
+  resolution: "@reearth/core@npm:0.0.7-alpha.76"
   dependencies:
     "@radix-ui/react-checkbox": "npm:^1.3.3"
     "@radix-ui/react-dialog": "npm:^1.1.15"
@@ -6019,7 +6019,7 @@ __metadata:
     cesium: 1.118.x
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/e2a61a13ea330ce298208251c6531ea9997ce53db66b9318d8549120b790d59d24038b6dfe81c0f34a8e7d74b2cdcb2536d080af3b71f7805b5a8f87e03200a2
+  checksum: 10c0/569bd497aeb13d971d9dcf3af5b2d1fee07edc1519c48bdfce1eb6c664c279bade6021e68138f67245bb418c6c18000b27c546edc279fad1bd5a40869d6b9b33
   languageName: node
   linkType: hard
 
@@ -6081,7 +6081,7 @@ __metadata:
     "@popperjs/core": "npm:2.11.8"
     "@radix-ui/react-select": "npm:2.2.6"
     "@radix-ui/react-slot": "npm:1.2.4"
-    "@reearth/core": "npm:0.0.7-alpha.75"
+    "@reearth/core": "npm:0.0.7-alpha.76"
     "@reearth/sentinel": "npm:0.1.2"
     "@reearth/zushi": "npm:0.3.0"
     "@rollup/plugin-yaml": "npm:4.1.2"


### PR DESCRIPTION
# Overview

Bumps \`@reearth/core\` from \`0.0.7-alpha.75\` to \`0.0.7-alpha.76\`.

\`alpha.75\` was tagged on 2026-07-15, two days before the fix in [reearth/core#145](https://github.com/reearth/core/pull/145) was merged on 2026-07-17, so the fix never made it into any previously published npm package. \`alpha.76\` is the first release that actually contains it.

## What I've done

- Bumped \`@reearth/core\` to \`0.0.7-alpha.76\` in \`package.json\`
- Updated \`yarn.lock\` accordingly

## What I haven't done

- No code changes — this is a dependency bump only.

## How I tested

Verified that \`0.0.7-alpha.76\` is live on npm (\`npm show @reearth/core dist-tags\`) and that the fix code (\`useEffect\` directly setting \`scene.backgroundColor\` and \`scene.skyBox._panorama.show\`) is present in the published package source.

## Which point I want you to review particularly

N/A — straightforward version bump.

## Memo

The two bugs fixed in \`alpha.76\` (via [reearth/core#145](https://github.com/reearth/core/pull/145)):

1. **\`scene.backgroundColor\` ignored after mount** — Resium's \`<Scene backgroundColor\>\` prop is initialization-only. The fix adds a \`useEffect\` that directly sets \`scene.backgroundColor\` on the Cesium scene object.
2. **\`skyBox.show = false\` has no effect in Cesium 1.139** — A bug in the Cesium 1.139 \`SkyBox\` constructor causes \`_panorama.show\` to be always \`true\`. The fix directly sets \`scene.skyBox._panorama.show\`.

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.