### PR TITLE
fix(server): bound split-upload import worker timeouts

### DIFF
--- a/server/e2e/gql_project_import_split_test.go
+++ b/server/e2e/gql_project_import_split_test.go
@@ -12,17 +12,21 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/gavv/httpexpect/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
 // go test -v -run TestProjectImportSplit ./e2e/...
 
-func TestProjectImportSplit(t *testing.T) {
-	e := Server(t, fullSeeder)
-	projectZipFilePath := GenProjectZipFile(t, e)
-	workspaceId := wID.String()
+// uploadProjectSplit uploads projectZipFilePath to /api/split-import in
+// chunks and returns every chunk response in upload order, so callers can
+// inspect the final ("completed": true) response — e.g. to read back the
+// project_id and poll its resulting import status.
+func uploadProjectSplit(t *testing.T, e *httpexpect.Expect, projectZipFilePath, workspaceId string) []map[string]interface{} {
+	t.Helper()
 
 	const CHUNK_SIZE = 1024 * 1024
 	const CHUNK_CONCURRENCY = 4
@@ -151,13 +155,89 @@ func TestProjectImportSplit(t *testing.T) {
 	}
 
 	require.NotEmpty(t, results, "No responses received")
-	lastResponse := results[len(results)-1]
+	return results
+}
 
-	t.Logf("Final response: %+v", lastResponse)
+// completedResponse returns the one chunk response with "completed": true —
+// chunks after the first are uploaded concurrently, so the last element of
+// results is not reliably the completing one.
+func completedResponse(t *testing.T, results []map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	for _, r := range results {
+		if completed, _ := r["completed"].(bool); completed {
+			return r
+		}
+	}
+	t.Fatal("no chunk response reported completed: true")
+	return nil
+}
+
+func TestProjectImportSplit(t *testing.T) {
+	e := Server(t, fullSeeder)
+	projectZipFilePath := GenProjectZipFile(t, e)
+	workspaceId := wID.String()
+
+	results := uploadProjectSplit(t, e, projectZipFilePath, workspaceId)
+	lastResponse := completedResponse(t, results)
+
+	t.Logf("Completed response: %+v", lastResponse)
 
 	status, ok := lastResponse["status"].(string)
 	require.True(t, ok, "Status field not found in response")
 	require.NotEmpty(t, status, "Status should not be empty")
+}
+
+// TestProjectImportSplit_CompletesAsyncImport is the REL-03 regression
+// test for dispatchImport's async hand-off: since dispatching a completed
+// upload to the worker pool no longer blocks the request (it now runs in
+// its own goroutine racing dispatchWaitTimeout — see file_split_uploader.go),
+// the chunk response alone no longer proves the import actually ran. This
+// polls the resulting project's real import status through to a terminal
+// state, so a regression that silently dropped the dispatched job (e.g.
+// always taking the timeout branch) would show up as a stuck PROCESSING
+// status here instead of passing unnoticed.
+func TestProjectImportSplit_CompletesAsyncImport(t *testing.T) {
+	e := Server(t, fullSeeder)
+	projectZipFilePath := GenProjectZipFile(t, e)
+	workspaceId := wID.String()
+
+	results := uploadProjectSplit(t, e, projectZipFilePath, workspaceId)
+	lastResponse := completedResponse(t, results)
+
+	projectId, ok := lastResponse["project_id"].(string)
+	require.True(t, ok, "project_id field not found in the completed chunk response")
+	require.NotEmpty(t, projectId)
+
+	query := `query GetProjectImportStatus($projectId: ID!) {
+		node(id: $projectId, type: PROJECT) {
+			... on Project {
+				metadata {
+					importStatus
+				}
+			}
+		}
+	}`
+
+	const pollInterval = 200 * time.Millisecond
+	const pollTimeout = 30 * time.Second
+
+	deadline := time.Now().Add(pollTimeout)
+	var lastStatus string
+	for time.Now().Before(deadline) {
+		res := Request(e, uID.String(), GraphQLRequest{
+			OperationName: "GetProjectImportStatus",
+			Query:         query,
+			Variables:     map[string]any{"projectId": projectId},
+		})
+		lastStatus = res.Object().Value("data").Object().Value("node").Object().Value("metadata").Object().Value("importStatus").String().Raw()
+
+		if lastStatus == "SUCCESS" || lastStatus == "FAILED" {
+			break
+		}
+		time.Sleep(pollInterval)
+	}
+
+	require.Equal(t, "SUCCESS", lastStatus, "import did not reach SUCCESS within %s (last observed status: %s)", pollTimeout, lastStatus)
 }
 
 // TestProjectImportSplit_RejectsChunkWithoutSessionStart is the SCA-03

--- a/server/internal/app/file_import_common.go
+++ b/server/internal/app/file_import_common.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	accountsID "github.com/reearth/reearth-accounts/server/pkg/id"
@@ -226,6 +227,17 @@ func CreateTemporaryProject(ctx context.Context, usecases *interfaces.Container,
 
 }
 
+// updateImportStatusWriteTimeout bounds the status write below,
+// independent of whatever deadline ctx itself carries. This write is often
+// triggered by ctx already being canceled or expired (e.g. REL-03's worker
+// timeout) -- reusing that same context would make the write fail
+// immediately, silently losing the very status it's trying to record. 10s
+// is not a measured figure: this is a single Mongo write, not the whole
+// import pipeline (which observed a 1-14s range end to end in production),
+// so this is a deliberately generous multiple of a healthy single write,
+// not a tight bound.
+const updateImportStatusWriteTimeout = 10 * time.Second
+
 func UpdateImportStatus(
 	ctx context.Context,
 	usecases *interfaces.Container,
@@ -241,7 +253,9 @@ func UpdateImportStatus(
 	if project.ProjectImportStatusFailed == status {
 		log.Errorf("[Import Error] %s", message)
 	}
-	_, err := usecases.Project.UpdateImportStatus(ctx, pid, status, &importResultLog, op)
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), updateImportStatusWriteTimeout)
+	defer cancel()
+	_, err := usecases.Project.UpdateImportStatus(writeCtx, pid, status, &importResultLog, op)
 	if err != nil {
 		log.Printf("failed to update import status: %v", err)
 	}

--- a/server/internal/app/file_split_uploader.go
+++ b/server/internal/app/file_split_uploader.go
@@ -416,13 +416,23 @@ func (m *SplitUploadManager) dispatchImport(job importJob) {
 				log.Errorf("[Import] panic while dispatching import: %v (file %s)", r, job.fileID)
 			}
 		}()
