### PR TITLE
fix(server): guard findOne against an empty filtered result (REL-10)

### DIFF
--- a/server/internal/infrastructure/mongo/project.go
+++ b/server/internal/infrastructure/mongo/project.go
@@ -1035,6 +1035,12 @@ func (r *Project) findOne(ctx context.Context, filter any, filterByWorkspaces bo
 	if err := r.client.FindOne(ctx, filter, c); err != nil {
 		return nil, err
 	}
+	// REL-10: FindOne can return no error while the readable/scene/workspace
+	// filter leaves Result empty; guard the index so that reads as not-found
+	// instead of panicking (same fix as storytelling.findOne).
+	if len(c.Result) == 0 {
+		return nil, rerror.ErrNotFound
+	}
 	return c.Result[0], nil
 }
 

--- a/server/internal/infrastructure/mongo/property.go
+++ b/server/internal/infrastructure/mongo/property.go
@@ -199,6 +199,12 @@ func (r *Property) findOne(ctx context.Context, filter any) (*property.Property,
 	if err := r.client.FindOne(ctx, filter, c); err != nil {
 		return nil, err
 	}
+	// REL-10: FindOne can return no error while the readable/scene/workspace
+	// filter leaves Result empty; guard the index so that reads as not-found
+	// instead of panicking (same fix as storytelling.findOne).
+	if len(c.Result) == 0 {
+		return nil, rerror.ErrNotFound
+	}
 	return c.Result[0], nil
 }
 

--- a/server/internal/infrastructure/mongo/scene.go
+++ b/server/internal/infrastructure/mongo/scene.go
@@ -9,6 +9,7 @@ import (
 	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearth/server/pkg/scene"
 	"github.com/reearth/reearthx/mongox"
+	"github.com/reearth/reearthx/rerror"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -136,6 +137,12 @@ func (r *Scene) findOne(ctx context.Context, filter any) (*scene.Scene, error) {
 	c := mongodoc.NewSceneConsumer(r.f.Readable)
 	if err := r.client.FindOne(ctx, filter, c); err != nil {
 		return nil, err
+	}
+	// REL-10: FindOne can return no error while the readable/scene/workspace
+	// filter leaves Result empty; guard the index so that reads as not-found
+	// instead of panicking (same fix as storytelling.findOne).
+	if len(c.Result) == 0 {
+		return nil, rerror.ErrNotFound
 	}
 	return c.Result[0], nil
 }

--- a/server/internal/infrastructure/mongo/style.go
+++ b/server/internal/infrastructure/mongo/style.go
@@ -10,6 +10,7 @@ import (
 	"github.com/reearth/reearth/server/internal/usecase/repo"
 	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearthx/mongox"
+	"github.com/reearth/reearthx/rerror"
 )
 
 var (
@@ -120,6 +121,12 @@ func (r *Style) findOne(ctx context.Context, filter any, filterByScene bool) (*s
 	c := mongodoc.NewStyleConsumer(f)
 	if err := r.client.FindOne(ctx, filter, c); err != nil {
 		return nil, err
+	}
+	// REL-10: FindOne can return no error while the readable/scene/workspace
+	// filter leaves Result empty; guard the index so that reads as not-found
+	// instead of panicking (same fix as storytelling.findOne).
+	if len(c.Result) == 0 {
+		return nil, rerror.ErrNotFound
 	}
 	return c.Result[0], nil
 }

--- a/server/internal/infrastructure/mongo/style_rel10_test.go
+++ b/server/internal/infrastructure/mongo/style_rel10_test.go
@@ -1,0 +1,36 @@
+package mongo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth/server/internal/usecase/repo"
+	"github.com/reearth/reearth/server/pkg/id"
+	"github.com/reearth/reearth/server/pkg/scene"
+	"github.com/reearth/reearthx/mongox"
+	"github.com/reearth/reearthx/mongox/mongotest"
+	"github.com/reearth/reearthx/rerror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStyle_FindByID_EmptyResultIsNotFound is a regression test for REL-10: a
+// scene-filtered findOne can match a document that the filter then drops,
+// leaving Result empty while FindOne returns no error. Indexing Result[0]
+// panicked; it must report not-found instead. The same guard was applied to
+// scene/property/project findOne.
+func TestStyle_FindByID_EmptyResultIsNotFound(t *testing.T) {
+	ctx := context.Background()
+	c := mongotest.Connect(t)(t)
+	r := NewStyle(mongox.NewClientWithDatabase(c))
+
+	victimScene := id.NewSceneID()
+	callerScene := id.NewSceneID()
+	st := scene.NewStyle().NewID().Name("s").Value(&scene.StyleValue{"k": "v"}).Scene(victimScene).MustBuild()
+	require.NoError(t, r.Save(ctx, *st))
+
+	scoped := r.Filtered(repo.SceneFilter{Readable: id.SceneIDList{callerScene}})
+	got, err := scoped.FindByID(ctx, st.ID())
+	assert.Nil(t, got)
+	assert.ErrorIs(t, err, rerror.ErrNotFound)
+}


### PR DESCRIPTION
## Overview

`findOne` in the style, scene, property, and project mongo repos returned `c.Result[0]` directly. `FindOne` can return no error while the readable/scene/workspace filter drops the matched document, leaving `Result` empty, so the index panicked (a 500) instead of reporting not-found. This applies the same length guard already merged for `storytelling.findOne`.

## Tests

- A representative regression test on the style repo: a scene-scoped read of an out-of-scene document returns not-found instead of panicking (verified it panics without the guard). The other three repos take the identical guard.
- Full `mongo` suite passes.

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.