### PR TITLE
chore(e2e): add CLAUDE.md and story ID annotations to E2E tests

### DIFF
--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -1,0 +1,286 @@
+# E2E Test Suite — AI Management Rules
+
+This file governs how AI (Claude) should read, write, and reason about the E2E test suite under `e2e/`. Read it in full before making any changes to tests, pages, or utilities.
+
+---
+
+## 1. Project Overview
+
+This is a **Playwright E2E test suite** for Re:Earth Visualizer. Tests run against a live staging environment with real auth and real GraphQL API calls.
+
+**Key facts:**
+- Runtime: **WebKit headless** (`Desktop Safari`) — the only browser in CI
+- Execution: **serial mode**, 2 workers, retries: 2 (CI) / 1 (local)
+- Timeouts: default 120s per test, action/navigation 35s, expect 35s
+- Auth: Auth0 storage state pre-loaded via `global-setup.ts`
+- Config: `playwright.config.ts` — **do not modify** (managed separately)
+- `global-setup.ts` — **do not modify** (managed via separate PR)
+
+---
+
+## 2. Directory Structure
+
+```
+e2e/
+├── tests/              # All spec files (*.spec.ts)
+├── pages/              # Page Object Model classes
+├── utils/              # Shared helpers (auth, cleanup, constants)
+├── api/                # GraphQL API test suite (separate project)
+├── global-setup.ts     # Auth setup — DO NOT EDIT
+├── global-teardown.ts  # Post-run cleanup
+└── playwright.config.ts
+```
+
+**Spec files:**
+
+| File | Feature Area | Notes |
+|------|-------------|-------|
+| `dashboard.spec.ts` | Dashboard, Recycle Bin | Full lifecycle |
+| `dashboardFeatures.spec.ts` | Project Features | Search, sort, view, rename, export |
+| `projectSettings.spec.ts` | Project Settings | All tabs (General/README/License/Story/Public/Assets) |
+| `projects.spec.ts` | Editor | Layer creation, map interaction |
+| `accountWorkspaceSettings.spec.ts` | Account & Workspace | **Entire suite skipped** — EE Config |
+| `members.spec.ts` | Members Management | Conditionally skipped — Feature Flag |
+| `layerDeletionReorder.spec.ts` | Layer Management | **Entire suite skipped** — WebKit DnD |
+| `multipleStyles.spec.ts` | Layer Styles | Fully automated |
+| `externalLayers.spec.ts` | External Layers | Mixed — some CI-skipped |
+| `photoOverlay.spec.ts` | Photo Overlay | Mixed — some CI-skipped |
+| `page-refresh-on-mutation.spec.ts` | Editor Mutations | **Entire suite skipped** — Canvas API |
+
+---
+
+## 3. User Story Database
+
+All stories are tracked in the internal project management tool (see team wiki for the link).
+
+- **Story ID format:** `US-{AREA}-{seq}` — e.g. `US-DASH-001`, `US-EDIT-003`
+- **Feature Areas:** DASH · RBIN · PFEAT · PSET · EDIT · LAYER · STYLE · EXTL · PHOTO · MEM · ACCT · AUTH · STORY · PUB · PLUG
+
+### Key fields
+
+| Field | Purpose |
+|-------|---------|
+| `Story ID` | Stable reference. Use this in AI prompts and Allure annotations. |
+| `Automation Status` | `Automated` / `Partial` / `Manual Only` / `Skipped (CI)` / `TODO` |
+| `Skip Reason` | Root cause when skipped: `WebKit DnD` / `EE Config` / `Feature Flag` / `Canvas API` / `Not Yet Implemented` |
+| `Spec File` | e.g. `tests/dashboard.spec.ts` |
+| `Test Names` | Exact `test("...")` strings, one per line — used to link CI failures back to stories |
+| `Acceptance Criteria` | Given/When/Then bullets. Each bullet = one `expect()` assertion. |
+| `Manual Test Protocol` | Step-by-step instructions for `Manual Only` or `Skipped (CI)` stories |
+
+### Automation Status lifecycle
+
+```
+TODO  ──(tests written)──►  Automated
+                             │
+              (suite skipped)▼
+                         Skipped (CI)
+                             │
+              (flag enabled) ▼
+                          Automated
+```
+
+---
+
+## 4. How to Use Stories Day-to-Day
+
+### Connecting test code to stories
+
+Every test should carry its Story ID as an Allure annotation so that CI failures link directly to the story:
+
+```typescript
+test("Verify dashboard is loaded", async ({ page }) => {
+  test.info().annotations.push({ type: "story", description: "US-DASH-001" });
+  // ...
+});
+```
+
+When CI fails, the Allure report shows the Story ID. Go to Notion, search that ID → open the story → read Acceptance Criteria to understand exactly what broke.
+
+**Example — CI failure to story in three steps:**
+
+```
+FAIL  tests/dashboard.spec.ts
+  ✗ Verify dashboard is loaded          ← test name
+    Expected sidebar-tab-projects-link visible
+    Received: timeout 35000ms
+```
+
+1. Allure report shows annotation `US-DASH-001`
+2. Open Notion → search `US-DASH-001`
+3. Acceptance Criteria reads: *"Given logged in, When visiting Dashboard URL, Then Projects nav entry is visible"* — now you know the failure scope is auth/navigation, not maps or data
+
+Or ask AI directly:
+> "US-DASH-001 failed in CI with `sidebar-tab-projects-link timeout`. Help me debug."
+
+AI will look up the story's Acceptance Criteria, Spec File, and recent context without needing further explanation.
+
+### Writing a new test from a story
+
+1. Find a story with `Automation Status = TODO`
+2. Read its `Acceptance Criteria` — each bullet becomes one `expect()` call
+3. Write the test; add the Story ID annotation
+4. Update the story: set `Automation Status → Automated`, fill in `Spec File` and `Test Names`
+
+### Adding a story for a new feature (manual trigger)
+
+When a new feature lands — via PR or code change — ask AI to generate the story:
+
+> "Scan the PR / scan `src/app/features/newFeature/` and generate a new user story for this feature."
+
+AI will:
+- Read the feature code or PR diff
+- Draft a story with Story ID, User Story, Acceptance Criteria, and `Automation Status = TODO`
+- Create it in the Notion V5 database
+
+Review the draft and adjust before writing tests.
+
+### Asking AI to implement a story
+
+> "Implement US-PFEAT-009 — write the Playwright test."
+
+AI will:
+1. Look up the story in Notion
+2. Map each Acceptance Criteria bullet to a `expect()` assertion
+3. Use the correct POM class from `pages/`
+4. Add the Allure annotation with the Story ID
+5. Propose the Spec File to add it to
+
+---
+
+## 5. Known CI Limitations — Skip Patterns
+
+These are structural constraints, **not bugs**. Do not attempt to "fix" them without understanding the root cause.
+
+### 5a. WebKit DnD — `layerDeletionReorder.spec.ts`
+- **Root cause:** SortableJS uses HTML5 `DragEvent` API, incompatible with headless WebKit
+- **Scope:** Entire `test.describe.skip`
+- **Resolution path:** Requires Chromium runner or a custom drag simulation utility
+
+### 5b. EE Config — `accountWorkspaceSettings.spec.ts`
+- **Root cause:** EE build redirects settings UI to an external URL via `externalAccountManagementUrl` feature flag
+- **Scope:** Entire suite `test.skip`
+
+### 5c. Feature Flag — `members.spec.ts`
+- **Root cause:** `membersManagementOnDashboard` flag controls Members tab visibility
+- **Pattern:** `test.skip(!membersTabVisible, "Members tab not visible in this environment")`
+- **Do not** remove the conditional skip — it protects non-EE deployments
+
+### 5d. Canvas API — `page-refresh-on-mutation.spec.ts`
+- **Root cause:** Cesium canvas rendering assertions are unreliable in headless WebKit
+
+### 5e. External Network / Not Yet Implemented
+- Sketch tools, GeoJSON URL sources, 3D Tiles URL — skip with `test.skip(true, "...")`
+
+---
+
+## 6. Page Object Model (POM)
+
+All UI interactions should go through POM classes in `pages/`. Avoid writing raw `page.locator()` calls directly in spec files; if an existing spec already uses one, do not introduce more — add the selector to the relevant POM class instead.
+
+| Class | File | Covers |
+|-------|------|--------|
+| `DashBoardPage` | `dashBoardPage.ts` | Sidebar, workspace nav |
+| `ProjectsPage` | `projectsPage.ts` | Project grid, create/menu |
+| `ProjectSettingsPage` | `projectSettingsPage.ts` | All settings tabs |
+| `RecycleBinPage` | `recycleBinPage.ts` | Recycle bin UI |
+| `MembersPage` | `membersPage.ts` | Members tab |
+| `AccountSettingsPage` | `accountSettingsPage.ts` | Account settings |
+| `WorkspaceSettingsPage` | `workspaceSettingsPage.ts` | Workspace settings |
+| `ProjectScreenPage` | `projectScreenPage.ts` | Editor/canvas |
+| `CesiumViewerPage` | `cesiumViewerPage.ts` | Map viewer |
+| `DataSourceManagerPage` | `dataSourceManagerPage.ts` | External layers |
+| `LayerStylePanelPage` | `layerStylePanelPage.ts` | Style panel |
+| `PhotoOverlayPage` | `photoOverlayPage.ts` | Photo overlay |
+| `LoginPage` | `loginPage.ts` | Login flow |
+
+**Rules:**
+- Add new selectors to the relevant POM, not inline in tests
+- Prefer `data-testid` attributes; fall back to `role` → `text` → CSS
+- New features need a corresponding POM before writing spec tests
+
+---
+
+## 7. Test Data & Cleanup
+
+- All test-created projects must be prefixed `e2e-`: `const projectName = "e2e-" + faker.lorem.words(2)`
+- `global-teardown.ts` deletes all `e2e-*` projects after the run
+- `cleanupStaleE2eProjects()` runs in global setup to clear leftovers from crashed runs
+- Recycle bin auto-cleared when count ≥ 16 (prevents recycle bin test failures)
+- Always use `faker` for unique project names/aliases — never hardcode
+- Every test that creates data must clean up in `afterAll`
+
+---
+
+## 8. Auth & Context
+
+- Storage state at `.auth/user.json` (written by `global-setup.ts`)
+- IAP environments: use `utils/iap-auth.ts` → `createIAPContext(browser, baseUrl, { storageState })`
+- **Never** commit `.auth/` or `.env` files
+
+---
+
+## 9. Writing New Tests
+
+```typescript
+test.describe.configure({ mode: "serial" });
+
+test.describe("FEATURE — Scenario Group", () => {
+  test.beforeAll(async ({ browser }) => { /* setup context + POMs */ });
+  test.afterAll(async () => { await context.close(); });
+
+  test("Setup: create prerequisites", async () => { /* ... */ });
+
+  test("Core: feature behavior", async () => {
+    test.info().annotations.push({ type: "story", description: "US-XXXX-000" });
+    // assertions map 1:1 to Acceptance Criteria bullets
+  });
+
+  test("Cleanup: remove test data", async () => { /* ... */ });
+});
+```
+
+**Valid skip reasons:**
+- `WebKit DnD` — SortableJS / HTML5 drag events
+- `External Network` — test requires external URL
+- `Feature Flag` — feature disabled in CI
+- `EE Config` — behavior differs in Enterprise Edition
+- `Canvas API` — Cesium canvas unreliable in headless WebKit
+- `Not Yet Implemented` — UI feature not yet available in test env
+
+---
+
+## 10. Common Pitfalls
+
+| Pitfall | Correct approach |
+|---------|-----------------|
+| `page.waitForTimeout(ms)` everywhere | Use `waitFor({ state })` or `toBeVisible()` instead |
+| Raw selectors in spec files | Move to POM; use `data-testid` |
+| Tests depend on prior test state | Use `beforeAll` setup; each describe block self-contained |
+| Missing cleanup | Every test that creates a project must clean up in `afterAll` |
+| Modifying `global-setup.ts` | Managed via separate PR — do not touch |
+| Writing raw GraphQL in spec files | Use `utils/project-cleanup.ts` or `api/graphql/client.ts` |
+| No Story ID annotation on test | Add `test.info().annotations.push(...)` so CI failures link to stories |
+
+---
+
+## 11. PR Guidelines
+
+- Scope each PR narrowly — one feature or one bug fix
+- Do not bundle spec changes with POM refactors
+- Run `npx playwright test --project=webkit <spec-file>` locally before submitting
+- Tag PRs that add `test.skip` with the skip reason documented in the skip message
+- After merging a PR that adds new tests: update the corresponding story's `Automation Status`, `Spec File`, and `Test Names` in Notion
+
+---
+
+## 12. Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `REEARTH_WEB_E2E_BASEURL` | Target application URL |
+| `REEARTH_E2E_USER_EMAIL` | Test user email |
+| `REEARTH_E2E_USER_PASSWORD` | Test user password |
+| `SKIP_STORAGE_STATE` | Set to `true` to skip auth setup (debugging) |
+
+Never commit `.env`. Use `env.example` as template.

