### PR TITLE
refactor(web): route plugin UI msg through zushi's builtin surface message events

### DIFF
--- a/web/docs/modules/features/plugin-system.md
+++ b/web/docs/modules/features/plugin-system.md
@@ -89,14 +89,15 @@ The plugin system serves multiple purposes:
 - Creates and starts Zushi Plugin instance
 - Sets up surface configuration with container refs
 - Handles plugin lifecycle (initialization, disposal)
-- Manages message routing between plugin and host
-- Tracks iframe windows for message filtering
+- Exposes `handleMessage` as the single dispatch point for plugin message handlers
+- Provides the `dispatchMessage` hook that the adapter wires to Zushi's built-in surface message events
 
 **zushiAdapter** provides the bridge:
 
 - Creates the exposed `reearth` API for plugin code
 - Maps Zushi surface methods to Re:Earth API methods
 - Handles message event registration (on/off/once)
+- Subscribes each surface's built-in `message` event and forwards messages to the plugin's extension handlers
 - Provides Re:Earth context (viewer, camera, layers, etc.)
 
 ## Dependencies
@@ -440,28 +441,33 @@ Each surface follows this lifecycle:
 
 ### Message Filtering
 
-To prevent plugins from receiving messages from other plugins, the system tracks iframe windows:
+Plugin UI messages are delivered through **Zushi's built-in surface `message` events** rather than a host-side window listener. Each `UISurface` owns a `SafeIFrame` whose message listener:
+
+- Consumes internal auto-resize messages (`___iframe_auto_resize___`) for iframe sizing only — they are **never** emitted as surface `message` events, so plugins never see them
+- Scopes messages to the surface's own iframe via `ev.source === iframe.contentWindow`, so messages from other plugins' iframes are ignored
+- Pumps the VM event loop after emitting, so async plugin message handlers run without extra wiring
+
+The adapter subscribes all three surfaces (UI, modal, popup) and forwards their `message` events into the plugin's extension message handlers:
 
 ```typescript
-// Track all iframe windows from plugin surfaces
-surfaceWindowsRef.current.add(iframe.contentWindow);
-
-// Filter messages by source
-window.addEventListener("message", (ev) => {
-  const isFromOurPlugin = surfaceWindowsRef.current.has(ev.source);
-  if (!isFromOurPlugin) return; // Ignore
-
-  handleMessage(ev.data);
-});
+// zushiAdapter.ts - createZushiExposedAPI
+const forwardSurfaceMessage = (name) => {
+  const unsubscribe = zushiCtx.surfaces[name].on("message", (msg) => {
+    messageHandlers.dispatchMessage(msg);
+  });
+  registerCleanup(unsubscribe);
+};
+forwardSurfaceMessage("ui");
+forwardSurfaceMessage("modal");
+forwardSurfaceMessage("popup");
 ```
 
 **Key Implementation**:
 
-- MutationObserver watches for dynamically added iframes
-- Waits for iframe.contentWindow to be available (load event)
-- Registers all iframe windows in a Set for fast lookup
+- No iframe-window tracking or MutationObserver is needed; `UISurface.on("message")` handles dynamic modal/popup iframes automatically
+- Subscriptions are cleaned up via `registerCleanup` when the plugin is disposed
 
-**Code Reference**: `src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.ts:276-326`
+**Code Reference**: `src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts`, `src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.ts`
 
 ## Message Handling
 
