### PR TITLE
fix(server): close pipe reader to prevent goroutine leak on publish upload failure (SCA-04)

### DIFF
--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -926,6 +926,9 @@ func (i *Project) uploadPublishScene(ctx context.Context, p *project.Project, s 
 
 	// publish
 	r, w := io.Pipe()
+	// If UploadBuiltScene returns early without draining r to EOF, the build goroutine's
+	// blocked Write leaks forever. Closing r unblocks it either way.
+	defer func() { _ = r.Close() }()
 
 	// Build
 	go func() {

--- a/server/internal/usecase/interactor/project_test.go
+++ b/server/internal/usecase/interactor/project_test.go
@@ -2,9 +2,13 @@ package interactor
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/url"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	accountsID "github.com/reearth/reearth-accounts/server/pkg/id"
 	accountsInfra "github.com/reearth/reearth-accounts/server/pkg/infrastructure"
@@ -14,6 +18,7 @@ import (
 	"github.com/reearth/reearth/server/internal/infrastructure/mongo"
 	"github.com/reearth/reearth/server/internal/testutil/factory"
 	"github.com/reearth/reearth/server/internal/usecase"
+	"github.com/reearth/reearth/server/internal/usecase/gateway"
 	"github.com/reearth/reearth/server/internal/usecase/interfaces"
 	"github.com/reearth/reearth/server/pkg/alias"
 	"github.com/reearth/reearth/server/pkg/builtin"
@@ -27,6 +32,7 @@ import (
 	"github.com/reearth/reearthx/usecasex"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -663,4 +669,82 @@ func TestProject_FindByWorkspaceAliasAndProjectAlias_VisibilityCheck(t *testing.
 		assert.Equal(t, privateProject.ID(), result.ID())
 		assert.Equal(t, "Private Project", result.Name())
 	})
+}
+
+// earlyFailFileGateway simulates a storage backend's early-return error paths (e.g. a bucket
+// lookup or delete failure) that return before ever reading from the content reader they were
+// given, the trigger condition for SCA-04's goroutine leak.
+type earlyFailFileGateway struct {
+	gateway.File
+}
+
+func (earlyFailFileGateway) UploadBuiltScene(context.Context, io.Reader, string) error {
+	return errors.New("simulated early storage failure")
+}
+
+// TestProject_uploadPublishScene_NoGoroutineLeakOnEarlyUploadFailure is a regression test for
+// SCA-04: the build goroutine writes into an io.Pipe that uploadPublishScene hands to the file
+// gateway. If the gateway returns early without draining that reader to EOF, the goroutine's
+// Write blocks forever with nothing left to unblock it, leaking for the life of the process.
+// This confirms the goroutine count returns to baseline shortly after the call returns, even
+// when the file gateway fails immediately without reading anything.
+func TestProject_uploadPublishScene_NoGoroutineLeakOnEarlyUploadFailure(t *testing.T) {
+	ctx := context.Background()
+
+	db := mongotest.Connect(t)(t)
+	client := mongox.NewClient(db.Name(), db.Client())
+	uc := createNewProjectUC(client)
+	uc.sceneLockRepo = mongo.NewSceneLock(client)
+	uc.file = earlyFailFileGateway{}
+
+	us := factory.NewUser()
+	require.NoError(t, uc.userRepo.Save(ctx, us))
+
+	ws := factory.NewWorkspace(func(w *accountsWorkspace.Builder) {
+		w.Members(map[accountsID.UserID]accountsWorkspace.Member{
+			accountsID.NewUserID(): {Role: accountsRole.RoleOwner, InvitedBy: accountsWorkspace.UserID(us.ID())},
+		})
+	})
+	require.NoError(t, uc.workspaceRepo.Save(ctx, ws))
+
+	pj := factory.NewProject(func(p *project.Builder) {
+		p.Workspace(ws.ID()).Alias("leak-test-alias")
+	})
+	require.NoError(t, uc.projectRepo.Save(ctx, pj))
+
+	sid := id.NewSceneID()
+	schema := builtin.GetPropertySchemaByVisualizer(visualizer.VisualizerCesiumBeta)
+	prop, err := property.New().NewID().Schema(schema.ID()).Scene(sid).Build()
+	require.NoError(t, err)
+	require.NoError(t, uc.propertyRepo.Save(ctx, prop))
+
+	sc := factory.NewScene(func(p *scene.Builder) {
+		p.ID(sid)
+		p.Project(pj.ID())
+		p.Workspace(pj.Workspace())
+		p.Property(prop.ID())
+	})
+	require.NoError(t, uc.sceneRepo.Save(ctx, sc))
+
+	// Let any goroutines from setup above settle before taking the baseline.
+	time.Sleep(50 * time.Millisecond)
+	runtime.GC()
+	baseline := runtime.NumGoroutine()
+
+	err = uc.uploadPublishScene(ctx, pj, sc, nil)
+	require.Error(t, err)
+
+	// Poll directly rather than via require.Eventually, whose own internal polling goroutine
+	// would otherwise be counted against the very baseline it's being compared to.
+	deadline := time.Now().Add(time.Second)
+	after := 0
+	for {
+		runtime.GC()
+		after = runtime.NumGoroutine()
+		if after <= baseline || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	assert.LessOrEqual(t, after, baseline, "build goroutine leaked: NumGoroutine did not return to baseline")
 }

--- a/server/internal/usecase/interactor/storytelling.go
+++ b/server/internal/usecase/interactor/storytelling.go
@@ -476,6 +476,8 @@ func (i *Storytelling) uploadPublishStory(ctx context.Context, story *storytelli
 
 	// publish
 	r, w := io.Pipe()
+	// See the matching comment in Project.uploadPublishScene.
+	defer func() { _ = r.Close() }()
 
 	// Build
 	go func() {


### PR DESCRIPTION
## Summary
uploadPublishScene and its storytelling counterpart stream the built scene JSON through an io.Pipe into the file gateway's upload. Several of the gcs and fs backends' error paths (bucket lookup, delete, mid-copy failures) return early without draining the pipe reader to EOF. Since io.Pipe blocks a Write until something reads those exact bytes, the build goroutine's Write then blocks forever with nothing left to unblock it, leaking the goroutine for the life of the process.

Checked real-world likelihood before fixing: published scene JSON files are only a few KB, so a transient network failure mid-upload is unlikely given how briefly the upload takes. The more realistic trigger is a GCS/fs-level error (bucket lookup, delete, permissions) rather than a network blip. Fixing anyway since the fix is essentially free and has no downside.

## Fix
Close the reader once the calling function returns, regardless of outcome. Any pending or future Write on the writer side then returns io.ErrClosedPipe immediately, so the goroutine can't leak no matter which internal path the upload took. This is a caller-side fix, so it protects all three storage backends (gcs, fs, s3) uniformly without needing to touch each one's internals.

## Test plan
- [x] `go build ./...` passes
- [x] Added a regression test that fails a scene's publish upload immediately (before the file gateway reads anything) and asserts the goroutine count returns to baseline afterward
- [x] Verified the test fails when the fix is reverted (confirmed one extra goroutine left running)
- [x] Full `internal/usecase/interactor` package test suite passes