### PR TITLE
chore(ci): allow promote-images to be run manually

### DIFF
--- a/.github/workflows/promote_images.yml
+++ b/.github/workflows/promote_images.yml
@@ -1,6 +1,8 @@
 # Retags an already-built image under a new tag via a registry-side manifest
 # copy (no rebuild, no pull/push of image layers). Used by stage.yml and
 # release.yml to promote nightly -> rc -> a version tag without re-running CI.
+# Can also be run by hand, which is useful when a release run failed after the
+# images were built but before they were promoted.
 name: promote-images
 on:
   workflow_call:
@@ -9,6 +11,16 @@ on:
         type: string
         required: true
       to_tag:
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      from_tag:
+        description: 'Existing tag to copy from, for example nightly or rc'
+        type: string
+        required: true
+      to_tag:
+        description: 'New tag to create, for example rc or 1.0.0-beta.16.22'
         type: string
         required: true
 


### PR DESCRIPTION
# Overview

## What I've done

Add a workflow_dispatch trigger to promote-images so it can be run by hand.

The 1.0.0-beta.16.22 release run failed at the step that pushes to main, which meant the promote job never ran and the version tag for the two images was never created. The images themselves are built and fine, only the tag is missing. There was no way to run the promotion on its own, because promote-images was workflow_call only, so dispatching it returned "Workflow does not have workflow_dispatch trigger".

## What I haven't done

The existing workflow_call trigger and all the job steps are unchanged, so stage and release keep calling this workflow exactly as before. This adds no automatic trigger, only a manual one.

Digests are not accepted as inputs. The steps interpolate the input as repo:TAG, so a digest would build an invalid reference. Supporting that would mean changing the shared steps, which felt out of scope here.

## How I tested

Confirmed the current failure mode first: dispatching promote-images returned HTTP 422 with "Workflow does not have workflow_dispatch trigger". After merging, the plan is to dispatch it with from_tag rc and to_tag 1.0.0-beta.16.22 and confirm both image tags appear.

## Which point I want you to review particularly

Whether the promote job should be limited to certain branches. I left it unguarded, because an if on github.ref would also apply when stage and release call the workflow, and I did not want to risk breaking those.

## Memo

The git tag, the GitHub release, and the changelog on main for 1.0.0-beta.16.22 have all been fixed already. The image tag is the last outstanding piece. It needs to happen before the next stage run repoints rc, since rc is currently the only tag pointing at the artifact that shipped.

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
