### PR TITLE
chore: split major Go dependency updates into separate Renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,19 @@
   "extends": [
     "github>reearth/renovate-config"
   ],
-  "rebaseWhen": "conflicted"
+  "rebaseWhen": "conflicted",
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Go dependencies",
+      "groupSlug": "gomod"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "{{depName}} (major)",
+      "groupSlug": "{{depNameSanitized}}-major"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- The shared renovate-config groups all gomod updates together regardless of update type. This recently bundled three breaking major bumps (echo v4 to v5, mongo-driver v1 to v2, retry-go v4 to v5) into a single PR alongside a dozen unrelated minor and patch bumps, making it hard to review and test safely
- This adds a repo-local packageRules override in .github/renovate.json that keeps minor and patch gomod updates grouped as before, but gives each major update its own PR so breaking changes get isolated review and testing
- This only affects reearth-visualizer, the shared reearth/renovate-config repo used by other projects is untouched

## Test plan

- [x] Validated the JSON is well formed