### PR TITLE
fix(web): content cleanup for plugin modal and popup close & fix ui surface sizing

### DIFF
--- a/web/src/app/features/Visualizer/Crust/Plugins/Plugin/ModalContainer/index.tsx
+++ b/web/src/app/features/Visualizer/Crust/Plugins/Plugin/ModalContainer/index.tsx
@@ -51,15 +51,23 @@ const ModalContainer: ForwardRefRenderFunction<
 
 const Wrapper = styled("div")<{ visible: boolean }>(({ visible, theme }) => ({
   position: css.position.absolute,
-  left: "50%",
-  top: " 50%",
-  transform: "translate(-50%, -50%)",
+  left: 0,
+  top: 0,
+  width: "100%",
+  height: "100%",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  pointerEvents: "none", // Allow clicks to pass through to Background
   visibility: visible ? "visible" : "hidden",
   zIndex: visible
     ? theme.zIndexes.visualizer.pluginModal
     : theme.zIndexes.hidden,
   transition: "opacity 0.25s",
-  opacity: visible ? "1" : "0"
+  opacity: visible ? "1" : "0",
+  "& > *": {
+    pointerEvents: "auto" // Modal content should receive clicks
+  }
 }));
 
 const Background = styled("div")<{ visible: boolean; background?: string }>(

--- a/web/src/app/features/Visualizer/Crust/Plugins/Plugin/hooks/usePluginInstance.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/Plugin/hooks/usePluginInstance.ts
@@ -31,6 +31,10 @@ export default function ({
   onPluginModalShow,
   shownPluginPopupInfo,
   onPluginPopupShow,
+  registerPluginModalClose,
+  unregisterPluginModalClose,
+  registerPluginPopupClose,
+  unregisterPluginPopupClose,
   onRender: _onRender,
   onResize: _onResize
 }: {
@@ -49,6 +53,10 @@ export default function ({
   onVisibilityChange?: (widgetId: string, v: boolean) => void;
   onPluginModalShow?: (modalInfo?: PluginModalInfo) => void;
   onPluginPopupShow?: (modalInfo?: PluginModalInfo) => void;
+  registerPluginModalClose?: (id: string, closeFn: () => void) => void;
+  unregisterPluginModalClose?: (id: string) => void;
+  registerPluginPopupClose?: (id: string, closeFn: () => void) => void;
+  unregisterPluginPopupClose?: (id: string) => void;
   onRender?: (
     options:
       | {
@@ -100,6 +108,10 @@ export default function ({
     onPluginPopupShow,
     shownPluginModalInfo,
     shownPluginPopupInfo,
+    registerPluginModalClose,
+    unregisterPluginModalClose,
+    registerPluginPopupClose,
+    unregisterPluginPopupClose,
     widget,
     block
   });
@@ -110,6 +122,10 @@ export default function ({
       onPluginPopupShow,
       shownPluginModalInfo,
       shownPluginPopupInfo,
+      registerPluginModalClose,
+      unregisterPluginModalClose,
+      registerPluginPopupClose,
+      unregisterPluginPopupClose,
       widget,
       block
     };
@@ -147,14 +163,16 @@ export default function ({
   }, []);
 
   // Update modal visibility based on external state
+  // Note: We don't call handleModalClose here anymore. Closing is now handled
+  // by the close-before-show pattern in Crust hooks, which calls our registered
+  // close callback directly. This prevents the race condition where we would
+  // clear the global state that a new plugin just set.
   useEffect(() => {
     const visible = shownPluginModalInfo?.id === (widget?.id ?? block?.id);
     if (modalVisible !== visible) {
       setModalVisibility(visible);
-      if (!visible) {
-        // Modal was closed externally
-        handleModalClose();
-      }
+      // Don't call handleModalClose() here - closing is handled by
+      // the close-before-show pattern via registered close callbacks
     }
   }, [
     modalVisible,
@@ -162,19 +180,17 @@ export default function ({
     pluginId,
     extensionId,
     widget?.id,
-    block?.id,
-    handleModalClose
+    block?.id
   ]);
 
   // Update popup visibility based on external state
+  // Same note as modal: closing is handled by close-before-show pattern
   useEffect(() => {
     const visible = shownPluginPopupInfo?.id === (widget?.id ?? block?.id);
     if (popupVisible !== visible) {
       setPopupVisibility(visible);
-      if (!visible) {
-        // Popup was closed externally
-        handlePopupClose();
-      }
+      // Don't call handlePopupClose() here - closing is handled by
+      // the close-before-show pattern via registered close callbacks
     }
   }, [
     popupVisible,
@@ -182,8 +198,7 @@ export default function ({
     pluginId,
     extensionId,
     widget?.id,
-    block?.id,
-    handlePopupClose
+    block?.id
   ]);
 
   const onError = useCallback(
@@ -262,6 +277,43 @@ export default function ({
   const handlePopupShow = useCallback((options?: PluginPopupInfo) => {
     callbacksRef.current.onPluginPopupShow?.(options);
   }, []);
+
+  /**
+   * Callback for PluginFrame to register modal close function.
+   * Wraps the close function with the plugin's instance ID and registers
+   * it with the Crust level so other plugins can close this modal.
+   */
+  const handleRegisterModalClose = useCallback((closeFn: () => void) => {
+    const instanceId =
+      callbacksRef.current.widget?.id ?? callbacksRef.current.block?.id;
+    if (instanceId) {
+      callbacksRef.current.registerPluginModalClose?.(instanceId, closeFn);
+    }
+  }, []);
+
+  /**
+   * Callback for PluginFrame to register popup close function.
+   * Wraps the close function with the plugin's instance ID and registers
+   * it with the Crust level so other plugins can close this popup.
+   */
+  const handleRegisterPopupClose = useCallback((closeFn: () => void) => {
+    const instanceId =
+      callbacksRef.current.widget?.id ?? callbacksRef.current.block?.id;
+    if (instanceId) {
+      callbacksRef.current.registerPluginPopupClose?.(instanceId, closeFn);
+    }
+  }, []);
+
+  // Unregister close callbacks on unmount
+  useEffect(() => {
+    const instanceId = widget?.id ?? block?.id;
+    return () => {
+      if (instanceId) {
+        callbacksRef.current.unregisterPluginModalClose?.(instanceId);
+        callbacksRef.current.unregisterPluginPopupClose?.(instanceId);
+      }
+    };
+  }, [widget?.id, block?.id]);
 
   // Plugin message sender registration ref
   const pluginMessageSenderRef = useRef<
@@ -382,6 +434,8 @@ export default function ({
     renderKey,
     pluginContext,
     onError,
-    onDispose: handleDispose
+    onDispose: handleDispose,
+    onRegisterModalClose: handleRegisterModalClose,
+    onRegisterPopupClose: handleRegisterPopupClose
   };
 }

--- a/web/src/app/features/Visualizer/Crust/Plugins/Plugin/index.tsx
+++ b/web/src/app/features/Visualizer/Crust/Plugins/Plugin/index.tsx
@@ -28,6 +28,24 @@ export type CommonProps = {
   shownPluginPopupInfo?: PluginPopupInfo;
   onPluginModalShow?: (modalInfo?: PluginModalInfo) => void;
   onPluginPopupShow?: (popupInfo?: PluginPopupInfo) => void;
+  /**
+   * Register a close callback for this plugin's modal.
+   * Called by the close-before-show pattern to close previous modal.
+   */
+  registerPluginModalClose?: (id: string, closeFn: () => void) => void;
+  /**
+   * Unregister the close callback for this plugin's modal.
+   */
+  unregisterPluginModalClose?: (id: string) => void;
+  /**
+   * Register a close callback for this plugin's popup.
+   * Called by the close-before-show pattern to close previous popup.
+   */
+  registerPluginPopupClose?: (id: string, closeFn: () => void) => void;
+  /**
+   * Unregister the close callback for this plugin's popup.
+   */
+  unregisterPluginPopupClose?: (id: string) => void;
 };
 
 export type ExternalPluginProps = Pick<
@@ -89,6 +107,10 @@ export default function Plugin({
   onVisibilityChange,
   onPluginModalShow,
   onPluginPopupShow,
+  registerPluginModalClose,
+  unregisterPluginModalClose,
+  registerPluginPopupClose,
+  unregisterPluginPopupClose,
   onClick,
   onRender,
   onResize
@@ -105,7 +127,9 @@ export default function Plugin({
     renderKey,
     pluginContext,
     onError,
-    onDispose
+    onDispose,
+    onRegisterModalClose,
+    onRegisterPopupClose
   } = usePluginInstance({
     mapRef,
     pluginId,
@@ -122,6 +146,10 @@ export default function Plugin({
     onVisibilityChange,
     onPluginModalShow,
     onPluginPopupShow,
+    registerPluginModalClose,
+    unregisterPluginModalClose,
+    registerPluginPopupClose,
+    unregisterPluginPopupClose,
     onRender,
     onResize
   });
@@ -146,6 +174,8 @@ export default function Plugin({
       onError={onError}
       onDispose={onDispose}
       onClick={onClick}
+      onRegisterModalClose={onRegisterModalClose}
+      onRegisterPopupClose={onRegisterPopupClose}
     />
   ) : null;
 }

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.test.tsx
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.test.tsx
@@ -119,10 +119,9 @@ describe("PluginFrame", () => {
 
     const uiDiv = container.querySelector(".test-plugin-ui");
     expect(uiDiv).toBeTruthy();
+    // UI surface uses inline-block to only take needed space in widget alignment system
     expect(uiDiv).toHaveStyle({
-      display: "block",
-      width: "100%",
-      height: "100%"
+      display: "inline-block"
     });
   });
 
@@ -174,7 +173,9 @@ describe("PluginFrame", () => {
     );
 
     // Modal is rendered in portal (ModalContainer Wrapper handles visibility)
-    const modalDiv = modalContainer.querySelector(".zushi-modal-surface-container") as HTMLElement;
+    const modalDiv = modalContainer.querySelector(
+      ".zushi-modal-surface-container"
+    ) as HTMLElement;
     expect(modalDiv).toBeTruthy();
     expect(modalDiv?.style.minWidth).toBe("300px");
     expect(modalDiv?.style.minHeight).toBe("200px");
@@ -196,7 +197,9 @@ describe("PluginFrame", () => {
     );
 
     // Modal container always exists (ModalContainer Wrapper controls visibility)
-    const modalDiv = modalContainer.querySelector(".zushi-modal-surface-container") as HTMLElement;
+    const modalDiv = modalContainer.querySelector(
+      ".zushi-modal-surface-container"
+    ) as HTMLElement;
     expect(modalDiv).toBeTruthy();
     expect(modalDiv?.style.minWidth).toBe("300px");
     expect(modalDiv?.style.minHeight).toBe("200px");
@@ -218,7 +221,9 @@ describe("PluginFrame", () => {
     );
 
     // Popup is rendered in portal (PopupContainer Wrapper controls visibility)
-    const popupDiv = popupContainer.querySelector(".zushi-popup-surface-container");
+    const popupDiv = popupContainer.querySelector(
+      ".zushi-popup-surface-container"
+    );
     expect(popupDiv).toBeTruthy();
     expect(popupDiv?.className).toContain("zushi-popup-surface-container");
 
@@ -308,7 +313,9 @@ describe("PluginFrame", () => {
     );
 
     // Check that modal element was appended
-    const modalDiv = modalContainer.querySelector(".zushi-modal-surface-container");
+    const modalDiv = modalContainer.querySelector(
+      ".zushi-modal-surface-container"
+    );
     expect(modalDiv).toBeTruthy();
     // Styles are set by useZushiPlugin, just verify the element exists
     expect(modalDiv?.className).toContain("zushi-modal-surface-container");
@@ -330,7 +337,9 @@ describe("PluginFrame", () => {
     );
 
     // Check that popup element was appended
-    const popupDiv = popupContainer.querySelector(".zushi-popup-surface-container");
+    const popupDiv = popupContainer.querySelector(
+      ".zushi-popup-surface-container"
+    );
     expect(popupDiv).toBeTruthy();
     // Styles are set by useZushiPlugin, just verify the element exists
     expect(popupDiv?.className).toContain("zushi-popup-surface-container");

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.tsx
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.tsx
@@ -141,11 +141,11 @@ const PluginFrameZushi: ForwardRefRenderFunction<Ref, Props> = (
           height: 100%;
           border: none;
         }
-        /* Modal and popup containers should size to content */
+        /* Modal and popup containers - let Zushi control dimensions, constrain to viewport */
         .zushi-modal-surface-container,
         .zushi-popup-surface-container {
-          width: fit-content !important;
-          height: fit-content !important;
+          max-width: 100%;
+          max-height: 100%;
         }
         .zushi-modal-surface-container iframe,
         .zushi-popup-surface-container iframe {

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.tsx
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.tsx
@@ -44,6 +44,18 @@ export type Props = {
   onDispose?: () => void;
   onClick?: () => void;
   onRender?: (type: string) => void;
+  /**
+   * Callback to register the modal close function.
+   * Used by the close-before-show pattern to close previous modal
+   * when a new plugin shows its modal.
+   */
+  onRegisterModalClose?: (closeFn: () => void) => void;
+  /**
+   * Callback to register the popup close function.
+   * Used by the close-before-show pattern to close previous popup
+   * when a new plugin shows its popup.
+   */
+  onRegisterPopupClose?: (closeFn: () => void) => void;
 };
 
 const PluginFrameZushi: ForwardRefRenderFunction<Ref, Props> = (
@@ -68,7 +80,9 @@ const PluginFrameZushi: ForwardRefRenderFunction<Ref, Props> = (
     onDispose,
     onClick,
     onMessage,
-    onRender: _onRender
+    onRender: _onRender,
+    onRegisterModalClose,
+    onRegisterPopupClose
   },
   ref
 ) => {
@@ -83,7 +97,9 @@ const PluginFrameZushi: ForwardRefRenderFunction<Ref, Props> = (
     onError,
     onPreInit,
     onDispose,
-    onMessage
+    onMessage,
+    onRegisterModalClose,
+    onRegisterPopupClose
   });
 
   // Populate UI container ref for popup positioning
@@ -120,12 +136,21 @@ const PluginFrameZushi: ForwardRefRenderFunction<Ref, Props> = (
     <>
       <style>{`
         /* Ensure Zushi iframes fill their containers */
-        .zushi-ui-surface-container iframe,
-        .zushi-modal-surface-container iframe,
-        .zushi-popup-surface-container iframe {
+        .zushi-ui-surface-container iframe {
           width: 100%;
           height: 100%;
           border: none;
+        }
+        /* Modal and popup containers should size to content */
+        .zushi-modal-surface-container,
+        .zushi-popup-surface-container {
+          width: fit-content !important;
+          height: fit-content !important;
+        }
+        .zushi-modal-surface-container iframe,
+        .zushi-popup-surface-container iframe {
+          border: none;
+          display: block;
         }
       `}</style>
 

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.tsx
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.tsx
@@ -135,11 +135,10 @@ const PluginFrameZushi: ForwardRefRenderFunction<Ref, Props> = (
   return (
     <>
       <style>{`
-        /* Ensure Zushi iframes fill their containers */
+        /* UI surface - let Zushi control dimensions, don't force 100% */
         .zushi-ui-surface-container iframe {
-          width: 100%;
-          height: 100%;
           border: none;
+          display: block;
         }
         /* Modal and popup containers - let Zushi control dimensions, constrain to viewport */
         .zushi-modal-surface-container,
@@ -159,9 +158,7 @@ const PluginFrameZushi: ForwardRefRenderFunction<Ref, Props> = (
         ref={surfaceRefs.uiContainer}
         className={`zushi-ui-surface-container ${className || ""}`}
         style={{
-          display: uiVisible ? "block" : "none",
-          width: "100%",
-          height: "100%",
+          display: uiVisible ? "inline-block" : "none",
           ...iFrameProps?.style
         }}
         onClick={onClick}

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.ts
@@ -17,7 +17,10 @@ import {
   useState
 } from "react";
 
-import type { ReearthPluginContext } from "../pluginAPI/zushiAdapter";
+import type {
+  ExternalCloseRefs,
+  ReearthPluginContext
+} from "../pluginAPI/zushiAdapter";
 import { createZushiExposedAPI } from "../pluginAPI/zushiAdapter";
 
 /**
@@ -35,6 +38,18 @@ export type Options = {
   onPreInit?: () => void;
   onDispose?: () => void;
   onMessage?: (msg: unknown) => void;
+  /**
+   * Callback to register the modal close function with the parent.
+   * Called when the plugin is initialized with a function that can
+   * externally close the modal (fires close events, hides surface).
+   */
+  onRegisterModalClose?: (closeFn: () => void) => void;
+  /**
+   * Callback to register the popup close function with the parent.
+   * Called when the plugin is initialized with a function that can
+   * externally close the popup (fires close events, hides surface).
+   */
+  onRegisterPopupClose?: (closeFn: () => void) => void;
 };
 
 /**
@@ -105,11 +120,20 @@ export default function useZushiPlugin({
   onPreInit,
   onError = defaultOnError,
   onDispose,
-  onMessage: rawOnMessage
+  onMessage: rawOnMessage,
+  onRegisterModalClose,
+  onRegisterPopupClose
 }: Options): UseZushiPluginReturn {
   const [loaded, setLoaded] = useState(false);
   const [code, setCode] = useState("");
   const pluginRef = useRef<Plugin | undefined>(undefined);
+
+  // External close refs - populated by the adapter and used for external close
+  // Note: getModalContainer/getPopupContainer will be set after containers are created
+  const externalCloseRefs = useRef<ExternalCloseRefs>({
+    modalCloseRef: { current: null },
+    popupCloseRef: { current: null }
+  });
 
   /**
    * pluginContextRef Pattern
@@ -292,7 +316,8 @@ export default function useZushiPlugin({
           exposed: createZushiExposedAPI(
             () => pluginContextRef.current,
             messageHandlers,
-            (fn) => disposeCallbacksRef.current.push(fn)
+            (fn) => disposeCallbacksRef.current.push(fn),
+            externalCloseRefs.current
           )
         });
 
@@ -484,6 +509,23 @@ export default function useZushiPlugin({
     popupContainer,
     runDisposeCallbacks
   ]);
+
+  // Register external close callbacks with parent when plugin is loaded
+  useEffect(() => {
+    if (!loaded) return;
+
+    // Register modal close callback
+    const modalClose = externalCloseRefs.current.modalCloseRef.current;
+    if (modalClose && onRegisterModalClose) {
+      onRegisterModalClose(modalClose);
+    }
+
+    // Register popup close callback
+    const popupClose = externalCloseRefs.current.popupCloseRef.current;
+    if (popupClose && onRegisterPopupClose) {
+      onRegisterPopupClose(popupClose);
+    }
+  }, [loaded, onRegisterModalClose, onRegisterPopupClose]);
 
   // Listen for window postMessage events from plugin UI
   // Filter based on iframe source window

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.ts
@@ -128,8 +128,8 @@ export default function useZushiPlugin({
   const [code, setCode] = useState("");
   const pluginRef = useRef<Plugin | undefined>(undefined);
 
-  // External close refs - populated by the adapter and used for external close
-  // Note: getModalContainer/getPopupContainer will be set after containers are created
+  // External close refs - populated by the modal/popup adapters so the parent can
+  // close surfaces (close-before-show) while still firing each surface's close events
   const externalCloseRefs = useRef<ExternalCloseRefs>({
     modalCloseRef: { current: null },
     popupCloseRef: { current: null }

--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.test.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.test.ts
@@ -630,6 +630,11 @@ describe("zushiAdapter", () => {
 
       const globalThis = factory(mockZushiContext as any);
 
+      // Must show first (idempotent guard requires modal to be open)
+      globalThis.reearth.modal.show("<div>test</div>", {});
+      vi.mocked(modalSurface.show).mockClear();
+      vi.mocked(modalSurface.setVisible).mockClear();
+
       // Call modal.close()
       globalThis.reearth.modal.close();
 
@@ -667,6 +672,9 @@ describe("zushiAdapter", () => {
       };
 
       const globalThis = factory(mockZushiContext as any);
+
+      // Must show first (idempotent guard requires modal to be open)
+      globalThis.reearth.modal.show("<div>test</div>", {});
 
       // Call modal.close()
       globalThis.reearth.modal.close();
@@ -711,6 +719,11 @@ describe("zushiAdapter", () => {
       };
 
       const globalThis = factory(mockZushiContext as any);
+
+      // Must show first (idempotent guard requires modal to be open)
+      globalThis.reearth.modal.show("<div>test</div>", {});
+      vi.mocked(modalSurface.show).mockClear();
+      vi.mocked(modalSurface.setVisible).mockClear();
 
       // Register a close event handler
       const closeHandler = vi.fn();
@@ -760,6 +773,11 @@ describe("zushiAdapter", () => {
 
       const globalThis = factory(mockZushiContext as any);
 
+      // Must show first (idempotent guard requires popup to be open)
+      globalThis.reearth.popup.show("<div>test</div>", {});
+      vi.mocked(popupSurface.show).mockClear();
+      vi.mocked(popupSurface.setVisible).mockClear();
+
       // Call popup.close()
       globalThis.reearth.popup.close();
 
@@ -797,6 +815,9 @@ describe("zushiAdapter", () => {
       };
 
       const globalThis = factory(mockZushiContext as any);
+
+      // Must show first (idempotent guard requires popup to be open)
+      globalThis.reearth.popup.show("<div>test</div>", {});
 
       // Call popup.close()
       globalThis.reearth.popup.close();
@@ -842,6 +863,11 @@ describe("zushiAdapter", () => {
 
       const globalThis = factory(mockZushiContext as any);
 
+      // Must show first (idempotent guard requires popup to be open)
+      globalThis.reearth.popup.show("<div>test</div>", {});
+      vi.mocked(popupSurface.show).mockClear();
+      vi.mocked(popupSurface.setVisible).mockClear();
+
       // Register a close event handler
       const closeHandler = vi.fn();
       globalThis.reearth.popup.on("close", closeHandler);
@@ -861,6 +887,214 @@ describe("zushiAdapter", () => {
       expect(closeHandler).toHaveBeenCalled();
 
       // Verify onPopupClose was NOT called (critical for close-before-show pattern)
+      expect(onPopupClose).not.toHaveBeenCalled();
+    });
+
+    test("modal.close() is idempotent - calling twice does not fire events twice", () => {
+      const onModalClose = vi.fn();
+      const reearthContext = {
+        ...createMockReearthContext(),
+        onModalClose
+      };
+      const messageHandlers = {
+        onMessage: vi.fn(),
+        offMessage: vi.fn(),
+        onceMessage: vi.fn()
+      };
+
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
+
+      const modalSurface = createMockSurface();
+      const mockZushiContext = {
+        surfaces: {
+          ui: createMockSurface(),
+          modal: modalSurface,
+          popup: createMockSurface()
+        },
+        startEventLoop: vi.fn()
+      };
+
+      const globalThis = factory(mockZushiContext as any);
+
+      // Show modal first
+      globalThis.reearth.modal.show("<div>test</div>", {});
+
+      // Register close handler
+      const closeHandler = vi.fn();
+      globalThis.reearth.modal.on("close", closeHandler);
+
+      // Close twice
+      globalThis.reearth.modal.close();
+      globalThis.reearth.modal.close();
+
+      // Verify close handler and onModalClose only called once
+      expect(closeHandler).toHaveBeenCalledTimes(1);
+      expect(onModalClose).toHaveBeenCalledTimes(1);
+    });
+
+    test("modal.close() after external close does not call onModalClose", () => {
+      const onModalClose = vi.fn();
+      const reearthContext = {
+        ...createMockReearthContext(),
+        onModalClose
+      };
+      const messageHandlers = {
+        onMessage: vi.fn(),
+        offMessage: vi.fn(),
+        onceMessage: vi.fn()
+      };
+
+      const externalCloseRefs: ExternalCloseRefs = {
+        modalCloseRef: { current: null },
+        popupCloseRef: { current: null }
+      };
+
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {},
+        externalCloseRefs
+      );
+
+      const modalSurface = createMockSurface();
+      const mockZushiContext = {
+        surfaces: {
+          ui: createMockSurface(),
+          modal: modalSurface,
+          popup: createMockSurface()
+        },
+        startEventLoop: vi.fn()
+      };
+
+      const globalThis = factory(mockZushiContext as any);
+
+      // Show modal first
+      globalThis.reearth.modal.show("<div>test</div>", {});
+
+      // Register close handler
+      const closeHandler = vi.fn();
+      globalThis.reearth.modal.on("close", closeHandler);
+
+      // External close (simulating another plugin taking over)
+      const externalClose = externalCloseRefs.modalCloseRef.current;
+      if (externalClose) {
+        externalClose();
+      }
+
+      // Plugin A tries to close its modal (unaware it was externally closed)
+      globalThis.reearth.modal.close();
+
+      // Verify close handler fired once (from external close)
+      expect(closeHandler).toHaveBeenCalledTimes(1);
+      // Verify onModalClose was never called (external close skips it, subsequent close is guarded)
+      expect(onModalClose).not.toHaveBeenCalled();
+    });
+
+    test("popup.close() is idempotent - calling twice does not fire events twice", () => {
+      const onPopupClose = vi.fn();
+      const reearthContext = {
+        ...createMockReearthContext(),
+        onPopupClose
+      };
+      const messageHandlers = {
+        onMessage: vi.fn(),
+        offMessage: vi.fn(),
+        onceMessage: vi.fn()
+      };
+
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
+
+      const popupSurface = createMockSurface();
+      const mockZushiContext = {
+        surfaces: {
+          ui: createMockSurface(),
+          modal: createMockSurface(),
+          popup: popupSurface
+        },
+        startEventLoop: vi.fn()
+      };
+
+      const globalThis = factory(mockZushiContext as any);
+
+      // Show popup first
+      globalThis.reearth.popup.show("<div>test</div>", {});
+
+      // Register close handler
+      const closeHandler = vi.fn();
+      globalThis.reearth.popup.on("close", closeHandler);
+
+      // Close twice
+      globalThis.reearth.popup.close();
+      globalThis.reearth.popup.close();
+
+      // Verify close handler and onPopupClose only called once
+      expect(closeHandler).toHaveBeenCalledTimes(1);
+      expect(onPopupClose).toHaveBeenCalledTimes(1);
+    });
+
+    test("popup.close() after external close does not call onPopupClose", () => {
+      const onPopupClose = vi.fn();
+      const reearthContext = {
+        ...createMockReearthContext(),
+        onPopupClose
+      };
+      const messageHandlers = {
+        onMessage: vi.fn(),
+        offMessage: vi.fn(),
+        onceMessage: vi.fn()
+      };
+
+      const externalCloseRefs: ExternalCloseRefs = {
+        modalCloseRef: { current: null },
+        popupCloseRef: { current: null }
+      };
+
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {},
+        externalCloseRefs
+      );
+
+      const popupSurface = createMockSurface();
+      const mockZushiContext = {
+        surfaces: {
+          ui: createMockSurface(),
+          modal: createMockSurface(),
+          popup: popupSurface
+        },
+        startEventLoop: vi.fn()
+      };
+
+      const globalThis = factory(mockZushiContext as any);
+
+      // Show popup first
+      globalThis.reearth.popup.show("<div>test</div>", {});
+
+      // Register close handler
+      const closeHandler = vi.fn();
+      globalThis.reearth.popup.on("close", closeHandler);
+
+      // External close (simulating another plugin taking over)
+      const externalClose = externalCloseRefs.popupCloseRef.current;
+      if (externalClose) {
+        externalClose();
+      }
+
+      // Plugin A tries to close its popup (unaware it was externally closed)
+      globalThis.reearth.popup.close();
+
+      // Verify close handler fired once (from external close)
+      expect(closeHandler).toHaveBeenCalledTimes(1);
+      // Verify onPopupClose was never called (external close skips it, subsequent close is guarded)
       expect(onPopupClose).not.toHaveBeenCalled();
     });
   });

--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.test.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.test.ts
@@ -11,7 +11,11 @@ import { describe, expect, test, vi } from "vitest";
 
 import type { Context } from "../types";
 
-import { createZushiExposedAPI, type ReearthPluginContext } from "./zushiAdapter";
+import {
+  createZushiExposedAPI,
+  type ExternalCloseRefs,
+  type ReearthPluginContext
+} from "./zushiAdapter";
 
 // Mock SurfaceAPI
 function createMockSurface(): SurfaceAPI {
@@ -585,6 +589,264 @@ describe("zushiAdapter", () => {
 
       expect(getCurrentLocationAsync).toHaveBeenCalled();
       expect(startEventLoop).toHaveBeenCalled();
+    });
+
+    test("modal.close() clears content with empty div", () => {
+      const reearthContext = createMockReearthContext();
+      const messageHandlers = {
+        onMessage: vi.fn(),
+        offMessage: vi.fn(),
+        onceMessage: vi.fn()
+      };
+
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
+
+      const modalSurface = createMockSurface();
+      const mockZushiContext = {
+        surfaces: {
+          ui: createMockSurface(),
+          modal: modalSurface,
+          popup: createMockSurface()
+        },
+        startEventLoop: vi.fn()
+      };
+
+      const globalThis = factory(mockZushiContext as any);
+
+      // Call modal.close()
+      globalThis.reearth.modal.close();
+
+      // Verify content was cleared with empty div
+      expect(modalSurface.show).toHaveBeenCalledWith("<div></div>", {});
+      expect(modalSurface.setVisible).toHaveBeenCalledWith(false);
+    });
+
+    test("modal.close() calls onModalClose callback", () => {
+      const onModalClose = vi.fn();
+      const reearthContext = {
+        ...createMockReearthContext(),
+        onModalClose
+      };
+      const messageHandlers = {
+        onMessage: vi.fn(),
+        offMessage: vi.fn(),
+        onceMessage: vi.fn()
+      };
+
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
+
+      const modalSurface = createMockSurface();
+      const mockZushiContext = {
+        surfaces: {
+          ui: createMockSurface(),
+          modal: modalSurface,
+          popup: createMockSurface()
+        },
+        startEventLoop: vi.fn()
+      };
+
+      const globalThis = factory(mockZushiContext as any);
+
+      // Call modal.close()
+      globalThis.reearth.modal.close();
+
+      // Verify onModalClose was called
+      expect(onModalClose).toHaveBeenCalled();
+    });
+
+    test("external modal close ref triggers close events without calling onModalClose", () => {
+      const onModalClose = vi.fn();
+      const reearthContext = {
+        ...createMockReearthContext(),
+        onModalClose
+      };
+      const messageHandlers = {
+        onMessage: vi.fn(),
+        offMessage: vi.fn(),
+        onceMessage: vi.fn()
+      };
+
+      // Create external close refs
+      const externalCloseRefs: ExternalCloseRefs = {
+        modalCloseRef: { current: null },
+        popupCloseRef: { current: null }
+      };
+
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {},
+        externalCloseRefs
+      );
+
+      const modalSurface = createMockSurface();
+      const mockZushiContext = {
+        surfaces: {
+          ui: createMockSurface(),
+          modal: modalSurface,
+          popup: createMockSurface()
+        },
+        startEventLoop: vi.fn()
+      };
+
+      const globalThis = factory(mockZushiContext as any);
+
+      // Register a close event handler
+      const closeHandler = vi.fn();
+      globalThis.reearth.modal.on("close", closeHandler);
+
+      // Verify external close ref was set
+      expect(externalCloseRefs.modalCloseRef.current).not.toBeNull();
+
+      // Call external close
+      externalCloseRefs.modalCloseRef.current!();
+
+      // Verify surface was hidden and content was cleared
+      expect(modalSurface.setVisible).toHaveBeenCalledWith(false);
+      expect(modalSurface.show).toHaveBeenCalledWith("<div></div>", {});
+
+      // Verify close event was triggered
+      expect(closeHandler).toHaveBeenCalled();
+
+      // Verify onModalClose was NOT called (critical for close-before-show pattern)
+      expect(onModalClose).not.toHaveBeenCalled();
+    });
+
+    test("popup.close() clears content with empty div", () => {
+      const reearthContext = createMockReearthContext();
+      const messageHandlers = {
+        onMessage: vi.fn(),
+        offMessage: vi.fn(),
+        onceMessage: vi.fn()
+      };
+
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
+
+      const popupSurface = createMockSurface();
+      const mockZushiContext = {
+        surfaces: {
+          ui: createMockSurface(),
+          modal: createMockSurface(),
+          popup: popupSurface
+        },
+        startEventLoop: vi.fn()
+      };
+
+      const globalThis = factory(mockZushiContext as any);
+
+      // Call popup.close()
+      globalThis.reearth.popup.close();
+
+      // Verify content was cleared with empty div
+      expect(popupSurface.show).toHaveBeenCalledWith("<div></div>", {});
+      expect(popupSurface.setVisible).toHaveBeenCalledWith(false);
+    });
+
+    test("popup.close() calls onPopupClose callback", () => {
+      const onPopupClose = vi.fn();
+      const reearthContext = {
+        ...createMockReearthContext(),
+        onPopupClose
+      };
+      const messageHandlers = {
+        onMessage: vi.fn(),
+        offMessage: vi.fn(),
+        onceMessage: vi.fn()
+      };
+
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
+
+      const popupSurface = createMockSurface();
+      const mockZushiContext = {
+        surfaces: {
+          ui: createMockSurface(),
+          modal: createMockSurface(),
+          popup: popupSurface
+        },
+        startEventLoop: vi.fn()
+      };
+
+      const globalThis = factory(mockZushiContext as any);
+
+      // Call popup.close()
+      globalThis.reearth.popup.close();
+
+      // Verify onPopupClose was called
+      expect(onPopupClose).toHaveBeenCalled();
+    });
+
+    test("external popup close ref triggers close events without calling onPopupClose", () => {
+      const onPopupClose = vi.fn();
+      const reearthContext = {
+        ...createMockReearthContext(),
+        onPopupClose
+      };
+      const messageHandlers = {
+        onMessage: vi.fn(),
+        offMessage: vi.fn(),
+        onceMessage: vi.fn()
+      };
+
+      // Create external close refs
+      const externalCloseRefs: ExternalCloseRefs = {
+        modalCloseRef: { current: null },
+        popupCloseRef: { current: null }
+      };
+
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {},
+        externalCloseRefs
+      );
+
+      const popupSurface = createMockSurface();
+      const mockZushiContext = {
+        surfaces: {
+          ui: createMockSurface(),
+          modal: createMockSurface(),
+          popup: popupSurface
+        },
+        startEventLoop: vi.fn()
+      };
+
+      const globalThis = factory(mockZushiContext as any);
+
+      // Register a close event handler
+      const closeHandler = vi.fn();
+      globalThis.reearth.popup.on("close", closeHandler);
+
+      // Verify external close ref was set
+      expect(externalCloseRefs.popupCloseRef.current).not.toBeNull();
+
+      // Call external close
+      externalCloseRefs.popupCloseRef.current!();
+
+      // Verify surface was hidden and content was cleared
+      expect(popupSurface.setVisible).toHaveBeenCalledWith(false);
+      expect(popupSurface.show).toHaveBeenCalledWith("<div></div>", {});
+
+      // Verify close event was triggered
+      expect(closeHandler).toHaveBeenCalled();
+
+      // Verify onPopupClose was NOT called (critical for close-before-show pattern)
+      expect(onPopupClose).not.toHaveBeenCalled();
     });
   });
 });

--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.test.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.test.ts
@@ -212,7 +212,10 @@ describe("zushiAdapter", () => {
       const globalThis = factory(mockZushiContext as any);
 
       // Test UI show
-      globalThis.reearth.ui.show("<div>test</div>", { width: 300, height: 400 });
+      globalThis.reearth.ui.show("<div>test</div>", {
+        width: 300,
+        height: 400
+      });
       expect(uiSurface.show).toHaveBeenCalledWith("<div>test</div>", {
         width: 300,
         height: 400,
@@ -261,11 +264,14 @@ describe("zushiAdapter", () => {
         width: "50%",
         height: 500
       });
-      expect(modalSurface.show).toHaveBeenCalledWith("<div>modal content</div>", {
-        width: "50%",
-        height: 500,
-        visible: true
-      });
+      expect(modalSurface.show).toHaveBeenCalledWith(
+        "<div>modal content</div>",
+        {
+          width: "50%",
+          height: 500,
+          visible: true
+        }
+      );
 
       // Test modal close
       globalThis.reearth.modal.close();
@@ -273,7 +279,9 @@ describe("zushiAdapter", () => {
 
       // Test modal postMessage
       globalThis.reearth.modal.postMessage({ action: "update" });
-      expect(modalSurface.postMessage).toHaveBeenCalledWith({ action: "update" });
+      expect(modalSurface.postMessage).toHaveBeenCalledWith({
+        action: "update"
+      });
     });
 
     test("modal.update updates dimensions and triggers onModalShow callback", () => {
@@ -525,7 +533,10 @@ describe("zushiAdapter", () => {
 
       // Reset and test getTerrainHeightAsync
       startEventLoop.mockClear();
-      await globalThis.reearth.viewer.tools.getTerrainHeightAsync(139.6503, 35.6762);
+      await globalThis.reearth.viewer.tools.getTerrainHeightAsync(
+        139.6503,
+        35.6762
+      );
       expect(getTerrainHeightAsync).toHaveBeenCalledWith(139.6503, 35.6762);
       expect(startEventLoop).toHaveBeenCalled();
 
@@ -538,7 +549,9 @@ describe("zushiAdapter", () => {
 
     test("wraps async viewer.tools methods to trigger event loop on error", async () => {
       const startEventLoop = vi.fn();
-      const getCurrentLocationAsync = vi.fn().mockRejectedValue(new Error("Location unavailable"));
+      const getCurrentLocationAsync = vi
+        .fn()
+        .mockRejectedValue(new Error("Location unavailable"));
 
       const reearthContext = {
         ...createMockReearthContext(),
@@ -703,11 +716,12 @@ describe("zushiAdapter", () => {
       const closeHandler = vi.fn();
       globalThis.reearth.modal.on("close", closeHandler);
 
-      // Verify external close ref was set
-      expect(externalCloseRefs.modalCloseRef.current).not.toBeNull();
-
-      // Call external close
-      externalCloseRefs.modalCloseRef.current!();
+      // Verify external close ref was set and call it
+      const externalClose = externalCloseRefs.modalCloseRef.current;
+      expect(externalClose).not.toBeNull();
+      if (externalClose) {
+        externalClose();
+      }
 
       // Verify surface was hidden and content was cleared
       expect(modalSurface.setVisible).toHaveBeenCalledWith(false);
@@ -832,11 +846,12 @@ describe("zushiAdapter", () => {
       const closeHandler = vi.fn();
       globalThis.reearth.popup.on("close", closeHandler);
 
-      // Verify external close ref was set
-      expect(externalCloseRefs.popupCloseRef.current).not.toBeNull();
-
-      // Call external close
-      externalCloseRefs.popupCloseRef.current!();
+      // Verify external close ref was set and call it
+      const externalClose = externalCloseRefs.popupCloseRef.current;
+      expect(externalClose).not.toBeNull();
+      if (externalClose) {
+        externalClose();
+      }
 
       // Verify surface was hidden and content was cleared
       expect(popupSurface.setVisible).toHaveBeenCalledWith(false);

--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
@@ -360,6 +360,13 @@ function createModalAdapter(
   const closeEvents = createCloseEventManager("Modal");
 
   /**
+   * Idempotent close guard - prevents duplicate close events and
+   * prevents a plugin from interfering with another plugin's modal
+   * after being externally closed.
+   */
+  let isOpen = false;
+
+  /**
    * Clears surface content to ensure fresh state on next show.
    * Uses a minimal HTML structure to avoid ResizeObserver errors
    * (empty string causes document.body.parentElement to be null).
@@ -373,6 +380,8 @@ function createModalAdapter(
   // call onModalClose (global state is managed by the new plugin)
   if (externalCloseRef) {
     externalCloseRef.current = () => {
+      if (!isOpen) return; // Already closed, do nothing
+      isOpen = false;
       surface.setVisible(false);
       clearContent();
       closeEvents.trigger();
@@ -382,6 +391,7 @@ function createModalAdapter(
 
   return {
     show: (html, options) => {
+      isOpen = true;
       surface.setVisible(true);
       surface.show(html, {
         width: options?.width,
@@ -395,6 +405,8 @@ function createModalAdapter(
       });
     },
     close: () => {
+      if (!isOpen) return; // Already closed, do nothing
+      isOpen = false;
       surface.setVisible(false);
       clearContent();
       closeEvents.trigger();
@@ -458,6 +470,13 @@ function createPopupAdapter(
   const closeEvents = createCloseEventManager("Popup");
 
   /**
+   * Idempotent close guard - prevents duplicate close events and
+   * prevents a plugin from interfering with another plugin's popup
+   * after being externally closed.
+   */
+  let isOpen = false;
+
+  /**
    * Clears surface content to ensure fresh state on next show.
    * Uses a minimal HTML structure to avoid ResizeObserver errors.
    */
@@ -470,6 +489,8 @@ function createPopupAdapter(
   // call onPopupClose (global state is managed by the new plugin)
   if (externalCloseRef) {
     externalCloseRef.current = () => {
+      if (!isOpen) return; // Already closed, do nothing
+      isOpen = false;
       surface.setVisible(false);
       clearContent();
       closeEvents.trigger();
@@ -479,6 +500,7 @@ function createPopupAdapter(
 
   return {
     show: (html, options) => {
+      isOpen = true;
       surface.setVisible(true);
       surface.show(html, {
         width: options?.width,
@@ -500,6 +522,8 @@ function createPopupAdapter(
       });
     },
     close: () => {
+      if (!isOpen) return; // Already closed, do nothing
+      isOpen = false;
       surface.setVisible(false);
       clearContent();
       closeEvents.trigger();

--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
@@ -361,11 +361,11 @@ function createModalAdapter(
 
   /**
    * Clears surface content to ensure fresh state on next show.
-   * The old implementation destroyed the iframe on close (enabled={false} returned null).
-   * This mimics that behavior by clearing content, so next show() creates fresh iframe.
+   * Uses a minimal HTML structure to avoid ResizeObserver errors
+   * (empty string causes document.body.parentElement to be null).
    */
   const clearContent = () => {
-    surface.show("", {});
+    surface.show("<div></div>", {});
   };
 
   // Store external close function in ref so it can be called from outside
@@ -459,11 +459,10 @@ function createPopupAdapter(
 
   /**
    * Clears surface content to ensure fresh state on next show.
-   * The old implementation destroyed the iframe on close (enabled={false} returned null).
-   * This mimics that behavior by clearing content, so next show() creates fresh iframe.
+   * Uses a minimal HTML structure to avoid ResizeObserver errors.
    */
   const clearContent = () => {
-    surface.show("", {});
+    surface.show("<div></div>", {});
   };
 
   // Store external close function in ref so it can be called from outside

--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
@@ -334,6 +334,11 @@ function createUIAdapter(
 
 /**
  * Creates Modal surface adapter
+ *
+ * @param externalCloseRef - Optional ref to store the external close function.
+ *   External close fires close events and hides surface but does NOT call
+ *   onModalClose (which clears global state). Used when another plugin
+ *   takes over the modal.
  */
 function createModalAdapter(
   surface: SurfaceAPI,
@@ -342,7 +347,8 @@ function createModalAdapter(
     background?: string;
     clickBgToClose?: boolean;
   }) => void,
-  onModalClose?: () => void
+  onModalClose?: () => void,
+  externalCloseRef?: { current: (() => void) | null }
 ): {
   show: Reearth["modal"]["show"];
   close: Reearth["modal"]["close"];
@@ -352,6 +358,27 @@ function createModalAdapter(
   off: Reearth["modal"]["off"];
 } {
   const closeEvents = createCloseEventManager("Modal");
+
+  /**
+   * Clears surface content to ensure fresh state on next show.
+   * The old implementation destroyed the iframe on close (enabled={false} returned null).
+   * This mimics that behavior by clearing content, so next show() creates fresh iframe.
+   */
+  const clearContent = () => {
+    surface.show("", {});
+  };
+
+  // Store external close function in ref so it can be called from outside
+  // External close: fires close events and hides surface, but does NOT
+  // call onModalClose (global state is managed by the new plugin)
+  if (externalCloseRef) {
+    externalCloseRef.current = () => {
+      surface.setVisible(false);
+      clearContent();
+      closeEvents.trigger();
+      // Note: onModalClose is NOT called - global state managed by new plugin
+    };
+  }
 
   return {
     show: (html, options) => {
@@ -369,6 +396,7 @@ function createModalAdapter(
     },
     close: () => {
       surface.setVisible(false);
+      clearContent();
       closeEvents.trigger();
       onModalClose?.();
     },
@@ -401,6 +429,11 @@ function createModalAdapter(
 
 /**
  * Creates Popup surface adapter
+ *
+ * @param externalCloseRef - Optional ref to store the external close function.
+ *   External close fires close events and hides surface but does NOT call
+ *   onPopupClose (which clears global state). Used when another plugin
+ *   takes over the popup.
  */
 function createPopupAdapter(
   surface: SurfaceAPI,
@@ -412,7 +445,8 @@ function createPopupAdapter(
   getBlock?: () =>
     | (() => Reearth["extension"]["block"] | undefined)
     | undefined,
-  getUIContainerRef?: () => { current: HTMLElement | null } | undefined
+  getUIContainerRef?: () => { current: HTMLElement | null } | undefined,
+  externalCloseRef?: { current: (() => void) | null }
 ): {
   show: Reearth["popup"]["show"];
   close: Reearth["popup"]["close"];
@@ -422,6 +456,27 @@ function createPopupAdapter(
   off: Reearth["popup"]["off"];
 } {
   const closeEvents = createCloseEventManager("Popup");
+
+  /**
+   * Clears surface content to ensure fresh state on next show.
+   * The old implementation destroyed the iframe on close (enabled={false} returned null).
+   * This mimics that behavior by clearing content, so next show() creates fresh iframe.
+   */
+  const clearContent = () => {
+    surface.show("", {});
+  };
+
+  // Store external close function in ref so it can be called from outside
+  // External close: fires close events and hides surface, but does NOT
+  // call onPopupClose (global state is managed by the new plugin)
+  if (externalCloseRef) {
+    externalCloseRef.current = () => {
+      surface.setVisible(false);
+      clearContent();
+      closeEvents.trigger();
+      // Note: onPopupClose is NOT called - global state managed by new plugin
+    };
+  }
 
   return {
     show: (html, options) => {
@@ -447,6 +502,7 @@ function createPopupAdapter(
     },
     close: () => {
       surface.setVisible(false);
+      clearContent();
       closeEvents.trigger();
       onPopupClose?.();
     },
@@ -780,6 +836,15 @@ function wrapCommonReearth(
 }
 
 /**
+ * External close refs for modal and popup surfaces
+ * These allow closing surfaces externally when another plugin takes over
+ */
+export type ExternalCloseRefs = {
+  modalCloseRef: { current: (() => void) | null };
+  popupCloseRef: { current: (() => void) | null };
+};
+
+/**
  * Creates the exposed API factory function for Zushi
  *
  * This function returns a factory that Zushi will call with its PluginContext.
@@ -791,12 +856,15 @@ function wrapCommonReearth(
  *
  * @param getContext - Getter function that returns the latest ReearthPluginContext
  * @param messageHandlers - Message event handlers
+ * @param registerCleanup - Callback to register cleanup functions
+ * @param externalCloseRefs - Optional refs to store external close functions
  * @returns Factory function for Zushi's exposed parameter
  */
 export function createZushiExposedAPI(
   getContext: () => ReearthPluginContext,
   messageHandlers: MessageHandlers,
-  registerCleanup: (fn: () => void) => void
+  registerCleanup: (fn: () => void) => void,
+  externalCloseRefs?: ExternalCloseRefs
 ) {
   return (zushiCtx: ZushiPluginContext): GlobalThis => {
     // Get initial context for callbacks that don't need freshness
@@ -830,7 +898,8 @@ export function createZushiExposedAPI(
       zushiCtx.surfaces.modal,
       onRender,
       onModalShow,
-      onModalClose
+      onModalClose,
+      externalCloseRefs?.modalCloseRef
     );
     const popup = createPopupAdapter(
       zushiCtx.surfaces.popup,
@@ -840,7 +909,8 @@ export function createZushiExposedAPI(
       // Widget/block getters are accessed dynamically to get latest values
       () => getContext().getWidget,
       () => getContext().getBlock,
-      getUIContainerRef
+      getUIContainerRef,
+      externalCloseRefs?.popupCloseRef
     );
 
     // Create extension message handler

--- a/web/src/app/features/Visualizer/Crust/hooks.tsx
+++ b/web/src/app/features/Visualizer/Crust/hooks.tsx
@@ -3,6 +3,7 @@ import {
   type ReactNode,
   type RefObject,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState
@@ -36,11 +37,82 @@ export default function useHook({
   const [shownPluginPopupInfo, setShownPluginPopupInfo] = useState<PluginPopupInfo>();
   const pluginPopupContainerRef = useRef<HTMLDivElement | null>(null);
 
+  // Registry of close callbacks for each plugin instance
+  // Used by the close-before-show pattern to close previous modal/popup
+  // when a new plugin shows its modal/popup
+  const pluginModalCloseCallbacks = useRef<Map<string, () => void>>(new Map());
+  const pluginPopupCloseCallbacks = useRef<Map<string, () => void>>(new Map());
+
+  // Ref to track current modal info for use in callback (avoids stale closure)
+  const shownPluginModalInfoRef = useRef<PluginModalInfo | undefined>(undefined);
+  const shownPluginPopupInfoRef = useRef<PluginPopupInfo | undefined>(undefined);
+
+  // Keep refs in sync with state
+  useEffect(() => {
+    shownPluginModalInfoRef.current = shownPluginModalInfo;
+  }, [shownPluginModalInfo]);
+
+  useEffect(() => {
+    shownPluginPopupInfoRef.current = shownPluginPopupInfo;
+  }, [shownPluginPopupInfo]);
+
+  // Register/unregister close callbacks for modal
+  const registerPluginModalClose = useCallback(
+    (id: string, closeFn: () => void) => {
+      pluginModalCloseCallbacks.current.set(id, closeFn);
+    },
+    []
+  );
+
+  const unregisterPluginModalClose = useCallback((id: string) => {
+    pluginModalCloseCallbacks.current.delete(id);
+  }, []);
+
+  // Register/unregister close callbacks for popup
+  const registerPluginPopupClose = useCallback(
+    (id: string, closeFn: () => void) => {
+      pluginPopupCloseCallbacks.current.set(id, closeFn);
+    },
+    []
+  );
+
+  const unregisterPluginPopupClose = useCallback((id: string) => {
+    pluginPopupCloseCallbacks.current.delete(id);
+  }, []);
+
+  /**
+   * Show a plugin's modal.
+   * Implements close-before-show pattern: if another plugin's modal is showing,
+   * close it first (triggering its close events) before showing the new one.
+   */
   const onPluginModalShow = useCallback((modalInfo?: PluginModalInfo) => {
+    const prevId = shownPluginModalInfoRef.current?.id;
+    const newId = modalInfo?.id;
+
+    // Close previous modal if exists and different from new one
+    if (prevId && prevId !== newId) {
+      const closeCallback = pluginModalCloseCallbacks.current.get(prevId);
+      closeCallback?.(); // Fires close events, hides surface
+    }
+
     setShownPluginModalInfo(modalInfo);
   }, []);
 
+  /**
+   * Show a plugin's popup.
+   * Implements close-before-show pattern: if another plugin's popup is showing,
+   * close it first (triggering its close events) before showing the new one.
+   */
   const onPluginPopupShow = useCallback((popupInfo?: PluginPopupInfo) => {
+    const prevId = shownPluginPopupInfoRef.current?.id;
+    const newId = popupInfo?.id;
+
+    // Close previous popup if exists and different from new one
+    if (prevId && prevId !== newId) {
+      const closeCallback = pluginPopupCloseCallbacks.current.get(prevId);
+      closeCallback?.(); // Fires close events, hides surface
+    }
+
     setShownPluginPopupInfo(popupInfo);
   }, []);
 
@@ -52,6 +124,10 @@ export default function useHook({
       pluginPopupContainer: pluginPopupContainerRef.current,
       shownPluginPopupInfo,
       onPluginPopupShow,
+      registerPluginModalClose,
+      unregisterPluginModalClose,
+      registerPluginPopupClose,
+      unregisterPluginPopupClose,
       pluginBaseUrl,
       pluginProperty,
       property: pluginProperty
@@ -61,6 +137,10 @@ export default function useHook({
       onPluginModalShow,
       shownPluginPopupInfo,
       onPluginPopupShow,
+      registerPluginModalClose,
+      unregisterPluginModalClose,
+      registerPluginPopupClose,
+      unregisterPluginPopupClose,
       pluginBaseUrl,
       pluginProperty
     ]


### PR DESCRIPTION
# Overview

  - Fix modal/popup close event handling when another plugin takes over (close-before-show pattern)
  - Clear iframe content on close to reset state for subsequent show calls
  - Improve modal centering with flexbox instead of transform positioning

## Changes

###  Close-Before-Show Pattern

  When plugin B shows a modal while plugin A's modal is visible, plugin A's close events now fire properly before plugin B takes over. This is implemented via registered close callbacks that can be invoked externally without clearing global modal state.

###  Content Clearing on Close

  Modal and popup surfaces now clear their iframe content when closed using surface.show("<div></div>", {}). This ensures a fresh state when the same or different plugin shows content again, preventing stale content from briefly appearing.

###  Modal Centering

  Changed modal container from transform-based centering to flexbox centering for more reliable positioning across different content sizes.

 ## Files Changed

  - ModalContainer/index.tsx - Flexbox centering, pointer-events handling
  - hooks/usePluginInstance.ts - Register modal/popup close callbacks
  - Plugin/index.tsx - Pass close registration callbacks to PluginFrame
  - PluginFrame/index.tsx - Forward close registration to useZushiPlugin
  - useZushiPlugin.ts - Store external close refs, register callbacks on load
  - zushiAdapter.ts - Add clearContent(), external close refs support
  - hooks.tsx - Implement close-before-show pattern with callback maps
 
## Additional fix: Widget UI container sizing

 ### Problem:
  The zushi-ui-surface-container was using display: block with width: 100% and height: 100%, causing widgets to cover the entire alignment area instead of only taking the space they need.

 ### Solution:
  1. Removed forced width: 100% and height: 100% from both the container's inline styles and the iframe's CSS
  2. Changed container from display: block to display: inline-block

 ### Why this works:
  - inline-block elements only expand to fit their content, not the full parent width
  - Removing forced 100% sizing lets Zushi control dimensions based on:
    - Explicit dimensions from reearth.ui.show(html, { width, height })
    - AutoResize behavior (sizing to iframe content)

  Result:
  Widgets now properly fit their content within the alignment system, allowing multiple widgets to coexist without overlapping or unnecessarily covering space.

## How I tested

## Which point I want you to review particularly

## Memo

I think there's some issue from auto resizing, need to confirm from feature design perspective later.

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
