### PR TITLE
revert: allow promote-images to be run manually

### DIFF
--- a/.github/workflows/promote_images.yml
+++ b/.github/workflows/promote_images.yml
@@ -1,8 +1,6 @@
 # Retags an already-built image under a new tag via a registry-side manifest
 # copy (no rebuild, no pull/push of image layers). Used by stage.yml and
 # release.yml to promote nightly -> rc -> a version tag without re-running CI.
-# Can also be run by hand, which is useful when a release run failed after the
-# images were built but before they were promoted.
 name: promote-images
 on:
   workflow_call:
@@ -11,16 +9,6 @@ on:
         type: string
         required: true
       to_tag:
-        type: string
-        required: true
-  workflow_dispatch:
-    inputs:
-      from_tag:
-        description: 'Existing tag to copy from, for example nightly or rc'
-        type: string
-        required: true
-      to_tag:
-        description: 'New tag to create, for example rc or 1.0.0-beta.16.22'
         type: string
         required: true
 


### PR DESCRIPTION
# Overview

## What I've done

Revert the workflow_dispatch trigger on promote-images, as planned once the release was finished.

It was added so the 1.0.0-beta.16.22 image tags could be created by hand, after the release run failed at the step that pushes to main and the promote job never ran. Both image tags now exist and match the artifact that shipped, so the manual trigger is no longer needed.

## What I haven't done

Nothing else. This restores the file to exactly what it was before, and the workflow_call path used by stage and release was never touched.

## How I tested

The revert is a clean single commit and the file is byte identical to its previous version. Confirmed before opening this that both image tags are in place, with digests matching rc.

## Which point I want you to review particularly

Nothing in particular. This is a straight revert.

## Memo

A reviewer suggested guarding the promote job by branch if the manual trigger were kept. Worth remembering if we ever add it back, along with one detail that is easy to get wrong: a guard cannot key off github.event_name, because in a reusable workflow that context belongs to the caller, and both callers are themselves workflow_dispatch. A check on github.ref works, since stage runs on main and release runs on release.

Also worth noting for the next release owner: without this trigger there is no way to promote images on their own, so a release that fails after the images are built again needs someone with Docker Hub push access on the reearth org, or a repeat of this workflow change.

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
