### PR TITLE
chore(web): add immutable flag to yarn install workflows and allow pull request target

### DIFF
--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -143,7 +143,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
       - name: Build
         run: yarn build
       - name: Pack

--- a/.github/workflows/ci_web.yml
+++ b/.github/workflows/ci_web.yml
@@ -38,7 +38,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install
-        run: yarn install
+        run: yarn install --immutable
       - name: type
         run: yarn run type
       - name: eslint

--- a/.github/workflows/reviewer_lottery.yml
+++ b/.github/workflows/reviewer_lottery.yml
@@ -1,8 +1,8 @@
 name: Reviewer lottery
 on:
-  pull_request_target:
+  pull_request_target: # git-cascade:allow
     paths:
-        - web/**
+      - web/**
     types: [opened, ready_for_review, reopened]
 
 permissions:


### PR DESCRIPTION
# Overview

Adding --immutable flag to yarn install in both build_web.yml and ci_web.yml
Adding comments to ignore scan on pull request target

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
