### PR TITLE
fix(server): stop scene lock release from getting stuck on a canceled context (REL-03)

### DIFF
--- a/server/internal/usecase/interactor/common.go
+++ b/server/internal/usecase/interactor/common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/url"
 	"strings"
+	"time"
 
 	accountsGateway "github.com/reearth/reearth-accounts/server/pkg/gateway"
 	accountsID "github.com/reearth/reearth-accounts/server/pkg/id"
@@ -18,6 +19,7 @@ import (
 	"github.com/reearth/reearth/server/pkg/project"
 	"github.com/reearth/reearth/server/pkg/scene"
 
+	"github.com/reearth/reearthx/log"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/reearth/reearthx/usecasex"
 )
@@ -176,16 +178,23 @@ func (i commonSceneLock) UpdateSceneLock(ctx context.Context, s id.SceneID, befo
 	return nil
 }
 
-// ReleaseSceneLock discards SaveLock's error and reuses the caller's context
-// as-is (compliance scan REL-03). If the caller's context is canceled (e.g. a
-// publish request whose client disconnected mid upload) the SaveLock write
-// itself can fail with "context canceled", which we swallow here rather than
-// retry on a fresh context. We're accepting this: it requires a publish to
-// fail with its request already canceled, which is rare in practice, and the
-// existing recovery path (SceneLock.ReleaseAllLock at process startup) clears
-// any scene left stuck this way on the next deploy/restart.
+// sceneLockReleaseTimeout bounds the lock-release write below, in case the
+// detached context's SaveLock call is itself slow or hangs.
+const sceneLockReleaseTimeout = 10 * time.Second
+
+// ReleaseSceneLock detaches ctx from its parent's cancellation before saving
+// the lock. Callers defer this from publish flows using the same request
+// context the publish itself was using (REL-03, compliance scan); if that
+// request context is canceled (e.g. the client disconnected mid upload), a
+// SaveLock call on the bare ctx would fail with "context canceled" and leave
+// the scene locked forever, since sceneLock has no TTL and the only other
+// unlock path runs solely at process startup.
 func (i commonSceneLock) ReleaseSceneLock(ctx context.Context, s id.SceneID) {
-	_ = i.sceneLockRepo.SaveLock(ctx, s, scene.LockModeFree)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sceneLockReleaseTimeout)
+	defer cancel()
+	if err := i.sceneLockRepo.SaveLock(ctx, s, scene.LockModeFree); err != nil {
+		log.Errorfc(ctx, "failed to release scene lock for %s: %v", s, err)
+	}
 }
 
 type SceneDeleter struct {

--- a/server/internal/usecase/interactor/common.go
+++ b/server/internal/usecase/interactor/common.go
@@ -185,7 +185,7 @@ const sceneLockReleaseTimeout = 10 * time.Second
 // ReleaseSceneLock detaches ctx from its parent's cancellation before saving
 // the lock. Callers defer this from publish flows using the same request
 // context the publish itself was using (REL-03, compliance scan); if that
-// request context is canceled (e.g. the client disconnected mid upload), a
+// request context is canceled (e.g. the client disconnected mid-upload), a
 // SaveLock call on the bare ctx would fail with "context canceled" and leave
 // the scene locked forever, since sceneLock has no TTL and the only other
 // unlock path runs solely at process startup.

--- a/server/internal/usecase/interactor/common.go
+++ b/server/internal/usecase/interactor/common.go
@@ -176,6 +176,14 @@ func (i commonSceneLock) UpdateSceneLock(ctx context.Context, s id.SceneID, befo
 	return nil
 }
 
+// ReleaseSceneLock discards SaveLock's error and reuses the caller's context
+// as-is (compliance scan REL-03). If the caller's context is canceled (e.g. a
+// publish request whose client disconnected mid upload) the SaveLock write
+// itself can fail with "context canceled", which we swallow here rather than
+// retry on a fresh context. We're accepting this: it requires a publish to
+// fail with its request already canceled, which is rare in practice, and the
+// existing recovery path (SceneLock.ReleaseAllLock at process startup) clears
+// any scene left stuck this way on the next deploy/restart.
 func (i commonSceneLock) ReleaseSceneLock(ctx context.Context, s id.SceneID) {
 	_ = i.sceneLockRepo.SaveLock(ctx, s, scene.LockModeFree)
 }

--- a/server/internal/usecase/interactor/common_test.go
+++ b/server/internal/usecase/interactor/common_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 type recordingSceneLockRepo struct {
+	saveLockCalled bool
 	saveLockCtxErr error
 }
 
@@ -22,6 +23,7 @@ func (r *recordingSceneLockRepo) GetAllLock(context.Context, id.SceneIDList) ([]
 }
 
 func (r *recordingSceneLockRepo) SaveLock(ctx context.Context, _ id.SceneID, _ scene.LockMode) error {
+	r.saveLockCalled = true
 	r.saveLockCtxErr = ctx.Err()
 	return ctx.Err()
 }
@@ -46,5 +48,6 @@ func TestReleaseSceneLock_SurvivesCanceledContext(t *testing.T) {
 
 	d.ReleaseSceneLock(ctx, id.NewSceneID())
 
+	assert.True(t, repo.saveLockCalled, "SaveLock must actually be called -- otherwise this test would pass even if ReleaseSceneLock stopped releasing the lock at all")
 	assert.NoError(t, repo.saveLockCtxErr)
 }

--- a/server/internal/usecase/interactor/common_test.go
+++ b/server/internal/usecase/interactor/common_test.go
@@ -1,0 +1,50 @@
+package interactor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth/server/pkg/id"
+	"github.com/reearth/reearth/server/pkg/scene"
+	"github.com/stretchr/testify/assert"
+)
+
+type recordingSceneLockRepo struct {
+	saveLockCtxErr error
+}
+
+func (r *recordingSceneLockRepo) GetLock(context.Context, id.SceneID) (scene.LockMode, error) {
+	return scene.LockModeFree, nil
+}
+
+func (r *recordingSceneLockRepo) GetAllLock(context.Context, id.SceneIDList) ([]scene.LockMode, error) {
+	return nil, nil
+}
+
+func (r *recordingSceneLockRepo) SaveLock(ctx context.Context, _ id.SceneID, _ scene.LockMode) error {
+	r.saveLockCtxErr = ctx.Err()
+	return ctx.Err()
+}
+
+func (r *recordingSceneLockRepo) ReleaseAllLock(context.Context) error {
+	return nil
+}
+
+// TestReleaseSceneLock_SurvivesCanceledContext is a regression test for REL-03:
+// ReleaseSceneLock is deferred from publish flows using the same request context
+// the publish itself used. If that request's context is already canceled (e.g.
+// the client disconnected mid upload), calling SaveLock on the bare context fails
+// with "context canceled" and leaves the scene stuck locked forever. This confirms
+// the SaveLock call underneath still runs against a live context even when the
+// caller's context is canceled first.
+func TestReleaseSceneLock_SurvivesCanceledContext(t *testing.T) {
+	repo := &recordingSceneLockRepo{}
+	d := commonSceneLock{sceneLockRepo: repo}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	d.ReleaseSceneLock(ctx, id.NewSceneID())
+
+	assert.NoError(t, repo.saveLockCtxErr)
+}


### PR DESCRIPTION
REL-03 from the compliance scan flags that ReleaseSceneLock discards SaveLock's error and reuses the same request context the failed publish was using. If that context is already canceled (client disconnected mid upload), the SaveLock write can fail silently and the scene lock stays stuck at LockModePublishing, blocking every later mutation on that scene (layer/property/style edits, further publishes, even deletion) until the next process restart.

Detaches the context before saving the lock, bounded by a short timeout, and logs the error instead of swallowing it. Same pattern already used elsewhere in this codebase for a status write that needs to survive a canceled parent context.

Added a regression test that fails without the fix (SaveLock receiving an already-canceled context) and passes with it.