### PR TITLE
docs(server): note accepted tradeoff for storage deletes inside project delete transaction (REL-01)

### DIFF
--- a/server/internal/usecase/interactor/common.go
+++ b/server/internal/usecase/interactor/common.go
@@ -259,18 +259,19 @@ type ProjectDeleter struct {
 	Asset           repo.Asset
 }
 
-// Delete runs the GCS deletes (assets, plugin files, built scene) inside the
-// same DB transaction as the Mongo removes. This means a transaction abort
-// after a storage delete already ran (e.g. a later step failing, or the
+// Delete runs the storage deletes (assets, plugin files, built scene, via
+// gateway.File -- GCS, S3, or local depending on deployment) inside the same
+// DB transaction as the Mongo removes. This means a transaction abort after
+// a storage delete already ran (e.g. a later step failing, or the
 // transaction hitting its time limit) can restore the project/scene rows
 // while the storage they point to is already gone (compliance scan REL-01).
 // We're accepting this tradeoff for now: splitting storage cleanup out of the
 // transaction would mean a delete that fails partway through can leave a
-// project's DB rows removed but some of its assets still in GCS -- orphaned
-// storage with no owning record. Given how rarely project deletes fail
-// partway through in practice, keeping deletion atomic against the DB (at the
-// cost of the rarer storage-outlives-rollback case above) is the safer
-// default.
+// project's DB rows removed but some of its assets still in storage --
+// orphaned with no owning record. Given how rarely project deletes fail
+// partway through in practice, keeping the database-side deletion
+// transactional (at the cost of the rarer storage-outlives-rollback case
+// above) is the safer default.
 func (d ProjectDeleter) Delete(ctx context.Context, prj *project.Project, force bool, operator *usecase.Operator) error {
 	if prj == nil {
 		return nil

--- a/server/internal/usecase/interactor/common.go
+++ b/server/internal/usecase/interactor/common.go
@@ -259,6 +259,18 @@ type ProjectDeleter struct {
 	Asset           repo.Asset
 }
 
+// Delete runs the GCS deletes (assets, plugin files, built scene) inside the
+// same DB transaction as the Mongo removes. This means a transaction abort
+// after a storage delete already ran (e.g. a later step failing, or the
+// transaction hitting its time limit) can restore the project/scene rows
+// while the storage they point to is already gone (compliance scan REL-01).
+// We're accepting this tradeoff for now: splitting storage cleanup out of the
+// transaction would mean a delete that fails partway through can leave a
+// project's DB rows removed but some of its assets still in GCS -- orphaned
+// storage with no owning record. Given how rarely project deletes fail
+// partway through in practice, keeping deletion atomic against the DB (at the
+// cost of the rarer storage-outlives-rollback case above) is the safer
+// default.
 func (d ProjectDeleter) Delete(ctx context.Context, prj *project.Project, force bool, operator *usecase.Operator) error {
 	if prj == nil {
 		return nil


### PR DESCRIPTION
REL-01 from the compliance scan flags that project deletion runs GCS deletes (assets, plugin files, built scene) inside the same MongoDB transaction as the DB removes. If the transaction aborts after a storage delete already ran, the DB rows come back but the storage they pointed to is already gone.

We are keeping this as is. Splitting storage cleanup out of the transaction would mean a delete that fails partway through can leave a project's DB rows removed while some of its assets are still sitting in GCS with no owning record. Project deletes failing partway through is rare in practice, so we are treating atomicity against the DB as the safer default and accepting the rarer storage-outlives-rollback case.

Added a comment at the site explaining the tradeoff so it is not mistaken for an oversight later.