### PR TITLE
fix(server): report a missing scene as not found, not operation denied

### DIFF
--- a/server/internal/usecase/interactor/nlslayer.go
+++ b/server/internal/usecase/interactor/nlslayer.go
@@ -118,8 +118,15 @@ func (i *NLSLayer) AddLayerSimple(ctx context.Context, inp interfaces.AddNLSLaye
 		}
 	}()
 
+	// Look up the scene first so a scene that does not exist is reported as not
+	// found rather than as a denial. CanWriteScene only consults the operator's
+	// writable list, so without this a missing scene id is indistinguishable
+	// from one the caller may not write.
+	if _, err := i.sceneRepo.FindByID(ctx, inp.SceneID); err != nil {
+		return nil, err
+	}
 	if err := i.CanWriteScene(inp.SceneID, operator); err != nil {
-		return nil, visualizer.ErrorWithCallerLogging(ctx, fmt.Sprintf("nlslayer: validateGeoJSONFeatureCollection err: %v", interfaces.ErrOperationDenied), interfaces.ErrOperationDenied)
+		return nil, interfaces.ErrOperationDenied
 	}
 
 	builder := nlslayer.NewNLSLayerSimple().

--- a/server/internal/usecase/interactor/nlslayer_test.go
+++ b/server/internal/usecase/interactor/nlslayer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/reearth/reearth/server/pkg/nlslayer"
 	"github.com/reearth/reearth/server/pkg/project"
 	"github.com/reearth/reearth/server/pkg/scene"
+	"github.com/reearth/reearthx/rerror"
 	"github.com/samber/lo"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -422,6 +423,18 @@ func TestAddLayerSimple(t *testing.T) {
 		assert.NotNil(t, layer)
 		assert.Equal(t, layerName, layer.Title())
 		assert.Nil(t, layer.DataSourceName())
+	})
+
+	t.Run("a scene that does not exist is not found, not denied", func(t *testing.T) {
+		layer, err := il.AddLayerSimple(ctx, interfaces.AddNLSLayerSimpleInput{
+			SceneID:   id.NewSceneID(), // never created
+			LayerType: "simple",
+			Title:     "orphan",
+		}, operator)
+
+		assert.Nil(t, layer)
+		assert.ErrorIs(t, err, rerror.ErrNotFound)
+		assert.NotErrorIs(t, err, interfaces.ErrOperationDenied)
 	})
 }
 

--- a/server/internal/usecase/interactor/storytelling.go
+++ b/server/internal/usecase/interactor/storytelling.go
@@ -86,17 +86,20 @@ func (i *Storytelling) Create(ctx context.Context, inp interfaces.CreateStoryInp
 		}
 	}()
 
+	// Fetch the scene first: a scene that does not exist must be reported as not
+	// found rather than as a denial, and nothing should be written until the
+	// scene is confirmed and the permission check has passed (addNewProperty
+	// below persists a property).
+	sc, err := i.sceneRepo.FindByID(ctx, inp.SceneID)
+	if err != nil {
+		return nil, err
+	}
 	if err := i.CanWriteScene(inp.SceneID, op); err != nil {
 		return nil, interfaces.ErrOperationDenied
 	}
 	storySchema := builtin.GetPropertySchema(builtin.PropertySchemaIDStory)
 	filter := Filter(inp.SceneID)
 	prop, err := i.addNewProperty(ctx, storySchema.ID(), inp.SceneID, &filter)
-	if err != nil {
-		return nil, err
-	}
-
-	sc, err := i.sceneRepo.FindByID(ctx, inp.SceneID)
 	if err != nil {
 		return nil, err
 	}
@@ -523,6 +526,11 @@ func (i *Storytelling) CreatePage(ctx context.Context, inp interfaces.CreatePage
 		}
 	}()
 
