### PR TITLE
fix(web): unsubscribe plugin viewer listeners and clear modal state on dispose

### DIFF
--- a/web/src/app/features/Visualizer/Crust/Plugins/Plugin/hooks/usePluginInstance.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/Plugin/hooks/usePluginInstance.ts
@@ -10,8 +10,8 @@ import type { InfoboxBlock as Block } from "../../../Infobox/types";
 import type { MapRef } from "../../../types";
 import type { Widget } from "../../../Widgets";
 import { usePluginContext } from "../../context";
-import { defaultIsMarshalable } from "../../PluginFrame/useZushiPlugin";
 import type { ReearthPluginContext } from "../../pluginAPI/zushiAdapter";
+import { defaultIsMarshalable } from "../../PluginFrame/useZushiPlugin";
 import type { PluginModalInfo } from "../ModalContainer";
 import type { PluginPopupInfo } from "../PopupContainer";
 
@@ -98,6 +98,8 @@ export default function ({
   const callbacksRef = useRef({
     onPluginModalShow,
     onPluginPopupShow,
+    shownPluginModalInfo,
+    shownPluginPopupInfo,
     widget,
     block
   });
@@ -106,6 +108,8 @@ export default function ({
     callbacksRef.current = {
       onPluginModalShow,
       onPluginPopupShow,
+      shownPluginModalInfo,
+      shownPluginPopupInfo,
       widget,
       block
     };
@@ -118,6 +122,28 @@ export default function ({
 
   const handlePopupClose = useCallback(() => {
     callbacksRef.current.onPluginPopupShow?.();
+  }, []);
+
+  /**
+   * Clears any modal/popup this instance owns when the plugin is disposed.
+   *
+   * WHY: shownPluginModalInfo/shownPluginPopupInfo are held one level up
+   * (Crust) and keyed by widget/block id, not by plugin lifetime. If this
+   * instance unmounts (deselect, page change, widget removal) while its
+   * modal or popup is open, nothing else clears that shared state - the
+   * ModalContainer/PopupContainer keep rendering a surface whose owning
+   * plugin no longer exists, leaving a click-blocking overlay behind.
+   */
+  const handleDispose = useCallback(() => {
+    const instanceId =
+      callbacksRef.current.widget?.id ?? callbacksRef.current.block?.id;
+    if (!instanceId) return;
+    if (callbacksRef.current.shownPluginModalInfo?.id === instanceId) {
+      callbacksRef.current.onPluginModalShow?.();
+    }
+    if (callbacksRef.current.shownPluginPopupInfo?.id === instanceId) {
+      callbacksRef.current.onPluginPopupShow?.();
+    }
   }, []);
 
   // Update modal visibility based on external state
@@ -222,7 +248,8 @@ export default function ({
 
   const handleModalShow = useCallback(
     (options?: { background?: string; clickBgToClose?: boolean }) => {
-      const instanceId = callbacksRef.current.widget?.id ?? callbacksRef.current.block?.id;
+      const instanceId =
+        callbacksRef.current.widget?.id ?? callbacksRef.current.block?.id;
       callbacksRef.current.onPluginModalShow?.({
         id: instanceId,
         background: options?.background,
@@ -232,30 +259,34 @@ export default function ({
     [] // Empty deps = stable callback identity
   );
 
-  const handlePopupShow = useCallback(
-    (options?: PluginPopupInfo) => {
-      callbacksRef.current.onPluginPopupShow?.(options);
-    },
-    []
-  );
+  const handlePopupShow = useCallback((options?: PluginPopupInfo) => {
+    callbacksRef.current.onPluginPopupShow?.(options);
+  }, []);
 
   // Plugin message sender registration ref
-  const pluginMessageSenderRef = useRef<((msg: { data: unknown; sender: string }) => void) | undefined>(undefined);
+  const pluginMessageSenderRef = useRef<
+    ((msg: { data: unknown; sender: string }) => void) | undefined
+  >(undefined);
 
   // Register/unregister callbacks using refs
   const handleRegisterPluginMessageSender = useCallback(
     (sender: (msg: { data: unknown; sender: string }) => void) => {
-      const instanceId = callbacksRef.current.widget?.id ?? callbacksRef.current.block?.id;
+      const instanceId =
+        callbacksRef.current.widget?.id ?? callbacksRef.current.block?.id;
       if (instanceId) {
         pluginMessageSenderRef.current = sender;
-        contextRef.current?.pluginInstances.addPluginMessageSender(instanceId, sender);
+        contextRef.current?.pluginInstances.addPluginMessageSender(
+          instanceId,
+          sender
+        );
       }
     },
     []
   );
 
   const handleUnregisterPluginMessageSender = useCallback(() => {
-    const instanceId = callbacksRef.current.widget?.id ?? callbacksRef.current.block?.id;
+    const instanceId =
+      callbacksRef.current.widget?.id ?? callbacksRef.current.block?.id;
     if (instanceId) {
       contextRef.current?.pluginInstances.removePluginMessageSender(instanceId);
       pluginMessageSenderRef.current = undefined;
@@ -350,6 +381,7 @@ export default function ({
     uiContainerRef,
     renderKey,
     pluginContext,
-    onError
+    onError,
+    onDispose: handleDispose
   };
 }

--- a/web/src/app/features/Visualizer/Crust/Plugins/Plugin/index.tsx
+++ b/web/src/app/features/Visualizer/Crust/Plugins/Plugin/index.tsx
@@ -104,7 +104,8 @@ export default function Plugin({
     uiContainerRef,
     renderKey,
     pluginContext,
-    onError
+    onError,
+    onDispose
   } = usePluginInstance({
     mapRef,
     pluginId,
@@ -143,6 +144,7 @@ export default function Plugin({
       isMarshalable={isMarshalable}
       pluginContext={pluginContext}
       onError={onError}
+      onDispose={onDispose}
       onClick={onClick}
     />
   ) : null;

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.test.tsx
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.test.tsx
@@ -85,7 +85,8 @@ describe("PluginFrame", () => {
         cameraEvents: { on: vi.fn(), off: vi.fn(), once: vi.fn() },
         timelineEvents: { on: vi.fn(), off: vi.fn(), once: vi.fn() },
         layersEvents: { on: vi.fn(), off: vi.fn(), once: vi.fn() },
-        sketchEvents: { on: vi.fn(), off: vi.fn(), once: vi.fn() }
+        sketchEvents: { on: vi.fn(), off: vi.fn(), once: vi.fn() },
+        spatialIdEvents: { on: vi.fn(), off: vi.fn(), once: vi.fn() }
       } as ReearthPluginContext["context"]
     };
   });

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.test.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.test.ts
@@ -123,7 +123,8 @@ describe("useZushiPlugin", () => {
         cameraEvents: { on: vi.fn(), off: vi.fn(), once: vi.fn() },
         timelineEvents: { on: vi.fn(), off: vi.fn(), once: vi.fn() },
         layersEvents: { on: vi.fn(), off: vi.fn(), once: vi.fn() },
-        sketchEvents: { on: vi.fn(), off: vi.fn(), once: vi.fn() }
+        sketchEvents: { on: vi.fn(), off: vi.fn(), once: vi.fn() },
+        spatialIdEvents: { on: vi.fn(), off: vi.fn(), once: vi.fn() }
       } as ReearthPluginContext["context"]
     };
   });
@@ -338,6 +339,54 @@ describe("useZushiPlugin", () => {
 
       expect(mockPluginContext.context.viewerEvents.off).toHaveBeenCalledWith(
         "click",
+        callback
+      );
+    });
+
+    test("removes camera event listeners registered through the exposed API on unmount", async () => {
+      let latest: UseZushiPluginReturn | undefined;
+      const { unmount } = render(
+        createElement(ZushiHarness, {
+          pluginContext: mockPluginContext,
+          onReady: (value) => {
+            latest = value;
+          }
+        })
+      );
+
+      await waitFor(() => expect(latest?.loaded).toBe(true));
+
+      const { Plugin: PluginMock } = await import("@reearth/zushi");
+      const config = (PluginMock as unknown as { mock: { calls: any[][] } })
+        .mock.calls[0][0];
+      const mockSurface = () => ({
+        show: vi.fn(),
+        update: vi.fn(),
+        setVisible: vi.fn(),
+        postMessage: vi.fn()
+      });
+      const api = config.exposed({
+        startEventLoop: vi.fn(),
+        surfaces: {
+          ui: mockSurface(),
+          modal: mockSurface(),
+          popup: mockSurface()
+        }
+      });
+
+      const callback = vi.fn();
+      api.reearth.camera.on("move", callback);
+
+      expect(mockPluginContext.context.cameraEvents.on).toHaveBeenCalledWith(
+        "move",
+        callback
+      );
+      expect(mockPluginContext.context.cameraEvents.off).not.toHaveBeenCalled();
+
+      unmount();
+
+      expect(mockPluginContext.context.cameraEvents.off).toHaveBeenCalledWith(
+        "move",
         callback
       );
     });

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.test.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.test.ts
@@ -4,22 +4,55 @@
  * Validates the Zushi plugin lifecycle management hook
  */
 
-import { renderHook, waitFor } from "@testing-library/react";
+import { render, renderHook, waitFor } from "@testing-library/react";
+import { createElement } from "react";
 import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
 
 import type { ReearthPluginContext } from "../pluginAPI/zushiAdapter";
 
-import useZushiPlugin, { defaultIsMarshalable, type Ref } from "./useZushiPlugin";
+import useZushiPlugin, {
+  defaultIsMarshalable,
+  type Ref,
+  type UseZushiPluginReturn
+} from "./useZushiPlugin";
+
+// useZushiPlugin's init effect only proceeds once surfaceRefs.uiContainer is
+// attached to a real DOM node (modal/popup containers are always non-null
+// detached elements), so exercising the real init/dispose flow - as opposed
+// to tests that only check the hook's synchronous return shape - requires an
+// actual render, not renderHook.
+function ZushiHarness({
+  pluginContext,
+  onReady
+}: {
+  pluginContext: ReearthPluginContext;
+  onReady: (value: UseZushiPluginReturn) => void;
+}) {
+  const value = useZushiPlugin({
+    sourceCode: "console.log('test');",
+    pluginContext,
+    skip: false
+  });
+  onReady(value);
+  return createElement("div", { ref: value.surfaceRefs.uiContainer });
+}
 
 // Mock Zushi Plugin
+let startImpl: () => Promise<void> = () => Promise.resolve();
+
 vi.mock("@reearth/zushi", () => {
   const mockPlugin = {
-    start: vi.fn().mockResolvedValue(undefined),
+    start: vi.fn(() => startImpl()),
     dispose: vi.fn()
   };
 
   return {
-    Plugin: vi.fn(() => mockPlugin),
+    // Must be a real function (not an arrow) so `new Plugin(...)` - as used
+    // by useZushiPlugin - can construct it; returning an object from a
+    // constructor call makes `new` yield that object instead of `this`.
+    Plugin: vi.fn(function () {
+      return mockPlugin;
+    }),
     quickjs: vi.fn(() => ({ isMarshalable: true }))
   };
 });
@@ -28,6 +61,7 @@ describe("useZushiPlugin", () => {
   let mockPluginContext: ReearthPluginContext;
 
   beforeEach(() => {
+    startImpl = () => Promise.resolve();
     mockPluginContext = {
       plugin: {
         id: "test-plugin",
@@ -36,7 +70,34 @@ describe("useZushiPlugin", () => {
         property: {}
       },
       context: {
-        reearth: {} as ReearthPluginContext["context"]["reearth"],
+        reearth: {
+          viewer: {
+            tools: {},
+            interactionMode: {},
+            property: {},
+            flyTo: vi.fn(),
+            lookAt: vi.fn()
+          },
+          camera: { position: {}, viewport: {}, flyTo: vi.fn() },
+          layers: {
+            layers: [],
+            add: vi.fn(),
+            delete: vi.fn(),
+            show: vi.fn(),
+            hide: vi.fn()
+          },
+          timeline: {
+            current: "",
+            start: "",
+            stop: "",
+            play: vi.fn(),
+            pause: vi.fn()
+          },
+          sketch: { create: vi.fn(), update: vi.fn(), delete: vi.fn() },
+          spatialId: {},
+          extension: { on: vi.fn(), off: vi.fn(), once: vi.fn() },
+          data: {}
+        } as unknown as ReearthPluginContext["context"]["reearth"],
         pluginInstances: {
           meta: { current: [] },
           postMessage: vi.fn(),
@@ -231,6 +292,80 @@ describe("useZushiPlugin", () => {
       expect(onDispose).toBeDefined();
 
       unmount();
+    });
+
+    test("removes viewer event listeners registered through the exposed API on unmount", async () => {
+      let latest: UseZushiPluginReturn | undefined;
+      const { unmount } = render(
+        createElement(ZushiHarness, {
+          pluginContext: mockPluginContext,
+          onReady: (value) => {
+            latest = value;
+          }
+        })
+      );
+
+      await waitFor(() => expect(latest?.loaded).toBe(true));
+
+      const { Plugin: PluginMock } = await import("@reearth/zushi");
+      const config = (PluginMock as unknown as { mock: { calls: any[][] } })
+        .mock.calls[0][0];
+      const mockSurface = () => ({
+        show: vi.fn(),
+        update: vi.fn(),
+        setVisible: vi.fn(),
+        postMessage: vi.fn()
+      });
+      const api = config.exposed({
+        startEventLoop: vi.fn(),
+        surfaces: {
+          ui: mockSurface(),
+          modal: mockSurface(),
+          popup: mockSurface()
+        }
+      });
+
+      const callback = vi.fn();
+      api.reearth.viewer.on("click", callback);
+
+      expect(mockPluginContext.context.viewerEvents.on).toHaveBeenCalledWith(
+        "click",
+        callback
+      );
+      expect(mockPluginContext.context.viewerEvents.off).not.toHaveBeenCalled();
+
+      unmount();
+
+      expect(mockPluginContext.context.viewerEvents.off).toHaveBeenCalledWith(
+        "click",
+        callback
+      );
+    });
+
+    test("disposes the plugin instead of resurrecting it when unmounted mid-start", async () => {
+      let resolveStart: () => void = () => {};
+      startImpl = () =>
+        new Promise((resolve) => {
+          resolveStart = resolve;
+        });
+
+      const { unmount } = render(
+        createElement(ZushiHarness, {
+          pluginContext: mockPluginContext,
+          onReady: () => {}
+        })
+      );
+
+      // Unmount while plugin.start() is still pending
+      unmount();
+
+      const { Plugin: PluginMock } = await import("@reearth/zushi");
+      const mockPlugin = (
+        PluginMock as unknown as () => { dispose: ReturnType<typeof vi.fn> }
+      )();
+
+      resolveStart();
+      await waitFor(() => expect(mockPlugin.dispose).toHaveBeenCalled());
     });
 
     test("handles message events", () => {

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.ts
@@ -419,6 +419,11 @@ export default function useZushiPlugin({
         pluginRef.current = plugin;
         setLoaded(true);
       } catch (err) {
+        // If code before this point (e.g. plugin.start()) registered any
+        // exposed-API cleanups - such as viewer event listeners - before
+        // failing, tear those down now instead of leaving them registered
+        // on the shared emitter until unmount.
+        runDisposeCallbacks();
         onError(err);
       }
     })();

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.ts
@@ -152,6 +152,20 @@ export default function useZushiPlugin({
   // Store MutationObserver for cleanup
   const iframeObserverRef = useRef<MutationObserver | undefined>(undefined);
 
+  // Cleanup callbacks registered by the exposed API (e.g. viewer event unsubscription)
+  const disposeCallbacksRef = useRef<(() => void)[]>([]);
+
+  const runDisposeCallbacks = useCallback(() => {
+    while (disposeCallbacksRef.current.length) {
+      const cleanup = disposeCallbacksRef.current.pop();
+      try {
+        cleanup?.();
+      } catch (err) {
+        console.error("Plugin cleanup: error running exposed API cleanup", err);
+      }
+    }
+  }, []);
+
   // Create modal and popup containers once - these will be manually appended
   const modalContainerElement = useMemo(() => {
     const div = document.createElement("div");
@@ -232,6 +246,11 @@ export default function useZushiPlugin({
 
     onPreInit?.();
 
+    // Guards against a mount/unmount race: if this effect's cleanup runs
+    // while `plugin.start()` is still pending, we must dispose the plugin
+    // that resolves afterward instead of resurrecting it into the refs below.
+    let disposed = false;
+
     (async () => {
       try {
         // Determine marshaling strategy
@@ -270,11 +289,28 @@ export default function useZushiPlugin({
             }
           },
           // Pass getter function to access latest context dynamically
-          exposed: createZushiExposedAPI(() => pluginContextRef.current, messageHandlers)
+          exposed: createZushiExposedAPI(
+            () => pluginContextRef.current,
+            messageHandlers,
+            (fn) => disposeCallbacksRef.current.push(fn)
+          )
         });
 
         // Start the plugin
         await plugin.start();
+
+        if (disposed) {
+          // Unmounted while start() was in flight - nothing above was assigned
+          // to pluginRef/iframeObserverRef yet, so just tear down what start()
+          // already registered (e.g. viewer event listeners) and dispose.
+          runDisposeCallbacks();
+          try {
+            plugin.dispose();
+          } catch (err) {
+            console.error("Zushi plugin dispose error", err);
+          }
+          return;
+        }
 
         /**
          * Iframe Window Registration with Load Event Handling
@@ -389,11 +425,16 @@ export default function useZushiPlugin({
 
     // Cleanup on unmount
     return () => {
+      disposed = true;
+
       // Disconnect MutationObserver
       if (iframeObserverRef.current) {
         iframeObserverRef.current.disconnect();
         iframeObserverRef.current = undefined;
       }
+
+      // Tear down anything the exposed API registered (e.g. viewer event listeners)
+      runDisposeCallbacks();
 
       // Call onDispose before cleanup
       try {
@@ -435,7 +476,8 @@ export default function useZushiPlugin({
     messageEvents,
     messageOnceEvents,
     modalContainer,
-    popupContainer
+    popupContainer,
+    runDisposeCallbacks
   ]);
 
   // Listen for window postMessage events from plugin UI

--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.test.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.test.ts
@@ -140,7 +140,11 @@ describe("zushiAdapter", () => {
         onceMessage: vi.fn()
       };
 
-      const factory = createZushiExposedAPI(() => reearthContext, messageHandlers);
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
 
       expect(typeof factory).toBe("function");
     });
@@ -153,7 +157,11 @@ describe("zushiAdapter", () => {
         onceMessage: vi.fn()
       };
 
-      const factory = createZushiExposedAPI(() => reearthContext, messageHandlers);
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
 
       const mockZushiContext = {
         surfaces: {
@@ -177,7 +185,11 @@ describe("zushiAdapter", () => {
         onceMessage: vi.fn()
       };
 
-      const factory = createZushiExposedAPI(() => reearthContext, messageHandlers);
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
 
       const uiSurface = createMockSurface();
       const mockZushiContext = {
@@ -218,7 +230,11 @@ describe("zushiAdapter", () => {
         onceMessage: vi.fn()
       };
 
-      const factory = createZushiExposedAPI(() => reearthContext, messageHandlers);
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
 
       const modalSurface = createMockSurface();
       const mockZushiContext = {
@@ -263,7 +279,11 @@ describe("zushiAdapter", () => {
         onceMessage: vi.fn()
       };
 
-      const factory = createZushiExposedAPI(() => reearthContext, messageHandlers);
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
 
       const modalSurface = createMockSurface();
       const mockZushiContext = {
@@ -306,7 +326,11 @@ describe("zushiAdapter", () => {
         onceMessage: vi.fn()
       };
 
-      const factory = createZushiExposedAPI(() => reearthContext, messageHandlers);
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
 
       const popupSurface = createMockSurface();
       const mockZushiContext = {
@@ -343,7 +367,11 @@ describe("zushiAdapter", () => {
         onceMessage: vi.fn()
       };
 
-      const factory = createZushiExposedAPI(() => reearthContext, messageHandlers);
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
 
       const mockZushiContext = {
         surfaces: {
@@ -375,7 +403,11 @@ describe("zushiAdapter", () => {
         onceMessage
       };
 
-      const factory = createZushiExposedAPI(() => reearthContext, messageHandlers);
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
 
       const mockZushiContext = {
         surfaces: {
@@ -404,7 +436,11 @@ describe("zushiAdapter", () => {
         onceMessage: vi.fn()
       };
 
-      const factory = createZushiExposedAPI(() => reearthContext, messageHandlers);
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
 
       const mockZushiContext = {
         surfaces: {
@@ -456,7 +492,11 @@ describe("zushiAdapter", () => {
         onceMessage: vi.fn()
       };
 
-      const factory = createZushiExposedAPI(() => reearthContext, messageHandlers);
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
 
       const mockZushiContext = {
         surfaces: {
@@ -514,7 +554,11 @@ describe("zushiAdapter", () => {
         onceMessage: vi.fn()
       };
 
-      const factory = createZushiExposedAPI(() => reearthContext, messageHandlers);
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
 
       const mockZushiContext = {
         surfaces: {

--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.test.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.test.ts
@@ -125,6 +125,11 @@ function createMockReearthContext(): ReearthPluginContext {
         on: vi.fn(),
         off: vi.fn(),
         once: vi.fn()
+      },
+      spatialIdEvents: {
+        on: vi.fn(),
+        off: vi.fn(),
+        once: vi.fn()
       }
     } as unknown as Context
   };

--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
@@ -64,10 +64,85 @@ import type {
 import type { Widget } from "../../Widgets";
 import type { PluginPopupInfo } from "../Plugin/PopupContainer";
 import type { Context } from "../types";
+import type { Events } from "../utils/events";
 
 import type { CommonReearth } from "./commonReearth";
 import { exposedReearth } from "./exposedReearth";
-import type { GlobalThis, Reearth, ViewerEventType } from "./types";
+import type { GlobalThis, Reearth } from "./types";
+
+/**
+ * Wraps an Events<E> emitter's on/off with per-plugin-instance tracking, so
+ * every listener registered through the returned pair gets removed via
+ * registerCleanup when the plugin is disposed.
+ *
+ * WHY: the emitters this wraps (viewerEvents, cameraEvents, timelineEvents,
+ * layersEvents, sketchEvents, spatialIdEvents, selectionModeEvents) are each
+ * created once per Visualizer instance, not per plugin. A plugin calling
+ * e.g. `reearth.camera.on(...)` registers directly on that shared,
+ * longer-lived emitter, so without this bookkeeping nothing removes the
+ * listener when the plugin instance is disposed - it keeps firing into a
+ * freed QuickJS runtime for the rest of the session.
+ *
+ * Tracks only listeners the plugin hasn't already turned off itself, so a
+ * plugin that cycles on/off frequently doesn't grow this unboundedly.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function trackedEventPair<E extends Record<string, any[]>>(
+  events: Events<E>,
+  registerCleanup: (fn: () => void) => void,
+  label: string
+): {
+  on: <T extends keyof E>(
+    type: T,
+    callback: (...args: E[T]) => void,
+    options?: { once?: boolean }
+  ) => void;
+  off: <T extends keyof E>(type: T, callback: (...args: E[T]) => void) => void;
+} {
+  const registrations: {
+    type: keyof E;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    callback: (...args: any[]) => void;
+  }[] = [];
+
+  const on = <T extends keyof E>(
+    type: T,
+    callback: (...args: E[T]) => void,
+    options?: { once?: boolean }
+  ) => {
+    registrations.push({ type, callback });
+    if (options?.once) {
+      events.once(type, callback);
+    } else {
+      events.on(type, callback);
+    }
+  };
+
+  const off = <T extends keyof E>(type: T, callback: (...args: E[T]) => void) => {
+    events.off(type, callback);
+    const index = registrations.findIndex(
+      (r) => r.type === type && r.callback === callback
+    );
+    if (index !== -1) registrations.splice(index, 1);
+  };
+
+  registerCleanup(() => {
+    while (registrations.length) {
+      const registration = registrations.pop();
+      if (!registration) continue;
+      try {
+        events.off(registration.type, registration.callback);
+      } catch (err) {
+        console.error(
+          `[Zushi Adapter] Error removing ${label} event listener on dispose:`,
+          err
+        );
+      }
+    }
+  });
+
+  return { on, off };
+}
 
 /**
  * Re:Earth plugin context passed to the adapter
@@ -545,8 +620,59 @@ function wrapClientStorage(
  */
 function wrapCommonReearth(
   commonReearth: CommonReearth,
-  startEventLoop: () => void
+  startEventLoop: () => void,
+  events: Pick<
+    Context,
+    | "cameraEvents"
+    | "timelineEvents"
+    | "layersEvents"
+    | "sketchEvents"
+    | "spatialIdEvents"
+    | "selectionModeEvents"
+  >,
+  registerCleanup: (fn: () => void) => void
 ): CommonReearth {
+  // camera/layers/sketch/spatialId/timeline/selectionMode listeners are
+  // otherwise passed straight through from `commonReearth` unmodified - see
+  // trackedEventPair() above for why that leaks a listener per plugin
+  // instance that ever calls one of these `.on(...)` methods.
+  const camera = trackedEventPair(events.cameraEvents, registerCleanup, "camera") as {
+    on: Reearth["camera"]["on"];
+    off: Reearth["camera"]["off"];
+  };
+  const timeline = trackedEventPair(
+    events.timelineEvents,
+    registerCleanup,
+    "timeline"
+  ) as {
+    on: Reearth["timeline"]["on"];
+    off: Reearth["timeline"]["off"];
+  };
+  const layers = trackedEventPair(events.layersEvents, registerCleanup, "layers") as {
+    on: Reearth["layers"]["on"];
+    off: Reearth["layers"]["off"];
+  };
+  const sketch = trackedEventPair(events.sketchEvents, registerCleanup, "sketch") as {
+    on: Reearth["sketch"]["on"];
+    off: Reearth["sketch"]["off"];
+  };
+  const spatialId = trackedEventPair(
+    events.spatialIdEvents,
+    registerCleanup,
+    "spatialId"
+  ) as {
+    on: Reearth["spatialId"]["on"];
+    off: Reearth["spatialId"]["off"];
+  };
+  const selectionMode = trackedEventPair(
+    events.selectionModeEvents,
+    registerCleanup,
+    "selectionMode"
+  ) as {
+    on: Reearth["viewer"]["interactionMode"]["selectionMode"]["on"];
+    off: Reearth["viewer"]["interactionMode"]["selectionMode"]["off"];
+  };
+
   return {
     ...commonReearth,
     viewer: {
@@ -565,7 +691,40 @@ function wrapCommonReearth(
           commonReearth.viewer.tools.getCurrentLocationAsync,
           startEventLoop
         )
+      },
+      interactionMode: {
+        ...commonReearth.viewer.interactionMode,
+        selectionMode: {
+          ...commonReearth.viewer.interactionMode.selectionMode,
+          on: selectionMode.on,
+          off: selectionMode.off
+        }
       }
+    },
+    camera: {
+      ...commonReearth.camera,
+      on: camera.on,
+      off: camera.off
+    },
+    timeline: {
+      ...commonReearth.timeline,
+      on: timeline.on,
+      off: timeline.off
+    },
+    layers: {
+      ...commonReearth.layers,
+      on: layers.on,
+      off: layers.off
+    },
+    sketch: {
+      ...commonReearth.sketch,
+      on: sketch.on,
+      off: sketch.off
+    },
+    spatialId: {
+      ...commonReearth.spatialId,
+      on: spatialId.on,
+      off: spatialId.off
     }
   };
 }
@@ -604,61 +763,16 @@ export function createZushiExposedAPI(
 
     const startEventLoop = zushiCtx.startEventLoop;
 
-    /**
-     * Viewer event listener tracking
-     *
-     * WHY: `reearthContext.context.viewerEvents` is a single emitter shared by
-     * the whole Visualizer (created once in useViewer.ts), not something scoped
-     * to this plugin instance. A plugin calling `reearth.viewer.on(...)`
-     * registers directly on that shared emitter, so without explicit bookkeeping
-     * here, nothing ever removes the listener when this plugin instance is
-     * disposed - it keeps firing (into a freed QuickJS runtime) for the rest of
-     * the session. registerCleanup() lets useZushiPlugin's unmount tear these
-     * down alongside the rest of plugin disposal.
-     */
-    const viewerEvents = reearthContext.context.viewerEvents;
-    // Tracks only listeners the plugin hasn't already turned off itself, so
-    // a plugin that cycles on/off frequently doesn't grow this unboundedly.
-    // `on`'s type/callback pair is generic per-call (keyof ViewerEventType),
-    // so this bookkeeping type-erases them - they're only ever handed back
-    // to viewerEvents.off, never invoked directly here.
-    const viewerEventRegistrations: {
-      type: keyof ViewerEventType;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      callback: (...args: any[]) => void;
-    }[] = [];
-
-    const viewerEventsOn: Reearth["viewer"]["on"] = (type, callback, options) => {
-      viewerEventRegistrations.push({ type, callback });
-      if (options?.once) {
-        viewerEvents.once(type, callback);
-      } else {
-        viewerEvents.on(type, callback);
-      }
+    // Tracked on/off for every shared, per-Visualizer emitter reachable from
+    // plugin code. See trackedEventPair() above for why this is necessary.
+    const { on: viewerEventsOn, off: viewerEventsOff } = trackedEventPair(
+      reearthContext.context.viewerEvents,
+      registerCleanup,
+      "viewer"
+    ) as {
+      on: Reearth["viewer"]["on"];
+      off: Reearth["viewer"]["off"];
     };
-
-    const viewerEventsOff: Reearth["viewer"]["off"] = (type, callback) => {
-      viewerEvents.off(type, callback);
-      const index = viewerEventRegistrations.findIndex(
-        (r) => r.type === type && r.callback === callback
-      );
-      if (index !== -1) viewerEventRegistrations.splice(index, 1);
-    };
-
-    registerCleanup(() => {
-      while (viewerEventRegistrations.length) {
-        const registration = viewerEventRegistrations.pop();
-        if (!registration) continue;
-        try {
-          viewerEvents.off(registration.type, registration.callback);
-        } catch (err) {
-          console.error(
-            "[Zushi Adapter] Error removing viewer event listener on dispose:",
-            err
-          );
-        }
-      }
-    });
 
     // Create surface adapters
     const ui = createUIAdapter(zushiCtx.surfaces.ui, onRender);
@@ -695,11 +809,15 @@ export function createZushiExposedAPI(
       startEventLoop
     );
 
-    // Wrap commonReearth async methods with event loop trigger
+    // Wrap commonReearth async methods with event loop trigger, and its
+    // camera/timeline/layers/sketch/spatialId/selectionMode listeners with
+    // dispose tracking (see trackedEventPair() above).
     // context.reearth is accessed via context getter, so it's fresh
     const wrappedCommonReearth = wrapCommonReearth(
       reearthContext.context.reearth,
-      startEventLoop
+      startEventLoop,
+      reearthContext.context,
+      registerCleanup
     );
 
     // Build and return the exposed API

--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
@@ -586,7 +586,8 @@ function wrapCommonReearth(
  */
 export function createZushiExposedAPI(
   getContext: () => ReearthPluginContext,
-  messageHandlers: MessageHandlers
+  messageHandlers: MessageHandlers,
+  registerCleanup: (fn: () => void) => void
 ) {
   return (zushiCtx: ZushiPluginContext): GlobalThis => {
     // Get initial context for callbacks that don't need freshness
@@ -602,6 +603,48 @@ export function createZushiExposedAPI(
     } = reearthContext;
 
     const startEventLoop = zushiCtx.startEventLoop;
+
+    /**
+     * Viewer event listener tracking
+     *
+     * WHY: `reearthContext.context.viewerEvents` is a single emitter shared by
+     * the whole Visualizer (created once in useViewer.ts), not something scoped
+     * to this plugin instance. A plugin calling `reearth.viewer.on(...)`
+     * registers directly on that shared emitter, so without explicit bookkeeping
+     * here, nothing ever removes the listener when this plugin instance is
+     * disposed - it keeps firing (into a freed QuickJS runtime) for the rest of
+     * the session. registerCleanup() lets useZushiPlugin's unmount tear these
+     * down alongside the rest of plugin disposal.
+     */
+    const viewerEvents = reearthContext.context.viewerEvents;
+    const viewerEventUnsubscribers: (() => void)[] = [];
+
+    const viewerEventsOn: Reearth["viewer"]["on"] = (type, callback, options) => {
+      viewerEventUnsubscribers.push(() => viewerEvents.off(type, callback));
+      if (options?.once) {
+        viewerEvents.once(type, callback);
+      } else {
+        viewerEvents.on(type, callback);
+      }
+    };
+
+    const viewerEventsOff: Reearth["viewer"]["off"] = (type, callback) => {
+      viewerEvents.off(type, callback);
+    };
+
+    registerCleanup(() => {
+      while (viewerEventUnsubscribers.length) {
+        const unsubscribe = viewerEventUnsubscribers.pop();
+        try {
+          unsubscribe?.();
+        } catch (err) {
+          console.error(
+            "[Zushi Adapter] Error removing viewer event listener on dispose:",
+            err
+          );
+        }
+      }
+    });
 
     // Create surface adapters
     const ui = createUIAdapter(zushiCtx.surfaces.ui, onRender);
@@ -650,9 +693,9 @@ export function createZushiExposedAPI(
       commonReearth: wrappedCommonReearth,
       // Access plugin dynamically to get latest property values
       plugin: () => getContext().plugin,
-      // Viewer events (accessed via context getter, already fresh)
-      viewerEventsOn: reearthContext.context.viewerEvents.on,
-      viewerEventsOff: reearthContext.context.viewerEvents.off,
+      // Viewer events (tracked above so they're removed on plugin dispose)
+      viewerEventsOn,
+      viewerEventsOff,
       // Timeline (accessed via context getter, already fresh)
       timelineManagerRef: reearthContext.context.timelineManagerRef,
       // UI surface

--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
@@ -67,7 +67,7 @@ import type { Context } from "../types";
 
 import type { CommonReearth } from "./commonReearth";
 import { exposedReearth } from "./exposedReearth";
-import type { GlobalThis, Reearth } from "./types";
+import type { GlobalThis, Reearth, ViewerEventType } from "./types";
 
 /**
  * Re:Earth plugin context passed to the adapter
@@ -617,10 +617,19 @@ export function createZushiExposedAPI(
      * down alongside the rest of plugin disposal.
      */
     const viewerEvents = reearthContext.context.viewerEvents;
-    const viewerEventUnsubscribers: (() => void)[] = [];
+    // Tracks only listeners the plugin hasn't already turned off itself, so
+    // a plugin that cycles on/off frequently doesn't grow this unboundedly.
+    // `on`'s type/callback pair is generic per-call (keyof ViewerEventType),
+    // so this bookkeeping type-erases them - they're only ever handed back
+    // to viewerEvents.off, never invoked directly here.
+    const viewerEventRegistrations: {
+      type: keyof ViewerEventType;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      callback: (...args: any[]) => void;
+    }[] = [];
 
     const viewerEventsOn: Reearth["viewer"]["on"] = (type, callback, options) => {
-      viewerEventUnsubscribers.push(() => viewerEvents.off(type, callback));
+      viewerEventRegistrations.push({ type, callback });
       if (options?.once) {
         viewerEvents.once(type, callback);
       } else {
@@ -630,13 +639,18 @@ export function createZushiExposedAPI(
 
     const viewerEventsOff: Reearth["viewer"]["off"] = (type, callback) => {
       viewerEvents.off(type, callback);
+      const index = viewerEventRegistrations.findIndex(
+        (r) => r.type === type && r.callback === callback
+      );
+      if (index !== -1) viewerEventRegistrations.splice(index, 1);
     };
 
     registerCleanup(() => {
-      while (viewerEventUnsubscribers.length) {
-        const unsubscribe = viewerEventUnsubscribers.pop();
+      while (viewerEventRegistrations.length) {
+        const registration = viewerEventRegistrations.pop();
+        if (!registration) continue;
         try {
-          unsubscribe?.();
+          viewerEvents.off(registration.type, registration.callback);
         } catch (err) {
           console.error(
             "[Zushi Adapter] Error removing viewer event listener on dispose:",

--- a/web/src/app/features/Visualizer/Crust/Plugins/storybook.tsx
+++ b/web/src/app/features/Visualizer/Crust/Plugins/storybook.tsx
@@ -276,6 +276,11 @@ export const context: Context = {
     on: act("sketchEvents.on"),
     off: act("sketchEvents.off"),
     once: act("sketchEvents.once")
+  },
+  spatialIdEvents: {
+    on: act("spatialIdEvents.on"),
+    off: act("spatialIdEvents.off"),
+    once: act("spatialIdEvents.once")
   }
 };
 

--- a/web/src/app/features/Visualizer/Crust/Plugins/types.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/types.ts
@@ -27,6 +27,7 @@ import {
   LayersEventType,
   SelectionModeEventType,
   SketchEventType,
+  SpatialIdEventType,
   TimelineEventType,
   ViewerEventType
 } from "./pluginAPI/types";
@@ -84,4 +85,5 @@ export type Context = {
   timelineEvents: Events<TimelineEventType>;
   layersEvents: Events<LayersEventType>;
   sketchEvents: Events<SketchEventType>;
+  spatialIdEvents: Events<SpatialIdEventType>;
 };


### PR DESCRIPTION
## Summary
- viewerEventsOn/Off bound directly to the app-wide shared viewer event emitter, so listeners a plugin registered were never removed when that plugin instance was disposed. They kept firing into a freed QuickJS runtime for the rest of the session, throwing on every matching event. This also restores the once option, which was silently dropped by the direct binding.
- Nothing cleared Crust's shown modal/popup state when the owning plugin instance unmounted, so a plugin's modal or popup could stay on screen, undismissible, after the plugin itself was gone.
- If a component unmounted while plugin.start() was still pending, the plugin resolved afterward and got assigned into the refs anyway, resurrecting a plugin instance nothing owned.

## Test plan
- [x] yarn type, yarn lint, yarn vitest run on the Plugins directory all pass
- [x] Manually verify in the browser: a plugin using reearth.viewer.on stops firing after its widget is deselected, and a plugin-shown modal clears when its widget is removed while open