### PR TITLE
fix(server): require the internal token before trusting the gRPC user-id (SEC-03)

### DIFF
--- a/server/internal/app/grpc.go
+++ b/server/internal/app/grpc.go
@@ -135,7 +135,8 @@ func unaryAttachOperatorInterceptor(cfg *ServerConfig) grpc.UnaryServerIntercept
 		// read or export that user's private projects (SEC-03). Verified here
 		// rather than trusting the earlier interceptor, so the guard cannot be
 		// reopened by a change to which methods skip the token check.
-		if tokenFromGrpcMetadata(md) != cfg.Config.Visualizer.InternalApi.Token {
+		token := tokenFromGrpcMetadata(md)
+		if token == "" || token != cfg.Config.Visualizer.InternalApi.Token {
 			log.Errorf("unaryAttachOperatorInterceptor: user-id supplied without a valid internal token")
 			return nil, errors.New("unauthorized")
 		}

--- a/server/internal/app/grpc.go
+++ b/server/internal/app/grpc.go
@@ -127,6 +127,19 @@ func unaryAttachOperatorInterceptor(cfg *ServerConfig) grpc.UnaryServerIntercept
 			return nil, errors.New("unauthorized")
 		}
 
+		// The operator built below carries user-id's real workspace memberships,
+		// so user-id is a privileged claim and must only be honoured on a request
+		// that proved it holds the internal token. unaryAuthInterceptor skips that
+		// check for read-only methods (and unconditionally for ExportProject), so
+		// without this an unauthenticated caller could set user-id to any user and
+		// read or export that user's private projects (SEC-03). Verified here
+		// rather than trusting the earlier interceptor, so the guard cannot be
+		// reopened by a change to which methods skip the token check.
+		if tokenFromGrpcMetadata(md) != cfg.Config.Visualizer.InternalApi.Token {
+			log.Errorf("unaryAttachOperatorInterceptor: user-id supplied without a valid internal token")
+			return nil, errors.New("unauthorized")
+		}
+
 		userID, err := accountsID.UserIDFrom(md["user-id"][0])
 		if err != nil {
 			log.Errorf("unaryAttachOperatorInterceptor: invalid user id")

--- a/server/internal/app/grpc_auth_test.go
+++ b/server/internal/app/grpc_auth_test.go
@@ -589,3 +589,30 @@ func TestUnaryAttachOperatorInterceptor_AnonymousReadStillAllowed(t *testing.T) 
 	assert.NoError(t, err)
 	assert.Equal(t, "success", result)
 }
+
+// TestUnaryAttachOperatorInterceptor_EmptyConfiguredTokenStillRejectsUserID
+// covers the config default where an active internal API has no token set. An
+// empty extracted token must not equal an empty configured token and let a
+// forged user-id through.
+func TestUnaryAttachOperatorInterceptor_EmptyConfiguredTokenStillRejectsUserID(t *testing.T) {
+	cfg := &ServerConfig{
+		Config: &config.Config{
+			Host: "https://example.com",
+			// InternalApi.Token intentionally left empty (the config default).
+		},
+	}
+	interceptor := unaryAttachOperatorInterceptor(cfg)
+	mockHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "success", nil
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+		"user-id": "01h0000000000000000000user",
+	}))
+	info := &grpc.UnaryServerInfo{FullMethod: "/reearth.visualizer.v1.ReEarthVisualizer/GetProject"}
+
+	result, err := interceptor(ctx, nil, info, mockHandler)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}

--- a/server/internal/app/grpc_auth_test.go
+++ b/server/internal/app/grpc_auth_test.go
@@ -505,3 +505,87 @@ func TestAuthenticationFlow(t *testing.T) {
 		})
 	}
 }
