### PR TITLE
fix(ci): pass image tags through env instead of interpolating into shell

### DIFF
--- a/.github/workflows/promote_images.yml
+++ b/.github/workflows/promote_images.yml
@@ -28,12 +28,18 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Retag web image
+        env:
+          FROM_TAG: ${{ inputs.from_tag }}
+          TO_TAG: ${{ inputs.to_tag }}
         run: |
           docker buildx imagetools create \
-            -t reearth/reearth-visualizer-web:${{ inputs.to_tag }} \
-            reearth/reearth-visualizer-web:${{ inputs.from_tag }}
+            -t "reearth/reearth-visualizer-web:${TO_TAG}" \
+            "reearth/reearth-visualizer-web:${FROM_TAG}"
       - name: Retag server image
+        env:
+          FROM_TAG: ${{ inputs.from_tag }}
+          TO_TAG: ${{ inputs.to_tag }}
         run: |
           docker buildx imagetools create \
-            -t reearth/reearth-visualizer-api:${{ inputs.to_tag }} \
-            reearth/reearth-visualizer-api:${{ inputs.from_tag }}
+            -t "reearth/reearth-visualizer-api:${TO_TAG}" \
+            "reearth/reearth-visualizer-api:${FROM_TAG}"


### PR DESCRIPTION
## Summary
- The retag steps in promote_images.yml interpolated to_tag and from_tag directly into the run: script text instead of passing them through env.
- These values originate from a free-text custom_version field on the Release workflow's manual dispatch form, with no format validation anywhere downstream.
- A crafted value could break out of the intended docker command and run arbitrary shell in a job that has already logged in to Docker Hub, exposing the push credentials.
- Fixed by passing both values through env and referencing them as quoted shell variables, so they're treated as data rather than script text.

## Test plan
- [x] Confirm the workflow still parses (actionlint or a dry run)