### PR TITLE
fix(web): provide both wrapped and raw block property

### DIFF
--- a/web/src/app/features/Published/convert-new-property.ts
+++ b/web/src/app/features/Published/convert-new-property.ts
@@ -115,7 +115,8 @@ function convertInfobox(
       pluginId: b.pluginId,
       extensionId: b.extensionId,
       extensionType: "infoboxBlock" as const,
-      property: processPropertyForPlugin(b.property)
+      property: processNewProperty(b.property),
+      propertyForPluginAPI: processPropertyForPlugin(b.property)
     }))
   };
 }

--- a/web/src/app/features/Published/hooks.ts
+++ b/web/src/app/features/Published/hooks.ts
@@ -20,7 +20,7 @@ import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import { WidgetThemeOptions } from "../Visualizer/Crust/theme";
 
 import { processProperty, processProperty as processPropertyForPlugin } from "./convert";
-import { processLayers } from "./convert-new-property";
+import { processLayers, processNewProperty } from "./convert-new-property";
 import { convertNLSLayers } from "./convert-nls-layers";
 import { useGA } from "./googleAnalytics/useGA";
 import type {
@@ -240,7 +240,8 @@ export default (alias?: string) => {
                   pluginId: b.pluginId,
                   extensionId: b.extensionId,
                   extensionType: "storyBlock" as const,
-                  property: processPropertyForPlugin(b.property)
+                  property: processNewProperty(b.property),
+                  propertyForPluginAPI: processPropertyForPlugin(b.property)
                 };
               })
             };


### PR DESCRIPTION
# Overview

Problem: Commit 84f722b50 switched both storyBlock and infoboxBlock in published projects to use raw processProperty for the property field. This fixed the plugin API (which needs raw values) but broke UI rendering (which needs the { value } wrapped format from processNewProperty).
Fix: Set both fields on blocks to match the Editor's pattern:
- property = processNewProperty(b.property) — wrapped format for UI rendering (block.property.default.FIELD_ID.value)
- propertyForPluginAPI = processPropertyForPlugin(b.property) — raw format for plugin API

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
