### PR TITLE
chore(web): bump version to 1.0.0-beta.16.22

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reearth/visualizer",
-  "version": "1.0.0-beta.16.21",
+  "version": "1.0.0-beta.16.22",
   "repository": "https://github.com/reearth/reearth-visualizer.git",
   "author": "Re:Earth contributors <community@reearth.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Bump web version to 1.0.0-beta.16.22.