### PR TITLE
fix(web): plugin extension infoboxBlock and storyBlock cannot get block property

### DIFF
--- a/web/src/app/features/Published/convert-new-property.ts
+++ b/web/src/app/features/Published/convert-new-property.ts
@@ -112,6 +112,7 @@ function convertInfobox(
       // name: blockNames?.[b.extensionId] ?? "Infobox Block",
       pluginId: b.pluginId,
       extensionId: b.extensionId,
+      extensionType: "infoboxBlock" as const,
       property: processNewProperty(b.property)
     }))
   };

--- a/web/src/app/features/Published/convert-new-property.ts
+++ b/web/src/app/features/Published/convert-new-property.ts
@@ -9,6 +9,8 @@ import {
 import type { LayerStyle } from "@reearth/services/api/layerStyle";
 import { mapValues } from "lodash-es";
 
+import { processProperty as processPropertyForPlugin } from "./convert";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const processNewProperty = (p: any): any => {
   // Property processing requires dynamic typing
@@ -113,7 +115,7 @@ function convertInfobox(
       pluginId: b.pluginId,
       extensionId: b.extensionId,
       extensionType: "infoboxBlock" as const,
-      property: processNewProperty(b.property)
+      property: processPropertyForPlugin(b.property)
     }))
   };
 }

--- a/web/src/app/features/Published/hooks.ts
+++ b/web/src/app/features/Published/hooks.ts
@@ -239,6 +239,7 @@ export default (alias?: string) => {
                   id: b.id,
                   pluginId: b.pluginId,
                   extensionId: b.extensionId,
+                  extensionType: "storyBlock" as const,
                   property: processNewProperty(b.property)
                 };
               })

--- a/web/src/app/features/Published/hooks.ts
+++ b/web/src/app/features/Published/hooks.ts
@@ -19,8 +19,8 @@ import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 
 import { WidgetThemeOptions } from "../Visualizer/Crust/theme";
 
-import { processProperty } from "./convert";
-import { processLayers, processNewProperty } from "./convert-new-property";
+import { processProperty, processProperty as processPropertyForPlugin } from "./convert";
+import { processLayers } from "./convert-new-property";
 import { convertNLSLayers } from "./convert-nls-layers";
 import { useGA } from "./googleAnalytics/useGA";
 import type {
@@ -240,7 +240,7 @@ export default (alias?: string) => {
                   pluginId: b.pluginId,
                   extensionId: b.extensionId,
                   extensionType: "storyBlock" as const,
-                  property: processNewProperty(b.property)
+                  property: processPropertyForPlugin(b.property)
                 };
               })
             };


### PR DESCRIPTION
# Overview

## Cause

  Published pages were missing the extensionType field when creating story blocks and infobox blocks. The plugin API (in exposedReearth.ts) checks for this field before exposing the block object:

```
  if (p?.extensionType === "infoboxBlock" || p?.extensionType === "storyBlock") {
    return {
      get block() {
        return { ...safeCall(getBlock), layer: safeCall(getLayer) };
      }
    };
  }
  return {}; // ← Block NOT exposed if extensionType is missing
```

  Without extensionType, the condition failed, so reearth.extension.block was never exposed to plugins, making reearth.extension.block.property undefined.

 At the same time, the property was using wrapped format (which is used for display editor panel in Editor) for the plugin API call incorrectly, fixed this as well. 

  ## Solution

  Added the extensionType field to blocks in published pages:
  - Story blocks: extensionType: "storyBlock" as const
  - Infobox blocks: extensionType: "infoboxBlock" as const

  This matches the pattern already used in Editor mode.
  
  Also using processProperty() (raw format) instead of processNewProperty() (wrapped format) 

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