+	// A missing scene is not found, not a denial (CanWriteScene only checks the
+	// operator's writable list).
+	if _, err := i.sceneRepo.FindByID(ctx, inp.SceneID); err != nil {
+		return nil, nil, err
+	}
 	if err := i.CanWriteScene(inp.SceneID, op); err != nil {
 		return nil, nil, interfaces.ErrOperationDenied
 	}
@@ -604,6 +612,11 @@ func (i *Storytelling) UpdatePage(ctx context.Context, inp interfaces.UpdatePage
 		}
 	}()
 
+	// A missing scene is not found, not a denial (CanWriteScene only checks the
+	// operator's writable list).
+	if _, err := i.sceneRepo.FindByID(ctx, inp.SceneID); err != nil {
+		return nil, nil, err
+	}
 	if err := i.CanWriteScene(inp.SceneID, op); err != nil {
 		return nil, nil, interfaces.ErrOperationDenied
 	}
@@ -676,6 +689,11 @@ func (i *Storytelling) RemovePage(ctx context.Context, inp interfaces.RemovePage
 		}
 	}()
 
+	// A missing scene is not found, not a denial (CanWriteScene only checks the
+	// operator's writable list).
+	if _, err := i.sceneRepo.FindByID(ctx, inp.SceneID); err != nil {
+		return nil, nil, err
+	}
 	if err := i.CanWriteScene(inp.SceneID, op); err != nil {
 		return nil, nil, interfaces.ErrOperationDenied
 	}

--- a/server/internal/usecase/interactor/storytelling_authz_test.go
+++ b/server/internal/usecase/interactor/storytelling_authz_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/reearth/reearth/server/pkg/project"
 	"github.com/reearth/reearth/server/pkg/scene"
 	"github.com/reearth/reearth/server/pkg/storytelling"
+	"github.com/reearth/reearthx/rerror"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -98,4 +99,70 @@ func TestStorytelling_RemovePage_RejectsForeignScene(t *testing.T) {
 	stored, ferr := env.db.Storytelling.FindByID(ctx, story.Id())
 	require.NoError(t, ferr)
 	assert.NotNil(t, stored.Pages().Page(pageID), "the page must still exist")
+}
+
+// TestStorytelling_CreateStory_SceneNotFound covers the denial-vs-not-found
+// mislabel: CreateStory took a client-supplied scene id and, for a scene that
+// did not exist, returned operation denied (CanWriteScene only checks the
+// operator's writable list). It now looks the scene up first, so a missing
+// scene is not found. Moving the lookup up also means no property is written
+// before the scene is confirmed.
+func TestStorytelling_CreateStory_SceneNotFound(t *testing.T) {
+	ctx := context.Background()
+	env := setupStorytellingTestEnv(ctx, t)
+
+	story, err := env.storytellingUC.Create(ctx, interfaces.CreateStoryInput{
+		SceneID: id.NewSceneID(), // never created
+		Title:   "orphan",
+	}, env.operator)
+
+	assert.Nil(t, story)
+	assert.ErrorIs(t, err, rerror.ErrNotFound)
+	assert.NotErrorIs(t, err, interfaces.ErrOperationDenied)
+}
+
+// TestStorytelling_PageMutations_SceneNotFound covers the same denial-vs-not-found
+// mislabel on the story page mutations: CreatePage, UpdatePage and RemovePage
+// authorized inp.SceneID before confirming the scene exists, so a scene that
+// does not exist was reported as operation denied. Each now looks the scene up
+// first.
+func TestStorytelling_PageMutations_SceneNotFound(t *testing.T) {
+	ctx := context.Background()
+	env := setupStorytellingTestEnv(ctx, t)
+	fakeScene := id.NewSceneID() // never created
+
+	t.Run("CreatePage", func(t *testing.T) {
+		story, page, err := env.storytellingUC.CreatePage(ctx, interfaces.CreatePageParam{
+			SceneID: fakeScene,
+			StoryID: id.NewStoryID(),
+		}, env.operator)
+		assert.Nil(t, story)
+		assert.Nil(t, page)
+		assert.ErrorIs(t, err, rerror.ErrNotFound)
+		assert.NotErrorIs(t, err, interfaces.ErrOperationDenied)
+	})
+
+	t.Run("UpdatePage", func(t *testing.T) {
+		story, page, err := env.storytellingUC.UpdatePage(ctx, interfaces.UpdatePageParam{
+			SceneID: fakeScene,
+			StoryID: id.NewStoryID(),
+			PageID:  id.NewPageID(),
+		}, env.operator)
+		assert.Nil(t, story)
+		assert.Nil(t, page)
+		assert.ErrorIs(t, err, rerror.ErrNotFound)
+		assert.NotErrorIs(t, err, interfaces.ErrOperationDenied)
+	})
+
+	t.Run("RemovePage", func(t *testing.T) {
+		story, pageID, err := env.storytellingUC.RemovePage(ctx, interfaces.RemovePageParam{
+			SceneID: fakeScene,
+			StoryID: id.NewStoryID(),
+			PageID:  id.NewPageID(),
+		}, env.operator)
+		assert.Nil(t, story)
+		assert.Nil(t, pageID)
+		assert.ErrorIs(t, err, rerror.ErrNotFound)
+		assert.NotErrorIs(t, err, interfaces.ErrOperationDenied)
+	})
 }