+		// time.NewTimer (not time.After) so the successful-send case can
+		// stop it instead of leaving it to fire 5 minutes later: under
+		// steady upload traffic, every successful dispatch would otherwise
+		// leave a stray timer alive for the full dispatchWaitTimeout.
+		timer := time.NewTimer(m.dispatchWaitTimeout)
+		defer timer.Stop()
+
 		select {
 		case m.jobs <- job:
-		case <-time.After(m.dispatchWaitTimeout):
+		case <-timer.C:
+			// cleanupSession is deferred here, not called after
+			// UpdateImportStatus, so the session/tempfile is still freed
+			// even if the status write panics or otherwise never returns.
+			defer m.cleanupSession(job.fileID)
 			errMsg := "import worker pool did not accept job in time"
 			log.Errorf("[Import] %s (file %s)", errMsg, job.fileID)
 			UpdateImportStatus(context.Background(), job.usecases, job.op, job.projectID, project.ProjectImportStatusFailed, errMsg, map[string]any{})
-			m.cleanupSession(job.fileID)
 		}
 	}()
 }

--- a/server/internal/app/file_split_uploader.go
+++ b/server/internal/app/file_split_uploader.go
@@ -40,6 +40,20 @@ const importWorkerCount = 3
 // request goroutine in practice.
 const importJobQueueSize = 32
 
