### PR TITLE
chore(server): upgrade Go from 1.26.4 to 1.26.5

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         # TODO: fix error=archive named dist/reearth_0.0.0-SNAPSHOT-xxxxxxxx.tar.gz already exists. Check your archive name template

--- a/go.work
+++ b/go.work
@@ -1,3 +1,3 @@
-go 1.26.4
+go 1.26.5
 
 use ./server

--- a/server/.tool-versions
+++ b/server/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.4
+golang 1.26.5

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine AS build
+FROM golang:1.26.5-alpine AS build
 ARG TAG=release
 ARG VERSION
 

--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine
+FROM golang:1.26.5-alpine
 
 RUN apk add --update --no-cache git ca-certificates build-base curl binutils-gold
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -233,4 +233,4 @@ require (
 	moul.io/http2curl/v2 v2.3.0 // indirect
 )
 
-go 1.26.4
+go 1.26.5


### PR DESCRIPTION
## Summary

- Bumps Go from 1.26.4 to 1.26.5 across all relevant files
- Updates server/go.mod, go.work, server/Dockerfile, server/Dockerfile.dev, server/.tool-versions, and .github/workflows/build_release.yml
- This patch release includes a fix for a symlink escape issue in os.Root and a PSK leak in the crypto/tls Encrypted Client Hello outer handshake, plus several runtime and cmd/go bug fixes

## Test plan

- [x] go mod tidy runs cleanly with no changes to go.sum
- [x] go build succeeds
- [x] go test ./... passes across all packages

## Note for reviewers

When pulling this branch locally, run docker pull golang:1.26.5-alpine before rebuilding the dev container, and use docker compose build --no-cache reearth-visualizer-dev since a cached image from the old base tag won't be rebuilt automatically.