### PR TITLE
fix(server): fail closed on basic-auth metadata lookup errors for published pages (REL-02)

### DIFF
--- a/server/internal/app/public.go
+++ b/server/internal/app/public.go
@@ -260,7 +260,11 @@ func PublishedAuthMiddleware() echo.MiddlewareFunc {
 		Validator: func(user string, password string, c echo.Context) (bool, error) {
 			md, ok := c.Request().Context().Value(key).(interfaces.PublishedMetadata)
 			if !ok {
-				return true, echo.ErrNotFound
+				// No metadata means the Skipper's own lookup failed (fail
+				// closed, REL-02) rather than genuinely finding no project --
+				// treat it as invalid credentials so this consistently
+				// produces a 401 challenge instead of a confusing 404.
+				return false, nil
 			}
 			return !md.IsBasicAuthActive || subtle.ConstantTimeCompare([]byte(user), []byte(md.BasicAuthUsername)) == 1 && subtle.ConstantTimeCompare([]byte(password), []byte(md.BasicAuthPassword)) == 1, nil
 		},
@@ -281,10 +285,10 @@ func PublishedAuthMiddleware() echo.MiddlewareFunc {
 				// a password" -- only safe when we positively know there's
 				// nothing to password-protect (name isn't a project at all).
 				// Any other error (e.g. a transient Mongo failure) must fail
-				// closed: the Validator below has no metadata to check
-				// against and will reject with echo.ErrNotFound, but at
-				// least the password gate itself never gets bypassed
-				// (REL-02, compliance scan).
+				// closed: the Validator above has no metadata to check
+				// against and forces a basic-auth challenge instead, so the
+				// password gate itself never gets bypassed (REL-02,
+				// compliance scan).
 				return errors.Is(err, rerror.ErrNotFound)
 			}
 

--- a/server/internal/app/public.go
+++ b/server/internal/app/public.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -276,7 +277,15 @@ func PublishedAuthMiddleware() echo.MiddlewareFunc {
 
 			md, err := contr.Metadata(c.Request().Context(), name)
 			if err != nil {
-				return true
+				// Skipping here means "run the next handler without checking
+				// a password" -- only safe when we positively know there's
+				// nothing to password-protect (name isn't a project at all).
+				// Any other error (e.g. a transient Mongo failure) must fail
+				// closed: the Validator below has no metadata to check
+				// against and will reject with echo.ErrNotFound, but at
+				// least the password gate itself never gets bypassed
+				// (REL-02, compliance scan).
+				return errors.Is(err, rerror.ErrNotFound)
 			}
 
 			c.SetRequest(c.Request().WithContext(context.WithValue(c.Request().Context(), key, md)))

--- a/server/internal/app/public_test.go
+++ b/server/internal/app/public_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -55,6 +56,14 @@ func TestPublishedAuthMiddleware(t *testing.T) {
 			PublishedName:     "active",
 			BasicAuthUsername: "fooo",
 			BasicAuthPassword: "baar",
+		},
+		{
+			// REL-02: a non-NotFound Metadata error (e.g. a transient Mongo
+			// failure) must fail closed -- basic auth still gets enforced --
+			// rather than skip the password check entirely.
+			Name:          "metadata lookup error fails closed",
+			PublishedName: "db-error",
+			Error:         echo.ErrUnauthorized,
 		},
 	}
 
@@ -295,6 +304,8 @@ func (p *mockPublished) Metadata(ctx context.Context, name string) (interfaces.P
 			BasicAuthUsername: "fooo",
 			BasicAuthPassword: "baar",
 		}, nil
+	case "db-error":
+		return interfaces.PublishedMetadata{}, errors.New("internal: server selection error")
 	}
 	return interfaces.PublishedMetadata{}, rerror.ErrNotFound
 }

--- a/server/internal/app/public_test.go
+++ b/server/internal/app/public_test.go
@@ -65,6 +65,17 @@ func TestPublishedAuthMiddleware(t *testing.T) {
 			PublishedName: "db-error",
 			Error:         echo.ErrUnauthorized,
 		},
+		{
+			// Same failure, but with credentials sent: the Validator has no
+			// metadata to check against either way, and must still produce a
+			// 401 challenge -- not a 404 -- so a legitimate user retrying
+			// their password during a blip isn't told the page is missing.
+			Name:              "metadata lookup error with credentials still fails closed",
+			PublishedName:     "db-error",
+			BasicAuthUsername: "fooo",
+			BasicAuthPassword: "baar",
+			Error:             echo.ErrUnauthorized,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Some published projects have a password ("Basic Authorization") turned on, so only people who know it can view the page. If the database had a brief hiccup while checking whether a password was needed, the code assumed there was nothing to protect and skipped the password check entirely, letting anyone view the page while that hiccup lasted.

Fix: only skip the password check when the page genuinely doesn't exist. Any other problem now still requires the password.

Verified locally: with the check working normally, a password is still required. With a simulated database outage, the page no longer opens without one. Added an automated test that fails without this fix and passes with it.

## Testing after release

We shouldn't cause a real database outage in production just to test this, so we watch for one happening naturally instead. The code already logs a warning whenever this specific lookup fails:

```
resource.type="cloud_run_revision"
resource.labels.service_name="reearth-visualizer-api"
jsonPayload.message:"published metadata: find by public name err"
```

If that ever fires, grab the request id from `jsonPayload.name` and check that request's response status:

```
resource.type="cloud_run_revision"
resource.labels.service_name="reearth-visualizer-api"
jsonPayload.request_id="<request id from above>"
```

It should be 401 or 404, never 200 with content.

Quick smoke test right after deploy: a real password-protected published page should still ask for a password. Note this only confirms no regression -- it can't confirm the actual fix, since the bug only shows up during a real database hiccup, not during normal operation.