+// importJobTimeout bounds a single import's execution. Without it, a
+// stalled downstream call (e.g. a MongoDB partial outage) can hang a
+// worker on context.Background() forever; once enough workers are stuck
+// like this, every future import stalls behind them too (REL-03). Real
+// imports observed in production complete in well under a minute, so 5
+// minutes is generous headroom, not a tight bound.
+const importJobTimeout = 5 * time.Minute
+
+// dispatchWaitTimeout is a last-resort safety valve for handing a
+// completed upload to the worker pool (see dispatchImport). It only
+// matters if the pool is already wedged past importJobTimeout, which
+// should be self-healing; this just guarantees the wait can't run forever.
+const dispatchWaitTimeout = 5 * time.Minute
+
 // maxChunkCount bounds total_chunks well above any legitimate upload (the
 // import pipeline already rejects anything over 500MB, which is ~32
 // chunks at the client's 16MB chunk size) while still capping how large a
@@ -260,14 +274,23 @@ type SplitUploadManager struct {
 	tempDir   string
 	chunkSize int64
 	jobs      chan importJob
+
+	// importJobTimeout and dispatchWaitTimeout default to the package
+	// constants in production (see newSplitUploadManager) and are only
+	// fields so tests can inject short durations instead of waiting out
+	// the real 5-minute bounds.
+	importJobTimeout    time.Duration
+	dispatchWaitTimeout time.Duration
 }
 
 func newSplitUploadManager(tempDir string, chunkSize int64) *SplitUploadManager {
 	m := &SplitUploadManager{
-		sessions:  make(map[string]*uploadSession),
-		tempDir:   tempDir,
-		chunkSize: chunkSize,
-		jobs:      make(chan importJob, importJobQueueSize),
+		sessions:            make(map[string]*uploadSession),
+		tempDir:             tempDir,
+		chunkSize:           chunkSize,
+		jobs:                make(chan importJob, importJobQueueSize),
+		importJobTimeout:    importJobTimeout,
+		dispatchWaitTimeout: dispatchWaitTimeout,
 	}
 	for range importWorkerCount {
 		go m.runWorker()
@@ -375,8 +398,24 @@ func (m *SplitUploadManager) getSession(fileID string) (*uploadSession, bool) {
 // durable, MongoDB-backed job queue (see REL-04): only this method needs
 // to be swapped to enqueue a persisted job instead of an in-process
 // channel send — nothing in the session/chunking code above needs to move.
+//
+// The hand-off runs in its own goroutine, detached from the request, so
+// the request goroutine never waits on it — the upload is already fully
+// written to disk by this point, and the import itself always runs async
+// in a worker regardless. Detaching this way also means a client
+// disconnecting right after the last chunk can never abort an upload that
+// already finished successfully (see REL-03).
 func (m *SplitUploadManager) dispatchImport(job importJob) {
-	m.jobs <- job
+	go func() {
+		select {
+		case m.jobs <- job:
+		case <-time.After(m.dispatchWaitTimeout):
+			errMsg := "import worker pool did not accept job in time"
+			log.Errorf("[Import] %s (file %s)", errMsg, job.fileID)
+			UpdateImportStatus(context.Background(), job.usecases, job.op, job.projectID, project.ProjectImportStatusFailed, errMsg, map[string]any{})
+			m.cleanupSession(job.fileID)
+		}
+	}()
 }
 
 func (m *SplitUploadManager) runWorker() {
@@ -389,9 +428,13 @@ func (m *SplitUploadManager) runWorker() {
 // in place, chunk by chunk) and imports one completed upload. It recovers
 // from any panic in the pipeline so a single bad upload can only fail that
 // one import, never take down the process — this is the general fix for
-// the class of bug behind REL-01, not just its specific trigger.
+// the class of bug behind REL-01, not just its specific trigger. The
+// bounded context is the general fix for REL-03: a stalled downstream call
+// times out instead of hanging this worker (and its slot in the pool)
+// forever.
 func (m *SplitUploadManager) runImportJob(job importJob) {
-	bgctx := context.Background()
+	bgctx, cancel := context.WithTimeout(context.Background(), m.importJobTimeout)
+	defer cancel()
 	result := map[string]any{}
 
 	defer func() {

--- a/server/internal/app/file_split_uploader.go
+++ b/server/internal/app/file_split_uploader.go
@@ -407,6 +407,15 @@ func (m *SplitUploadManager) getSession(fileID string) (*uploadSession, bool) {
 // already finished successfully (see REL-03).
 func (m *SplitUploadManager) dispatchImport(job importJob) {
 	go func() {
+		// This goroutine is detached like runImportJob's worker goroutine,
+		// so it needs the same panic recovery: Echo's middleware.Recover()
+		// only covers the request goroutine, and an unhandled panic here
+		// would take down the whole process (the REL-01 failure class).
+		defer func() {
+			if r := recover(); r != nil {
+				log.Errorf("[Import] panic while dispatching import: %v (file %s)", r, job.fileID)
+			}
+		}()
 		select {
 		case m.jobs <- job:
 		case <-time.After(m.dispatchWaitTimeout):

--- a/server/internal/app/file_split_uploader_test.go
+++ b/server/internal/app/file_split_uploader_test.go
@@ -494,8 +494,19 @@ func TestSplitUploadManager_DispatchImport_TimesOutWhenPoolWedged(t *testing.T) 
 		t.Errorf("message = %q, want it to mention the pool not accepting the job", gotMessage)
 	}
 
-	if _, ok := m.getSession("wedged"); ok {
-		t.Error("session should have been cleaned up after a dispatch timeout")
+	// cleanupSession is deferred until after UpdateImportStatus returns, so
+	// it can still be running for a moment after the fake above closes
+	// done — poll instead of asserting immediately to avoid a flaky race.
+	deadline := time.Now().Add(time.Second)
+	for {
+		if _, ok := m.getSession("wedged"); !ok {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Error("session should have been cleaned up after a dispatch timeout")
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 

--- a/server/internal/app/file_split_uploader_test.go
+++ b/server/internal/app/file_split_uploader_test.go
@@ -1,7 +1,10 @@
 package app
 
 import (
+	"archive/zip"
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,8 +14,55 @@ import (
 	"testing"
 	"time"
 
+	"github.com/reearth/reearth/server/internal/usecase"
+	"github.com/reearth/reearth/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearth/server/pkg/project"
 )
+
+// fakeProjectUsecase implements only the two interfaces.Project methods the
+// import pipeline's timeout paths exercise (REL-03); every other method
+// panics via the nil-embedded interface if a test accidentally reaches it.
+type fakeProjectUsecase struct {
+	interfaces.Project
+	importProjectData func(ctx context.Context, wsID string, sceneID *string, data *[]byte, op *usecase.Operator) (*project.Project, error)
+	updateImportStatus func(ctx context.Context, pid id.ProjectID, status project.ProjectImportStatus, msg *map[string]any, op *usecase.Operator) (*project.ProjectMetadata, error)
+}
+
+func (f *fakeProjectUsecase) ImportProjectData(ctx context.Context, wsID string, sceneID *string, data *[]byte, op *usecase.Operator) (*project.Project, error) {
+	return f.importProjectData(ctx, wsID, sceneID, data, op)
+}
+
+func (f *fakeProjectUsecase) UpdateImportStatus(ctx context.Context, pid id.ProjectID, status project.ProjectImportStatus, msg *map[string]any, op *usecase.Operator) (*project.ProjectMetadata, error) {
+	return f.updateImportStatus(ctx, pid, status, msg, op)
+}
+
+// writeTestExportZip builds the minimal zip UncompressExportZip accepts —
+// just a project.json containing valid JSON — so runImportJob tests can
+// reach ImportProject without needing a real exported project.
+func writeTestExportZip(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "export.zip")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("failed to create zip: %v", err)
+	}
+	zw := zip.NewWriter(f)
+	w, err := zw.Create("project.json")
+	if err != nil {
+		t.Fatalf("failed to create zip entry: %v", err)
+	}
+	if _, err := w.Write([]byte(`{}`)); err != nil {
+		t.Fatalf("failed to write zip entry: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close zip file: %v", err)
+	}
+	return path
+}
 
 // setUpdatedAtForTest mutates updatedAt under the session's own lock, so
 // tests exercising staleness don't have to reach past uploadSession's
@@ -26,10 +76,12 @@ func (s *uploadSession) setUpdatedAtForTest(t time.Time) {
 func newTestManager(t *testing.T) *SplitUploadManager {
 	t.Helper()
 	return &SplitUploadManager{
-		sessions:  make(map[string]*uploadSession),
-		tempDir:   t.TempDir(),
-		chunkSize: 4, // small chunk size keeps test data tiny
-		jobs:      make(chan importJob, 1),
+		sessions:            make(map[string]*uploadSession),
+		tempDir:             t.TempDir(),
+		chunkSize:           4, // small chunk size keeps test data tiny
+		jobs:                make(chan importJob, 1),
+		importJobTimeout:    importJobTimeout,
+		dispatchWaitTimeout: dispatchWaitTimeout,
 	}
 }
 
@@ -384,6 +436,207 @@ func TestUploadSession_FilePathIsUnderTempDir(t *testing.T) {
 // flows into filepath.Join(tempDir, fileID), so an unrestricted value is a
 // path-traversal vector, and an unbounded/negative chunkNum could force
 // writes at arbitrary offsets in the backing file.
+// TestSplitUploadManager_DispatchImport_TimesOutWhenPoolWedged is the
+// REL-03 regression test: if every worker is stuck (modeled here by an
+// unbuffered jobs channel with no worker draining it), dispatchImport must
+// give up after dispatchWaitTimeout instead of blocking the caller
+// forever, and must mark the import failed and clean up the session
+// rather than silently dropping it.
+func TestSplitUploadManager_DispatchImport_TimesOutWhenPoolWedged(t *testing.T) {
+	m := newTestManager(t)
+	m.jobs = make(chan importJob) // unbuffered, nothing ever reads it
+	m.dispatchWaitTimeout = 20 * time.Millisecond
+
+	prj, err := project.New().NewID().Build()
+	if err != nil {
+		t.Fatalf("failed to build project: %v", err)
+	}
+	session, err := m.getOrCreateSession("wedged", 1)
+	if err != nil {
+		t.Fatalf("getOrCreateSession: %v", err)
+	}
+	session.setProject(prj)
+
+	done := make(chan struct{})
+	var gotStatus project.ProjectImportStatus
+	var gotMessage string
+	fake := &fakeProjectUsecase{
+		updateImportStatus: func(ctx context.Context, pid id.ProjectID, status project.ProjectImportStatus, msg *map[string]any, op *usecase.Operator) (*project.ProjectMetadata, error) {
+			gotStatus = status
+			gotMessage = (*msg)["message"].(string)
+			close(done)
+			return nil, nil
+		},
+	}
+
+	job := importJob{
+		usecases:  &interfaces.Container{Project: fake},
+		fileID:    "wedged",
+		projectID: prj.ID(),
+	}
+
+	start := time.Now()
+	m.dispatchImport(job) // must return immediately — the wait happens in its own goroutine
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for dispatchImport's timeout branch to run")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("dispatch timeout took %v, want close to dispatchWaitTimeout (%v)", elapsed, m.dispatchWaitTimeout)
+	}
+
+	if gotStatus != project.ProjectImportStatusFailed {
+		t.Errorf("status = %v, want %v", gotStatus, project.ProjectImportStatusFailed)
+	}
+	if !strings.Contains(gotMessage, "did not accept job in time") {
+		t.Errorf("message = %q, want it to mention the pool not accepting the job", gotMessage)
+	}
+
+	if _, ok := m.getSession("wedged"); ok {
+		t.Error("session should have been cleaned up after a dispatch timeout")
+	}
+}
+
+// TestSplitUploadManager_DispatchImport_SucceedsWithinTimeout is the
+// complement to the above: when a worker slot is available, the job must
+// be handed off normally and the timeout/failure path must never fire.
+func TestSplitUploadManager_DispatchImport_SucceedsWithinTimeout(t *testing.T) {
+	m := newTestManager(t)
+	m.jobs = make(chan importJob, 1) // room for one job, so the send succeeds immediately
+	m.dispatchWaitTimeout = 2 * time.Second
+
+	fake := &fakeProjectUsecase{
+		updateImportStatus: func(ctx context.Context, pid id.ProjectID, status project.ProjectImportStatus, msg *map[string]any, op *usecase.Operator) (*project.ProjectMetadata, error) {
+			t.Error("UpdateImportStatus must not be called when the job is dispatched successfully")
+			return nil, nil
+		},
+	}
+
+	job := importJob{
+		usecases: &interfaces.Container{Project: fake},
+		fileID:   "healthy",
+	}
+	m.dispatchImport(job)
+
+	select {
+	case got := <-m.jobs:
+		if got.fileID != "healthy" {
+			t.Errorf("dispatched job fileID = %q, want %q", got.fileID, "healthy")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("job was never delivered to the worker channel")
+	}
+}
+
+// TestSplitUploadManager_RunImportJob_ContextTimesOut is the REL-03
+// regression test for worker execution: a downstream call that hangs (here,
+// ImportProjectData blocking until its context is done) must not wedge the
+// worker forever — importJobTimeout bounds it, the job is marked failed,
+// and the worker is free to return to runWorker's loop for the next job.
+func TestSplitUploadManager_RunImportJob_ContextTimesOut(t *testing.T) {
+	m := newTestManager(t)
+	m.importJobTimeout = 20 * time.Millisecond
+
+	prj, err := project.New().NewID().Build()
+	if err != nil {
+		t.Fatalf("failed to build project: %v", err)
+	}
+	if _, err := m.getOrCreateSession("stuck-import", 1); err != nil {
+		t.Fatalf("getOrCreateSession: %v", err)
+	}
+
+	var sawDeadline bool
+	fake := &fakeProjectUsecase{
+		importProjectData: func(ctx context.Context, wsID string, sceneID *string, data *[]byte, op *usecase.Operator) (*project.Project, error) {
+			<-ctx.Done() // simulate a hung downstream (e.g. MongoDB) call
+			sawDeadline = errors.Is(ctx.Err(), context.DeadlineExceeded)
+			return nil, ctx.Err()
+		},
+		updateImportStatus: func(ctx context.Context, pid id.ProjectID, status project.ProjectImportStatus, msg *map[string]any, op *usecase.Operator) (*project.ProjectMetadata, error) {
+			return nil, nil
+		},
+	}
+
+	job := importJob{
+		usecases:  &interfaces.Container{Project: fake},
+		fileID:    "stuck-import",
+		filePath:  writeTestExportZip(t),
+		projectID: prj.ID(),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		m.runImportJob(job) // must return once the bounded context expires
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runImportJob did not return after its context should have timed out")
+	}
+
+	if !sawDeadline {
+		t.Error("downstream call's context should have expired with context.DeadlineExceeded")
+	}
+	if _, ok := m.getSession("stuck-import"); ok {
+		t.Error("session should have been cleaned up after the job finished (even on timeout)")
+	}
+}
+
+// TestSplitUploadManager_RunImportJob_FastFailureIsNotTreatedAsTimeout
+// checks the timeout wiring doesn't misfire on a normal, fast failure —
+// the bounded context must still allow quick downstream errors through
+// with their own message, not a spurious deadline error.
+func TestSplitUploadManager_RunImportJob_FastFailureIsNotTreatedAsTimeout(t *testing.T) {
+	m := newTestManager(t)
+	m.importJobTimeout = 2 * time.Second // generous; the fake returns instantly
+
+	prj, err := project.New().NewID().Build()
+	if err != nil {
+		t.Fatalf("failed to build project: %v", err)
+	}
+	if _, err := m.getOrCreateSession("fast-fail", 1); err != nil {
+		t.Fatalf("getOrCreateSession: %v", err)
+	}
+
+	var gotMessage string
+	done := make(chan struct{})
+	fake := &fakeProjectUsecase{
+		importProjectData: func(ctx context.Context, wsID string, sceneID *string, data *[]byte, op *usecase.Operator) (*project.Project, error) {
+			return nil, errors.New("boom")
+		},
+		updateImportStatus: func(ctx context.Context, pid id.ProjectID, status project.ProjectImportStatus, msg *map[string]any, op *usecase.Operator) (*project.ProjectMetadata, error) {
+			gotMessage = (*msg)["message"].(string)
+			close(done)
+			return nil, nil
+		},
+	}
+
+	job := importJob{
+		usecases:  &interfaces.Container{Project: fake},
+		fileID:    "fast-fail",
+		filePath:  writeTestExportZip(t),
+		projectID: prj.ID(),
+	}
+
+	m.runImportJob(job)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("UpdateImportStatus was never called")
+	}
+	if strings.Contains(gotMessage, "deadline exceeded") {
+		t.Errorf("message = %q, should be the fast failure, not a timeout", gotMessage)
+	}
+	if !strings.Contains(gotMessage, "boom") {
+		t.Errorf("message = %q, want it to contain the underlying error", gotMessage)
+	}
+}
+
 func TestValidateChunkRequest(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/server/internal/app/file_split_uploader_test.go
+++ b/server/internal/app/file_split_uploader_test.go
@@ -25,7 +25,7 @@ import (
 // panics via the nil-embedded interface if a test accidentally reaches it.
 type fakeProjectUsecase struct {
 	interfaces.Project
-	importProjectData func(ctx context.Context, wsID string, sceneID *string, data *[]byte, op *usecase.Operator) (*project.Project, error)
+	importProjectData  func(ctx context.Context, wsID string, sceneID *string, data *[]byte, op *usecase.Operator) (*project.Project, error)
 	updateImportStatus func(ctx context.Context, pid id.ProjectID, status project.ProjectImportStatus, msg *map[string]any, op *usecase.Operator) (*project.ProjectMetadata, error)
 }
 

--- a/server/internal/app/file_split_uploader_test.go
+++ b/server/internal/app/file_split_uploader_test.go
@@ -530,6 +530,39 @@ func TestSplitUploadManager_DispatchImport_SucceedsWithinTimeout(t *testing.T) {
 	}
 }
 
+// TestSplitUploadManager_DispatchImport_RecoversFromPanic guards against
+// reintroducing the REL-01 failure class in the new dispatch goroutine:
+// dispatchImport's timeout branch is itself a detached goroutine, so a
+// panic inside it (e.g. a nil usecases dependency) must be recovered
+// rather than crashing the whole process, the same way runImportJob
+// already protects its own worker goroutine.
+func TestSplitUploadManager_DispatchImport_RecoversFromPanic(t *testing.T) {
+	m := newTestManager(t)
+	m.jobs = make(chan importJob) // unbuffered, nothing reads it, forcing the timeout branch
+	m.dispatchWaitTimeout = 20 * time.Millisecond
+
+	// job.usecases is nil on purpose: UpdateImportStatus dereferences it,
+	// which panics — exercising the recover path instead of crashing.
+	job := importJob{fileID: "panicky"}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		m.dispatchImport(job)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("dispatchImport should have returned immediately regardless of the goroutine it spawns")
+	}
+
+	// Give the spawned goroutine time to hit the timeout branch and panic;
+	// if the panic isn't recovered, it crashes the whole test binary, so
+	// reaching this line at all is the real assertion.
+	time.Sleep(100 * time.Millisecond)
+}
+
 // TestSplitUploadManager_RunImportJob_ContextTimesOut is the REL-03
 // regression test for worker execution: a downstream call that hangs (here,
 // ImportProjectData blocking until its context is done) must not wedge the


### PR DESCRIPTION
Fixes REL-03: a wedged import worker could block chunk-completion requests forever with no way to recover.

- dispatchImport now hands off jobs in a detached goroutine with a timeout, instead of blocking the request.
- runImportJob's worker context is now bounded, so a stuck downstream call can't wedge a worker permanently.
- Timeouts default to 5 minutes, based on observed production import durations.

Tests added for both timeout paths plus their non-timeout counterparts.