### PR TITLE
fix(server): retry property value updates on write conflict

### DIFF
--- a/server/internal/usecase/interactor/common.go
+++ b/server/internal/usecase/interactor/common.go
@@ -3,6 +3,7 @@ package interactor
 import (
 	"context"
 	"errors"
+	"math/rand/v2"
 	"net/url"
 	"strings"
 	"time"
@@ -24,15 +25,57 @@ import (
 	"github.com/reearth/reearthx/usecasex"
 )
 
+// txMaxRetries is the number of additional attempts a contended transaction
+// gets. Kept in one place so the retried call sites stay consistent.
+const txMaxRetries = 3
+
+// txRetryBaseDelay is the first backoff step between transaction attempts.
+// Retrying immediately is not enough on its own: MongoDB gives up on a
+// contended transaction after about 5ms of lock waiting
+// (maxTransactionLockRequestTimeoutMillis), so an immediate retry tends to land
+// inside the same contention window as the attempt that just failed. A short
+// randomised delay lets the winning transaction commit first.
+const txRetryBaseDelay = 10 * time.Millisecond
+
+// txRetryMaxShift caps the exponent so the delay cannot overflow or grow
+// unreasonably if a caller passes a large maxRetries.
+const txRetryMaxShift = 6
+
+// txRetryDelay returns the backoff before the attempt after the given one,
+// using exponential growth with full jitter. Jitter matters more than the mean
+// here: without it, two transactions that collided will tend to wake together
+// and collide again.
+func txRetryDelay(attempt int) time.Duration {
+	shift := attempt
+	if shift > txRetryMaxShift {
+		shift = txRetryMaxShift
+	}
+	window := int64(txRetryBaseDelay) << shift
+	return time.Duration(rand.Int64N(window))
+}
+
 // runWithTxRetry runs fn in a fresh MongoDB transaction for each attempt,
 // retrying up to maxRetries additional times on TransientTransactionError.
-// Each retry starts a new session so the driver can safely renegotiate locks.
+// Each retry starts a new session so the driver can safely renegotiate locks,
+// and re-runs fn so its reads observe the state committed by whichever
+// transaction won the previous round. Retrying without re-reading would turn a
+// write conflict into a lost update.
 func runWithTxRetry(ctx context.Context, t usecasex.Transaction, maxRetries int, fn func(context.Context) error) error {
 	if t == nil {
 		return fn(ctx)
 	}
 	var lastErr error
 	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			// Wait before re-attempting, but give up if the caller is already
+			// gone -- there is no point holding a request open to retry a
+			// transaction whose response nobody will read.
+			select {
+			case <-ctx.Done():
+				return lastErr
+			case <-time.After(txRetryDelay(attempt - 1)):
+			}
+		}
 		tx, err := t.Begin(ctx)
 		if err != nil {
 			return err

--- a/server/internal/usecase/interactor/common_txretry_test.go
+++ b/server/internal/usecase/interactor/common_txretry_test.go
@@ -1,0 +1,118 @@
+package interactor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/reearth/reearthx/usecasex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunWithTxRetry_RetriesTransactionErrorsUntilSuccess(t *testing.T) {
+	tr := &usecasex.NopTransaction{}
+	attempts := 0
+
+	err := runWithTxRetry(context.Background(), tr, txMaxRetries, func(context.Context) error {
+		attempts++
+		if attempts < 3 {
+			return usecasex.ErrTransaction
+		}
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 3, attempts, "should retry until the transaction succeeds")
+}
+
+func TestRunWithTxRetry_DoesNotRetryOtherErrors(t *testing.T) {
+	tr := &usecasex.NopTransaction{}
+	boom := errors.New("boom")
+	attempts := 0
+
+	err := runWithTxRetry(context.Background(), tr, txMaxRetries, func(context.Context) error {
+		attempts++
+		return boom
+	})
+
+	assert.ErrorIs(t, err, boom)
+	assert.Equal(t, 1, attempts, "a non-transaction error must fail immediately")
+}
+
+func TestRunWithTxRetry_GivesUpAfterMaxRetries(t *testing.T) {
+	tr := &usecasex.NopTransaction{}
+	attempts := 0
+
+	err := runWithTxRetry(context.Background(), tr, 2, func(context.Context) error {
+		attempts++
+		return usecasex.ErrTransaction
+	})
+
+	assert.ErrorIs(t, err, usecasex.ErrTransaction)
+	assert.Equal(t, 3, attempts, "maxRetries=2 means one initial attempt plus two retries")
+}
+
+// The retry is only useful if it waits: MongoDB abandons a contended
+// transaction after ~5ms of lock waiting, so retrying with no delay lands in
+// the same contention window. Assert that some backoff actually elapses rather
+// than asserting an exact duration, which would be flaky.
+func TestRunWithTxRetry_BacksOffBetweenAttempts(t *testing.T) {
+	tr := &usecasex.NopTransaction{}
+	attempts := 0
+	start := time.Now()
+
+	err := runWithTxRetry(context.Background(), tr, 3, func(context.Context) error {
+		attempts++
+		return usecasex.ErrTransaction
+	})
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, usecasex.ErrTransaction)
+	assert.Equal(t, 4, attempts)
+	assert.Greater(t, elapsed, time.Duration(0), "retries must not run back-to-back with no delay")
+}
+
+func TestRunWithTxRetry_StopsWhenContextIsCanceled(t *testing.T) {
+	tr := &usecasex.NopTransaction{}
+	ctx, cancel := context.WithCancel(context.Background())
+	attempts := 0
+
+	err := runWithTxRetry(ctx, tr, 5, func(context.Context) error {
+		attempts++
+		cancel() // the caller goes away after the first failed attempt
+		return usecasex.ErrTransaction
+	})
+
+	assert.ErrorIs(t, err, usecasex.ErrTransaction)
+	assert.Equal(t, 1, attempts, "must not keep retrying once the caller is gone")
+}
+
+func TestRunWithTxRetry_RunsWithoutTransaction(t *testing.T) {
+	attempts := 0
+
+	err := runWithTxRetry(context.Background(), nil, txMaxRetries, func(context.Context) error {
+		attempts++
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, attempts)
+}
+
+func TestTxRetryDelay_GrowsAndIsCapped(t *testing.T) {
+	// Full jitter means each delay is a random value below its window, so
+	// compare the windows rather than individual samples.
+	for attempt := 0; attempt < txRetryMaxShift; attempt++ {
+		d := txRetryDelay(attempt)
+		window := time.Duration(int64(txRetryBaseDelay) << attempt)
+		assert.GreaterOrEqual(t, d, time.Duration(0))
+		assert.Less(t, d, window, "delay must stay inside its jitter window")
+	}
+
+	// Beyond the cap the window stops growing, so the delay stays bounded.
+	capped := time.Duration(int64(txRetryBaseDelay) << txRetryMaxShift)
+	for _, attempt := range []int{txRetryMaxShift, txRetryMaxShift + 10, 1000} {
+		assert.Less(t, txRetryDelay(attempt), capped, "delay must remain capped")
+	}
+}

--- a/server/internal/usecase/interactor/property.go
+++ b/server/internal/usecase/interactor/property.go
@@ -57,47 +57,47 @@ func (i *Property) FetchSchema(ctx context.Context, ids []id.PropertySchemaID, o
 	return i.propertySchemaRepo.FindByIDs(ctx, ids)
 }
 
-func (i *Property) UpdateValue(ctx context.Context, inp interfaces.UpdatePropertyValueParam, operator *usecase.Operator) (p *property.Property, _ *property.GroupList, _ *property.Group, _ *property.Field, err error) {
-	tx, err := i.transaction.Begin(ctx)
-	if err != nil {
-		return
-	}
+// UpdateValue is retried on write conflict: the editor issues these in bursts
+// (a single user dragging or applying values produced ~16 calls/second in
+// production), and concurrent edits all rewrite the same property document, so
+// MongoDB aborts the losers with a WriteConflict. Every attempt re-reads the
+// property inside the new transaction, so a retry applies its change on top of
+// whichever write landed first rather than clobbering it.
+func (i *Property) UpdateValue(ctx context.Context, inp interfaces.UpdatePropertyValueParam, operator *usecase.Operator) (*property.Property, *property.GroupList, *property.Group, *property.Field, error) {
+	var p *property.Property
+	var pgl *property.GroupList
+	var pg *property.Group
+	var field *property.Field
 
-	ctx = tx.Context()
-	defer func() {
-		if err2 := tx.End(ctx); err == nil && err2 != nil {
-			err = err2
+	if err := runWithTxRetry(ctx, i.transaction, txMaxRetries, func(txCtx context.Context) error {
+		var err error
+		p, err = i.propertyRepo.FindByID(txCtx, inp.PropertyID)
+		if err != nil {
+			return err
 		}
-	}()
+		if err := i.CanWriteScene(p.Scene(), operator); err != nil {
+			return err
+		}
 
-	p, err = i.propertyRepo.FindByID(ctx, inp.PropertyID)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-	if err := i.CanWriteScene(p.Scene(), operator); err != nil {
-		return nil, nil, nil, nil, err
-	}
+		if err := i.CheckSceneLock(txCtx, p.Scene()); err != nil {
+			return err
+		}
 
-	if err := i.CheckSceneLock(ctx, p.Scene()); err != nil {
-		return nil, nil, nil, nil, err
-	}
+		ps, err := i.propertySchemaRepo.FindByID(txCtx, p.Schema())
+		if err != nil {
+			return err
+		}
 
-	ps, err := i.propertySchemaRepo.FindByID(ctx, p.Schema())
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
+		field, pgl, pg, err = p.UpdateValue(ps, inp.Pointer, inp.Value)
+		if err != nil {
+			return err
+		}
 
-	field, pgl, pg, err := p.UpdateValue(ps, inp.Pointer, inp.Value)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-
-	err = i.propertyRepo.Save(ctx, p)
-	if err != nil {
+		return i.propertyRepo.Save(txCtx, p)
+	}); err != nil {
 		return nil, nil, nil, nil, err
 	}
 
-	tx.Commit()
 	return p, pgl, pg, field, nil
 }
 


### PR DESCRIPTION
## Problem

Updating a property value fails with a MongoDB WriteConflict when two edits to the same property overlap. The editor sends these in bursts, so a single user can cause the overlap on their own. Production logs show one user issuing about 16 updatePropertyValue calls per second, nine of which failed within two and a half seconds. Each failure reaches the user as "transaction error" and the edit is lost.

## Fix

Retry UpdateValue when the transaction fails with a conflict. Each attempt runs in a new transaction and re-reads the property first, so a retry applies its change on top of whichever write landed first instead of overwriting it.

Also add backoff to runWithTxRetry, which previously looped with no delay. MongoDB gives up on a contended transaction after about 5ms of waiting for locks, so retrying straight away tends to land in the same window as the attempt that just failed. Delays now grow exponentially with random spread, and the loop stops early if the caller has gone away.

## Verification

- go build, go vet and go test ./... all pass (46 packages, no failures)
- New unit tests cover retrying until success, not retrying other errors, giving up after the retry limit, backoff actually elapsing, stopping on context cancellation, and the delay staying capped

## Not included

Other operations that write the shared project document still lack retries. Those are a separate contention path and are tracked separately.

---

Overlapping edits to the same property failed with a Mongo WriteConflict that reached the user as "transaction error" and lost the edit; now retried in a fresh re-read transaction with exponential backoff.

VIZ-DEV-81
