### PR TITLE
fix(web): use inline-block only when not horizontally extended

### DIFF
--- a/web/src/app/features/Visualizer/Crust/Plugins/Plugin/index.tsx
+++ b/web/src/app/features/Visualizer/Crust/Plugins/Plugin/index.tsx
@@ -171,6 +171,7 @@ export default function Plugin({
       uiContainerRef={uiContainerRef}
       isMarshalable={isMarshalable}
       pluginContext={pluginContext}
+      extensionType={extensionType}
       extended={widget?.extended}
       onError={onError}
       onDispose={onDispose}

--- a/web/src/app/features/Visualizer/Crust/Plugins/Plugin/index.tsx
+++ b/web/src/app/features/Visualizer/Crust/Plugins/Plugin/index.tsx
@@ -171,6 +171,7 @@ export default function Plugin({
       uiContainerRef={uiContainerRef}
       isMarshalable={isMarshalable}
       pluginContext={pluginContext}
+      extended={widget?.extended}
       onError={onError}
       onDispose={onDispose}
       onClick={onClick}

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.test.tsx
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.test.tsx
@@ -119,7 +119,7 @@ describe("PluginFrame", () => {
 
     const uiDiv = container.querySelector(".test-plugin-ui");
     expect(uiDiv).toBeTruthy();
-    // UI surface uses inline-block to only take needed space in widget alignment system
+    // Non-extended widgets use inline-block to size to content
     expect(uiDiv).toHaveStyle({
       display: "inline-block"
     });

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.tsx
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.tsx
@@ -39,6 +39,11 @@ export type Props = {
   isMarshalable?: boolean | "json" | ((target: unknown) => boolean | "json");
   pluginContext: ReearthPluginContext;
   /**
+   * Extension type - used to determine display behavior
+   * storyBlock and infoboxBlock always use block display
+   */
+  extensionType?: string;
+  /**
    * Widget extension settings - determines if widget fills available space
    * horizontally: widget fills full width of its alignment area
    * vertically: widget fills full height of its alignment area
@@ -84,6 +89,7 @@ const PluginFrameZushi: ForwardRefRenderFunction<Ref, Props> = (
     uiContainerRef,
     isMarshalable,
     pluginContext,
+    extensionType,
     extended,
     onPreInit,
     onError,
@@ -150,6 +156,7 @@ const PluginFrameZushi: ForwardRefRenderFunction<Ref, Props> = (
           width: 100%;
           height: 100%;
           border: none;
+          display: block;
         }
         /* Modal and popup containers - let Zushi control dimensions, constrain to viewport */
         .zushi-modal-surface-container,
@@ -169,14 +176,21 @@ const PluginFrameZushi: ForwardRefRenderFunction<Ref, Props> = (
         ref={surfaceRefs.uiContainer}
         className={`zushi-ui-surface-container ${className || ""}`}
         style={{
-          // Extended horizontally uses block (full width), otherwise inline-block (content width)
+          // storyBlock/infoboxBlock always use block, extended horizontally uses block, otherwise inline-block
           display: uiVisible
-            ? extended?.horizontally
+            ? extensionType === "storyBlock" ||
+              extensionType === "infoboxBlock" ||
+              extended?.horizontally
               ? "block"
               : "inline-block"
             : "none",
-          // Extended widgets fill their alignment area, non-extended size to content
-          width: extended?.horizontally ? "100%" : undefined,
+          // storyBlock/infoboxBlock and extended horizontally fill their area, non-extended size to content
+          width:
+            extensionType === "storyBlock" ||
+            extensionType === "infoboxBlock" ||
+            extended?.horizontally
+              ? "100%"
+              : undefined,
           height: extended?.vertically ? "100%" : undefined,
           ...iFrameProps?.style
         }}

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.tsx
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/index.tsx
@@ -38,6 +38,15 @@ export type Props = {
   uiContainerRef?: MutableRefObject<HTMLElement | null>;
   isMarshalable?: boolean | "json" | ((target: unknown) => boolean | "json");
   pluginContext: ReearthPluginContext;
+  /**
+   * Widget extension settings - determines if widget fills available space
+   * horizontally: widget fills full width of its alignment area
+   * vertically: widget fills full height of its alignment area
+   */
+  extended?: {
+    horizontally?: boolean;
+    vertically?: boolean;
+  };
   onMessage?: (message: unknown) => void;
   onPreInit?: () => void;
   onError?: (err: unknown) => void;
@@ -75,6 +84,7 @@ const PluginFrameZushi: ForwardRefRenderFunction<Ref, Props> = (
     uiContainerRef,
     isMarshalable,
     pluginContext,
+    extended,
     onPreInit,
     onError,
     onDispose,
@@ -135,10 +145,11 @@ const PluginFrameZushi: ForwardRefRenderFunction<Ref, Props> = (
   return (
     <>
       <style>{`
-        /* UI surface - let Zushi control dimensions, don't force 100% */
+        /* UI surface iframe fills its container */
         .zushi-ui-surface-container iframe {
+          width: 100%;
+          height: 100%;
           border: none;
-          display: block;
         }
         /* Modal and popup containers - let Zushi control dimensions, constrain to viewport */
         .zushi-modal-surface-container,
@@ -158,7 +169,15 @@ const PluginFrameZushi: ForwardRefRenderFunction<Ref, Props> = (
         ref={surfaceRefs.uiContainer}
         className={`zushi-ui-surface-container ${className || ""}`}
         style={{
-          display: uiVisible ? "inline-block" : "none",
+          // Extended horizontally uses block (full width), otherwise inline-block (content width)
+          display: uiVisible
+            ? extended?.horizontally
+              ? "block"
+              : "inline-block"
+            : "none",
+          // Extended widgets fill their alignment area, non-extended size to content
+          width: extended?.horizontally ? "100%" : undefined,
+          height: extended?.vertically ? "100%" : undefined,
           ...iFrameProps?.style
         }}
         onClick={onClick}


### PR DESCRIPTION
# Overview

Earlier fix using inline-block and removed sizing styles in order to prevent the widget took additional space in WAS, however it leads to extend feature not working well. 
This PR conditionally apply the inline-block only when it's not horizontally extended, also add back the sizing styles.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
