### PR TITLE
fix(web): only touch the system tile when its widget mutation succeeds

### DIFF
--- a/web/src/app/features/Editor/Widgets/WidgetManagerPanel/hooks.test.ts
+++ b/web/src/app/features/Editor/Widgets/WidgetManagerPanel/hooks.test.ts
@@ -1,0 +1,111 @@
+import { STREET_VIEW_WIDGET_ID } from "@reearth/services/api/widget";
+import { renderHook, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import useHooks from "./hooks";
+
+const addWidget = vi.fn();
+const removeWidget = vi.fn();
+const addSystemTile = vi.fn();
+const removeSystemTile = vi.fn();
+
+const installedGSSVWidget = {
+  id: "installed-widget-id",
+  pluginId: "reearth",
+  extensionId: "streetView",
+  property: { id: "property-id" }
+};
+let installedWidgets: (typeof installedGSSVWidget)[] = [];
+
+vi.mock("@reearth/app/utils/value", () => ({
+  toWidgetAlignSystemType: () => "OUTER"
+}));
+
+vi.mock("@reearth/services/api/widget", () => ({
+  GOOGLE_MAP_SEARCH_BUILTIN_WIDGET_ID: "reearth/googleMapSearch",
+  STREET_VIEW_WIDGET_ID: "reearth/streetView",
+  useInstallableWidgets: () => ({ installableWidgets: [] }),
+  useInstalledWidgets: () => ({
+    get installedWidgets() {
+      return installedWidgets;
+    }
+  }),
+  useWidgetMutations: () => ({ addWidget, removeWidget })
+}));
+
+vi.mock("./useSystemTile", () => ({
+  useSystemTile: () => ({ addSystemTile, removeSystemTile })
+}));
+
+vi.mock("../../atoms", () => ({
+  useWidgetsViewDevice: () => [undefined]
+}));
+
+const selectWidget = vi.fn();
+
+describe("WidgetManagerPanel hooks", () => {
+  beforeEach(() => {
+    addWidget.mockReset();
+    removeWidget.mockReset();
+    addSystemTile.mockReset();
+    removeSystemTile.mockReset();
+    selectWidget.mockReset();
+    installedWidgets = [];
+  });
+
+  it("does not create the system tile when addWidget fails (REL-05)", async () => {
+    addWidget.mockResolvedValue({ status: "error" });
+    const { result } = renderHook(() =>
+      useHooks({ sceneId: "scene-id", selectWidget })
+    );
+
+    await act(async () => {
+      await result.current.handleWidgetAdd(STREET_VIEW_WIDGET_ID);
+    });
+
+    expect(addWidget).toHaveBeenCalled();
+    expect(addSystemTile).not.toHaveBeenCalled();
+  });
+
+  it("creates the system tile when addWidget succeeds", async () => {
+    addWidget.mockResolvedValue({ status: "success" });
+    const { result } = renderHook(() =>
+      useHooks({ sceneId: "scene-id", selectWidget })
+    );
+
+    await act(async () => {
+      await result.current.handleWidgetAdd(STREET_VIEW_WIDGET_ID);
+    });
+
+    expect(addSystemTile).toHaveBeenCalled();
+  });
+
+  it("does not remove the system tile when removeWidget fails (REL-06)", async () => {
+    installedWidgets = [installedGSSVWidget];
+    removeWidget.mockResolvedValue({ status: "error" });
+    const { result } = renderHook(() =>
+      useHooks({ sceneId: "scene-id", selectWidget })
+    );
+
+    await act(async () => {
+      await result.current.handleWidgetRemove("installed-widget-id");
+    });
+
+    expect(removeWidget).toHaveBeenCalled();
+    expect(removeSystemTile).not.toHaveBeenCalled();
+  });
+
+  it("removes the system tile when removeWidget succeeds", async () => {
+    installedWidgets = [installedGSSVWidget];
+    removeWidget.mockResolvedValue({ status: "success" });
+    const { result } = renderHook(() =>
+      useHooks({ sceneId: "scene-id", selectWidget })
+    );
+
+    await act(async () => {
+      await result.current.handleWidgetRemove("installed-widget-id");
+    });
+
+    expect(removeSystemTile).toHaveBeenCalled();
+  });
+});

--- a/web/src/app/features/Editor/Widgets/WidgetManagerPanel/hooks.ts
+++ b/web/src/app/features/Editor/Widgets/WidgetManagerPanel/hooks.ts
@@ -43,8 +43,7 @@ export default ({ sceneId, selectWidget }: Props) => {
     type: widgetsViewDevice
   });
 
-  const { addSystemTile, removeSystemTile } =
-    useSystemTile(sceneId);
+  const { addSystemTile, removeSystemTile } = useSystemTile(sceneId);
 
   const hasInstalledGSSVWidget = useCallback(
     (excludeWidgetId?: string) =>
@@ -62,9 +61,13 @@ export default ({ sceneId, selectWidget }: Props) => {
       const shouldEnsureSystemTile =
         isGSSVWidgetId(id) && !hasInstalledGSSVWidget();
 
-      await addWidget(sceneId, id, toWidgetAlignSystemType(widgetsViewDevice));
+      const result = await addWidget(
+        sceneId,
+        id,
+        toWidgetAlignSystemType(widgetsViewDevice)
+      );
 
-      if (shouldEnsureSystemTile) {
+      if (shouldEnsureSystemTile && result.status === "success") {
         await addSystemTile();
       }
     },
@@ -91,13 +94,13 @@ export default ({ sceneId, selectWidget }: Props) => {
       const shouldRemoveSystemTile =
         isRemovingGSSVWidget && !hasInstalledGSSVWidget(id);
 
-      await removeWidget(
+      const result = await removeWidget(
         sceneId,
         id,
         toWidgetAlignSystemType(widgetsViewDevice)
       );
 
-      if (shouldRemoveSystemTile) {
+      if (shouldRemoveSystemTile && result.status === "success") {
         await removeSystemTile();
       }
     },


### PR DESCRIPTION
## Summary

- REL-05: adding a Street View / Google Map Search widget created the Google Maps system tile even when the `addWidget` mutation itself failed. The tile has no delete option in the UI (system tiles are read-only), so the user was left with a permanent extra base map they couldn't remove after seeing a "Failed to add widget" error.
- REL-06: removing that widget deleted the system tile even when the `removeWidget` mutation failed. The widget stayed installed but lost the tile it depends on to render imagery, with no way to re-add just the tile from the UI.

Both mutations return `{status: "error"}` on failure instead of throwing, but the calling code never checked that status before running the tile add/remove side effect.

## Fix

`handleWidgetAdd` and `handleWidgetRemove` in `WidgetManagerPanel/hooks.ts` now only touch the system tile when the widget mutation they depend on actually returned `status: "success"`.

## Testing

Added `hooks.test.ts` covering both cases. Verified the tests fail against the old code (confirmed via a temporary revert) and pass with the fix. Full `yarn type`, `yarn eslint`, and `yarn vitest run` are clean.