--- a/server/internal/usecase/interactor/style.go
+++ b/server/internal/usecase/interactor/style.go
@@ -57,6 +57,12 @@ func (i *Style) AddStyle(ctx context.Context, param interfaces.AddStyleInput, op
 		}
 	}()
 
+	// Look up the scene first so a scene that does not exist is reported as not
+	// found rather than as a denial (CanWriteScene only checks the operator's
+	// writable list).
+	if _, err := i.sceneRepo.FindByID(ctx, param.SceneID); err != nil {
+		return nil, err
+	}
 	if err := i.CanWriteScene(param.SceneID, operator); err != nil {
 		return nil, err
 	}

--- a/server/internal/usecase/interactor/style_test.go
+++ b/server/internal/usecase/interactor/style_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/reearth/reearth/server/pkg/id"
 	"github.com/reearth/reearth/server/pkg/project"
 	"github.com/reearth/reearth/server/pkg/scene"
+	"github.com/reearth/reearthx/rerror"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -84,5 +85,15 @@ func TestStyle_CrossTenantIDOR(t *testing.T) {
 		}, owner)
 		assert.NoError(t, err)
 		assert.Equal(t, newName, s.Name())
+	})
+
+	t.Run("AddStyle to a scene that does not exist is not found, not denied", func(t *testing.T) {
+		s, err := uc.AddStyle(ctx, interfaces.AddStyleInput{
+			SceneID: id.NewSceneID(), // never created
+			Name:    "orphan style",
+		}, owner)
+		assert.Nil(t, s)
+		assert.ErrorIs(t, err, rerror.ErrNotFound)
+		assert.NotErrorIs(t, err, interfaces.ErrOperationDenied)
 	})
 }


### PR DESCRIPTION
Six mutations (`AddLayerSimple`, `AddStyle`, `CreateStory`, `CreatePage`, `UpdatePage`, `RemovePage`) called `CanWriteScene` on a client-supplied scene id before confirming the scene exists, so a missing scene came back as `operation denied` instead of `not found`. Each now looks the scene up first, matching `AddWidget`.

Scenes that exist are unaffected, so the SEC-01 / VIZ-DEV-98/99 permission tests still hold. Two fall-outs: `CreateStory` no longer writes a property before the scene is confirmed, and nlslayer drops a copy-pasted `validateGeoJSONFeatureCollection` log message.

Six tests cover the missing-scene case. `go test ./...` and `golangci-lint --new-from-rev=origin/main` clean.

Task: VIZ-DEV-81