### PR TITLE
fix(web): preserve viewer getters in plugin API wrapper

### DIFF
--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
@@ -728,10 +728,8 @@ function wrapCommonReearth(
 
   return {
     ...commonReearth,
-    viewer: {
-      ...commonReearth.viewer,
-      tools: {
-        ...commonReearth.viewer.tools,
+    viewer: copyWithOverrides(commonReearth.viewer, {
+      tools: copyWithOverrides(commonReearth.viewer.tools, {
         getTerrainHeightAsync: wrapAsync(
           commonReearth.viewer.tools.getTerrainHeightAsync,
           startEventLoop
@@ -744,16 +742,20 @@ function wrapCommonReearth(
           commonReearth.viewer.tools.getCurrentLocationAsync,
           startEventLoop
         )
-      },
-      interactionMode: {
-        ...commonReearth.viewer.interactionMode,
-        selectionMode: {
-          ...commonReearth.viewer.interactionMode.selectionMode,
-          on: selectionMode.on,
-          off: selectionMode.off
+      }),
+      interactionMode: copyWithOverrides(
+        commonReearth.viewer.interactionMode,
+        {
+          selectionMode: copyWithOverrides(
+            commonReearth.viewer.interactionMode.selectionMode,
+            {
+              on: selectionMode.on,
+              off: selectionMode.off
+            }
+          )
         }
-      }
-    },
+      )
+    }),
     camera: copyWithOverrides(commonReearth.camera, {
       on: camera.on,
       off: camera.off

--- a/web/src/app/features/Visualizer/Crust/Plugins/utils/copyWithOverrides.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/utils/copyWithOverrides.ts
@@ -4,11 +4,11 @@
 // camera.position) which would otherwise be evaluated once and captured as
 // static snapshots if using object spread ({ ...source }).
 export function copyWithOverrides<T extends object>(
-  source: T,
+  source: T | undefined | null,
   overrides: Partial<Record<PropertyKey, unknown>>
 ): T {
   const descriptors: Record<PropertyKey, PropertyDescriptor> = {};
-  const sourceDescs = Object.getOwnPropertyDescriptors(source);
+  const sourceDescs = Object.getOwnPropertyDescriptors(source ?? {});
   for (const key of Reflect.ownKeys(sourceDescs)) {
     descriptors[key] = sourceDescs[key as string];
   }


### PR DESCRIPTION
# Overview

## What I've done

reearth.viewer.property (tiles, terrain, viewport, interactionMode) was frozen at plugin-mount time instead of reflecting live state.

Root cause: wrapCommonReearth in zushiAdapter.ts built the exposed viewer object using a plain object spread. Spreading an object with getters evaluates each getter once and bakes in the resulting value as a static field, so any later change made through overrideProperty() was invisible to the plugin.

This caused a real bug on a published site: selecting a different basemap tile worked, but toggling terrain afterward silently reverted the basemap back to the default, because the terrain-toggle handler read a stale snapshot of the tiles array and resubmitted it.

Fix: use copyWithOverrides() for viewer (and its nested tools and interactionMode), the same utility already used for camera, timeline, layers, sketch, and spatialId to solve this exact problem in a previous PR. copyWithOverrides() copies property descriptors instead of values, so getters stay live.

copyWithOverrides() also needed to tolerate a null or undefined source, matching plain-spread semantics, since interactionMode.selectionMode does not exist on the base object and is only added by the wrapper.

## What I haven't done

Did not touch the JSDoc example at the top of zushiAdapter.ts, which still shows the old plain-spread pattern as a template for adding new methods.

## How I tested

- Reproduced the bug on the live published site that reported it: selected a different basemap tile, then toggled terrain on, and the basemap reverted to the default while the tile-selector UI still showed the previously selected tile as active.
- Built a minimal test plugin and ran it in the plugin playground against the unfixed code (checked out main): confirmed reearth.viewer.property.tiles stayed frozen on its initial value through every overrideProperty() call, regardless of what was set.
- Checked out this fix branch and reran the identical test plugin in the plugin playground: tile opacity changes now correctly persisted through a terrain toggle.
- Also built a small real plugin package from the reearth-visualizer-plugin-shadcn-template (not just pasted into the playground editor) with the same test buttons, installed it, and confirmed the same passing result.
- All existing unit tests pass (zushiAdapter.test.ts, copyWithOverrides.test.ts) and yarn type is clean.
- Separately verified that camera position is unaffected by terrain toggling, on both the live site and the playground. This came up during investigation but turned out to be an unrelated, expected side effect of terrain revealing real ground elevation under a fixed camera, not a bug.

## Which point I want you to review particularly

Whether copyWithOverrides() should also be applied anywhere else in the plugin API surface. I checked camera, timeline, layers, sketch, and spatialId and confirmed their nested getters are all backed by a stable ref-reading pattern (useGet/useCallback), so they were not affected by this bug even before this fix. viewer was the only gap.

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.