### PR TITLE
fix(web): plugin playground import: filter out macOS metadata and handle nested file properly [VIZ-DEV-153]

### DIFF
--- a/web/src/app/features/PluginPlayground/Plugins/usePlugins.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/usePlugins.ts
@@ -209,10 +209,13 @@ export default () => {
           if (file.name.startsWith("__MACOSX/")) return false;
 
           const parts = file.name.split("/").filter((p) => p !== "");
-          // Only allow root level files: "file.js" (1 part) or "folder/file.js" (2 parts)
+          // Allow only zip-root files ("file.js") or files within a single top-level folder ("folder/file.js")
           if (parts.length > 2) return false;
           // Exclude macOS metadata files
-          if (parts.some((part) => part.startsWith("._"))) return false;
+          if (
+            parts.some((part) => part.startsWith("._") || part === ".DS_Store")
+          )
+            return false;
 
           return true;
         });

--- a/web/src/app/features/PluginPlayground/Plugins/usePlugins.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/usePlugins.ts
@@ -204,7 +204,18 @@ export default () => {
 
       const zip = new JSZip();
       zip.loadAsync(file).then((zip) => {
-        const files = Object.values(zip.files).filter((file) => !file.dir);
+        const files = Object.values(zip.files).filter((file) => {
+          if (file.dir) return false;
+          if (file.name.startsWith("__MACOSX/")) return false;
+
+          const parts = file.name.split("/").filter((p) => p !== "");
+          // Only allow root level files: "file.js" (1 part) or "folder/file.js" (2 parts)
+          if (parts.length > 2) return false;
+          // Exclude macOS metadata files
+          if (parts.some((part) => part.startsWith("._"))) return false;
+
+          return true;
+        });
 
         if (files.length === 0) {
           setNotification({ type: "error", text: t("Zip file is empty") });
@@ -215,11 +226,15 @@ export default () => {
 
         Promise.all(filePromises)
           .then((fileContents) => {
-            const pluginFiles = fileContents.map((content, index) => ({
-              id: uuidv4(),
-              title: files[index].name.split("/")[1],
-              sourceCode: content
-            }));
+            const pluginFiles = fileContents.map((content, index) => {
+              const pathParts = files[index].name.split("/");
+              const fileName = pathParts[pathParts.length - 1];
+              return {
+                id: uuidv4(),
+                title: fileName,
+                sourceCode: content
+              };
+            });
 
             const newPlugin = {
               id: "my-plugin", // NOTE: id of the custom plugin


### PR DESCRIPTION
# Overview

Fix plugin zip import in Plugin Playground to handle edge cases:

  - Filter out macOS `__MACOSX/` folder and `._` prefixed metadata files, also .DS_Store
  - Limit import to root-level files or files within a single top-level folder
  - Extract filename from last path segment instead of assuming index [1]

  Previously, importing a zip created on macOS would include hidden metadata
  files (e.g., `._map-quiz.js`), doubling the file count. Additionally, zips
  without a containing folder would cause "Cannot read properties of undefined"
  errors when accessing `split("/")[1]` on root-level filenames.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
