### PR TITLE
fix(server): scope story lookup to the authorized scene in page mutations

### DIFF
--- a/server/internal/infrastructure/mongo/storytelling.go
+++ b/server/internal/infrastructure/mongo/storytelling.go
@@ -178,6 +178,12 @@ func (r *Storytelling) findOne(ctx context.Context, filter any, filterByScene bo
 	if err := r.client.FindOne(ctx, filter, c); err != nil {
 		return nil, err
 	}
+	// FindOne matched a document, but the consumer drops it when it is outside
+	// the scene filter, leaving Result empty. Treat that as not found rather
+	// than indexing into an empty slice and panicking.
+	if len(c.Result) == 0 {
+		return nil, rerror.ErrNotFound
+	}
 	return c.Result[0], nil
 }
 

--- a/server/internal/infrastructure/mongo/storytelling_authz_test.go
+++ b/server/internal/infrastructure/mongo/storytelling_authz_test.go
@@ -1,0 +1,64 @@
+package mongo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth/server/internal/usecase/repo"
+	"github.com/reearth/reearth/server/pkg/id"
+	"github.com/reearth/reearth/server/pkg/storytelling"
+	"github.com/reearth/reearthx/mongox"
+	"github.com/reearth/reearthx/mongox/mongotest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStorytelling_FindByID_RespectsSceneFilter: unfiltered returns/saves any
+// scene; filtered returns not found outside the filter.
+func TestStorytelling_FindByID_RespectsSceneFilter(t *testing.T) {
+	ctx := context.Background()
+	c := mongotest.Connect(t)(t)
+	r := NewStorytelling(mongox.NewClientWithDatabase(c))
+
+	victimScene := id.NewSceneID()
+	callerScene := id.NewSceneID()
+
+	page := storytelling.NewPage().NewID().Property(id.NewPropertyID()).MustBuild()
+	story := storytelling.NewStory().
+		NewID().
+		Scene(victimScene).
+		Title("Their story").
+		Property(id.NewPropertyID()).
+		Pages(storytelling.NewPageList([]*storytelling.Page{page})).
+		MustBuild()
+	require.NoError(t, r.Save(ctx, *story))
+
+	t.Run("unfiltered read returns a story from another scene", func(t *testing.T) {
+		got, err := r.FindByID(ctx, story.Id())
+		assert.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, victimScene, got.Scene())
+	})
+
+	t.Run("unfiltered write persists a story from another scene", func(t *testing.T) {
+		got, err := r.FindByID(ctx, story.Id())
+		require.NoError(t, err)
+		got.Rename("edited by someone else")
+
+		assert.NoError(t, r.Save(ctx, *got), "Save on an unfiltered repo accepts any scene")
+
+		reread, err := r.FindByID(ctx, story.Id())
+		require.NoError(t, err)
+		assert.Equal(t, "edited by someone else", reread.Title())
+	})
+
+	t.Run("scoping the read to the caller's scene is what blocks it", func(t *testing.T) {
+		scoped := r.Filtered(repo.SceneFilter{
+			Readable: id.SceneIDList{callerScene},
+			Writable: id.SceneIDList{callerScene},
+		})
+
+		_, err := scoped.FindByID(ctx, story.Id())
+		assert.Error(t, err, "a story outside the filter must not be readable")
+	})
+}

--- a/server/internal/usecase/interactor/storytelling.go
+++ b/server/internal/usecase/interactor/storytelling.go
@@ -608,7 +608,9 @@ func (i *Storytelling) UpdatePage(ctx context.Context, inp interfaces.UpdatePage
 		return nil, nil, interfaces.ErrOperationDenied
 	}
 
