### PR TITLE
fix(ci): stop release.yml from double-prefixing version with v

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,8 @@ jobs:
     permissions:
       contents: write
     outputs:
-      version: ${{ steps.changelog.outputs.version }}
+      version: ${{ steps.version.outputs.version }}
+      sha: ${{ steps.commit.outputs.sha }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -57,15 +58,22 @@ jobs:
         with:
           name: changelog-${{ steps.changelog.outputs.version }}
           path: CHANGELOG_latest.md
-      - name: Commit & push to release
+      - id: version
+        name: Determine version
         env:
-          TAG: v${{ github.event.inputs.version == 'custom' && github.event.inputs.custom_version || steps.changelog.outputs.version }}
+          RAW_VERSION: ${{ github.event.inputs.version == 'custom' && github.event.inputs.custom_version || steps.changelog.outputs.version }}
+        run: echo "version=${RAW_VERSION#v}" >> "$GITHUB_OUTPUT"
+      - id: commit
+        name: Commit & push to release
+        env:
+          TAG: v${{ steps.version.outputs.version }}
         run: |
           rm CHANGELOG_latest.md
           git add CHANGELOG.md
           git commit -am "$TAG"
           git tag $TAG
           git push --atomic origin release $TAG
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Commit & push to main
         run: git switch main && git cherry-pick release && git push
 
@@ -108,6 +116,7 @@ jobs:
           allowUpdates: true
           artifacts: ${{ env.ARTIFACT }}
           artifactContentType: application/gzip
+          commit: ${{ needs.release.outputs.sha }}
           name: ${{ env.TAG }}
           tag: ${{ env.TAG }}
           bodyFile: CHANGELOG_latest.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,16 +53,16 @@ jobs:
           version: ${{ github.event.inputs.version == 'custom' && github.event.inputs.custom_version || github.event.inputs.version }}
           repo: ${{ github.repository }}
           latest: CHANGELOG_latest.md
-      - name: Upload latest CHANGELOG
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: changelog-${{ steps.changelog.outputs.version }}
-          path: CHANGELOG_latest.md
       - id: version
         name: Determine version
         env:
           RAW_VERSION: ${{ github.event.inputs.version == 'custom' && github.event.inputs.custom_version || steps.changelog.outputs.version }}
         run: echo "version=${RAW_VERSION#v}" >> "$GITHUB_OUTPUT"
+      - name: Upload latest CHANGELOG
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: changelog-${{ steps.version.outputs.version }}
+          path: CHANGELOG_latest.md
       - id: commit
         name: Commit & push to release
         env:


### PR DESCRIPTION
# Overview

v1.0.0-beta.16.14 ended up with two GitHub tags (correct v1.0.0-beta.16.14 and erroneous vv1.0.0-beta.16.14), plus the wrong Docker Hub tag. Root cause: the changelog action's own version output already includes a leading v (confirmed from its source), but the raw custom_version input doesn't. Downstream code assumed one or the other and mis-prefixed depending on which path fed it.

## What I've done

- Added a step that strips any leading v from whichever source fed the version, then re-adds it exactly once, only where a tag actually needs one.
- release job now exposes this normalized, always-bare version as its output, so promote-to-version and publish-release both use the same unambiguous value.
- publish-release now explicitly pins the release commit instead of defaulting to whatever main's tip happens to be, which is what put the erroneous tag on the wrong commit.

## What I haven't done

- Didn't touch the already-published v1.0.0-beta.16.14 release or its missing bare Docker Hub tag, handled manually already.

## How I tested

- actionlint clean aside from a pre-existing note unrelated to this change.
- Pulled reearth/changelog-action's actual source to confirm its output format, not just inference from logs.

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.