### PR TITLE
fix(web): preserve dynamic getters in plugin API wrapper

### DIFF
--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
@@ -64,6 +64,7 @@ import type {
 import type { Widget } from "../../Widgets";
 import type { PluginPopupInfo } from "../Plugin/PopupContainer";
 import type { Context } from "../types";
+import { copyWithOverrides } from "../utils/copyWithOverrides";
 import type { Events } from "../utils/events";
 
 import type { CommonReearth } from "./commonReearth";
@@ -118,7 +119,10 @@ function trackedEventPair<E extends Record<string, any[]>>(
     }
   };
 
-  const off = <T extends keyof E>(type: T, callback: (...args: E[T]) => void) => {
+  const off = <T extends keyof E>(
+    type: T,
+    callback: (...args: E[T]) => void
+  ) => {
     events.off(type, callback);
     const index = registrations.findIndex(
       (r) => r.type === type && r.callback === callback
@@ -242,7 +246,10 @@ function createCloseEventManager(surfaceName: string): CloseEventManager {
         try {
           handler();
         } catch (err) {
-          console.error(`[Zushi Adapter] Error in ${surfaceName} close handler:`, err);
+          console.error(
+            `[Zushi Adapter] Error in ${surfaceName} close handler:`,
+            err
+          );
         }
       });
       // Execute once handlers and clear them
@@ -250,7 +257,10 @@ function createCloseEventManager(surfaceName: string): CloseEventManager {
         try {
           handler();
         } catch (err) {
-          console.error(`[Zushi Adapter] Error in ${surfaceName} close once handler:`, err);
+          console.error(
+            `[Zushi Adapter] Error in ${surfaceName} close once handler:`,
+            err
+          );
         }
       });
       onceHandlers.clear();
@@ -328,7 +338,10 @@ function createUIAdapter(
 function createModalAdapter(
   surface: SurfaceAPI,
   onRender?: (type: string) => void,
-  onModalShow?: (options?: { background?: string; clickBgToClose?: boolean }) => void,
+  onModalShow?: (options?: {
+    background?: string;
+    clickBgToClose?: boolean;
+  }) => void,
   onModalClose?: () => void
 ): {
   show: Reearth["modal"]["show"];
@@ -396,7 +409,9 @@ function createPopupAdapter(
   onPopupClose?: () => void,
   // Getters return getter functions to access latest widget/block
   getWidget?: () => (() => Widget | undefined) | undefined,
-  getBlock?: () => (() => Reearth["extension"]["block"] | undefined) | undefined,
+  getBlock?: () =>
+    | (() => Reearth["extension"]["block"] | undefined)
+    | undefined,
   getUIContainerRef?: () => { current: HTMLElement | null } | undefined
 ): {
   show: Reearth["popup"]["show"];
@@ -491,7 +506,10 @@ function createExtensionMessageHandler(
         try {
           handler(msg);
         } catch (err) {
-          console.error("[Zushi Adapter] Error in extensionMessage handler:", err);
+          console.error(
+            "[Zushi Adapter] Error in extensionMessage handler:",
+            err
+          );
         }
       });
       // Emit to once handlers and clear them
@@ -499,7 +517,10 @@ function createExtensionMessageHandler(
         try {
           handler(msg);
         } catch (err) {
-          console.error("[Zushi Adapter] Error in extensionMessage once handler:", err);
+          console.error(
+            "[Zushi Adapter] Error in extensionMessage once handler:",
+            err
+          );
         }
       });
       extensionMessageOnceHandlers.clear();
@@ -517,7 +538,11 @@ function createExtensionMessageHandler(
     postMessage: (id: string, msg: unknown, sender: string) => {
       context.pluginInstances.postMessage(id, msg, sender);
     },
-    on: (type: string, callback: (...args: any[]) => void, options?: { once?: boolean }) => {
+    on: (
+      type: string,
+      callback: (...args: any[]) => void,
+      options?: { once?: boolean }
+    ) => {
       if (type === "message") {
         if (options?.once) {
           messageHandlers.onceMessage(callback as (msg: unknown) => void);
@@ -589,11 +614,26 @@ function wrapClientStorage(
 ): Context["clientStorage"] {
   return {
     ...clientStorage,
-    getAsync: wrapAsync(clientStorage.getAsync.bind(clientStorage), startEventLoop),
-    setAsync: wrapAsync(clientStorage.setAsync.bind(clientStorage), startEventLoop),
-    deleteAsync: wrapAsync(clientStorage.deleteAsync.bind(clientStorage), startEventLoop),
-    keysAsync: wrapAsync(clientStorage.keysAsync.bind(clientStorage), startEventLoop),
-    dropStore: wrapAsync(clientStorage.dropStore.bind(clientStorage), startEventLoop)
+    getAsync: wrapAsync(
+      clientStorage.getAsync.bind(clientStorage),
+      startEventLoop
+    ),
+    setAsync: wrapAsync(
+      clientStorage.setAsync.bind(clientStorage),
+      startEventLoop
+    ),
+    deleteAsync: wrapAsync(
+      clientStorage.deleteAsync.bind(clientStorage),
+      startEventLoop
+    ),
+    keysAsync: wrapAsync(
+      clientStorage.keysAsync.bind(clientStorage),
+      startEventLoop
+    ),
+    dropStore: wrapAsync(
+      clientStorage.dropStore.bind(clientStorage),
+      startEventLoop
+    )
   };
 }
 
@@ -618,6 +658,7 @@ function wrapClientStorage(
  * SOLUTION: Use wrapAsync() utility to wrap each async method, ensuring the
  * plugin continues execution regardless of success or failure.
  */
+
 function wrapCommonReearth(
   commonReearth: CommonReearth,
   startEventLoop: () => void,
@@ -636,7 +677,11 @@ function wrapCommonReearth(
   // otherwise passed straight through from `commonReearth` unmodified - see
   // trackedEventPair() above for why that leaks a listener per plugin
   // instance that ever calls one of these `.on(...)` methods.
-  const camera = trackedEventPair(events.cameraEvents, registerCleanup, "camera") as {
+  const camera = trackedEventPair(
+    events.cameraEvents,
+    registerCleanup,
+    "camera"
+  ) as {
     on: Reearth["camera"]["on"];
     off: Reearth["camera"]["off"];
   };
@@ -648,11 +693,19 @@ function wrapCommonReearth(
     on: Reearth["timeline"]["on"];
     off: Reearth["timeline"]["off"];
   };
-  const layers = trackedEventPair(events.layersEvents, registerCleanup, "layers") as {
+  const layers = trackedEventPair(
+    events.layersEvents,
+    registerCleanup,
+    "layers"
+  ) as {
     on: Reearth["layers"]["on"];
     off: Reearth["layers"]["off"];
   };
-  const sketch = trackedEventPair(events.sketchEvents, registerCleanup, "sketch") as {
+  const sketch = trackedEventPair(
+    events.sketchEvents,
+    registerCleanup,
+    "sketch"
+  ) as {
     on: Reearth["sketch"]["on"];
     off: Reearth["sketch"]["off"];
   };
@@ -701,31 +754,26 @@ function wrapCommonReearth(
         }
       }
     },
-    camera: {
-      ...commonReearth.camera,
+    camera: copyWithOverrides(commonReearth.camera, {
       on: camera.on,
       off: camera.off
-    },
-    timeline: {
-      ...commonReearth.timeline,
+    }),
+    timeline: copyWithOverrides(commonReearth.timeline, {
       on: timeline.on,
       off: timeline.off
-    },
-    layers: {
-      ...commonReearth.layers,
+    }),
+    layers: copyWithOverrides(commonReearth.layers, {
       on: layers.on,
       off: layers.off
-    },
-    sketch: {
-      ...commonReearth.sketch,
+    }),
+    sketch: copyWithOverrides(commonReearth.sketch, {
       on: sketch.on,
       off: sketch.off
-    },
-    spatialId: {
-      ...commonReearth.spatialId,
+    }),
+    spatialId: copyWithOverrides(commonReearth.spatialId, {
       on: spatialId.on,
       off: spatialId.off
-    }
+    })
   };
 }
 

--- a/web/src/app/features/Visualizer/Crust/Plugins/utils/copyWithOverrides.test.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/utils/copyWithOverrides.test.ts
@@ -160,4 +160,52 @@ describe("copyWithOverrides", () => {
     data.push(4);
     expect(fixedResult.items).toEqual([1, 2, 3, 4]); // reflects latest
   });
+
+  test("copies symbol-keyed properties", () => {
+    const sym = Symbol("test");
+    const source = { [sym]: 42 };
+    const result = copyWithOverrides(source, {});
+
+    expect((result as Record<PropertyKey, unknown>)[sym]).toBe(42);
+  });
+
+  test("overrides symbol-keyed properties", () => {
+    const sym = Symbol("test");
+    const source = { [sym]: 42 };
+    const result = copyWithOverrides(source, { [sym]: 99 });
+
+    expect((result as Record<PropertyKey, unknown>)[sym]).toBe(99);
+  });
+
+  test("preserves symbol-keyed getters", () => {
+    let counter = 0;
+    const sym = Symbol("dynamic");
+    const source = {
+      get [sym]() {
+        return ++counter;
+      }
+    };
+    const result = copyWithOverrides(source, {});
+
+    expect((result as Record<PropertyKey, unknown>)[sym]).toBe(1);
+    expect((result as Record<PropertyKey, unknown>)[sym]).toBe(2);
+  });
+
+  test("mixes string-keyed and symbol-keyed properties", () => {
+    let counter = 0;
+    const sym = Symbol("sym");
+    const source = {
+      get value() {
+        return ++counter;
+      },
+      [sym]: "symbol-value",
+      plain: "string-value"
+    };
+    const result = copyWithOverrides(source, { plain: "overridden" });
+
+    expect(result.value).toBe(1);
+    expect(result.value).toBe(2);
+    expect(result.plain).toBe("overridden");
+    expect((result as Record<PropertyKey, unknown>)[sym]).toBe("symbol-value");
+  });
 });

--- a/web/src/app/features/Visualizer/Crust/Plugins/utils/copyWithOverrides.test.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/utils/copyWithOverrides.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { copyWithOverrides } from "./copyWithOverrides";
+
+describe("copyWithOverrides", () => {
+  test("copies plain data properties", () => {
+    const source = { a: 1, b: "hello", c: true };
+    const result = copyWithOverrides(source, {});
+
+    expect(result).toEqual(source);
+    expect(result).not.toBe(source);
+    expect(result.a).toBe(1);
+    expect(result.b).toBe("hello");
+    expect(result.c).toBe(true);
+  });
+
+  test("overrides specified keys", () => {
+    const source = { a: 1, b: 2, c: 3 };
+    const result = copyWithOverrides(source, { b: 99 });
+
+    expect(result.a).toBe(1);
+    expect(result.b).toBe(99);
+    expect(result.c).toBe(3);
+  });
+
+  test("preserves getters that return dynamic values", () => {
+    let counter = 0;
+    const source = {
+      get value() {
+        return ++counter;
+      }
+    };
+    const result = copyWithOverrides(source, {});
+
+    expect(result.value).toBe(1);
+    expect(result.value).toBe(2);
+    expect(result.value).toBe(3);
+  });
+
+  test("preserves getters that return the latest reference", () => {
+    let data = [1, 2, 3];
+    const source = {
+      get items() {
+        return [...data];
+      }
+    };
+    const result = copyWithOverrides(source, {});
+
+    expect(result.items).toEqual([1, 2, 3]);
+
+    data.push(4);
+    expect(result.items).toEqual([1, 2, 3, 4]);
+
+    data = [];
+    expect(result.items).toEqual([]);
+  });
+
+  test("getters on result are own property descriptors, not prototype-based", () => {
+    const source = { get x() { return 42; } };
+    const result = copyWithOverrides(source, {});
+
+    const ownDesc = Object.getOwnPropertyDescriptor(result, "x");
+    expect(ownDesc).toBeDefined();
+    expect(ownDesc?.get).toBeDefined();
+    expect(ownDesc?.value).toBeUndefined();
+  });
+
+  test("overridden keys become plain data properties, not getters", () => {
+    let counter = 0;
+    const source = {
+      get tracked() {
+        return ++counter;
+      }
+    };
+    const trackedFn = vi.fn(() => "overridden");
+    const result = copyWithOverrides(source, { tracked: trackedFn });
+
+    const ownDesc = Object.getOwnPropertyDescriptor(result, "tracked");
+    expect(ownDesc?.get).toBeUndefined();
+    expect(ownDesc?.value).toBe(trackedFn);
+
+    expect(result.tracked).toBe(trackedFn);
+  });
+
+  test("non-overridden getter and overridden data property coexist", () => {
+    let counter = 0;
+    const source = {
+      get dynamic() {
+        return ++counter;
+      },
+      static: "unchanged"
+    };
+    const result = copyWithOverrides(source, { static: "changed" });
+
+    expect(result.dynamic).toBe(1);
+    expect(result.dynamic).toBe(2);
+    expect(result.static).toBe("changed");
+  });
+
+  test("works with method properties", () => {
+    const fn = () => "hello";
+    const source = { greet: fn };
+    const result = copyWithOverrides(source, {});
+
+    expect(result.greet).toBe(fn);
+    expect(result.greet()).toBe("hello");
+  });
+
+  test("works with empty source", () => {
+    const result = copyWithOverrides({}, {});
+    expect(Object.keys(result)).toEqual([]);
+  });
+
+  test("key ordering: overrides are own properties, existing keys are preserved", () => {
+    const source = { a: 1, b: 2, c: 3 };
+    const result = copyWithOverrides(source, { b: 99, d: 4 });
+
+    expect(Object.keys(result).sort()).toEqual(["a", "b", "c", "d"]);
+    expect((result as Record<string, unknown>).d).toBe(4);
+  });
+
+  test("demonstrates the spread bug: spread evaluates getters once", () => {
+    // This test validates the bug that copyWithOverrides fixes
+    let counter = 0;
+    const source = {
+      get value() {
+        return ++counter;
+      }
+    };
+
+    // With spread: getter evaluated once
+    const spreadResult = { ...source };
+    expect(spreadResult.value).toBe(1);
+    expect(spreadResult.value).toBe(1); // stuck at 1 — getter already evaluated
+
+    // With copyWithOverrides: getter preserved
+    counter = 0;
+    const fixedResult = copyWithOverrides(source, {});
+    expect(fixedResult.value).toBe(1);
+    expect(fixedResult.value).toBe(2);
+    expect(fixedResult.value).toBe(3);
+  });
+
+  test("demonstrates array snapshot with spread vs dynamic with copyWithOverrides", () => {
+    let data: number[] = [1, 2, 3];
+    const source = {
+      get items() {
+        return [...data];
+      }
+    };
+
+    const spreadResult = { ...source };
+    expect(spreadResult.items).toEqual([1, 2, 3]);
+    data.push(4);
+    expect(spreadResult.items).toEqual([1, 2, 3]); // stale snapshot
+
+    data = [1, 2, 3];
+    const fixedResult = copyWithOverrides(source, {});
+    expect(fixedResult.items).toEqual([1, 2, 3]);
+    data.push(4);
+    expect(fixedResult.items).toEqual([1, 2, 3, 4]); // reflects latest
+  });
+});

--- a/web/src/app/features/Visualizer/Crust/Plugins/utils/copyWithOverrides.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/utils/copyWithOverrides.ts
@@ -1,0 +1,24 @@
+// Copies all property descriptors (including getters) from source as own
+// properties on a new object, overriding only the specified keys with plain
+// values. This preserves lazy evaluation of source getters (e.g. layers.layers,
+// camera.position) which would otherwise be evaluated once and captured as
+// static snapshots if using object spread ({ ...source }).
+export function copyWithOverrides<T extends object>(
+  source: T,
+  overrides: Partial<Record<string, unknown>>
+): T {
+  const descriptors: Record<string, PropertyDescriptor> = {};
+  const sourceDescs = Object.getOwnPropertyDescriptors(source);
+  for (const key of Object.keys(sourceDescs)) {
+    descriptors[key] = sourceDescs[key];
+  }
+  for (const key of Object.keys(overrides)) {
+    descriptors[key] = {
+      value: (overrides as Record<string, unknown>)[key],
+      writable: true,
+      enumerable: true,
+      configurable: true
+    };
+  }
+  return Object.defineProperties({}, descriptors as PropertyDescriptorMap) as T;
+}

--- a/web/src/app/features/Visualizer/Crust/Plugins/utils/copyWithOverrides.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/utils/copyWithOverrides.ts
@@ -5,16 +5,16 @@
 // static snapshots if using object spread ({ ...source }).
 export function copyWithOverrides<T extends object>(
   source: T,
-  overrides: Partial<Record<string, unknown>>
+  overrides: Partial<Record<PropertyKey, unknown>>
 ): T {
-  const descriptors: Record<string, PropertyDescriptor> = {};
+  const descriptors: Record<PropertyKey, PropertyDescriptor> = {};
   const sourceDescs = Object.getOwnPropertyDescriptors(source);
-  for (const key of Object.keys(sourceDescs)) {
-    descriptors[key] = sourceDescs[key];
+  for (const key of Reflect.ownKeys(sourceDescs)) {
+    descriptors[key] = sourceDescs[key as string];
   }
-  for (const key of Object.keys(overrides)) {
+  for (const key of Reflect.ownKeys(overrides)) {
     descriptors[key] = {
-      value: (overrides as Record<string, unknown>)[key],
+      value: (overrides as Record<PropertyKey, unknown>)[key],
       writable: true,
       enumerable: true,
       configurable: true


### PR DESCRIPTION
# Overview

## Problem

When a plugin accesses `reearth.layers.layers` (or `camera.position`, `timeline.currentTime`, etc.), it receives a stale static snapshot captured at plugin initialization time instead of the current value. The same API works correctly when accessed from the browser console via `window.reearth`.

## Root Cause

In `wrapCommonReearth` (`zushiAdapter.ts`), object spread (`{ ...source }`) was used to wrap `camera`, `timeline`, `layers`, `sketch`, and `spatialId` with tracked `on`/`off` event handlers. The spread operator evaluates all JavaScript getters at the time of spreading, capturing their return values as static data properties. Since `wrapCommonReearth` runs at plugin init (when layers may not be loaded yet), `reearth.layers.layers` returns an empty array forever.

`window.reearth` bypasses `wrapCommonReearth`, so its getters remain intact and work correctly — explaining why the bug only manifests in real plugins.

## Fix

Introduced a `copyWithOverrides` utility that uses `Object.getOwnPropertyDescriptors` + `Object.defineProperties` to copy all property descriptors (including getters) as own properties on a new object. This preserves lazy getter evaluation — only the specified `on` and `off` keys are overridden. Applied to `camera`, `timeline`, `layers`, `sketch`, and `spatialId`.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
