### PR TITLE
fix(server): check workspace membership for private project access (SEC-03)

### DIFF
--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -194,8 +194,10 @@ func (i *Project) FindActiveById(ctx context.Context, pid id.ProjectID, operator
 		return nil, err
 	}
 
-	if operator == nil && pj.Visibility() == string(project.VisibilityPrivate) {
-		return nil, errors.New("project is private")
+	if pj.Visibility() == string(project.VisibilityPrivate) {
+		if operator == nil || !operator.IsReadableWorkspace(pj.Workspace()) {
+			return nil, errors.New("project is private")
+		}
 	}
 
 	meta, err := i.projectMetadataRepo.FindByProjectID(ctx, pj.ID())

--- a/server/internal/usecase/interactor/project_test.go
+++ b/server/internal/usecase/interactor/project_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/reearth/reearthx/usecasex"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -427,6 +428,22 @@ func TestProject_FindActiveById(t *testing.T) {
 	t.Run("when project is private and no operator", func(t *testing.T) {
 		result, err := uc.FindActiveById(ctx, pj.ID(), nil)
 		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Equal(t, "project is private", err.Error())
+	})
+
+	// SEC-03 regression: a non-nil operator with no relationship to the project's workspace
+	// used to be enough to read a private project, since the check only tested operator
+	// presence, not membership. A caller reaching the internal API and forging any existing
+	// user's "user-id" metadata (see unaryAttachOperatorInterceptor in internal/app/grpc.go)
+	// got a non-nil operator with no proof of workspace membership.
+	t.Run("when project is private and operator has no relationship to the workspace", func(t *testing.T) {
+		result, err := uc.FindActiveById(ctx, pj.ID(), &usecase.Operator{
+			AcOperator: &accountsWorkspace.Operator{
+				ReadableWorkspaces: accountsID.WorkspaceIDList{accountsID.NewWorkspaceID()},
+			},
+		})
+		require.Error(t, err)
 		assert.Nil(t, result)
 		assert.Equal(t, "project is private", err.Error())
 	})


### PR DESCRIPTION
## Summary
`FindActiveById` only checked whether an operator was present, not whether that operator actually belonged to the project's workspace. Any non-nil operator satisfied the check.

This matters for the internal gRPC API's `GetProject`: for read-only methods, the auth interceptor skips the bearer-token check entirely, and the operator-attaching interceptor builds a full operator from a bare `user-id` metadata header with no proof of identity. So a caller who can reach the internal gRPC port could name any existing user ID with no credentials and read a private project belonging to a workspace that user has no relationship to.

Real-world exploitability is limited: the internal gRPC port is VPC-internal only in the current deployment, not reachable from the public internet. This closes the gap regardless, since it's a genuine authorization bug independent of network exposure, and the current network boundary is an infra detail, not a code guarantee.

## Fix
Check the operator's actual workspace membership (`operator.IsReadableWorkspace(pj.Workspace())`) instead of just its presence, matching the pattern already used elsewhere in this file (e.g. `Fetch`) for project access checks.

## Test plan
- [x] `go build ./...` passes
- [x] Added a regression test case: an operator that exists but has no relationship to the project's workspace is denied access to a private project
- [x] Verified the new test case fails when the fix is reverted, confirming it catches the regression
- [x] Confirmed `internalapi/server.go`'s `GetProject` is the only caller of this interactor method, so the fix is scoped correctly