### PR TITLE
chore(web): update @reearth/core to 0.0.7-alpha.78

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -131,7 +131,7 @@
     "@popperjs/core": "2.11.8",
     "@radix-ui/react-select": "2.2.6",
     "@radix-ui/react-slot": "1.2.4",
-    "@reearth/core": "0.0.7-alpha.77",
+    "@reearth/core": "0.0.7-alpha.78",
     "@reearth/sentinel": "0.1.2",
     "@reearth/zushi": "0.3.0",
     "@rot1024/use-transition": "1.0.0",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5963,9 +5963,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reearth/core@npm:0.0.7-alpha.77":
-  version: 0.0.7-alpha.77
-  resolution: "@reearth/core@npm:0.0.7-alpha.77"
+"@reearth/core@npm:0.0.7-alpha.78":
+  version: 0.0.7-alpha.78
+  resolution: "@reearth/core@npm:0.0.7-alpha.78"
   dependencies:
     "@radix-ui/react-checkbox": "npm:^1.3.3"
     "@radix-ui/react-dialog": "npm:^1.1.15"
@@ -6019,7 +6019,7 @@ __metadata:
     cesium: 1.118.x
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/1d059a4e7cb8558bf6868109cf15ca51be4df2f3fbe6bdec7cf217664aa6ea4a6ca5cdf1ec6882820dc795b508114d9b2a1721245b135d92c26eede5b4eab539
+  checksum: 10c0/16c65c4a15681f9110419891ef4baa217661db8eaa7ca870f78e4d4687a20b7ff87555a047613a77187b59dff845fabc88425cf8ca88a78d888d61815a4e1dca
   languageName: node
   linkType: hard
 
@@ -6081,7 +6081,7 @@ __metadata:
     "@popperjs/core": "npm:2.11.8"
     "@radix-ui/react-select": "npm:2.2.6"
     "@radix-ui/react-slot": "npm:1.2.4"
-    "@reearth/core": "npm:0.0.7-alpha.77"
+    "@reearth/core": "npm:0.0.7-alpha.78"
     "@reearth/sentinel": "npm:0.1.2"
     "@reearth/zushi": "npm:0.3.0"
     "@rollup/plugin-yaml": "npm:4.1.2"


### PR DESCRIPTION
## Summary
- Bumps `@reearth/core` from `0.0.7-alpha.77` → `0.0.7-alpha.78`
- Updates `yarn.lock` accordingly

## Changes in @reearth/core 0.0.7-alpha.78
- fix(cesium): enable requestWaterMask for all terrain providers — [reearth/core#158](https://github.com/reearth/core/pull/158)
- docs: add alpha release guide to README — [reearth/core#159](https://github.com/reearth/core/pull/159)