+
+// TestUnaryAttachOperatorInterceptor_UserIDRequiresToken is a regression test
+// for SEC-03. The operator built from user-id carries that user's real
+// workspace memberships, and unaryAuthInterceptor skips the token check for
+// read-only methods, so before the fix a caller could set user-id to any user
+// on GetProject/ExportProject with no valid token and act as them. A user-id
+// must now be backed by the internal token.
+func TestUnaryAttachOperatorInterceptor_UserIDRequiresToken(t *testing.T) {
+	cfg := &ServerConfig{
+		Config: &config.Config{
+			Host: "https://example.com",
+			Visualizer: config.VisualizerConfig{
+				InternalApi: config.InternalApiConfig{
+					Token: "test-token",
+				},
+			},
+		},
+	}
+	interceptor := unaryAttachOperatorInterceptor(cfg)
+	mockHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "success", nil
+	}
+
+	// GetProject is read-only, so unaryAuthInterceptor lets it through without a
+	// token; the guard has to live in this interceptor.
+	const readOnly = "/reearth.visualizer.v1.ReEarthVisualizer/GetProject"
+
+	testCases := []struct {
+		name     string
+		metadata metadata.MD
+	}{
+		{
+			name: "user-id with no token is rejected",
+			metadata: metadata.New(map[string]string{
+				"user-id": "01h0000000000000000000user",
+			}),
+		},
+		{
+			name: "user-id with a wrong token is rejected",
+			metadata: metadata.New(map[string]string{
+				"authorization": "Bearer not-the-internal-token",
+				"user-id":       "01h0000000000000000000user",
+			}),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := metadata.NewIncomingContext(context.Background(), tc.metadata)
+			info := &grpc.UnaryServerInfo{FullMethod: readOnly}
+
+			result, err := interceptor(ctx, nil, info, mockHandler)
+
+			assert.Error(t, err)
+			assert.Nil(t, result)
+		})
+	}
+}
+
+// TestUnaryAttachOperatorInterceptor_AnonymousReadStillAllowed confirms the fix
+// does not close the anonymous read path: a read-only call with no user-id
+// proceeds without an operator, which is what public project browsing relies on.
+func TestUnaryAttachOperatorInterceptor_AnonymousReadStillAllowed(t *testing.T) {
+	cfg := &ServerConfig{
+		Config: &config.Config{
+			Host: "https://example.com",
+			Visualizer: config.VisualizerConfig{
+				InternalApi: config.InternalApiConfig{Token: "test-token"},
+			},
+		},
+	}
+	interceptor := unaryAttachOperatorInterceptor(cfg)
+	mockHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "success", nil
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{}))
+	info := &grpc.UnaryServerInfo{FullMethod: "/reearth.visualizer.v1.ReEarthVisualizer/GetProject"}
+
+	result, err := interceptor(ctx, nil, info, mockHandler)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "success", result)
+}


### PR DESCRIPTION
# Overview

The internal gRPC API builds its operator from the caller-supplied `user-id` metadata, which carries that user's workspace memberships. The auth interceptor skips the token check for read-only methods and unconditionally for `ExportProject`, so a caller inside the VPC could set `user-id` to any user and read or export that user's private projects. User IDs are not secret, so naming a valid member is no barrier on its own.

The operator interceptor now verifies the internal token before honouring `user-id`. Anonymous read-only calls that send no `user-id` still pass through, so public project browsing is unaffected.

Affected read-only methods: `GetProject`, `GetProjectList`, `GetAllProjects`, `GetProjectByWorkspaceAliasAndProjectAlias`, `ExportProject`.

Two notes on scope:

- The check lives in the operator interceptor, which runs for every method, not only the read-only ones. It matters most on the read-only endpoints because those were the ones skipping the token; writes already required it.
- This is reachable only with direct access to the internal gRPC port (`:50051`), which is not internet-facing. The realistic threat is a compromised or buggy neighbouring service inside the VPC, not an external attacker, which is what keeps it HIGH rather than CRITICAL.

## How I tested

Reproduced against the internal service on a local stack with grpcurl: a request with no token and a forged `user-id` returned the target's project before the fix, and returns `unauthorized` after. A valid token plus `user-id` still passes, and an anonymous call with no `user-id` is unchanged. Unit tests cover the two reject cases and the anonymous-read case, and were checked by reverting the fix.

Prod logs on the internal service show all five methods in active use, no auth errors in 7 days and no user-id metadata errors in 30, and successful write calls that already require token plus user-id together. The dashboard is the only caller and always sends both.

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.