@@ -470,11 +476,12 @@ window.addEventListener("message", (ev) => {
 ```
 Plugin Code → window.parent.postMessage()
      ↓
-Iframe contentWindow (source)
+Surface iframe contentWindow (source)
      ↓
-Host window.addEventListener("message")
+Zushi UISurface built-in "message" event
+(auto-resize messages are consumed internally, never emitted)
      ↓
-Message Filter (check source)
+dispatchMessage() (zushiAdapter)
      ↓
 handleMessage() (useZushiPlugin)
      ↓
@@ -542,8 +549,8 @@ await plugin.start();
 ### 3. Message Exchange
 
 - Plugin sends messages via `window.parent.postMessage()`
-- Host filters messages by iframe source
-- Host calls registered message handlers
+- Zushi's surface `message` events deliver them (auto-resize consumed internally, messages scoped to the surface's iframe)
+- The adapter forwards them to registered message handlers
 - Host can send messages to plugin via `postMessage()`
 
 ### 4. Cleanup/Disposal
@@ -818,45 +825,13 @@ test("shows UI surface when uiVisible=true", () => {
 
 ### Issue: "Modal/Popup close button doesn't work"
 
-**Symptoms**: Clicking close button in modal or popup has no effect. Messages from modal/popup iframes show `isFromOurPlugin: false` in logs.
+**Symptoms**: Clicking close button in modal or popup has no effect. Messages from modal/popup iframes don't reach the plugin.
 
-**Cause**: When Zushi creates an iframe for modal/popup surface, the iframe element exists in the DOM immediately, but `iframe.contentWindow` is `null` until the iframe loads. The system was trying to register contentWindow during initial collection, getting null, and never registering the window for message filtering.
+**Cause (historical)**: In the previous window-listener approach, the system tracked iframe windows (`surfaceWindowsRef`) to filter `postMessage` events. A modal/popup iframe's `contentWindow` could be `null` at registration time, so the window was never registered and messages from it were filtered out.
 
-**Root Cause**: Two collection points, both had the same issue:
-1. Initial collection after `plugin.start()` - iframe exists but not loaded
-2. MutationObserver for dynamically added iframes - detects iframe before it loads
+**Solution**: Message delivery now uses **Zushi's built-in surface `message` events** (`UISurface.on("message")`), which scope messages to each surface's own iframe via `ev.source` internally. No iframe-window tracking or MutationObserver is needed — messages from dynamically shown modal/popup iframes are delivered automatically once the iframe loads.
 
-**Solution**: The system now waits for iframe load event at both collection points:
-
-```typescript
-const collectIframeWindows = (container: HTMLElement) => {
-  const iframes = container.querySelectorAll('iframe');
-  iframes.forEach(iframe => {
-    const registerWindow = () => {
-      if (iframe.contentWindow) {
-        surfaceWindowsRef.current.add(iframe.contentWindow);
-        return true;
-      }
-      return false;
-    };
-
-    // Try to register immediately
-    if (!registerWindow()) {
-      // If contentWindow is not available yet, wait for load event
-      iframe.addEventListener('load', () => {
-        registerWindow();
-      }, { once: true });
-    }
-  });
-};
-```
-
-**Impact**: This pattern is applied to:
-- Initial iframe collection after plugin.start()
-- MutationObserver detection of dynamically added iframes
-- All three surfaces: UI, Modal, and Popup
-
-**Code Reference**: `src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.ts:290-310`
+**Code Reference**: `src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts` (surface `message` subscriptions in `createZushiExposedAPI`)
 
 ### Issue: "Plugin not loading"
 
@@ -881,16 +856,9 @@ if (!uiContainer.current || !modalContainer.current || !popupContainer.current) 
 
 **Symptoms**: Plugin receives messages intended for other plugins.
 
-**Cause**: Message filtering not working correctly.
+**Cause (historical)**: The previous window-listener approach re-filtered messages by tracked iframe windows; if registration was incomplete, messages could leak.
 
-**Solution**: System tracks iframe windows and filters by source:
-
-```typescript
-const isFromOurPlugin = surfaceWindowsRef.current.has(ev.source as Window);
-if (!isFromOurPlugin) return; // Ignore
-```
-
-Ensure MutationObserver is properly set up to track all iframes.
+**Solution**: Message delivery relies on Zushi's built-in surface `message` events, which scope each message to the surface's own iframe (`ev.source === iframe.contentWindow`). Messages from other plugins' iframes are never emitted as surface `message` events, so cross-plugin leakage is prevented by the framework itself. No additional filtering is required.
 
 ## Performance Considerations
 
@@ -1237,6 +1205,16 @@ reearth.ui.close();
 
 ## Changelog
 
+### 2026-08-07 - Use Zushi Built-in Surface Message Events
+
+**Changed:**
+- **Removed**: The host-side `window` "message" listener and iframe-window tracking (`surfaceWindowsRef`, MutationObserver) from `useZushiPlugin`
+- **Changed**: Plugin UI messages are now delivered through **Zushi's built-in surface `message` events** (`UISurface.on("message")`)
+  - `createZushiExposedAPI` subscribes the UI/modal/popup surfaces and forwards messages to the plugin's extension handlers via `messageHandlers.dispatchMessage`
+  - Auto-resize messages (`___iframe_auto_resize___`) are consumed internally by Zushi's `SafeIFrame` and never exposed to plugins
+  - Messages are scoped to each surface's own iframe by Zushi, preventing cross-plugin leakage
+  - The VM event loop is pumped automatically by Zushi after emitting, so async plugin message handlers run correctly
+
 ### 2026-07-07 - Plugin System Refactoring and Cleanup
 
 **Breaking Changes:**
@@ -1296,5 +1274,5 @@ reearth.ui.close();
 
 ---
 
-**Last Updated**: 2026-07-07
+**Last Updated**: 2026-08-07
 **Maintained By**: Platform Team

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.test.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.test.ts
@@ -449,6 +449,59 @@ describe("useZushiPlugin", () => {
       expect(onMessage).toHaveBeenCalledWith(testMessage);
     });
 
+    test("forwards surface message events to plugin extension message handlers", async () => {
+      let latest: UseZushiPluginReturn | undefined;
+      render(
+        createElement(ZushiHarness, {
+          pluginContext: mockPluginContext,
+          onReady: (value) => {
+            latest = value;
+          }
+        })
+      );
+
+      await waitFor(() => expect(latest?.loaded).toBe(true));
+
+      // Register an extension message handler through the exposed API
+      const { Plugin: PluginMock } = await import("@reearth/zushi");
+      const config = (PluginMock as unknown as { mock: { calls: any[][] } })
+        .mock.calls[0][0];
+
+      // Capture the callbacks the adapter subscribes for each surface's
+      // built-in "message" event
+      const messageSubscribers = new Set<(msg: unknown) => void>();
+      const createSurface = () => ({
+        show: vi.fn(),
+        update: vi.fn(),
+        setVisible: vi.fn(),
+        postMessage: vi.fn(),
+        close: vi.fn(),
+        on: vi.fn((type: string, cb: (msg: unknown) => void) => {
+          if (type === "message") messageSubscribers.add(cb);
+          return () => {};
+        }),
+        off: vi.fn()
+      });
+      const api = config.exposed({
+        startEventLoop: vi.fn(),
+        surfaces: {
+          ui: createSurface(),
+          modal: createSurface(),
+          popup: createSurface()
+        }
+      });
+
+      const handler = vi.fn();
+      api.reearth.extension.on("message", handler);
+
+      // Messages emitted through Zushi's built-in surface "message" event
+      // must reach the plugin's extension message handlers
+      const emitted = { type: "myMessage", value: 1 };
+      messageSubscribers.forEach((cb) => cb(emitted));
+
+      expect(handler).toHaveBeenCalledWith(emitted);
+    });
+
     test("loads code from src URL", async () => {
       const fetchSpy = vi
         .spyOn(globalThis, "fetch")

--- a/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/PluginFrame/useZushiPlugin.ts
@@ -170,12 +170,6 @@ export default function useZushiPlugin({
   // Surface container refs
   const uiContainer = useRef<HTMLDivElement>(null);
 
-  // Store references to surface iframe windows for message filtering
-  const surfaceWindowsRef = useRef<Set<Window>>(new Set());
-
-  // Store MutationObserver for cleanup
-  const iframeObserverRef = useRef<MutationObserver | undefined>(undefined);
-
   // Cleanup callbacks registered by the exposed API (e.g. viewer event unsubscription)
   const disposeCallbacksRef = useRef<(() => void)[]>([]);
 
@@ -286,10 +280,14 @@ export default function useZushiPlugin({
               : true;
 
         // Create message handlers for the adapter
+        // dispatchMessage routes messages from Zushi's built-in surface
+        // message events (see createZushiExposedAPI) into the plugin's
+        // registered extension message handlers.
         const messageHandlers = {
           onMessage,
           offMessage,
-          onceMessage
+          onceMessage,
+          dispatchMessage: handleMessage
         };
 
         // Create Zushi plugin instance
@@ -326,8 +324,8 @@ export default function useZushiPlugin({
 
         if (disposed) {
           // Unmounted while start() was in flight - nothing above was assigned
-          // to pluginRef/iframeObserverRef yet, so just tear down what start()
-          // already registered (e.g. viewer event listeners) and dispose.
+          // to pluginRef yet, so just tear down what start() already registered
+          // (e.g. viewer event listeners) and dispose.
           runDisposeCallbacks();
           try {
             plugin.dispose();
@@ -336,110 +334,6 @@ export default function useZushiPlugin({
           }
           return;
         }
-
-        /**
-         * Iframe Window Registration with Load Event Handling
-         *
-         * WHY: We need to track which iframe windows belong to this plugin instance
-         * to filter postMessage events. Only messages from our plugin's iframes should
-         * be processed; messages from other plugins must be ignored.
-         *
-         * PROBLEM: When an iframe is created, its contentWindow may not be immediately
-         * available:
-         * - Zushi calls surface.show() which creates an iframe
-         * - The iframe element exists in the DOM
-         * - But iframe.contentWindow is null until the iframe loads
-         * - If we try to register it immediately, we get null
-         *
-         * This caused the modal close button bug: the modal iframe existed but its
-         * contentWindow was never registered, so messages from it were filtered out.
-         *
-         * SOLUTION: Try to register immediately, but if contentWindow is null, attach
-         * a load event listener to register it later when the iframe loads.
-         *
-         * HOW:
-         * 1. Query for all iframes in the container
-         * 2. Try to register iframe.contentWindow immediately
-         * 3. If null, attach a 'load' event listener (once: true)
-         * 4. When iframe loads, register its contentWindow
-         *
-         * This pattern is applied to:
-         * - Initial collection after plugin.start()
-         * - MutationObserver detection of dynamically added iframes
-         */
-        surfaceWindowsRef.current.clear();
-        const collectIframeWindows = (container: HTMLElement) => {
-          const iframes = container.querySelectorAll('iframe');
-          iframes.forEach(iframe => {
-            const registerWindow = () => {
-              if (iframe.contentWindow) {
-                surfaceWindowsRef.current.add(iframe.contentWindow);
-                return true;
-              }
-              return false;
-            };
-
-            // Try to register immediately
-            if (!registerWindow()) {
-              // If contentWindow is not available yet, wait for load event
-              iframe.addEventListener('load', () => {
-                registerWindow();
-              }, { once: true });
-            }
-          });
-        };
-
-        if (uiContainer.current) collectIframeWindows(uiContainer.current);
-        if (modalContainer.current) collectIframeWindows(modalContainer.current);
-        if (popupContainer.current) collectIframeWindows(popupContainer.current);
-
-        // Watch for dynamically added iframes (e.g., when popup.show() is called)
-        const observerCallback: MutationCallback = (mutations) => {
-          mutations.forEach((mutation) => {
-            mutation.addedNodes.forEach((node) => {
-              if (node.nodeType === Node.ELEMENT_NODE) {
-                const element = node as HTMLElement;
-
-                // Check if it's an iframe
-                if (element.tagName === 'IFRAME') {
-                  const iframe = element as HTMLIFrameElement;
-
-                  // contentWindow might be null immediately after creation
-                  // Try to register immediately, or wait for load
-                  const registerWindow = () => {
-                    if (iframe.contentWindow) {
-                      surfaceWindowsRef.current.add(iframe.contentWindow);
-                      return true;
-                    }
-                    return false;
-                  };
-
-                  // Try immediately
-                  if (!registerWindow()) {
-                    // If not available, wait for load event
-                    iframe.addEventListener('load', () => {
-                      registerWindow();
-                    }, { once: true });
-                  }
-                }
-                // Check if the added element contains nested iframes
-                // Use collectIframeWindows to handle load event timing
-                collectIframeWindows(element);
-              }
-            });
-          });
-        };
-
-        const observer = new MutationObserver(observerCallback);
-        const observerConfig = { childList: true, subtree: true };
-
-        // Observe all surface containers
-        if (uiContainer.current) observer.observe(uiContainer.current, observerConfig);
-        if (modalContainer.current) observer.observe(modalContainer.current, observerConfig);
-        if (popupContainer.current) observer.observe(popupContainer.current, observerConfig);
-
-        // Store observer for cleanup
-        iframeObserverRef.current = observer;
 
         pluginRef.current = plugin;
         setLoaded(true);
@@ -456,12 +350,6 @@ export default function useZushiPlugin({
     // Cleanup on unmount
     return () => {
       disposed = true;
-
-      // Disconnect MutationObserver
-      if (iframeObserverRef.current) {
-        iframeObserverRef.current.disconnect();
-        iframeObserverRef.current = undefined;
-      }
 
       // Tear down anything the exposed API registered (e.g. viewer event listeners)
       runDisposeCallbacks();
@@ -503,6 +391,7 @@ export default function useZushiPlugin({
     onMessage,
     offMessage,
     onceMessage,
+    handleMessage,
     messageEvents,
     messageOnceEvents,
     modalContainer,
@@ -526,32 +415,6 @@ export default function useZushiPlugin({
       onRegisterPopupClose(popupClose);
     }
   }, [loaded, onRegisterModalClose, onRegisterPopupClose]);
-
-  // Listen for window postMessage events from plugin UI
-  // Filter based on iframe source window
-  useEffect(() => {
-    const handleWindowMessage = (ev: MessageEvent) => {
-      if (!loaded) return;
-
-      // Check if the message comes from one of our plugin's surface iframes
-      const isFromOurPlugin = surfaceWindowsRef.current.has(ev.source as Window);
-
-      // Only process messages from our plugin's iframes
-      if (!isFromOurPlugin) {
-        // Silently ignore messages from other plugins
-        return;
-      }
-
-      // Route message to plugin extension
-      handleMessage(ev.data);
-    };
-
-    window.addEventListener("message", handleWindowMessage);
-
-    return () => {
-      window.removeEventListener("message", handleWindowMessage);
-    };
-  }, [loaded, handleMessage]);
 
   // Expose plugin instance via ref
   useImperativeHandle(

--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.test.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.test.ts
@@ -23,7 +23,9 @@ function createMockSurface(): SurfaceAPI {
     show: vi.fn(),
     update: vi.fn(),
     setVisible: vi.fn(),
-    postMessage: vi.fn()
+    postMessage: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn()
   } as unknown as SurfaceAPI;
 }
 
@@ -146,7 +148,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -163,7 +166,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -191,7 +195,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -239,7 +244,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -293,7 +299,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -340,7 +347,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -381,7 +389,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -417,7 +426,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage,
         offMessage,
-        onceMessage
+        onceMessage,
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -445,12 +455,70 @@ describe("zushiAdapter", () => {
       expect(offMessage).toHaveBeenCalledWith(testCallback);
     });
 
+    test("subscribes to built-in surface message events and forwards them", () => {
+      const reearthContext = createMockReearthContext();
+      const dispatchMessage = vi.fn();
+
+      const messageHandlers = {
+        onMessage: vi.fn(),
+        offMessage: vi.fn(),
+        onceMessage: vi.fn(),
+        dispatchMessage
+      };
+
+      const factory = createZushiExposedAPI(
+        () => reearthContext,
+        messageHandlers,
+        () => {}
+      );
+
+      // Capture the callbacks registered for each surface's "message" event
+      const messageSubscribers: Record<string, Set<(msg: unknown) => void>> = {
+        ui: new Set(),
+        modal: new Set(),
+        popup: new Set()
+      };
+      const createSurface = (name: "ui" | "modal" | "popup") => ({
+        show: vi.fn(),
+        update: vi.fn(),
+        setVisible: vi.fn(),
+        postMessage: vi.fn(),
+        close: vi.fn(),
+        on: vi.fn((type: string, cb: (msg: unknown) => void) => {
+          if (type === "message") messageSubscribers[name].add(cb);
+          return () => {};
+        }),
+        off: vi.fn()
+      });
+
+      const mockZushiContext = {
+        surfaces: {
+          ui: createSurface("ui"),
+          modal: createSurface("modal"),
+          popup: createSurface("popup")
+        }
+      };
+
+      factory(mockZushiContext as any);
+
+      // All three surfaces must be subscribed to their built-in "message" event
+      for (const name of ["ui", "modal", "popup"] as const) {
+        expect(messageSubscribers[name].size).toBe(1);
+      }
+
+      // Emitting a message on any surface must forward to dispatchMessage
+      const testMessage = { type: "myMessage", value: 1 };
+      messageSubscribers.ui.forEach((cb) => cb(testMessage));
+      expect(dispatchMessage).toHaveBeenCalledWith(testMessage);
+    });
+
     test("provides console access", () => {
       const reearthContext = createMockReearthContext();
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -506,7 +574,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -573,7 +642,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -609,7 +679,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -652,7 +723,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -692,7 +764,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       // Create external close refs
@@ -752,7 +825,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -795,7 +869,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -835,7 +910,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       // Create external close refs
@@ -899,7 +975,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -945,7 +1022,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const externalCloseRefs: ExternalCloseRefs = {
@@ -1003,7 +1081,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const factory = createZushiExposedAPI(
@@ -1049,7 +1128,8 @@ describe("zushiAdapter", () => {
       const messageHandlers = {
         onMessage: vi.fn(),
         offMessage: vi.fn(),
-        onceMessage: vi.fn()
+        onceMessage: vi.fn(),
+        dispatchMessage: vi.fn()
       };
 
       const externalCloseRefs: ExternalCloseRefs = {

--- a/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
+++ b/web/src/app/features/Visualizer/Crust/Plugins/pluginAPI/zushiAdapter.ts
@@ -194,6 +194,7 @@ type MessageHandlers = {
   onMessage: (handler: (msg: unknown) => void) => void;
   offMessage: (handler: (msg: unknown) => void) => void;
   onceMessage: (handler: (msg: unknown) => void) => void;
+  dispatchMessage: (msg: unknown) => void;
 };
 
 /**
@@ -944,6 +945,30 @@ export function createZushiExposedAPI(
       startEventLoop,
       registerPluginMessageSender
     );
+
+    // Forward surface iframe messages to the plugin's extension message
+    // handlers through Zushi's built-in surface `message` events.
+    //
+    // WHY (vs. a host-side window "message" listener):
+    // Zushi's SafeIFrame already:
+    //   - filters internal auto-resize messages (___iframe_auto_resize___),
+    //     so they are used only for iframe sizing and never reach plugins
+    //   - scopes messages to the surface's own iframe via ev.source, so
+    //     messages from other plugins' iframes are ignored
+    //   - pumps the VM event loop after emitting, so plugin message handlers
+    //     (including async ones) run without an extra startEventLoop call
+    const forwardSurfaceMessage = (name: "ui" | "modal" | "popup") => {
+      const surface = zushiCtx.surfaces[name];
+      const unsubscribe = surface.on?.("message", (msg: unknown) => {
+        messageHandlers.dispatchMessage(msg);
+      });
+      if (typeof unsubscribe === "function") {
+        registerCleanup(unsubscribe);
+      }
+    };
+    forwardSurfaceMessage("ui");
+    forwardSurfaceMessage("modal");
+    forwardSurfaceMessage("popup");
 
     // Wrap client storage with event loop trigger
     // context.clientStorage is accessed via context getter, so it's fresh


### PR DESCRIPTION
# Overview

## Summary

Replaces the host-side `window` "message" listener used to deliver plugin UI messages with Zushi's built-in surface `message` events (`UISurface.on("message")`).

## Problem

Plugins were receiving Zushi's internal iframe auto-resize messages (`___iframe_auto_resize___`). The old routing layer added a second global `window` "message" listener in `useZushiPlugin` that forwarded every message from the plugin's surface iframes straight to the plugin's extension message handlers, bypassing the filtering Zushi's `SafeIFrame` already does. 

## Fix

`zushiAdapter.ts` now subscribes each surface (UI/modal/popup) to its built-in `message` event and forwards messages to the plugin's extension handlers via `messageHandlers.dispatchMessage`, with subscriptions cleaned up through `registerCleanup`. `useZushiPlugin.ts` drops the second window listener and the iframe-window tracking it relied on (`surfaceWindowsRef`, MutationObserver, `collectIframeWindows`), and exposes `handleMessage` as `dispatchMessage`.

## Why this is more correct

Zushi's `SafeIFrame` already provides everything the old listener re-implemented: auto-resize filtering (`___iframe_auto_resize___` is consumed internally for iframe sizing and never emitted as a surface `message` event, so plugins never see it); source isolation (messages are scoped to each surface's own iframe via `ev.source`, preventing cross-plugin leakage); event-loop pumping (`UISurface` triggers `startEventLoop()` after emitting, so async plugin message handlers run without extra wiring); and no dynamic-iframe bookkeeping (modal/popup iframes created later are handled automatically, removing the previous `contentWindow` timing workaround). Cross-extension messaging (`reearth.extension.postMessage` / `extension.on("extensionMessage")`) is an independent channel and is unaffected.

## Tests

Updated `useZushiPlugin.test.ts` (surface `message` events are forwarded to the plugin's extension message handlers) and `zushiAdapter.test.ts` (all three surfaces subscribe to `message` and forward to `dispatchMessage`). Plugin test suite: 116 tests passing; `yarn type` and `yarn eslint` clean.

## Docs

Updated `docs/modules/features/plugin-system.md`: message flow, Message Filtering section, Common Issues, and a changelog entry.

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
