### PR TITLE
ci(server): pin golangci-lint to v2, matching the v2 config schema

### DIFF
--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -26,7 +26,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.10.1
           args: --new-from-rev=origin/main --timeout=10m
           working-directory: server
       - name: Run go generate

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -26,7 +26,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.10.1
+          version: v2.12.2
           args: --new-from-rev=origin/main --timeout=10m
           working-directory: server
       - name: Run go generate

--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -4,7 +4,7 @@ RUN apk add --update --no-cache git ca-certificates build-base curl binutils-gol
 
 # Install development tools
 RUN go install github.com/air-verse/air@v1.61.5 && \
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 
 WORKDIR /reearth-visualizer
 

--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -4,7 +4,7 @@ RUN apk add --update --no-cache git ca-certificates build-base curl binutils-gol
 
 # Install development tools
 RUN go install github.com/air-verse/air@v1.61.5 && \
-    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
 WORKDIR /reearth-visualizer
 


### PR DESCRIPTION
## Summary

Fixes a version mismatch around golangci-lint that was surfaced while pinning GitHub Actions to SHA in a separate PR.

`server/.golangci.yml` already uses the v2 config schema (`version: "2"`, the newer `linters.exclusions.presets` structure), but `server/Dockerfile.dev` still installed golangci-lint v1.62.2 for local dev, and CI ran the linter with `version: latest` in `ci_server.yml`. This meant local dev and CI could silently drift to different versions and even different config parsing behavior.

While attempting to pin CI to match Dockerfile.dev's v1.62.2 in the actions-SHA-pinning PR, CI failed outright: `golangci-lint-action` v9 dropped support for v1 binaries entirely, so pinning to the old v1 version isn't actually viable anymore.

## What changed

- `server/Dockerfile.dev`: installs golangci-lint v2.12.2 instead of v1.62.2 (module path also updated to `github.com/golangci/golangci-lint/v2/cmd/golangci-lint`, required for v2+)
- `.github/workflows/ci_server.yml`: pins the `version:` input to `v2.12.2` instead of `latest`

Both are now pinned to the same version, so local dev and CI lint with an identical binary and config.

v2.12.2 is the latest golangci-lint release as of this PR. An earlier revision of this PR pinned to v2.10.1 (the version already installed on my machine, so it was easy to test first), then got bumped to v2.12.2 once that was verified too.

## Verified

- Installed golangci-lint v2.10.1 locally and ran it against the server module with the same arguments CI uses (`--new-from-rev=origin/main`): 0 issues. Also ran a full unscoped lint pass to confirm the v2 config parses and lints correctly end to end.
- Repeated both checks after bumping to v2.12.2: installs cleanly via the same `go install` path, 0 issues with CI's actual args, and the full unscoped run reports the same pre-existing issue count as v2.10.1 (32 issues, same categories), confirming the newer version didn't introduce new lint rules that would break the build.

## Test plan

- [x] Confirm ci_server.yml's lint job passes on this branch
- [x] Confirm building the dev Docker image installs golangci-lint successfully
