### PR TITLE
docs(server): note accepted tradeoff for in-memory export zip assembly (SCA-07)

### DIFF
--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -1101,6 +1101,14 @@ func (i *Project) ExportProjectData(ctx context.Context, pid id.ProjectID, zipWr
 // (exportZipState.trackWrite) rather than a single check after the whole zip has already been
 // built -- by the time a post-hoc check could catch an oversized export, the damage (memory,
 // disk, GCS reads) is already done.
+//
+// SCA-07 (accepted tradeoff): the zip is assembled in the container filesystem, which on Cloud Run
+// is in memory, so peak memory scales with the export size. Kept as-is deliberately: real exports
+// are small, so the concern is dormant at current load; lowering this cap would make a legitimate
+// large export fail, and raising instance memory or isolating export onto its own worker is
+// disproportionate to the current risk. Revisit if export sizes or concurrency grow materially;
+// shrinking the cap is not the answer -- the options (each with tradeoffs) are weighed in the
+// internal tracker.
 var maxExportZipBytes int64 = 500 * 1024 * 1024 // 500MB
 
 // exportZipState carries state across the whole SearchAssetURL/AddZipAsset recursion for one


### PR DESCRIPTION
## Overview

The project export zip is assembled in memory, so peak memory scales with the export size.

This is a docs-only change: an accepted-tradeoff note at `maxExportZipBytes` so the reasoning lives in the code (and is visible to the compliance scan), not only in the tracker. No behaviour change.

## Rationale

At current load this is a dormant, low-risk concern, and the change it would take to address it is not justified today. It is documented in code with a revisit trigger; the analysis and the options are tracked internally.

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.