### PR TITLE
fix(web): resolve @reearth/zushi alias in Storybook build

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -6,6 +6,7 @@ node_modules
 /dist
 /vendor
 /storybook-static
+/Users
 __screenshots__
 /playwright-report
 /test-results

--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -55,6 +55,10 @@ const config: StorybookConfig = {
             )
           },
           {
+            find: "@reearth/zushi",
+            replacement: resolve(__dirname, "..", "node_modules/@reearth/zushi")
+          },
+          {
             find: "@reearth",
             replacement: resolve(__dirname, "..", "src")
           }


### PR DESCRIPTION
## Summary
- Storybook's generic @reearth alias was catching @reearth/zushi and rewriting it to src/zushi, which does not exist, breaking build:preview
- Added an explicit alias entry for @reearth/zushi pointing to node_modules, matching the existing carve-outs for @reearth/core and @reearth/sentinel
- Ignored the web/Users directory, a stray artifact produced by a path-join bug when building Storybook

## Test plan
- [x] Run yarn build:preview in web and confirm Storybook builds without the ENOENT error on src/zushi