--- a/e2e/tests/account/accountWorkspaceSettings.spec.ts
+++ b/e2e/tests/account/accountWorkspaceSettings.spec.ts
@@ -60,6 +60,7 @@ test.describe("ACCOUNT & WORKSPACE SETTINGS", () => {
   // Profile Menu — Account Settings Navigation
   // ──────────────────────────────────────────────────
   test.skip("Profile menu should have Account settings option", async () => {
+    test.info().annotations.push({ type: "story", description: "US-ACCT-001" });
     test.setTimeout(30000);
     await dashBoardPage.profileDropdownButton.click();
     await page.waitForTimeout(500);
@@ -73,6 +74,7 @@ test.describe("ACCOUNT & WORKSPACE SETTINGS", () => {
   });
 
   test.skip("Account settings: should navigate (new tab or same page)", async () => {
+    test.info().annotations.push({ type: "story", description: "US-ACCT-001" });
     test.setTimeout(45000);
     await dashBoardPage.profileDropdownButton.click();
     await page.waitForTimeout(500);
@@ -128,6 +130,7 @@ test.describe("ACCOUNT & WORKSPACE SETTINGS", () => {
   });
 
   test.skip("Account: should display page layout", async () => {
+    test.info().annotations.push({ type: "story", description: "US-ACCT-001" });
     test.skip(
       !accountSettingsLoaded,
       "Account settings page not accessible (EE uses external URL)"
@@ -136,27 +139,32 @@ test.describe("ACCOUNT & WORKSPACE SETTINGS", () => {
   });
 
   test.skip("Account: should display name field (readonly)", async () => {
+    test.info().annotations.push({ type: "story", description: "US-ACCT-002" });
     test.skip(!accountSettingsLoaded, "Account settings page not accessible");
     await expect(accountSettings.nameField).toBeVisible();
   });
 
   test.skip("Account: should display email field (readonly)", async () => {
+    test.info().annotations.push({ type: "story", description: "US-ACCT-001" });
     test.skip(!accountSettingsLoaded, "Account settings page not accessible");
     await expect(accountSettings.emailField).toBeVisible();
   });
 
   test.skip("Account: should display password field with change button", async () => {
+    test.info().annotations.push({ type: "story", description: "US-ACCT-003" });
     test.skip(!accountSettingsLoaded, "Account settings page not accessible");
     await expect(accountSettings.passwordField).toBeVisible();
     await expect(accountSettings.changePasswordButton).toBeVisible();
   });
 
   test.skip("Account: should display language selector", async () => {
+    test.info().annotations.push({ type: "story", description: "US-ACCT-001" });
     test.skip(!accountSettingsLoaded, "Account settings page not accessible");
     await expect(accountSettings.languageField).toBeVisible();
   });
 
   test.skip("Account: should open password change modal", async () => {
+    test.info().annotations.push({ type: "story", description: "US-ACCT-003" });
     test.skip(!accountSettingsLoaded, "Account settings page not accessible");
     test.setTimeout(30000);
     await accountSettings.openPasswordModal();
@@ -167,6 +175,7 @@ test.describe("ACCOUNT & WORKSPACE SETTINGS", () => {
   });
 
   test.skip("Account: password modal should close on cancel", async () => {
+    test.info().annotations.push({ type: "story", description: "US-ACCT-003" });
     test.skip(!accountSettingsLoaded, "Account settings page not accessible");
     await accountSettings.passwordModalCancelButton.click();
     await settingsPage.waitForTimeout(500);
@@ -174,6 +183,7 @@ test.describe("ACCOUNT & WORKSPACE SETTINGS", () => {
   });
 
   test.skip("Profile menu should have Workspace settings option", async () => {
+    test.info().annotations.push({ type: "story", description: "US-ACCT-004" });
     test.setTimeout(30000);
     await page.bringToFront();
     if (!page.url().includes("/dashboard/")) {
@@ -198,6 +208,7 @@ test.describe("ACCOUNT & WORKSPACE SETTINGS", () => {
   });
 
   test.skip("Workspace settings: should navigate (new tab or same page)", async () => {
+    test.info().annotations.push({ type: "story", description: "US-ACCT-004" });
     test.setTimeout(45000);
 
     if (accountSettingsLoaded) {
@@ -284,6 +295,7 @@ test.describe("ACCOUNT & WORKSPACE SETTINGS", () => {
   });
 
   test.skip("Workspace: should display workspace name field", async () => {
+    test.info().annotations.push({ type: "story", description: "US-ACCT-005" });
     test.skip(
       !workspaceSettingsLoaded,
       "Workspace settings page not accessible (EE uses external URL)"
@@ -292,6 +304,7 @@ test.describe("ACCOUNT & WORKSPACE SETTINGS", () => {
   });
 
   test.skip("Workspace: should display sidebar with Account and Workspace tabs", async () => {
+    test.info().annotations.push({ type: "story", description: "US-ACCT-004" });
     test.skip(
       !workspaceSettingsLoaded,
       "Workspace settings page not accessible"
@@ -301,6 +314,7 @@ test.describe("ACCOUNT & WORKSPACE SETTINGS", () => {
   });
 
   test.skip("Workspace: sidebar navigation to Account Settings", async () => {
+    test.info().annotations.push({ type: "story", description: "US-ACCT-004" });
     test.skip(
       !workspaceSettingsLoaded,
       "Workspace settings page not accessible"

--- a/e2e/tests/account/members.spec.ts
+++ b/e2e/tests/account/members.spec.ts
@@ -51,6 +51,7 @@ test.describe("MEMBERS PAGE - Test cases", () => {
   });
 
   test("Navigate to members page via sidebar", async () => {
+    test.info().annotations.push({ type: "story", description: "US-MEM-001" });
     const membersLink = page.getByTestId("sidebar-tab-members-link");
     const membersVisible = await membersLink
       .isVisible({ timeout: 5000 })
@@ -70,6 +71,7 @@ test.describe("MEMBERS PAGE - Test cases", () => {
   });
 
   test("Display members page with table headers", async () => {
+    test.info().annotations.push({ type: "story", description: "US-MEM-002" });
     const membersLink = page.getByTestId("sidebar-tab-members-link");
     if (!(await membersLink.isVisible().catch(() => false))) {
       test.skip(true, "Members tab not available");
@@ -82,6 +84,7 @@ test.describe("MEMBERS PAGE - Test cases", () => {
   });
 
   test("Display search input for filtering members", async () => {
+    test.info().annotations.push({ type: "story", description: "US-MEM-003" });
     const membersLink = page.getByTestId("sidebar-tab-members-link");
     if (!(await membersLink.isVisible().catch(() => false))) {
       test.skip(true, "Members tab not available");
@@ -92,6 +95,7 @@ test.describe("MEMBERS PAGE - Test cases", () => {
   });
 
   test("Display invite user button", async () => {
+    test.info().annotations.push({ type: "story", description: "US-MEM-004" });
     const membersLink = page.getByTestId("sidebar-tab-members-link");
     if (!(await membersLink.isVisible().catch(() => false))) {
       test.skip(true, "Members tab not available");
@@ -102,6 +106,7 @@ test.describe("MEMBERS PAGE - Test cases", () => {
   });
 
   test("Display at least one member", async () => {
+    test.info().annotations.push({ type: "story", description: "US-MEM-002" });
     const membersLink = page.getByTestId("sidebar-tab-members-link");
     if (!(await membersLink.isVisible().catch(() => false))) {
       test.skip(true, "Members tab not available");
@@ -114,6 +119,7 @@ test.describe("MEMBERS PAGE - Test cases", () => {
   });
 
   test("Filter members by name or email", async () => {
+    test.info().annotations.push({ type: "story", description: "US-MEM-003" });
     const membersLink = page.getByTestId("sidebar-tab-members-link");
     if (!(await membersLink.isVisible().catch(() => false))) {
       test.skip(true, "Members tab not available");
@@ -145,6 +151,7 @@ test.describe("MEMBERS PAGE - Test cases", () => {
   });
 
   test("Show no results for non-existing member", async () => {
+    test.info().annotations.push({ type: "story", description: "US-MEM-003" });
     const membersLink = page.getByTestId("sidebar-tab-members-link");
     if (!(await membersLink.isVisible().catch(() => false))) {
       test.skip(true, "Members tab not available");
@@ -159,6 +166,7 @@ test.describe("MEMBERS PAGE - Test cases", () => {
   });
 
   test("Restore member list when search is cleared", async () => {
+    test.info().annotations.push({ type: "story", description: "US-MEM-003" });
     const membersLink = page.getByTestId("sidebar-tab-members-link");
     if (!(await membersLink.isVisible().catch(() => false))) {
       test.skip(true, "Members tab not available");
@@ -172,6 +180,7 @@ test.describe("MEMBERS PAGE - Test cases", () => {
   });
 
   test("Open add member modal", async () => {
+    test.info().annotations.push({ type: "story", description: "US-MEM-004" });
     const membersLink = page.getByTestId("sidebar-tab-members-link");
     if (!(await membersLink.isVisible().catch(() => false))) {
       test.skip(true, "Members tab not available");
@@ -186,6 +195,7 @@ test.describe("MEMBERS PAGE - Test cases", () => {
   });
 
   test("Show warning for non-existing user in add modal", async () => {
+    test.info().annotations.push({ type: "story", description: "US-MEM-004" });
     const membersLink = page.getByTestId("sidebar-tab-members-link");
     if (!(await membersLink.isVisible().catch(() => false))) {
       test.skip(true, "Members tab not available");
@@ -201,6 +211,7 @@ test.describe("MEMBERS PAGE - Test cases", () => {
   });
 
   test("Close add member modal on cancel", async () => {
+    test.info().annotations.push({ type: "story", description: "US-MEM-004" });
     const membersLink = page.getByTestId("sidebar-tab-members-link");
     if (!(await membersLink.isVisible().catch(() => false))) {
       test.skip(true, "Members tab not available");
@@ -213,6 +224,7 @@ test.describe("MEMBERS PAGE - Test cases", () => {
   });
 
   test("Display member context menu with actions", async () => {
+    test.info().annotations.push({ type: "story", description: "US-MEM-005" });
     const membersLink = page.getByTestId("sidebar-tab-members-link");
     if (!(await membersLink.isVisible().catch(() => false))) {
       test.skip(true, "Members tab not available");

--- a/e2e/tests/dashboard/dashboard.spec.ts
+++ b/e2e/tests/dashboard/dashboard.spec.ts
@@ -67,6 +67,7 @@ test.describe("DASHBOARD - Test cases", () => {
   });
 
   test("Verify dashboard is loaded", async () => {
+    test.info().annotations.push({ type: "story", description: "US-DASH-001" });
     await expect(dashBoardPage.projects).toBeVisible();
     await expect(dashBoardPage.recycleBin).toBeVisible();
     await expect(dashBoardPage.pluginPlayground).toBeVisible();
@@ -74,6 +75,7 @@ test.describe("DASHBOARD - Test cases", () => {
   });
 
   test("Verify project creation modal", async () => {
+    test.info().annotations.push({ type: "story", description: "US-DASH-002" });
     await dashBoardPage.projects.click();
     await projectsPage.newProjectButton.waitFor({ state: "visible" });
     await page.waitForTimeout(500);
@@ -86,11 +88,13 @@ test.describe("DASHBOARD - Test cases", () => {
   });
 
   test("Verify project creation with empty name", async () => {
+    test.info().annotations.push({ type: "story", description: "US-DASH-002" });
     await projectsPage.projectNameInput.waitFor({ state: "visible" });
     await expect(projectsPage.applyButton).toBeDisabled();
   });
 
   test("Create a new project and verify after its creation", async () => {
+    test.info().annotations.push({ type: "story", description: "US-DASH-003" });
     await projectsPage.createNewProject(
       projectName,
       projectAlias,
@@ -101,6 +105,7 @@ test.describe("DASHBOARD - Test cases", () => {
   });
 
   test("Remove the project to the Recycle Bin", async () => {
+    test.info().annotations.push({ type: "story", description: "US-RBIN-001" });
     await projectsPage.deleteProject(projectName);
     // await expect(
     //   page.getByText("Successfully moved to Recycle bin!")
@@ -108,17 +113,20 @@ test.describe("DASHBOARD - Test cases", () => {
   });
 
   test("Go to the Recycle Bin and Recover the Deleted Project", async () => {
+    test.info().annotations.push({ type: "story", description: "US-RBIN-004" });
     await dashBoardPage.recycleBin.click();
     // await expect(recycleBinPage.projectTitles).toBeVisible();
     await recycleBinPage.recoverProject(projectName);
   });
 
   test("Verify the project has successfully been recover", async () => {
+    test.info().annotations.push({ type: "story", description: "US-RBIN-002" });
     await dashBoardPage.projects.click();
     await expect(page.getByText(projectName)).toBeVisible();
   });
 
   test("Remove the project, Go to the Recycle Bin And delete it ", async () => {
+    test.info().annotations.push({ type: "story", description: "US-RBIN-003" });
     await projectsPage.deleteProject(projectName);
     await expect(projectsPage.gridProjectItem(projectName)).not.toBeVisible();
     await dashBoardPage.recycleBin.click();
@@ -129,6 +137,7 @@ test.describe("DASHBOARD - Test cases", () => {
   });
 
   test("Verify project creation with special characters in name", async () => {
+    test.info().annotations.push({ type: "story", description: "US-DASH-004" });
     await dashBoardPage.projects.click();
     const specialProjectDescription = "Test project with special characters";
     await projectsPage.newProjectButton.waitFor({ state: "visible" });
@@ -144,6 +153,7 @@ test.describe("DASHBOARD - Test cases", () => {
   });
 
   test("Starred and UnStarred the Project and verify it", async () => {
+    test.info().annotations.push({ type: "story", description: "US-DASH-005" });
     await projectsPage.starredProject(specialProjectName);
     await projectsPage.verifyStarredProject(specialProjectName);
     await projectsPage.starredProjectNameMenuBar(specialProjectName);
@@ -156,6 +166,7 @@ test.describe("DASHBOARD - Test cases", () => {
   });
 
   test("Move the project to the Recycle Bin And delete it ", async () => {
+    test.info().annotations.push({ type: "story", description: "US-RBIN-003" });
     await projectsPage.deleteProject(specialProjectName);
     await expect(projectsPage.gridProjectItem(specialProjectName)).not.toBeVisible();
     await dashBoardPage.recycleBin.click();
@@ -216,6 +227,7 @@ test.describe("DASHBOARD - Test cases", () => {
       await context.close();
     });
     test("Verify dashboard is loaded", async () => {
+      test.info().annotations.push({ type: "story", description: "US-DASH-001" });
       await page.goto(REEARTH_WEB_E2E_BASEURL + "/dashboard", {
         waitUntil: "domcontentloaded"
       });

--- a/e2e/tests/dashboard/dashboardFeatures.spec.ts
+++ b/e2e/tests/dashboard/dashboardFeatures.spec.ts
@@ -59,6 +59,7 @@ test.describe("DASHBOARD FEATURES - Search, Sort, Views, Rename, Export", () => 
   });
 
   test("Create a project for feature tests", async () => {
+    test.info().annotations.push({ type: "story", description: "US-DASH-008" });
     await dashBoardPage.projects.click();
     await projectsPage.newProjectButton.waitFor({ state: "visible" });
     await page.waitForTimeout(500);
@@ -73,6 +74,7 @@ test.describe("DASHBOARD FEATURES - Search, Sort, Views, Rename, Export", () => 
   });
 
   test("Filter projects by name", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PFEAT-001" });
     await projectsPage.searchProject(projectName);
     await page.waitForTimeout(2000);
     await expect(
@@ -81,6 +83,7 @@ test.describe("DASHBOARD FEATURES - Search, Sort, Views, Rename, Export", () => 
   });
 
   test("Show no results for non-existing project", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PFEAT-002" });
     const randomSearch = faker.string.alpha(20);
     await projectsPage.searchProject(randomSearch);
     await page.waitForTimeout(2000);
@@ -90,6 +93,7 @@ test.describe("DASHBOARD FEATURES - Search, Sort, Views, Rename, Export", () => 
   });
 
   test("Restore all projects when search is cleared", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PFEAT-003" });
     await projectsPage.clearSearch();
     await page.waitForTimeout(2000);
     await expect(
@@ -98,11 +102,13 @@ test.describe("DASHBOARD FEATURES - Search, Sort, Views, Rename, Export", () => 
   });
 
   test("Display sort dropdown with options", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PFEAT-004" });
     await expect(projectsPage.sortLabel).toBeVisible();
     await expect(projectsPage.sortDropdown).toBeVisible();
   });
 
   test("Sort projects by Last Created", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PFEAT-004" });
     await projectsPage.selectSortOption("Last Created");
     await page
       .getByTestId("projects-container")
@@ -114,6 +120,7 @@ test.describe("DASHBOARD FEATURES - Search, Sort, Views, Rename, Export", () => 
   });
 
   test("Sort projects by A To Z", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PFEAT-005" });
     await projectsPage.selectSortOption("A To Z");
     await page
       .getByTestId("projects-container")
@@ -126,6 +133,7 @@ test.describe("DASHBOARD FEATURES - Search, Sort, Views, Rename, Export", () => 
   });
 
   test("Sort projects by Last Updated", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PFEAT-006" });
     await projectsPage.selectSortOption("Last Updated");
     await page
       .getByTestId("projects-container")
@@ -138,6 +146,7 @@ test.describe("DASHBOARD FEATURES - Search, Sort, Views, Rename, Export", () => 
   });
 
   test("Switch to list view", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PFEAT-007" });
     await projectsPage.switchToListView();
     await page.waitForTimeout(1000);
     await expect(
@@ -149,6 +158,7 @@ test.describe("DASHBOARD FEATURES - Search, Sort, Views, Rename, Export", () => 
   });
 
   test("List view shows project dates", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PFEAT-007" });
     await expect(
       projectsPage.listProjectUpdated(projectName).first()
     ).toBeVisible();
@@ -158,6 +168,7 @@ test.describe("DASHBOARD FEATURES - Search, Sort, Views, Rename, Export", () => 
   });
 
   test("Switch back to grid view", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PFEAT-008" });
     await projectsPage.switchToGridView();
     await page.waitForTimeout(1000);
     await expect(
@@ -166,6 +177,7 @@ test.describe("DASHBOARD FEATURES - Search, Sort, Views, Rename, Export", () => 
   });
 
   test("Open context menu with rename option", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PFEAT-009" });
     const menuBtn = projectsPage.gridProjectMenuButton(projectName).first();
     await menuBtn.click();
     await expect(projectsPage.renameMenuItem).toBeVisible();
@@ -176,12 +188,14 @@ test.describe("DASHBOARD FEATURES - Search, Sort, Views, Rename, Export", () => 
   });
 
   test("Rename project via context menu", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PFEAT-009" });
     await projectsPage.renameProject(projectName, renamedProjectName);
     await page.waitForTimeout(2000);
     await expect(page.getByText(renamedProjectName).first()).toBeVisible();
   });
 
   test("Export project from context menu", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PFEAT-010" });
     const downloadPromise = page.waitForEvent("download", { timeout: 30000 });
 
     await projectsPage.exportProject(renamedProjectName);
@@ -198,6 +212,7 @@ test.describe("DASHBOARD FEATURES - Search, Sort, Views, Rename, Export", () => 
   });
 
   test("Delete the test project", async () => {
+    test.info().annotations.push({ type: "story", description: "US-RBIN-001" });
     await dashBoardPage.projects.click();
     await page.waitForTimeout(2000);
 

--- a/e2e/tests/layer/externalLayers.spec.ts
+++ b/e2e/tests/layer/externalLayers.spec.ts
@@ -107,12 +107,14 @@ test.describe("Adding Layers from External Resources", () => {
   });
 
   test("Open Data Source Manager and verify all tabs", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EXTL-001" });
     await openDataSourceManager();
     await dataSourceManager.verifyAllTabs();
     await dataSourceManager.close();
   });
 
   test("Add a GeoJSON layer from web URL", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EXTL-003" });
     // Skipped in CI: loads from raw.githubusercontent.com — external resource outside company
     // control, unreliable from CI runners. Run locally to verify.
     test.skip(!!process.env.CI, "External resource (raw.githubusercontent.com) unreliable in CI");
@@ -131,6 +133,7 @@ test.describe("Adding Layers from External Resources", () => {
   });
 
   test("Add a GeoJSON layer from inline value", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EXTL-004" });
     // Skipped in CI: Cesium layer count check fails in headless webkit on a 2-CPU runner —
     // waitForLoaderToDisappear() silently times out and the layer is not added. Run locally to verify.
     test.skip(!!process.env.CI, "Cesium layer rendering unreliable in CI headless webkit");
@@ -158,6 +161,7 @@ test.describe("Adding Layers from External Resources", () => {
   });
 
   test("Add a 3D Tiles layer (Cesium OSM)", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EXTL-002" });
     test.setTimeout(60000);
     const layersBefore = await cesiumViewer.getLayerCount();
 
@@ -177,6 +181,7 @@ test.describe("Adding Layers from External Resources", () => {
   });
 
   test("Add a 3D Tiles layer from URL", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EXTL-005" });
     // Skipped in CI: loads from assets.cms.plateau.reearth.io — company-hosted but may fail to
     // fetch from CI runner IPs or be slow to respond. TODO: investigate why and re-enable.
     test.skip(!!process.env.CI, "Tile server (assets.cms.plateau.reearth.io) may be unreachable from CI runners");
@@ -195,6 +200,7 @@ test.describe("Adding Layers from External Resources", () => {
   });
 
   test("Verify all added layers are listed", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EXTL-002" });
     // Skipped in CI: depends on GeoJSON from inline value and 3D Tiles URL tests which are
     // skipped in CI, so the expected layer count (≥4) would not be reached.
     test.skip(!!process.env.CI, "Depends on layer-adding tests skipped in CI");
@@ -203,6 +209,7 @@ test.describe("Adding Layers from External Resources", () => {
   });
 
   test("Canceling Data Source Manager does not add a layer", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EXTL-001" });
     const layersBefore = await cesiumViewer.getLayerCount();
 
     await openDataSourceManager();

--- a/e2e/tests/layer/layerDeletionReorder.spec.ts
+++ b/e2e/tests/layer/layerDeletionReorder.spec.ts
@@ -104,6 +104,7 @@ test.describe.skip("Layer Deletion & Reordering", () => {
   });
 
   test("Add three sketch layers", async () => {
+    test.info().annotations.push({ type: "story", description: "US-LAYER-001" });
     test.setTimeout(90000);
     for (const name of layerNames) {
       await projectScreen.createNewLayer(name);
@@ -116,6 +117,7 @@ test.describe.skip("Layer Deletion & Reordering", () => {
   });
 
   test("Delete a layer via context menu", async () => {
+    test.info().annotations.push({ type: "story", description: "US-LAYER-001" });
     const layerItems = page.getByTestId("layer-item");
     const initialCount = await layerItems.count();
 
@@ -150,6 +152,7 @@ test.describe.skip("Layer Deletion & Reordering", () => {
   });
 
   test("Deleted layer is no longer in the list", async () => {
+    test.info().annotations.push({ type: "story", description: "US-LAYER-001" });
     const deletedLayer = projectScreen.getLayerByName(layerNames[0]);
     await expect(deletedLayer).not.toBeVisible();
 
@@ -159,11 +162,13 @@ test.describe.skip("Layer Deletion & Reordering", () => {
   });
 
   test("Can select a layer after another was deleted", async () => {
+    test.info().annotations.push({ type: "story", description: "US-LAYER-001" });
     await projectScreen.clickLayer(layerNames[1]);
     await expect(page.getByText("Inspector")).toBeVisible();
   });
 
   test.skip("Reorder layers via drag and drop", async () => {
+    test.info().annotations.push({ type: "story", description: "US-LAYER-002" });
     // SortableJS uses HTML5 drag events which Playwright's mouse API
     // cannot trigger in headless WebKit. Layer reorder is covered by
     // the API test suite (api/tests/layer-infobox.api.spec.ts).
@@ -208,6 +213,7 @@ test.describe.skip("Layer Deletion & Reordering", () => {
   });
 
   test("Rename a layer via context menu", async () => {
+    test.info().annotations.push({ type: "story", description: "US-LAYER-005" });
     const layerItems = page.getByTestId("layer-item");
     const targetLayer = layerItems.filter({ hasText: layerNames[1] });
 
@@ -236,6 +242,7 @@ test.describe.skip("Layer Deletion & Reordering", () => {
   });
 
   test("Toggle layer visibility", async () => {
+    test.info().annotations.push({ type: "story", description: "US-LAYER-006" });
     const layerItems = page.getByTestId("layer-item");
     const targetLayer = layerItems.filter({ hasText: "Renamed Layer" });
 
@@ -256,6 +263,7 @@ test.describe.skip("Layer Deletion & Reordering", () => {
   });
 
   test("Delete all remaining layers one by one", async () => {
+    test.info().annotations.push({ type: "story", description: "US-LAYER-001" });
     test.setTimeout(120000);
     const layerItems = page.getByTestId("layer-item");
     let count = await layerItems.count();
@@ -300,6 +308,7 @@ test.describe.skip("Layer Deletion & Reordering", () => {
   });
 
   test("Verify empty layer list and New Layer button is available", async () => {
+    test.info().annotations.push({ type: "story", description: "US-LAYER-001" });
     const layerItems = page.getByTestId("layer-item");
     const count = await layerItems.count();
     expect(count).toBe(0);

--- a/e2e/tests/layer/multipleStyles.spec.ts
+++ b/e2e/tests/layer/multipleStyles.spec.ts
@@ -105,6 +105,7 @@ test.describe("Multiple Style Assignment and Switching", () => {
   });
 
   test("Add an Empty style", async () => {
+    test.info().annotations.push({ type: "story", description: "US-STYLE-001" });
     await stylePanel.addPresetStyle("Empty");
     await expect(stylePanel.getStyleByName("Empty.01")).toBeVisible({
       timeout: 10_000
@@ -112,6 +113,7 @@ test.describe("Multiple Style Assignment and Switching", () => {
   });
 
   test("Add a Default style as second style", async () => {
+    test.info().annotations.push({ type: "story", description: "US-STYLE-002" });
     await stylePanel.addPresetStyle("Default");
     await expect(stylePanel.getStyleByName("Default.01")).toBeVisible({
       timeout: 10_000
@@ -119,6 +121,7 @@ test.describe("Multiple Style Assignment and Switching", () => {
   });
 
   test("Add a Professional style as third style", async () => {
+    test.info().annotations.push({ type: "story", description: "US-STYLE-002" });
     await stylePanel.addPresetStyle("Professional");
     await expect(stylePanel.getStyleByName("Professional.01")).toBeVisible({
       timeout: 10_000
@@ -126,7 +129,9 @@ test.describe("Multiple Style Assignment and Switching", () => {
   });
 
   test("Switch between styles by clicking style entries", async () => {
+    test.info().annotations.push({ type: "story", description: "US-STYLE-003" });
     await stylePanel.selectStyle("Empty.01");
+
     await expect(stylePanel.interfaceTab).toBeVisible();
 
     await stylePanel.selectStyle("Default.01");
@@ -134,11 +139,13 @@ test.describe("Multiple Style Assignment and Switching", () => {
   });
 
   test("Style editor shows Interface and Code tabs", async () => {
+    test.info().annotations.push({ type: "story", description: "US-STYLE-003" });
     await expect(stylePanel.interfaceTab).toBeVisible();
     await expect(stylePanel.codeTab).toBeVisible();
   });
 
   test("Switch to Code tab and back to Interface", async () => {
+    test.info().annotations.push({ type: "story", description: "US-STYLE-003" });
     await stylePanel.codeTab.click();
     await page.waitForTimeout(500);
     await stylePanel.interfaceTab.click();
@@ -146,13 +153,14 @@ test.describe("Multiple Style Assignment and Switching", () => {
   });
 
   test("Rename a style via context menu", async () => {
+    test.info().annotations.push({ type: "story", description: "US-STYLE-004" });
     await stylePanel.renameStyle("Empty.01", "Custom Style");
     await expect(stylePanel.getStyleByName("Custom Style")).toBeVisible();
   });
 
   test("Delete a style via context menu", async () => {
+    test.info().annotations.push({ type: "story", description: "US-STYLE-005" });
     await expect(stylePanel.getStyleByName("Professional.01")).toBeVisible();
-
     await stylePanel.deleteStyle("Professional.01");
 
     await expect(
@@ -161,6 +169,7 @@ test.describe("Multiple Style Assignment and Switching", () => {
   });
 
   test("Styles persist after deselecting and reselecting layer", async () => {
+    test.info().annotations.push({ type: "story", description: "US-STYLE-006" });
     await expect(stylePanel.getStyleByName("Custom Style")).toBeVisible();
     await expect(stylePanel.getStyleByName("Default.01")).toBeVisible();
 

--- a/e2e/tests/layer/photoOverlay.spec.ts
+++ b/e2e/tests/layer/photoOverlay.spec.ts
@@ -137,6 +137,7 @@ test.describe("Photo Overlay Feature", () => {
   });
 
   test("Enable Photo Overlay on the sketch layer", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PHOTO-001" });
     test.setTimeout(60000);
     await projectScreen.clickLayer(layerName);
     await page.waitForTimeout(1000);
@@ -149,6 +150,7 @@ test.describe("Photo Overlay Feature", () => {
   });
 
   test("Select a feature and verify Photo Overlay section", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PHOTO-001" });
     test.setTimeout(90000);
     await photoOverlay.selectFeatureAndOpenInspector(400, 400);
     await expect(page.getByText("Photo Overlay").first()).toBeVisible();
@@ -156,6 +158,7 @@ test.describe("Photo Overlay Feature", () => {
   });
 
   test("Open Photo Overlay Editor and verify panel", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PHOTO-001" });
     test.setTimeout(60000);
     await photoOverlay.openPhotoOverlayEditor();
     await expect(photoOverlay.editorPanel).toBeVisible();
@@ -168,6 +171,7 @@ test.describe("Photo Overlay Feature", () => {
   });
 
   test("Upload an image and submit the Photo Overlay", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PHOTO-002" });
     test.setTimeout(90000);
     const testImagePath = path.resolve(__dirname, "../../test-data/testimage.jpg");
     await photoOverlay.uploadAsset(testImagePath);
@@ -182,6 +186,7 @@ test.describe("Photo Overlay Feature", () => {
   });
 
   test("Re-select feature and verify editor fields", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PHOTO-004" });
     test.setTimeout(90000);
     await projectScreen.clickLayer(layerName);
     await page.waitForTimeout(2000);
@@ -200,6 +205,7 @@ test.describe("Photo Overlay Feature", () => {
   });
 
   test.skip("Switch between size modes and verify width slider", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PHOTO-005" });
     test.setTimeout(90000);
     await projectScreen.clickLayer(layerName);
     await page.waitForTimeout(2000);
@@ -223,6 +229,7 @@ test.describe("Photo Overlay Feature", () => {
   });
 
   test.skip("Set transparency to edge values", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PHOTO-006" });
     test.setTimeout(90000);
     await projectScreen.clickLayer(layerName);
     await page.waitForTimeout(2000);
@@ -242,6 +249,7 @@ test.describe("Photo Overlay Feature", () => {
   });
 
   test.skip("Cancel editor closes panel without saving", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PHOTO-007" });
     test.setTimeout(90000);
     await projectScreen.clickLayer(layerName);
     await page.waitForTimeout(2000);

--- a/e2e/tests/project/projectSettings.spec.ts
+++ b/e2e/tests/project/projectSettings.spec.ts
@@ -72,6 +72,7 @@ test.describe("PROJECT SETTINGS - All Tabs", () => {
   });
 
   test("Navigate to Project Settings via context menu", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-001" });
     test.setTimeout(30000);
     const menuBtn = projectsPage.gridProjectMenuButton(projectName).first();
     await menuBtn.click();
@@ -84,10 +85,12 @@ test.describe("PROJECT SETTINGS - All Tabs", () => {
   });
 
   test("General: should display sidebar tabs", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-002" });
     await settingsPage.verifySidebarTabsVisible();
   });
 
   test("General: should display basic settings fields", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-004" });
     test.setTimeout(30000);
     await expect(settingsPage.generalSettingsTitle).toBeVisible();
     await expect(settingsPage.projectNameLabel).toBeVisible();
@@ -98,12 +101,14 @@ test.describe("PROJECT SETTINGS - All Tabs", () => {
   });
 
   test("General: should display thumbnail section", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-004" });
     await expect(settingsPage.thumbnailLabel).toBeVisible();
     await expect(settingsPage.thumbnailChooseButton).toBeVisible();
     await expect(settingsPage.thumbnailUploadButton).toBeVisible();
   });
 
   test("General: should display danger zone", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-005" });
     await expect(settingsPage.dangerZoneTitle).toBeVisible();
     await expect(settingsPage.removeProjectTitle).toBeVisible();
     await expect(settingsPage.removeProjectDescription).toBeVisible();
@@ -111,14 +116,17 @@ test.describe("PROJECT SETTINGS - All Tabs", () => {
   });
 
   test("General: should show correct project name", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-003" });
     await expect(settingsPage.projectNameInput).toHaveValue(projectName);
   });
 
   test("General: should show correct project alias", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-003" });
     await expect(settingsPage.projectAliasInput).toHaveValue(projectAlias);
   });
 
   test("README: should navigate and display editor", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-007" });
     test.setTimeout(30000);
     await settingsPage.navigateToReadmeTab();
     await expect(settingsPage.contentReadme).toBeVisible();
@@ -126,19 +134,23 @@ test.describe("PROJECT SETTINGS - All Tabs", () => {
   });
 
   test("README: should have Edit and Preview tabs", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-008" });
     await expect(settingsPage.readmeEditTab).toBeVisible();
     await expect(settingsPage.readmePreviewTab).toBeVisible();
   });
 
   test("README: should have Save button", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-010" });
     await expect(settingsPage.readmeSaveButton).toBeVisible();
   });
 
   test("README: should show textarea in edit mode", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-009" });
     await expect(settingsPage.readmeTextarea).toBeVisible();
   });
 
   test("README: should switch to preview mode", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-008" });
     await settingsPage.readmePreviewTab.click();
     await page.waitForTimeout(500);
     await expect(settingsPage.readmeTextarea).not.toBeVisible();
@@ -148,6 +160,7 @@ test.describe("PROJECT SETTINGS - All Tabs", () => {
   });
 
   test("License: should navigate and display editor", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-011" });
     test.setTimeout(30000);
     await settingsPage.navigateToLicenseTab();
     await expect(settingsPage.contentLicense).toBeVisible();
@@ -155,16 +168,19 @@ test.describe("PROJECT SETTINGS - All Tabs", () => {
   });
 
   test("License: should have Edit and Preview tabs", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-012" });
     await expect(settingsPage.licenseEditTab).toBeVisible();
     await expect(settingsPage.licensePreviewTab).toBeVisible();
   });
 
   test("License: should have Save and Choose Template buttons", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-013" });
     await expect(settingsPage.licenseSaveButton).toBeVisible();
     await expect(settingsPage.licenseChooseTemplateButton).toBeVisible();
   });
 
   test("License: should open template modal", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-014" });
     test.setTimeout(30000);
     await settingsPage.licenseChooseTemplateButton.click();
     await page.waitForTimeout(1000);
@@ -177,6 +193,7 @@ test.describe("PROJECT SETTINGS - All Tabs", () => {
   });
 
   test("Story: should navigate and display settings", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-015" });
     test.setTimeout(30000);
     await settingsPage.navigateToStoryTab();
     await expect(settingsPage.contentStory).toBeVisible();
@@ -184,16 +201,19 @@ test.describe("PROJECT SETTINGS - All Tabs", () => {
   });
 
   test("Story: should display panel position selector", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-016" });
     await expect(
       page.getByText("Panel Position", { exact: true })
     ).toBeVisible();
   });
 
   test("Story: should display background color field", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-017" });
     await expect(settingsPage.storyBackgroundColorField).toBeVisible();
   });
 
   test("Public: should navigate and display settings", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-018" });
     test.setTimeout(30000);
     // Public tab has sub-items (Scene/Story) that may already be visible.
     // Click the "Scene" sub-link directly to navigate to Public settings.
@@ -214,30 +234,36 @@ test.describe("PROJECT SETTINGS - All Tabs", () => {
   });
 
   test("Public: should display published page settings section", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-019" });
     await expect(settingsPage.publicInfoTitle).toBeVisible();
   });
 
   test("Public: should display alias setting section", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-019" });
     await expect(settingsPage.publicAliasSettingTitle).toBeVisible();
   });
 
   test("Public: should display basic authorization section", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-020" });
     await expect(settingsPage.publicBasicAuthTitle).toBeVisible();
     await expect(settingsPage.publicEnableBasicAuthSwitch).toBeVisible();
   });
 
   test("Public: should display Google Analytics section", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-020" });
     await expect(settingsPage.publicGoogleAnalyticsTitle).toBeVisible();
     await expect(settingsPage.publicEnableGASwitch).toBeVisible();
   });
 
   test("Assets: should navigate and display content", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-021" });
     test.setTimeout(30000);
     await settingsPage.navigateToAssetsTab();
     await expect(settingsPage.contentAssets).toBeVisible();
   });
 
   test("Cleanup: Move project to recycle bin from settings", async () => {
+    test.info().annotations.push({ type: "story", description: "US-PSET-006" });
     test.setTimeout(60000);
     await settingsPage.navigateToGeneralTab();
     await page.waitForTimeout(1000);

--- a/e2e/tests/project/projects.spec.ts
+++ b/e2e/tests/project/projects.spec.ts
@@ -75,6 +75,7 @@ test.describe("Project Management", () => {
   });
 
   test("Verify dashboard is loaded", async () => {
+    test.info().annotations.push({ type: "story", description: "US-DASH-001" });
     await expect(dashBoardPage.projects).toBeVisible();
     await expect(dashBoardPage.recycleBin).toBeVisible();
     await expect(dashBoardPage.pluginPlayground).toBeVisible();
@@ -82,6 +83,7 @@ test.describe("Project Management", () => {
   });
 
   test("Verify project creation modal", async () => {
+    test.info().annotations.push({ type: "story", description: "US-DASH-002" });
     await dashBoardPage.projects.click();
     await projectsPage.newProjectButton.waitFor({ state: "visible" });
     await page.waitForTimeout(500);
@@ -94,6 +96,7 @@ test.describe("Project Management", () => {
   });
 
   test("Create a new project and verify after its creation", async () => {
+    test.info().annotations.push({ type: "story", description: "US-DASH-003" });
     await projectsPage.createNewProject(
       projectName,
       projectAlias,
@@ -104,12 +107,14 @@ test.describe("Project Management", () => {
   });
 
   test("Go to the newly created project", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EDIT-001" });
     await projectsPage.goToProjectPage(projectName);
     await expect(projectScreen.newLayerButton).toBeVisible();
     await expect(projectScreen.addNewStyleButton).toBeVisible();
   });
 
   test("Should add new layer and add points on the map", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EDIT-002" });
     test.setTimeout(60000);
     await projectScreen.createNewLayer(layerName);
     await projectScreen.verifyLayerAdded(layerName);
@@ -145,11 +150,13 @@ test.describe("Project Management", () => {
   });
 
   test.skip("Should verify sketch tools are visible after adding style", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EDIT-003" });
     test.setTimeout(60000);
     await projectScreen.verifySketchToolsVisible();
   });
 
   test.skip("Should draw a polyline on the map", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EDIT-003" });
     test.setTimeout(90000);
     const polylineLayerName = faker.string.alpha(5);
 
@@ -198,6 +205,7 @@ test.describe("Project Management", () => {
   });
 
   test.skip("Should draw a polygon on the map", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EDIT-004" });
     test.setTimeout(90000);
     const polygonLayerName = faker.string.alpha(5);
 
@@ -229,6 +237,7 @@ test.describe("Project Management", () => {
   });
 
   test.skip("Should draw a circle on the map", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EDIT-005" });
     test.setTimeout(90000);
     const circleLayerName = faker.string.alpha(5);
 
@@ -254,6 +263,7 @@ test.describe("Project Management", () => {
   });
 
   test.skip("Should draw a square on the map", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EDIT-006" });
     test.setTimeout(90000);
     const squareLayerName = faker.string.alpha(5);
 
@@ -279,6 +289,7 @@ test.describe("Project Management", () => {
   });
 
   test("Should create layer with custom text property", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EDIT-002" });
     test.setTimeout(60000);
     const customLayerName = faker.string.alpha(5);
 
@@ -291,6 +302,7 @@ test.describe("Project Management", () => {
   });
 
   test("Should create layer with custom number property", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EDIT-002" });
     test.setTimeout(60000);
     const customLayerName = faker.string.alpha(5);
 
@@ -303,6 +315,7 @@ test.describe("Project Management", () => {
   });
 
   test.skip("Should navigate to Scene panel and verify scene items", async () => {
+    test.info().annotations.push({ type: "story", description: "US-EDIT-003" });
     test.setTimeout(60000);
     await projectScreen.scenePanel.click();
     await page.waitForTimeout(1000);


### PR DESCRIPTION
## Overview

Add an AI management guide (`e2e/CLAUDE.md`) for the E2E test suite and attach story ID annotations to existing E2E tests for traceability.

## What I've done

- **Added `e2e/CLAUDE.md`** — documents rules for how AI (Claude) should read, write, and reason about the E2E suite: directory structure, page-object conventions, annotation format, what not to touch (`playwright.config.ts`, `global-setup.ts`), and a stable test-ID system
- **Added story ID annotations** to existing tests across 10 spec files:
  - `account/accountWorkspaceSettings.spec.ts`
  - `account/members.spec.ts`
  - `dashboard/dashboard.spec.ts`
  - `dashboard/dashboardFeatures.spec.ts`
  - `layer/externalLayers.spec.ts`
  - `layer/layerDeletionReorder.spec.ts`
  - `layer/multipleStyles.spec.ts`
  - `layer/photoOverlay.spec.ts`
  - `project/projectSettings.spec.ts`
  - `project/projects.spec.ts`

  Each annotation uses `test.info().annotations.push({ type: "story", description: "US-XXX-NNN" })` to link tests to user stories in the tracking system.

## What I haven't done

- No new test scenarios added; existing test logic is unchanged
- `playwright.config.ts` and `global-setup.ts` not modified

## How I tested

- Annotation syntax is consistent with the Playwright `TestInfo.annotations` API — no runtime impact on test execution
- Existing tests pass without modification

## Which point I want you to review particularly

- Story ID assignments (`US-STYLE-xxx`, `US-PSET-xxx`, etc.) — confirm they match the correct user stories in the tracking system

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.