### PR TITLE
fix(server): handle group-shaped legacy tiles in SetTileCategory migration

### DIFF
--- a/server/internal/infrastructure/mongo/migration/260804000000_set_tile_category.go
+++ b/server/internal/infrastructure/mongo/migration/260804000000_set_tile_category.go
@@ -16,6 +16,32 @@ import (
 // have a system tile (tile_type=google_satellite, tile_category=system).
 var streetViewPluginExtensions = []string{"streetView", "googleMapSearch"}
 
+// tileTypeFromTilesItem reads the tile_type field off a "tiles" schema group item,
+// regardless of whether it was persisted as a single "group" (fields directly on the
+// item, as the streetView widget's tiles schema historically had no list:true) or as
+// a "grouplist" (fields nested under Groups, as the scene-level tiles schema has).
+func tileTypeFromTilesItem(item *mongodoc.PropertyItemDocument) (string, bool) {
+	if item == nil || item.SchemaGroup != "tiles" {
+		return "", false
+	}
+
+	fieldSets := item.Groups
+	if item.Type == "group" {
+		fieldSets = []*mongodoc.PropertyItemDocument{item}
+	}
+
+	for _, group := range fieldSets {
+		for _, field := range group.Fields {
+			if field.Field == "tile_type" {
+				if val, ok := field.Value.(string); ok && val != "" {
+					return val, true
+				}
+			}
+		}
+	}
+	return "", false
+}
+
 // SetTileCategory migrates scene properties by ensuring that any scene with a
 // streetView or googleMapSearch widget has a system tile (tile_type=google_satellite,
 // tile_category=system). Existing user-added tiles are preserved as-is.
@@ -110,17 +136,8 @@ func SetTileCategory(ctx context.Context, c DBClient) error {
 						continue
 					}
 					for _, item := range doc.Items {
-						if item.SchemaGroup != "tiles" || item.Type != "grouplist" {
-							continue
-						}
-						for _, group := range item.Groups {
-							for _, field := range group.Fields {
-								if field.Field == "tile_type" {
-									if val, ok := field.Value.(string); ok && val != "" {
-										widgetTileTypes[doc.ID] = val
-									}
-								}
-							}
+						if val, ok := tileTypeFromTilesItem(item); ok {
+							widgetTileTypes[doc.ID] = val
 						}
 					}
 				}
@@ -302,17 +319,8 @@ func SetTileCategory(ctx context.Context, c DBClient) error {
 				filtered := doc.Items[:0]
 				removed := false
 				for _, item := range doc.Items {
-					if item.SchemaGroup == "tiles" && item.Type == "grouplist" {
-						var val string
-						for _, group := range item.Groups {
-							for _, field := range group.Fields {
-								if field.Field == "tile_type" {
-									if v, ok := field.Value.(string); ok && v != "" {
-										val = v
-									}
-								}
-							}
-						}
+					if item.SchemaGroup == "tiles" && (item.Type == "grouplist" || item.Type == "group") {
+						val, _ := tileTypeFromTilesItem(item)
 						fmt.Printf("[migration] SetTileCategory: widget property %q had tile_type=%q before removal\n", doc.ID, val)
 						removed = true
 						continue

--- a/server/internal/infrastructure/mongo/migration/260804000000_set_tile_category.go
+++ b/server/internal/infrastructure/mongo/migration/260804000000_set_tile_category.go
@@ -30,16 +30,22 @@ func tileTypeFromTilesItem(item *mongodoc.PropertyItemDocument) (string, bool) {
 		fieldSets = []*mongodoc.PropertyItemDocument{item}
 	}
 
+	// Scan every field rather than returning on the first match, so behavior
+	// matches the original grouplist-only implementation: the last non-empty
+	// tile_type wins if a tiles item somehow holds more than one.
+	found := false
+	var result string
 	for _, group := range fieldSets {
 		for _, field := range group.Fields {
 			if field.Field == "tile_type" {
 				if val, ok := field.Value.(string); ok && val != "" {
-					return val, true
+					result = val
+					found = true
 				}
 			}
 		}
 	}
-	return "", false
+	return result, found
 }
 
 // SetTileCategory migrates scene properties by ensuring that any scene with a

--- a/server/internal/infrastructure/mongo/migration/260804000000_set_tile_category.go
+++ b/server/internal/infrastructure/mongo/migration/260804000000_set_tile_category.go
@@ -25,9 +25,14 @@ func tileTypeFromTilesItem(item *mongodoc.PropertyItemDocument) (string, bool) {
 		return "", false
 	}
 
-	fieldSets := item.Groups
-	if item.Type == "group" {
+	var fieldSets []*mongodoc.PropertyItemDocument
+	switch item.Type {
+	case "group":
 		fieldSets = []*mongodoc.PropertyItemDocument{item}
+	case "grouplist":
+		fieldSets = item.Groups
+	default:
+		return "", false
 	}
 
 	// Scan every field rather than returning on the first match, so behavior

--- a/server/internal/infrastructure/mongo/migration/260804000000_set_tile_category_test.go
+++ b/server/internal/infrastructure/mongo/migration/260804000000_set_tile_category_test.go
@@ -343,6 +343,86 @@ func TestSetTileCategory_CleansUpWidgetPropertyTilesGroup(t *testing.T) {
 	}
 }
 
+// TestSetTileCategory_CarriesOverLegacyTileType_GroupShaped verifies that when the
+// widget property's legacy tiles item is stored as a single "group" (fields directly
+// on the item, no Groups list) rather than a "grouplist" - the shape the streetView
+// widget's tiles schema actually produced, since it never had list:true - the system
+// tile still carries over the legacy tile_type and the widget property is still
+// cleaned up.
+func TestSetTileCategory_CarriesOverLegacyTileType_GroupShaped(t *testing.T) {
+	ctx := context.Background()
+	db := mongotest.Connect(t)(t)
+	client := mongox.NewClientWithDatabase(db)
+	sceneCol := client.WithCollection("scene").Client()
+	propCol := client.WithCollection("property").Client()
+
+	_, err := sceneCol.InsertOne(ctx, sceneDocForMigration{
+		ID:       "scene6",
+		Property: "prop6",
+		Widgets: []struct {
+			ID        string `bson:"id"`
+			Plugin    string `bson:"plugin"`
+			Extension string `bson:"extension"`
+			Property  string `bson:"property"`
+			Enabled   bool   `bson:"enabled"`
+		}{
+			{ID: "w6", Plugin: "reearth", Extension: "streetView", Property: "wprop6", Enabled: true},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = propCol.InsertOne(ctx, mongodoc.PropertyDocument{
+		ID:    "prop6",
+		Scene: "scene6",
+		Items: []*mongodoc.PropertyItemDocument{},
+	})
+	require.NoError(t, err)
+
+	// Widget property's legacy tile setting is a "group", not a "grouplist".
+	_, err = propCol.InsertOne(ctx, mongodoc.PropertyDocument{
+		ID:    "wprop6",
+		Scene: "scene6",
+		Items: []*mongodoc.PropertyItemDocument{
+			{
+				Type:        "group",
+				SchemaGroup: "tiles",
+				Fields: []*mongodoc.PropertyFieldDocument{
+					{Field: "tile_type", Type: "string", Value: "google_roadmap"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, SetTileCategory(ctx, client))
+
+	var result mongodoc.PropertyDocument
+	require.NoError(t, propCol.FindOne(ctx, bson.M{"id": "prop6"}).Decode(&result))
+
+	require.Len(t, result.Items, 1)
+	require.Len(t, result.Items[0].Groups, 1)
+
+	var tileType, tileCategory string
+	for _, f := range result.Items[0].Groups[0].Fields {
+		if f.Field == "tile_type" {
+			tileType = f.Value.(string)
+		}
+		if f.Field == "tile_category" {
+			tileCategory = f.Value.(string)
+		}
+	}
+	assert.Equal(t, "google_roadmap", tileType, "should carry over legacy tile type from group-shaped widget property")
+	assert.Equal(t, "system", tileCategory)
+
+	var widgetProp mongodoc.PropertyDocument
+	require.NoError(t, propCol.FindOne(ctx, bson.M{"id": "wprop6"}).Decode(&widgetProp))
+	for _, item := range widgetProp.Items {
+		if item.SchemaGroup == "tiles" {
+			t.Errorf("expected legacy tiles group to be removed from widget property, but found one")
+		}
+	}
+}
+
 // TestSetTileCategory_NoMatchingScenes verifies that when no scenes with
 // streetView/googleMapSearch widgets exist, the migration completes without error and
 // makes no changes.

--- a/server/internal/infrastructure/mongo/migration/260804013000_repair_set_tile_category_legacy_tile_type.go
+++ b/server/internal/infrastructure/mongo/migration/260804013000_repair_set_tile_category_legacy_tile_type.go
@@ -183,6 +183,7 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 			}
 
 			if len(ids) > 0 {
+				fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: saving scene properties: %v\n", ids)
 				return propCol.SaveAll(ctx, ids, newRows)
 			}
 			return nil
@@ -211,6 +212,8 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 				removed := false
 				for _, item := range doc.Items {
 					if item.SchemaGroup == "tiles" && item.Type == "group" {
+						val, _ := tileTypeFromTilesItem(item)
+						fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: widget property %q had tile_type=%q before removal\n", doc.ID, val)
 						removed = true
 						continue
 					}
@@ -226,6 +229,7 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 			}
 
 			if len(ids) > 0 {
+				fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: saving widget properties: %v\n", ids)
 				return propCol.SaveAll(ctx, ids, newRows)
 			}
 			return nil

--- a/server/internal/infrastructure/mongo/migration/260804013000_repair_set_tile_category_legacy_tile_type.go
+++ b/server/internal/infrastructure/mongo/migration/260804013000_repair_set_tile_category_legacy_tile_type.go
@@ -35,6 +35,7 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 	}
 
 	sceneToWidgetProps := map[string][]string{}
+	widgetToSceneProp := map[string]string{}
 	var widgetPropertyIDs []string
 	if err := sceneCol.Find(ctx, sceneFilter, &mongox.BatchConsumer{
 		Size: 1000,
@@ -58,6 +59,7 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 						if w.Extension == ext && w.Property != "" {
 							widgetPropertyIDs = append(widgetPropertyIDs, w.Property)
 							sceneToWidgetProps[doc.Property] = append(sceneToWidgetProps[doc.Property], w.Property)
+							widgetToSceneProp[w.Property] = doc.Property
 						}
 					}
 				}
@@ -119,14 +121,24 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 		affectedWidgetPropertyIDs = append(affectedWidgetPropertyIDs, wPropID)
 	}
 
-	// Map affected scene property ID -> correct tile_type.
+	// Map affected scene property ID -> correct tile_type. If a scene has more than
+	// one widget with a leftover legacy value, the first one wins (same policy as
+	// SetTileCategory) - log the rest so a discarded value is visible, not silent.
 	sceneTileType := map[string]string{}
+	sceneChosenWidget := map[string]string{}
 	for scenePropID, wPropIDs := range sceneToWidgetProps {
 		for _, wPropID := range wPropIDs {
-			if t, ok := widgetTileTypes[wPropID]; ok {
-				sceneTileType[scenePropID] = t
-				break // use the first widget's tile type
+			t, ok := widgetTileTypes[wPropID]
+			if !ok {
+				continue
 			}
+			if chosen, already := sceneChosenWidget[scenePropID]; already {
+				fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: scene property %q has more than one legacy widget tile value; keeping %q from widget property %q, discarding widget property %q (tile_type=%q)\n",
+					scenePropID, sceneTileType[scenePropID], chosen, wPropID, t)
+				continue
+			}
+			sceneTileType[scenePropID] = t
+			sceneChosenWidget[scenePropID] = wPropID
 		}
 	}
 
@@ -135,7 +147,14 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 		scenePropertyIDs = append(scenePropertyIDs, scenePropID)
 	}
 
-	var totalFixed, totalSkipped int
+	// confirmedSceneIDs tracks scene properties whose system tile group was actually
+	// found and now holds the correct tile_type - whether corrected here or already
+	// right. Only widget properties belonging to a confirmed scene are safe to clean
+	// up below: if a scene property is missing, fails to unmarshal, or has no system
+	// tile group to correct, its widget's leftover data is the only remaining record
+	// of the legacy value, so it must be left in place rather than deleted.
+	confirmedSceneIDs := map[string]bool{}
+	var totalFixed, totalSkipped, totalUnconfirmed int
 	if err := propCol.Find(ctx, bson.M{"id": bson.M{"$in": scenePropertyIDs}}, &mongox.BatchConsumer{
 		Size: 1000,
 		Callback: func(rows []bson.Raw) error {
@@ -159,6 +178,7 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 				}
 
 				fixed := false
+				foundSystemGroup := false
 				for _, item := range doc.Items {
 					if item.SchemaGroup != "tiles" || item.Type != "grouplist" {
 						continue
@@ -175,6 +195,7 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 						if !isSystem {
 							continue
 						}
+						foundSystemGroup = true
 						for _, field := range group.Fields {
 							if field.Field != "tile_type" {
 								continue
@@ -188,11 +209,18 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 					}
 				}
 
+				if foundSystemGroup {
+					confirmedSceneIDs[doc.ID] = true
+				} else {
+					fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: WARNING scene property %q has no system tile group to correct (expected tile_type=%q); its widget's leftover tiles item will NOT be cleaned up this run\n", doc.ID, correctTileType)
+					totalUnconfirmed++
+				}
+
 				if fixed {
 					ids = append(ids, doc.ID)
 					newRows = append(newRows, doc)
 					totalFixed++
-				} else {
+				} else if foundSystemGroup {
 					totalSkipped++
 				}
 			}
@@ -206,12 +234,30 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 	}); err != nil {
 		return fmt.Errorf("failed to repair scene properties: %w", err)
 	}
-	fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: scene properties fixed=%d skipped=%d\n", totalFixed, totalSkipped)
+	fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: scene properties fixed=%d skipped=%d unconfirmed=%d\n", totalFixed, totalSkipped, totalUnconfirmed)
+
+	// Only clean up widget properties whose scene was confirmed above - otherwise
+	// their leftover legacy tile data is the only remaining record of the value and
+	// deleting it here would make the scene's wrong default unrecoverable.
+	confirmedWidgetPropertyIDs := make([]string, 0, len(affectedWidgetPropertyIDs))
+	for _, wPropID := range affectedWidgetPropertyIDs {
+		scenePropID, ok := widgetToSceneProp[wPropID]
+		if ok && confirmedSceneIDs[scenePropID] {
+			confirmedWidgetPropertyIDs = append(confirmedWidgetPropertyIDs, wPropID)
+			continue
+		}
+		fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: WARNING skipping cleanup of widget property %q (tile_type=%q) because its scene property %q was not confirmed corrected\n", wPropID, widgetTileTypes[wPropID], scenePropID)
+	}
+
+	if len(confirmedWidgetPropertyIDs) == 0 {
+		fmt.Println("[migration] RepairSetTileCategoryLegacyTileType: no confirmed widget properties to clean up")
+		return nil
+	}
 
 	// Now that the value has been carried over, remove the leftover group-shaped
 	// widget tiles items.
 	var widgetCleaned int
-	if err := propCol.Find(ctx, bson.M{"id": bson.M{"$in": affectedWidgetPropertyIDs}}, &mongox.BatchConsumer{
+	if err := propCol.Find(ctx, bson.M{"id": bson.M{"$in": confirmedWidgetPropertyIDs}}, &mongox.BatchConsumer{
 		Size: 1000,
 		Callback: func(rows []bson.Raw) error {
 			ids := make([]string, 0, len(rows))

--- a/server/internal/infrastructure/mongo/migration/260804013000_repair_set_tile_category_legacy_tile_type.go
+++ b/server/internal/infrastructure/mongo/migration/260804013000_repair_set_tile_category_legacy_tile_type.go
@@ -1,0 +1,239 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/reearth/reearth/server/internal/infrastructure/mongo/mongodoc"
+	"github.com/reearth/reearthx/mongox"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// RepairSetTileCategoryLegacyTileType repairs scene properties that SetTileCategory
+// (260804000000) processed incorrectly. That migration only recognized a widget's
+// legacy tiles setting when stored as a "grouplist", but the streetView widget's
+// tiles schema historically had no list:true and so persisted as a plain "group".
+// Scenes hit by that gap ended up with the "google_satellite" default instead of
+// their real legacy tile_type, and the leftover widget-level tiles item was never
+// cleaned up.
+//
+// This migration re-derives the correct tile_type from any remaining "group"-shaped
+// widget tiles item, corrects the scene property's system tile, and removes the
+// leftover widget property item. It is a no-op once no "group"-shaped widget tiles
+// items remain, so it is safe to run repeatedly.
+func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error {
+	sceneCol := c.WithCollection("scene")
+
+	sceneFilter := bson.M{
+		"widgets": bson.M{
+			"$elemMatch": bson.M{
+				"extension": bson.M{
+					"$in": streetViewPluginExtensions,
+				},
+			},
+		},
+	}
+
+	sceneToWidgetProps := map[string][]string{}
+	var widgetPropertyIDs []string
+	if err := sceneCol.Find(ctx, sceneFilter, &mongox.BatchConsumer{
+		Size: 1000,
+		Callback: func(rows []bson.Raw) error {
+			for _, row := range rows {
+				var doc struct {
+					Property string `bson:"property"`
+					Widgets  []struct {
+						Extension string `bson:"extension"`
+						Property  string `bson:"property"`
+					} `bson:"widgets"`
+				}
+				if err := bson.Unmarshal(row, &doc); err != nil {
+					return fmt.Errorf("failed to unmarshal scene document: %w", err)
+				}
+				if doc.Property == "" {
+					continue
+				}
+				for _, w := range doc.Widgets {
+					for _, ext := range streetViewPluginExtensions {
+						if w.Extension == ext && w.Property != "" {
+							widgetPropertyIDs = append(widgetPropertyIDs, w.Property)
+							sceneToWidgetProps[doc.Property] = append(sceneToWidgetProps[doc.Property], w.Property)
+						}
+					}
+				}
+			}
+			return nil
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to query scenes: %w", err)
+	}
+
+	if len(widgetPropertyIDs) == 0 {
+		fmt.Println("[migration] RepairSetTileCategoryLegacyTileType: no streetView/googleMapSearch widgets found, nothing to do")
+		return nil
+	}
+
+	propCol := c.WithCollection("property")
+
+	// Find widget properties still holding a "group"-shaped legacy tiles item -
+	// these are exactly the ones SetTileCategory failed to read and clean up.
+	widgetTileTypes := map[string]string{}
+	var affectedWidgetPropertyIDs []string
+	if err := propCol.Find(ctx, bson.M{"id": bson.M{"$in": widgetPropertyIDs}}, &mongox.BatchConsumer{
+		Size: 1000,
+		Callback: func(rows []bson.Raw) error {
+			for _, row := range rows {
+				var doc mongodoc.PropertyDocument
+				if err := bson.Unmarshal(row, &doc); err != nil {
+					continue
+				}
+				for _, item := range doc.Items {
+					if item.SchemaGroup != "tiles" || item.Type != "group" {
+						continue
+					}
+					if val, ok := tileTypeFromTilesItem(item); ok {
+						widgetTileTypes[doc.ID] = val
+						affectedWidgetPropertyIDs = append(affectedWidgetPropertyIDs, doc.ID)
+					}
+				}
+			}
+			return nil
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to read widget properties: %w", err)
+	}
+
+	if len(affectedWidgetPropertyIDs) == 0 {
+		fmt.Println("[migration] RepairSetTileCategoryLegacyTileType: no leftover group-shaped widget tiles found, nothing to do")
+		return nil
+	}
+	fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: found %d widget properties with leftover group-shaped tiles\n", len(affectedWidgetPropertyIDs))
+
+	// Map affected scene property ID -> correct tile_type.
+	sceneTileType := map[string]string{}
+	for scenePropID, wPropIDs := range sceneToWidgetProps {
+		for _, wPropID := range wPropIDs {
+			if t, ok := widgetTileTypes[wPropID]; ok {
+				sceneTileType[scenePropID] = t
+				break // use the first widget's tile type
+			}
+		}
+	}
+
+	scenePropertyIDs := make([]string, 0, len(sceneTileType))
+	for scenePropID := range sceneTileType {
+		scenePropertyIDs = append(scenePropertyIDs, scenePropID)
+	}
+
+	var totalFixed, totalSkipped int
+	if err := propCol.Find(ctx, bson.M{"id": bson.M{"$in": scenePropertyIDs}}, &mongox.BatchConsumer{
+		Size: 1000,
+		Callback: func(rows []bson.Raw) error {
+			ids := make([]string, 0, len(rows))
+			newRows := make([]any, 0, len(rows))
+
+			for _, row := range rows {
+				var doc mongodoc.PropertyDocument
+				if err := bson.Unmarshal(row, &doc); err != nil {
+					continue
+				}
+
+				correctTileType, ok := sceneTileType[doc.ID]
+				if !ok {
+					continue
+				}
+
+				fixed := false
+				for _, item := range doc.Items {
+					if item.SchemaGroup != "tiles" || item.Type != "grouplist" {
+						continue
+					}
+					for _, group := range item.Groups {
+						isSystem := false
+						for _, field := range group.Fields {
+							if field.Field == "tile_category" {
+								if v, ok := field.Value.(string); ok && v == "system" {
+									isSystem = true
+								}
+							}
+						}
+						if !isSystem {
+							continue
+						}
+						for _, field := range group.Fields {
+							if field.Field != "tile_type" {
+								continue
+							}
+							if v, ok := field.Value.(string); ok && v != correctTileType {
+								fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: correcting property %q tile_type %q -> %q\n", doc.ID, v, correctTileType)
+								field.Value = correctTileType
+								fixed = true
+							}
+						}
+					}
+				}
+
+				if fixed {
+					ids = append(ids, doc.ID)
+					newRows = append(newRows, doc)
+					totalFixed++
+				} else {
+					totalSkipped++
+				}
+			}
+
+			if len(ids) > 0 {
+				return propCol.SaveAll(ctx, ids, newRows)
+			}
+			return nil
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to repair scene properties: %w", err)
+	}
+	fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: scene properties fixed=%d skipped=%d\n", totalFixed, totalSkipped)
+
+	// Now that the value has been carried over, remove the leftover group-shaped
+	// widget tiles items.
+	var widgetCleaned int
+	if err := propCol.Find(ctx, bson.M{"id": bson.M{"$in": affectedWidgetPropertyIDs}}, &mongox.BatchConsumer{
+		Size: 1000,
+		Callback: func(rows []bson.Raw) error {
+			ids := make([]string, 0, len(rows))
+			newRows := make([]any, 0, len(rows))
+
+			for _, row := range rows {
+				var doc mongodoc.PropertyDocument
+				if err := bson.Unmarshal(row, &doc); err != nil {
+					continue
+				}
+
+				filtered := doc.Items[:0]
+				removed := false
+				for _, item := range doc.Items {
+					if item.SchemaGroup == "tiles" && item.Type == "group" {
+						removed = true
+						continue
+					}
+					filtered = append(filtered, item)
+				}
+
+				if removed {
+					doc.Items = filtered
+					ids = append(ids, doc.ID)
+					newRows = append(newRows, doc)
+					widgetCleaned++
+				}
+			}
+
+			if len(ids) > 0 {
+				return propCol.SaveAll(ctx, ids, newRows)
+			}
+			return nil
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to clean up widget properties: %w", err)
+	}
+	fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: widget properties cleaned=%d\n", widgetCleaned)
+
+	return nil
+}

--- a/server/internal/infrastructure/mongo/migration/260804013000_repair_set_tile_category_legacy_tile_type.go
+++ b/server/internal/infrastructure/mongo/migration/260804013000_repair_set_tile_category_legacy_tile_type.go
@@ -77,14 +77,20 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 
 	// Find widget properties still holding a "group"-shaped legacy tiles item -
 	// these are exactly the ones SetTileCategory failed to read and clean up.
+	// Keyed by property ID so a document with more than one matching item (or a
+	// re-scanned document) is only ever counted once.
 	widgetTileTypes := map[string]string{}
-	var affectedWidgetPropertyIDs []string
 	if err := propCol.Find(ctx, bson.M{"id": bson.M{"$in": widgetPropertyIDs}}, &mongox.BatchConsumer{
 		Size: 1000,
 		Callback: func(rows []bson.Raw) error {
 			for _, row := range rows {
 				var doc mongodoc.PropertyDocument
 				if err := bson.Unmarshal(row, &doc); err != nil {
+					var raw struct {
+						ID string `bson:"id"`
+					}
+					_ = bson.Unmarshal(row, &raw)
+					fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: failed to unmarshal widget property id=%q, skipping: %v\n", raw.ID, err)
 					continue
 				}
 				for _, item := range doc.Items {
@@ -93,7 +99,6 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 					}
 					if val, ok := tileTypeFromTilesItem(item); ok {
 						widgetTileTypes[doc.ID] = val
-						affectedWidgetPropertyIDs = append(affectedWidgetPropertyIDs, doc.ID)
 					}
 				}
 			}
@@ -103,11 +108,16 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 		return fmt.Errorf("failed to read widget properties: %w", err)
 	}
 
-	if len(affectedWidgetPropertyIDs) == 0 {
+	if len(widgetTileTypes) == 0 {
 		fmt.Println("[migration] RepairSetTileCategoryLegacyTileType: no leftover group-shaped widget tiles found, nothing to do")
 		return nil
 	}
-	fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: found %d widget properties with leftover group-shaped tiles\n", len(affectedWidgetPropertyIDs))
+	fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: found %d widget properties with leftover group-shaped tiles\n", len(widgetTileTypes))
+
+	affectedWidgetPropertyIDs := make([]string, 0, len(widgetTileTypes))
+	for wPropID := range widgetTileTypes {
+		affectedWidgetPropertyIDs = append(affectedWidgetPropertyIDs, wPropID)
+	}
 
 	// Map affected scene property ID -> correct tile_type.
 	sceneTileType := map[string]string{}
@@ -135,6 +145,11 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 			for _, row := range rows {
 				var doc mongodoc.PropertyDocument
 				if err := bson.Unmarshal(row, &doc); err != nil {
+					var raw struct {
+						ID string `bson:"id"`
+					}
+					_ = bson.Unmarshal(row, &raw)
+					fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: failed to unmarshal scene property id=%q, skipping: %v\n", raw.ID, err)
 					continue
 				}
 
@@ -205,6 +220,11 @@ func RepairSetTileCategoryLegacyTileType(ctx context.Context, c DBClient) error 
 			for _, row := range rows {
 				var doc mongodoc.PropertyDocument
 				if err := bson.Unmarshal(row, &doc); err != nil {
+					var raw struct {
+						ID string `bson:"id"`
+					}
+					_ = bson.Unmarshal(row, &raw)
+					fmt.Printf("[migration] RepairSetTileCategoryLegacyTileType: failed to unmarshal widget property id=%q, skipping: %v\n", raw.ID, err)
 					continue
 				}
 

--- a/server/internal/infrastructure/mongo/migration/260804013000_repair_set_tile_category_legacy_tile_type_test.go
+++ b/server/internal/infrastructure/mongo/migration/260804013000_repair_set_tile_category_legacy_tile_type_test.go
@@ -100,6 +100,73 @@ func TestRepairSetTileCategoryLegacyTileType_FixesGroupShapedLeftover(t *testing
 	assert.Empty(t, widgetPropResult.Items, "leftover group-shaped widget tiles item should have been removed")
 }
 
+// TestRepairSetTileCategoryLegacyTileType_LeavesWidgetIntactIfSceneUnconfirmed
+// verifies that when a scene property has no system tile group to correct (e.g. the
+// tiles item is missing entirely), the migration does NOT delete the corresponding
+// widget's leftover legacy tiles item - since that item is the only remaining record
+// of the correct tile_type, deleting it here would make the scene unrecoverable.
+func TestRepairSetTileCategoryLegacyTileType_LeavesWidgetIntactIfSceneUnconfirmed(t *testing.T) {
+	ctx := context.Background()
+	db := mongotest.Connect(t)(t)
+	client := mongox.NewClientWithDatabase(db)
+	sceneCol := client.WithCollection("scene").Client()
+	propCol := client.WithCollection("property").Client()
+
+	_, err := sceneCol.InsertOne(ctx, sceneDocForMigration{
+		ID:       "repair_scene3",
+		Property: "repair_prop3",
+		Widgets: []struct {
+			ID        string `bson:"id"`
+			Plugin    string `bson:"plugin"`
+			Extension string `bson:"extension"`
+			Property  string `bson:"property"`
+			Enabled   bool   `bson:"enabled"`
+		}{
+			{ID: "rw3", Plugin: "reearth", Extension: "streetView", Property: "repair_wprop3", Enabled: true},
+		},
+	})
+	require.NoError(t, err)
+
+	// Scene property has no tiles item at all - SetTileCategory never created a
+	// system tile for it, so there is nothing here for the repair migration to
+	// correct.
+	_, err = propCol.InsertOne(ctx, mongodoc.PropertyDocument{
+		ID:    "repair_prop3",
+		Scene: "repair_scene3",
+		Items: []*mongodoc.PropertyItemDocument{},
+	})
+	require.NoError(t, err)
+
+	_, err = propCol.InsertOne(ctx, mongodoc.PropertyDocument{
+		ID:    "repair_wprop3",
+		Scene: "repair_scene3",
+		Items: []*mongodoc.PropertyItemDocument{
+			{
+				Type:        "group",
+				SchemaGroup: "tiles",
+				Fields: []*mongodoc.PropertyFieldDocument{
+					{Field: "tile_type", Type: "string", Value: "google_roadmap"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, RepairSetTileCategoryLegacyTileType(ctx, client))
+
+	var widgetPropResult mongodoc.PropertyDocument
+	require.NoError(t, propCol.FindOne(ctx, bson.M{"id": "repair_wprop3"}).Decode(&widgetPropResult))
+	require.Len(t, widgetPropResult.Items, 1, "leftover legacy tiles item should NOT have been removed since the scene was never confirmed corrected")
+
+	var tileType string
+	for _, f := range widgetPropResult.Items[0].Fields {
+		if f.Field == "tile_type" {
+			tileType = f.Value.(string)
+		}
+	}
+	assert.Equal(t, "google_roadmap", tileType, "the only remaining record of the legacy value must be preserved")
+}
+
 // TestRepairSetTileCategoryLegacyTileType_NoOpWhenAlreadyClean verifies that scenes
 // with no leftover group-shaped widget tiles item are left untouched.
 func TestRepairSetTileCategoryLegacyTileType_NoOpWhenAlreadyClean(t *testing.T) {

--- a/server/internal/infrastructure/mongo/migration/260804013000_repair_set_tile_category_legacy_tile_type_test.go
+++ b/server/internal/infrastructure/mongo/migration/260804013000_repair_set_tile_category_legacy_tile_type_test.go
@@ -157,5 +157,12 @@ func TestRepairSetTileCategoryLegacyTileType_NoOpWhenAlreadyClean(t *testing.T) 
 	var scenePropResult mongodoc.PropertyDocument
 	require.NoError(t, propCol.FindOne(ctx, bson.M{"id": "repair_prop2"}).Decode(&scenePropResult))
 	require.Len(t, scenePropResult.Items[0].Groups, 1)
-	assert.Equal(t, "google_roadmap", scenePropResult.Items[0].Groups[0].Fields[0].Value.(string), "should remain unchanged")
+
+	var tileType string
+	for _, f := range scenePropResult.Items[0].Groups[0].Fields {
+		if f.Field == "tile_type" {
+			tileType = f.Value.(string)
+		}
+	}
+	assert.Equal(t, "google_roadmap", tileType, "should remain unchanged")
 }

--- a/server/internal/infrastructure/mongo/migration/260804013000_repair_set_tile_category_legacy_tile_type_test.go
+++ b/server/internal/infrastructure/mongo/migration/260804013000_repair_set_tile_category_legacy_tile_type_test.go
@@ -1,0 +1,161 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth/server/internal/infrastructure/mongo/mongodoc"
+	"github.com/reearth/reearthx/mongox"
+	"github.com/reearth/reearthx/mongox/mongotest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// TestRepairSetTileCategoryLegacyTileType_FixesGroupShapedLeftover verifies that a
+// scene already processed by the buggy SetTileCategory (system tile stuck on the
+// "google_satellite" default, widget property still holding its group-shaped legacy
+// tiles item) gets its scene property corrected and its widget property cleaned up.
+func TestRepairSetTileCategoryLegacyTileType_FixesGroupShapedLeftover(t *testing.T) {
+	ctx := context.Background()
+	db := mongotest.Connect(t)(t)
+	client := mongox.NewClientWithDatabase(db)
+	sceneCol := client.WithCollection("scene").Client()
+	propCol := client.WithCollection("property").Client()
+
+	_, err := sceneCol.InsertOne(ctx, sceneDocForMigration{
+		ID:       "repair_scene1",
+		Property: "repair_prop1",
+		Widgets: []struct {
+			ID        string `bson:"id"`
+			Plugin    string `bson:"plugin"`
+			Extension string `bson:"extension"`
+			Property  string `bson:"property"`
+			Enabled   bool   `bson:"enabled"`
+		}{
+			{ID: "rw1", Plugin: "reearth", Extension: "streetView", Property: "repair_wprop1", Enabled: true},
+		},
+	})
+	require.NoError(t, err)
+
+	// Scene property already has a system tile, but stuck on the default because
+	// SetTileCategory failed to read the widget's group-shaped legacy value.
+	_, err = propCol.InsertOne(ctx, mongodoc.PropertyDocument{
+		ID:    "repair_prop1",
+		Scene: "repair_scene1",
+		Items: []*mongodoc.PropertyItemDocument{
+			{
+				Type:        "grouplist",
+				SchemaGroup: "tiles",
+				Groups: []*mongodoc.PropertyItemDocument{
+					{
+						Fields: []*mongodoc.PropertyFieldDocument{
+							{Field: "tile_type", Type: "string", Value: "google_satellite"},
+							{Field: "tile_category", Type: "string", Value: "system"},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Widget property still has its group-shaped legacy tiles item, never cleaned up.
+	_, err = propCol.InsertOne(ctx, mongodoc.PropertyDocument{
+		ID:    "repair_wprop1",
+		Scene: "repair_scene1",
+		Items: []*mongodoc.PropertyItemDocument{
+			{
+				Type:        "group",
+				SchemaGroup: "tiles",
+				Fields: []*mongodoc.PropertyFieldDocument{
+					{Field: "tile_type", Type: "string", Value: "google_roadmap"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, RepairSetTileCategoryLegacyTileType(ctx, client))
+
+	var scenePropResult mongodoc.PropertyDocument
+	require.NoError(t, propCol.FindOne(ctx, bson.M{"id": "repair_prop1"}).Decode(&scenePropResult))
+	require.Len(t, scenePropResult.Items, 1)
+	require.Len(t, scenePropResult.Items[0].Groups, 1)
+
+	var tileType, tileCategory string
+	for _, f := range scenePropResult.Items[0].Groups[0].Fields {
+		if f.Field == "tile_type" {
+			tileType = f.Value.(string)
+		}
+		if f.Field == "tile_category" {
+			tileCategory = f.Value.(string)
+		}
+	}
+	assert.Equal(t, "google_roadmap", tileType, "system tile's tile_type should have been corrected")
+	assert.Equal(t, "system", tileCategory)
+
+	var widgetPropResult mongodoc.PropertyDocument
+	require.NoError(t, propCol.FindOne(ctx, bson.M{"id": "repair_wprop1"}).Decode(&widgetPropResult))
+	assert.Empty(t, widgetPropResult.Items, "leftover group-shaped widget tiles item should have been removed")
+}
+
+// TestRepairSetTileCategoryLegacyTileType_NoOpWhenAlreadyClean verifies that scenes
+// with no leftover group-shaped widget tiles item are left untouched.
+func TestRepairSetTileCategoryLegacyTileType_NoOpWhenAlreadyClean(t *testing.T) {
+	ctx := context.Background()
+	db := mongotest.Connect(t)(t)
+	client := mongox.NewClientWithDatabase(db)
+	sceneCol := client.WithCollection("scene").Client()
+	propCol := client.WithCollection("property").Client()
+
+	_, err := sceneCol.InsertOne(ctx, sceneDocForMigration{
+		ID:       "repair_scene2",
+		Property: "repair_prop2",
+		Widgets: []struct {
+			ID        string `bson:"id"`
+			Plugin    string `bson:"plugin"`
+			Extension string `bson:"extension"`
+			Property  string `bson:"property"`
+			Enabled   bool   `bson:"enabled"`
+		}{
+			{ID: "rw2", Plugin: "reearth", Extension: "streetView", Property: "repair_wprop2", Enabled: true},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = propCol.InsertOne(ctx, mongodoc.PropertyDocument{
+		ID:    "repair_prop2",
+		Scene: "repair_scene2",
+		Items: []*mongodoc.PropertyItemDocument{
+			{
+				Type:        "grouplist",
+				SchemaGroup: "tiles",
+				Groups: []*mongodoc.PropertyItemDocument{
+					{
+						Fields: []*mongodoc.PropertyFieldDocument{
+							{Field: "tile_type", Type: "string", Value: "google_roadmap"},
+							{Field: "tile_category", Type: "string", Value: "system"},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Widget property already cleaned up (correctly, by the fixed SetTileCategory).
+	_, err = propCol.InsertOne(ctx, mongodoc.PropertyDocument{
+		ID:    "repair_wprop2",
+		Scene: "repair_scene2",
+		Items: []*mongodoc.PropertyItemDocument{},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, RepairSetTileCategoryLegacyTileType(ctx, client))
+
+	var scenePropResult mongodoc.PropertyDocument
+	require.NoError(t, propCol.FindOne(ctx, bson.M{"id": "repair_prop2"}).Decode(&scenePropResult))
+	require.Len(t, scenePropResult.Items[0].Groups, 1)
+	assert.Equal(t, "google_roadmap", scenePropResult.Items[0].Groups[0].Fields[0].Value.(string), "should remain unchanged")
+}

--- a/server/internal/infrastructure/mongo/migration/migrations.go
+++ b/server/internal/infrastructure/mongo/migration/migrations.go
@@ -47,4 +47,5 @@ var migrations = migration.Migrations[DBClient]{
 	260525120000: MigrateLegacyTilesToCesiumIon,
 	260701120000: MoveImportStatusToOwnCollection,
 	260804000000: SetTileCategory,
+	260804013000: RepairSetTileCategoryLegacyTileType,
 }


### PR DESCRIPTION
## Summary
- The streetView widget's legacy tiles setting was sometimes stored as a single group instead of a list of groups, because its schema never had the list flag set. The SetTileCategory migration only checked for the list shape, so affected scenes silently lost their tile type preference (falling back to the default) and the old widget data was never cleaned up.
- Fixed both places in SetTileCategory that only matched the list shape, so it now reads and cleans up either shape.
- Added a follow up migration to repair scenes that already ran through the old, buggy version: it corrects the tile type on the scene and removes the leftover widget data. It does nothing if there is nothing left to fix, so it is safe to run more than once.

## Test plan
- [x] go test ./internal/infrastructure/mongo/migration/... passes, including new tests for the group shaped case and the repair migration
- [x] Verified locally against real data pulled from the dev database that showed this exact issue: after running the repair migration, the tile type was corrected and the leftover widget data was removed