-	story, err := i.storytellingRepo.FindByID(ctx, inp.StoryID)
+	// Scope the lookup to the authorized scene so the story resolves consistently
+	// with the permission check above.
+	story, err := i.storytellingRepo.Filtered(Filter(inp.SceneID)).FindByID(ctx, inp.StoryID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -678,7 +680,9 @@ func (i *Storytelling) RemovePage(ctx context.Context, inp interfaces.RemovePage
 		return nil, nil, interfaces.ErrOperationDenied
 	}
 
-	story, err := i.storytellingRepo.FindByID(ctx, inp.StoryID)
+	// Scope the lookup to the authorized scene so the story resolves consistently
+	// with the permission check above.
+	story, err := i.storytellingRepo.Filtered(Filter(inp.SceneID)).FindByID(ctx, inp.StoryID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/internal/usecase/interactor/storytelling_authz_test.go
+++ b/server/internal/usecase/interactor/storytelling_authz_test.go
@@ -1,0 +1,101 @@
+package interactor
+
+import (
+	"context"
+	"testing"
+
+	accountsID "github.com/reearth/reearth-accounts/server/pkg/id"
+	accountsWorkspace "github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/reearth/reearth/server/internal/usecase/gateway"
+	"github.com/reearth/reearth/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth/server/pkg/id"
+	"github.com/reearth/reearth/server/pkg/project"
+	"github.com/reearth/reearth/server/pkg/scene"
+	"github.com/reearth/reearth/server/pkg/storytelling"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTwoWorkspaceStory: a story in a scene the operator cannot access, and a
+// separate scene it can write.
+func setupTwoWorkspaceStory(ctx context.Context, t *testing.T) (*storytellingTestEnv, id.SceneID, *storytelling.Story) {
+	t.Helper()
+	env := setupStorytellingTestEnv(ctx, t)
+	env.mockPolicyChecker.On("CheckPolicy", mock.Anything, mock.Anything).
+		Return(&gateway.PolicyCheckResponse{Allowed: true}, nil).
+		Maybe()
+
+	// the operator's own scene
+	ownPrj := project.New().NewID().Workspace(env.wsID).Name("Mine").MustBuild()
+	require.NoError(t, env.db.Project.Save(ctx, ownPrj))
+	ownScene := lo.Must(scene.New().NewID().Workspace(env.wsID).Project(ownPrj.ID()).Build())
+	require.NoError(t, env.db.Scene.Save(ctx, ownScene))
+
+	// somebody else's workspace, scene and story
+	victimWs := accountsID.NewWorkspaceID()
+	require.NoError(t, env.db.Workspace.Save(ctx, accountsWorkspace.New().ID(victimWs).MustBuild()))
+	victimPrj := project.New().NewID().Workspace(victimWs).Name("Theirs").MustBuild()
+	require.NoError(t, env.db.Project.Save(ctx, victimPrj))
+	victimScene := lo.Must(scene.New().NewID().Workspace(victimWs).Project(victimPrj.ID()).Build())
+	require.NoError(t, env.db.Scene.Save(ctx, victimScene))
+
+	page := storytelling.NewPage().NewID().Property(id.NewPropertyID()).MustBuild()
+	story := storytelling.NewStory().
+		NewID().
+		Scene(victimScene.ID()).
+		Title("Their story").
+		Property(id.NewPropertyID()).
+		Pages(storytelling.NewPageList([]*storytelling.Page{page})).
+		MustBuild()
+	require.NoError(t, env.db.Storytelling.Save(ctx, *story))
+
+	// the operator can write only their own scene
+	env.operator.WritableScenes = []id.SceneID{ownScene.ID()}
+	env.operator.AcOperator = &accountsWorkspace.Operator{
+		WritableWorkspaces: accountsID.WorkspaceIDList{env.wsID},
+		OwningWorkspaces:   accountsID.WorkspaceIDList{env.wsID},
+	}
+
+	return env, ownScene.ID(), story
+}
+
+// TestStorytelling_UpdatePage_RejectsForeignScene: story not in the named scene => fail.
+func TestStorytelling_UpdatePage_RejectsForeignScene(t *testing.T) {
+	ctx := context.Background()
+	env, ownScene, story := setupTwoWorkspaceStory(ctx, t)
+
+	title := "pwned"
+	_, _, err := env.storytellingUC.UpdatePage(ctx, interfaces.UpdatePageParam{
+		SceneID: ownScene,   // a scene the caller may write
+		StoryID: story.Id(), // a story in a different scene
+		PageID:  story.Pages().Pages()[0].Id(),
+		Title:   &title,
+	}, env.operator)
+
+	assert.Error(t, err, "story not in the named scene must fail")
+
+	stored, ferr := env.db.Storytelling.FindByID(ctx, story.Id())
+	require.NoError(t, ferr)
+	assert.NotEqual(t, title, stored.Pages().Pages()[0].Title(), "the page must be unchanged")
+}
+
+// TestStorytelling_RemovePage_RejectsForeignScene: same, for delete.
+func TestStorytelling_RemovePage_RejectsForeignScene(t *testing.T) {
+	ctx := context.Background()
+	env, ownScene, story := setupTwoWorkspaceStory(ctx, t)
+	pageID := story.Pages().Pages()[0].Id()
+
+	_, _, err := env.storytellingUC.RemovePage(ctx, interfaces.RemovePageParam{
+		SceneID: ownScene,
+		StoryID: story.Id(),
+		PageID:  pageID,
+	}, env.operator)
+
+	assert.Error(t, err, "story not in the named scene must fail")
+
+	stored, ferr := env.db.Storytelling.FindByID(ctx, story.Id())
+	require.NoError(t, ferr)
+	assert.NotNil(t, stored.Pages().Page(pageID), "the page must still exist")
+}


### PR DESCRIPTION
## Problem

`updateStoryPage` and `removeStoryPage` scoped the story lookup differently from the permission check, so the two could refer to different scenes. This tightens them to the same scope.

`mongo` `findOne` also indexed into an empty result when a document was filtered out by scene, returning a 500 instead of not found.

## Fix

Both mutations scope the story lookup with `Filtered(Filter(inp.SceneID))`, matching `moveStoryBlock`. `findOne` returns `rerror.ErrNotFound` on an empty result.

## Verification

New repo and interactor tests fail without each change and pass with it. `go test` on the affected packages and `golangci-lint run --new-from-rev=origin/main` are clean.

Task: VIZ-DEV-81