### PR TITLE
fix(web): plugin playground: infobox block and story block cannot get block properties [VIZ-DEV-137]

### DIFF
--- a/web/src/app/features/PluginPlayground/Code/hook.ts
+++ b/web/src/app/features/PluginPlayground/Code/hook.ts
@@ -210,6 +210,12 @@ export default ({
           extensionId: cur.id,
           pluginId: ymlJson.id,
           extensionType: "infoboxBlock",
+          property: generateProperty(
+            cur.schema,
+            fieldValues,
+            ymlJson.id,
+            cur.id
+          ),
           propertyForPluginAPI: generateProperty(
             cur.schema,
             fieldValues,
@@ -241,6 +247,12 @@ export default ({
         extensionId: cur.id,
         pluginId: ymlJson.id,
         extensionType: "storyBlock",
+        property: generateProperty(
+          cur.schema,
+          fieldValues,
+          ymlJson.id,
+          cur.id
+        ),
         propertyForPluginAPI: generateProperty(
           cur.schema,
           fieldValues,

--- a/web/src/app/features/PluginPlayground/types.ts
+++ b/web/src/app/features/PluginPlayground/types.ts
@@ -39,6 +39,8 @@ type CommonBlock = {
   __REEARTH_SOURCECODE: string;
   extensionId: string;
   pluginId: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  property?: any;
   propertyForPluginAPI: Record<string, unknown>;
 };
 


### PR DESCRIPTION
# Overview

Missing property

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
