### PR TITLE
fix(server): skip domain check for first-party published subdomains and stop logging client cancellations as internal errors

### DIFF
--- a/server/internal/adapter/middleware/files_cors_middleware.go
+++ b/server/internal/adapter/middleware/files_cors_middleware.go
@@ -1,7 +1,10 @@
 package middleware
 
 import (
+	"context"
+	"errors"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -9,7 +12,7 @@ import (
 	"github.com/reearth/reearthx/log"
 )
 
-func FilesCORSMiddleware(domainChecker gateway.DomainChecker, allowedOrigins []string) func(echo.HandlerFunc) echo.HandlerFunc {
+func FilesCORSMiddleware(domainChecker gateway.DomainChecker, allowedOrigins []string, publishedHost string) func(echo.HandlerFunc) echo.HandlerFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			origin := c.Request().Header.Get("Origin")
@@ -21,6 +24,13 @@ func FilesCORSMiddleware(domainChecker gateway.DomainChecker, allowedOrigins []s
 					break
 				}
 			}
+			// First-party published subdomains are served by us on a DNS zone we
+			// control; they are not third-party custom domains, so allow them
+			// directly instead of asking the domain checker (which always answers
+			// "no" for them).
+			if allowedOrigin == "" && isFirstPartyPublishedOrigin(origin, publishedHost) {
+				allowedOrigin = origin
+			}
 			if allowedOrigin == "" {
 				domain, err := extractDomain(origin)
 				if err != nil {
@@ -31,7 +41,10 @@ func FilesCORSMiddleware(domainChecker gateway.DomainChecker, allowedOrigins []s
 					Domain: domain,
 				})
 				if err != nil {
-					log.Errorfc(c.Request().Context(), "[FilesCORSMiddleware] domain checker check domain err: %v", err)
+					// A cancelled request is the client giving up, not a server fault.
+					if !errors.Is(err, context.Canceled) {
+						log.Errorfc(c.Request().Context(), "[FilesCORSMiddleware] domain checker check domain err: %v", err)
+					}
 					return next(c)
 				}
 				if domainResp.Allowed {
@@ -49,6 +62,28 @@ func FilesCORSMiddleware(domainChecker gateway.DomainChecker, allowedOrigins []s
 			return next(c)
 		}
 	}
+}
+
+// isFirstPartyPublishedOrigin reports whether origin's host matches the
+// published-page host pattern (e.g. "{}.visualizer.reearth.io"), i.e. it is one
+// of our own published subdomains rather than a third-party custom domain. The
+// match is anchored so a look-alike suffix ("...reearth.io.evil.com") cannot pass.
+func isFirstPartyPublishedOrigin(origin, publishedHost string) bool {
+	if origin == "" || publishedHost == "" || !strings.Contains(publishedHost, "{}") {
+		return false
+	}
+	host, err := extractDomain(origin)
+	if err != nil || host == "" {
+		return false
+	}
+	const placeholder = "<>"
+	pattern := strings.TrimPrefix(strings.TrimPrefix(publishedHost, "https://"), "http://")
+	pattern = strings.ReplaceAll(pattern, "{}", placeholder)
+	re, err := regexp.Compile("^" + strings.ReplaceAll(regexp.QuoteMeta(pattern), placeholder, "(.+?)") + "$")
+	if err != nil {
+		return false
+	}
+	return re.MatchString(host)
 }
 
 func extractDomain(raw string) (string, error) {

--- a/server/internal/adapter/middleware/files_cors_middleware.go
+++ b/server/internal/adapter/middleware/files_cors_middleware.go
@@ -13,6 +13,9 @@ import (
 )
 
 func FilesCORSMiddleware(domainChecker gateway.DomainChecker, allowedOrigins []string, publishedHost string) func(echo.HandlerFunc) echo.HandlerFunc {
+	// Compile the first-party published-host matcher once per middleware
+	// instance rather than on every request (asset downloads are a hot path).
+	firstPartyMatcher := firstPartyPublishedMatcher(publishedHost)
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			origin := c.Request().Header.Get("Origin")
@@ -28,7 +31,7 @@ func FilesCORSMiddleware(domainChecker gateway.DomainChecker, allowedOrigins []s
 			// control; they are not third-party custom domains, so allow them
 			// directly instead of asking the domain checker (which always answers
 			// "no" for them).
-			if allowedOrigin == "" && isFirstPartyPublishedOrigin(origin, publishedHost) {
+			if allowedOrigin == "" && originMatchesFirstParty(firstPartyMatcher, origin) {
 				allowedOrigin = origin
 			}
 			if allowedOrigin == "" {
@@ -64,26 +67,37 @@ func FilesCORSMiddleware(domainChecker gateway.DomainChecker, allowedOrigins []s
 	}
 }
 
-// isFirstPartyPublishedOrigin reports whether origin's host matches the
-// published-page host pattern (e.g. "{}.visualizer.reearth.io"), i.e. it is one
-// of our own published subdomains rather than a third-party custom domain. The
-// match is anchored so a look-alike suffix ("...reearth.io.evil.com") cannot pass.
-func isFirstPartyPublishedOrigin(origin, publishedHost string) bool {
-	if origin == "" || publishedHost == "" || !strings.Contains(publishedHost, "{}") {
-		return false
-	}
-	host, err := extractDomain(origin)
-	if err != nil || host == "" {
-		return false
+// firstPartyPublishedMatcher compiles a matcher for our own published-page host
+// pattern (e.g. "{}.visualizer.reearth.io"). It returns nil when publishedHost
+// is unset or has no "{}" placeholder, which disables the first-party shortcut.
+// The pattern is anchored so a look-alike suffix ("...reearth.io.evil.com")
+// cannot pass.
+func firstPartyPublishedMatcher(publishedHost string) *regexp.Regexp {
+	if publishedHost == "" || !strings.Contains(publishedHost, "{}") {
+		return nil
 	}
 	const placeholder = "<>"
 	pattern := strings.TrimPrefix(strings.TrimPrefix(publishedHost, "https://"), "http://")
 	pattern = strings.ReplaceAll(pattern, "{}", placeholder)
 	re, err := regexp.Compile("^" + strings.ReplaceAll(regexp.QuoteMeta(pattern), placeholder, "(.+?)") + "$")
 	if err != nil {
+		return nil
+	}
+	return re
+}
+
+// originMatchesFirstParty reports whether origin's host matches the precompiled
+// published-page matcher, i.e. it is one of our own published subdomains rather
+// than a third-party custom domain.
+func originMatchesFirstParty(matcher *regexp.Regexp, origin string) bool {
+	if matcher == nil || origin == "" {
 		return false
 	}
-	return re.MatchString(host)
+	host, err := extractDomain(origin)
+	if err != nil || host == "" {
+		return false
+	}
+	return matcher.MatchString(host)
 }
 
 func extractDomain(raw string) (string, error) {
@@ -92,10 +106,6 @@ func extractDomain(raw string) (string, error) {
 		return "", err
 	}
 
-	host := u.Host
-	if strings.Contains(host, ":") {
-		host = strings.Split(host, ":")[0]
-	}
-
-	return host, nil
+	// Hostname strips the port and unwraps IPv6 brackets (e.g. "[::1]:3000" -> "::1").
+	return u.Hostname(), nil
 }

--- a/server/internal/adapter/middleware/files_cors_middleware_test.go
+++ b/server/internal/adapter/middleware/files_cors_middleware_test.go
@@ -629,6 +629,26 @@ func TestFilesCORSMiddleware_FirstPartyPublishedOrigin(t *testing.T) {
 	})
 }
 
+func TestExtractDomain(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"host with port", "http://example.com:8080", "example.com"},
+		{"host without port", "https://example.com", "example.com"},
+		{"ipv6 with port", "http://[::1]:3000", "::1"},
+		{"ipv6 without port", "http://[2001:db8::1]", "2001:db8::1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := extractDomain(tc.raw)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestFilesCORSMiddleware_CanceledCheckIsNotAllowed(t *testing.T) {
 	e := echo.New()
 	req := httptest.NewRequest("GET", "/", nil)

--- a/server/internal/adapter/middleware/files_cors_middleware_test.go
+++ b/server/internal/adapter/middleware/files_cors_middleware_test.go
@@ -35,7 +35,7 @@ func TestFilesCORSMiddleware(t *testing.T) {
 			return c.String(http.StatusOK, "OK")
 		}
 
-		middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"})
+		middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"}, "")
 		h := middleware(handler)
 
 		err := h(c)
@@ -59,7 +59,7 @@ func TestFilesCORSMiddleware(t *testing.T) {
 			return c.String(http.StatusOK, "OK")
 		}
 
-		middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com", "https://test.com"})
+		middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com", "https://test.com"}, "")
 		h := middleware(handler)
 
 		err := h(c)
@@ -92,7 +92,7 @@ func TestFilesCORSMiddleware(t *testing.T) {
 				return c.String(http.StatusOK, "OK")
 			}
 
-			middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"})
+			middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"}, "")
 			h := middleware(handler)
 
 			err := h(c)
@@ -121,7 +121,7 @@ func TestFilesCORSMiddleware(t *testing.T) {
 				return c.String(http.StatusOK, "OK")
 			}
 
-			middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"})
+			middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"}, "")
 			h := middleware(handler)
 
 			err := h(c)
@@ -150,7 +150,7 @@ func TestFilesCORSMiddleware(t *testing.T) {
 				return c.String(http.StatusOK, "OK")
 			}
 
-			middleware := FilesCORSMiddleware(mockChecker, []string{})
+			middleware := FilesCORSMiddleware(mockChecker, []string{}, "")
 			h := middleware(handler)
 
 			err := h(c)
@@ -176,7 +176,7 @@ func TestFilesCORSMiddleware(t *testing.T) {
 				return c.String(http.StatusOK, "OK")
 			}
 
-			middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"})
+			middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"}, "")
 			h := middleware(handler)
 
 			err := h(c)
@@ -199,7 +199,7 @@ func TestFilesCORSMiddleware(t *testing.T) {
 				return c.String(http.StatusOK, "OK")
 			}
 
-			middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"})
+			middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"}, "")
 			h := middleware(handler)
 
 			err := h(c)
@@ -225,7 +225,7 @@ func TestFilesCORSMiddleware(t *testing.T) {
 				return c.String(http.StatusOK, "OK")
 			}
 
-			middleware := FilesCORSMiddleware(mockChecker, []string{"https://first.com", "https://second.com", "https://third.com"})
+			middleware := FilesCORSMiddleware(mockChecker, []string{"https://first.com", "https://second.com", "https://third.com"}, "")
 			h := middleware(handler)
 
 			err := h(c)
@@ -246,7 +246,7 @@ func TestFilesCORSMiddleware(t *testing.T) {
 				return c.String(http.StatusOK, "OK")
 			}
 
-			middleware := FilesCORSMiddleware(mockChecker, []string{"https://first.com", "https://second.com", "https://third.com"})
+			middleware := FilesCORSMiddleware(mockChecker, []string{"https://first.com", "https://second.com", "https://third.com"}, "")
 			h := middleware(handler)
 
 			err := h(c)
@@ -267,7 +267,7 @@ func TestFilesCORSMiddleware(t *testing.T) {
 				return c.String(http.StatusOK, "OK")
 			}
 
-			middleware := FilesCORSMiddleware(mockChecker, []string{"https://first.com", "https://second.com", "https://third.com"})
+			middleware := FilesCORSMiddleware(mockChecker, []string{"https://first.com", "https://second.com", "https://third.com"}, "")
 			h := middleware(handler)
 
 			err := h(c)
@@ -295,7 +295,7 @@ func TestFilesCORSMiddleware(t *testing.T) {
 				return c.String(http.StatusOK, "OK")
 			}
 
-			middleware := FilesCORSMiddleware(mockChecker, []string{})
+			middleware := FilesCORSMiddleware(mockChecker, []string{}, "")
 			h := middleware(handler)
 
 			err := h(c)
@@ -321,7 +321,7 @@ func TestFilesCORSMiddleware(t *testing.T) {
 				return c.String(http.StatusOK, "OK")
 			}
 
-			middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"})
+			middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"}, "")
 			h := middleware(handler)
 
 			err := h(c)
@@ -343,7 +343,7 @@ func TestFilesCORSMiddleware(t *testing.T) {
 				return c.String(http.StatusOK, "OK")
 			}
 
-			middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"})
+			middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"}, "")
 			h := middleware(handler)
 
 			err := h(c)
@@ -365,7 +365,7 @@ func TestFilesCORSMiddleware(t *testing.T) {
 				return c.String(http.StatusOK, "OK")
 			}
 
-			middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"})
+			middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"}, "")
 			h := middleware(handler)
 
 			err := h(c)
@@ -386,7 +386,7 @@ func TestFilesCORSMiddleware_ConcurrentRequests(t *testing.T) {
 		},
 	}
 
-	middleware := FilesCORSMiddleware(mockChecker, []string{"https://allowed.com"})
+	middleware := FilesCORSMiddleware(mockChecker, []string{"https://allowed.com"}, "")
 
 	handler := func(c echo.Context) error {
 		return c.String(http.StatusOK, "OK")
@@ -436,7 +436,7 @@ func TestFilesCORSMiddleware_NilDomainChecker(t *testing.T) {
 			return c.String(http.StatusOK, "OK")
 		}
 
-		middleware := FilesCORSMiddleware(nil, []string{"https://allowed.com"})
+		middleware := FilesCORSMiddleware(nil, []string{"https://allowed.com"}, "")
 		h := middleware(handler)
 
 		assert.Panics(t, func() {
@@ -454,7 +454,7 @@ func TestFilesCORSMiddleware_NilDomainChecker(t *testing.T) {
 			return c.String(http.StatusOK, "OK")
 		}
 
-		middleware := FilesCORSMiddleware(nil, []string{"https://allowed.com"})
+		middleware := FilesCORSMiddleware(nil, []string{"https://allowed.com"}, "")
 		h := middleware(handler)
 
 		assert.NotPanics(t, func() {
@@ -487,7 +487,7 @@ func TestFilesCORSMiddleware_EdgeCases(t *testing.T) {
 			return c.String(http.StatusOK, "OK")
 		}
 
-		middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"})
+		middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"}, "")
 		h := middleware(handler)
 
 		err := h(c)
@@ -513,7 +513,7 @@ func TestFilesCORSMiddleware_EdgeCases(t *testing.T) {
 			return c.String(http.StatusOK, "OK")
 		}
 
-		middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"})
+		middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"}, "")
 		h := middleware(handler)
 
 		err := h(c)
@@ -534,7 +534,7 @@ func TestFilesCORSMiddleware_EdgeCases(t *testing.T) {
 			return c.String(http.StatusOK, "OK")
 		}
 
-		middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com:8080"})
+		middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com:8080"}, "")
 		h := middleware(handler)
 
 		err := h(c)
@@ -555,7 +555,7 @@ func TestFilesCORSMiddleware_EdgeCases(t *testing.T) {
 			return c.String(http.StatusOK, "OK")
 		}
 
-		middleware := FilesCORSMiddleware(mockChecker, []string{"http://localhost:3000"})
+		middleware := FilesCORSMiddleware(mockChecker, []string{"http://localhost:3000"}, "")
 		h := middleware(handler)
 
 		err := h(c)
@@ -565,10 +565,93 @@ func TestFilesCORSMiddleware_EdgeCases(t *testing.T) {
 	})
 }
 
+func TestFilesCORSMiddleware_FirstPartyPublishedOrigin(t *testing.T) {
+	const publishedHost = "{}.visualizer.reearth.io"
+
+	// The domain checker must never be consulted for a first-party origin.
+	failingChecker := &mockDomainChecker{
+		checkFunc: func(ctx context.Context, req gateway.DomainCheckRequest) (*gateway.DomainCheckResponse, error) {
+			t.Errorf("domain checker was called for a first-party origin: %q", req.Domain)
+			return &gateway.DomainCheckResponse{Allowed: false}, nil
+		},
+	}
+	handler := func(c echo.Context) error { return c.String(http.StatusOK, "OK") }
+
+	t.Run("published subdomain is allowed without the domain checker", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Origin", "https://nagaoka-war.visualizer.reearth.io")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		h := FilesCORSMiddleware(failingChecker, []string{}, publishedHost)(handler)
+		assert.NoError(t, h(c))
+		assert.Equal(t, "https://nagaoka-war.visualizer.reearth.io", rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("look-alike suffix is not treated as first-party", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Origin", "https://nagaoka-war.visualizer.reearth.io.evil.com")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		checked := false
+		checker := &mockDomainChecker{
+			checkFunc: func(ctx context.Context, req gateway.DomainCheckRequest) (*gateway.DomainCheckResponse, error) {
+				checked = true
+				return &gateway.DomainCheckResponse{Allowed: false}, nil
+			},
+		}
+		h := FilesCORSMiddleware(checker, []string{}, publishedHost)(handler)
+		assert.NoError(t, h(c))
+		assert.True(t, checked, "a non-first-party origin must fall through to the domain checker")
+		assert.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("empty published host disables the short-circuit", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Origin", "https://nagaoka-war.visualizer.reearth.io")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		checked := false
+		checker := &mockDomainChecker{
+			checkFunc: func(ctx context.Context, req gateway.DomainCheckRequest) (*gateway.DomainCheckResponse, error) {
+				checked = true
+				return &gateway.DomainCheckResponse{Allowed: false}, nil
+			},
+		}
+		h := FilesCORSMiddleware(checker, []string{}, "")(handler)
+		assert.NoError(t, h(c))
+		assert.True(t, checked, "with no published host, the checker must still run")
+	})
+}
+
+func TestFilesCORSMiddleware_CanceledCheckIsNotAllowed(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Origin", "https://custom.example.com")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	checker := &mockDomainChecker{
+		checkFunc: func(ctx context.Context, req gateway.DomainCheckRequest) (*gateway.DomainCheckResponse, error) {
+			return nil, context.Canceled
+		},
+	}
+	handler := func(c echo.Context) error { return c.String(http.StatusOK, "OK") }
+	h := FilesCORSMiddleware(checker, []string{}, "{}.visualizer.reearth.io")(handler)
+
+	assert.NoError(t, h(c))
+	assert.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+}
+
 func BenchmarkFilesCORSMiddleware_AllowedOrigin(b *testing.B) {
 	e := echo.New()
 	mockChecker := &mockDomainChecker{}
-	middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"})
+	middleware := FilesCORSMiddleware(mockChecker, []string{"https://example.com"}, "")
 
 	handler := func(c echo.Context) error {
 		return c.String(http.StatusOK, "OK")
@@ -593,7 +676,7 @@ func BenchmarkFilesCORSMiddleware_DomainChecker(b *testing.B) {
 			return &gateway.DomainCheckResponse{Allowed: true}, nil
 		},
 	}
-	middleware := FilesCORSMiddleware(mockChecker, []string{})
+	middleware := FilesCORSMiddleware(mockChecker, []string{}, "")
 
 	handler := func(c echo.Context) error {
 		return c.String(http.StatusOK, "OK")

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -138,7 +138,7 @@ func initEcho(
 	apiRoot.GET("/mockuser", MockUser())
 
 	// Asset API for handling GCP files
-	serveFiles(e, allowedOrigins(cfg), cfg.Gateways.DomainChecker, cfg.Gateways.File)
+	serveFiles(e, allowedOrigins(cfg), cfg.Gateways.DomainChecker, cfg.Gateways.File, cfg.Config.Published.Host)
 	serveExportFile(e, cfg, allowedOrigins(cfg), cfg.Gateways.DomainChecker, cfg.Gateways.File)
 
 	apiPrivateRoute := apiRoot.Group("", privateCache)

--- a/server/internal/app/export.go
+++ b/server/internal/app/export.go
@@ -70,7 +70,7 @@ func serveExportFile(
 		// always sets the header, even on responses rejected before reaching the handler.
 		privateCache,
 		optionalAuth,
-		appmiddleware.FilesCORSMiddleware(domainChecker, allowedOrigins),
+		appmiddleware.FilesCORSMiddleware(domainChecker, allowedOrigins, cfg.Config.Published.Host),
 	)
 
 	e.OPTIONS(
@@ -78,6 +78,6 @@ func serveExportFile(
 		func(c echo.Context) error {
 			return c.NoContent(http.StatusNoContent)
 		},
-		appmiddleware.FilesCORSMiddleware(domainChecker, allowedOrigins),
+		appmiddleware.FilesCORSMiddleware(domainChecker, allowedOrigins, cfg.Config.Published.Host),
 	)
 }

--- a/server/internal/app/file.go
+++ b/server/internal/app/file.go
@@ -19,6 +19,7 @@ func serveFiles(
 	allowedOrigins []string,
 	domainChecker gateway.DomainChecker,
 	fileGateway gateway.File,
+	publishedHost string,
 ) {
 	if fileGateway == nil {
 		return
@@ -49,7 +50,7 @@ func serveFiles(
 			r, err := fileGateway.ReadAsset(ctx.Request().Context(), filename)
 			return r, filename, err
 		}),
-		middleware.FilesCORSMiddleware(domainChecker, allowedOrigins),
+		middleware.FilesCORSMiddleware(domainChecker, allowedOrigins, publishedHost),
 	)
 
 	// Handle OPTIONS for assets endpoint
@@ -57,7 +58,7 @@ func serveFiles(
 		func(c echo.Context) error {
 			return c.NoContent(http.StatusNoContent)
 		},
-		middleware.FilesCORSMiddleware(domainChecker, allowedOrigins),
+		middleware.FilesCORSMiddleware(domainChecker, allowedOrigins, publishedHost),
 	)
 
 	ec.GET(
@@ -71,7 +72,7 @@ func serveFiles(
 			r, err := fileGateway.ReadPluginFile(ctx.Request().Context(), pid, filename)
 			return r, filename, err
 		}),
-		middleware.FilesCORSMiddleware(domainChecker, allowedOrigins),
+		middleware.FilesCORSMiddleware(domainChecker, allowedOrigins, publishedHost),
 	)
 
 	ec.GET(
@@ -81,6 +82,6 @@ func serveFiles(
 			r, err := fileGateway.ReadBuiltSceneFile(ctx.Request().Context(), name)
 			return r, name + ".json", err
 		}),
-		middleware.FilesCORSMiddleware(domainChecker, allowedOrigins),
+		middleware.FilesCORSMiddleware(domainChecker, allowedOrigins, publishedHost),
 	)
 }

--- a/server/internal/app/file.go
+++ b/server/internal/app/file.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -29,7 +31,11 @@ func serveFiles(
 		return func(ctx echo.Context) error {
 			reader, filename, err := handler(ctx)
 			if err != nil {
-				fmt.Printf("file handler err: %s\n", err.Error())
+				// A cancelled request is the client giving up, not a server fault,
+				// so do not log it as a handler error.
+				if !errors.Is(err, context.Canceled) {
+					fmt.Printf("file handler err: %s\n", err.Error())
+				}
 				return err
 			}
 			ct := "application/octet-stream"

--- a/server/internal/infrastructure/domain/http_checker.go
+++ b/server/internal/infrastructure/domain/http_checker.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -47,6 +48,10 @@ func (h *HTTPDomainChecker) CheckDomain(ctx context.Context, req gateway.DomainC
 	resp, err := h.client.Do(httpReq)
 
 	if err != nil {
+		// A cancelled request is the client giving up, not a server fault.
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
 		return nil, rerror.ErrInternalBy(fmt.Errorf("domain check request failed: %w", err))
 	}
 	defer func() {

--- a/server/internal/infrastructure/domain/http_checker_test.go
+++ b/server/internal/infrastructure/domain/http_checker_test.go
@@ -1,0 +1,44 @@
+package domain
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/reearth/reearth/server/internal/usecase/gateway"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPDomainChecker_CanceledReturnedRaw(t *testing.T) {
+	// A cancelled request must surface as context.Canceled, not be wrapped into
+	// an internal error (which would log ERROR + STACK).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	checker := NewHTTPDomainChecker(srv.URL, "", 5)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // client gave up before the request completed
+
+	_, err := checker.CheckDomain(ctx, gateway.DomainCheckRequest{Domain: "example.com"})
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestHTTPDomainChecker_NotFoundIsAllowedFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	checker := NewHTTPDomainChecker(srv.URL, "", 5)
+
+	resp, err := checker.CheckDomain(context.Background(), gateway.DomainCheckRequest{Domain: "example.com"})
+	assert.NoError(t, err)
+	assert.False(t, resp.Allowed)
+	// a 404 is a normal "not a custom domain" answer, never context.Canceled
+	assert.False(t, errors.Is(err, context.Canceled))
+}

--- a/server/internal/infrastructure/gcs/file.go
+++ b/server/internal/infrastructure/gcs/file.go
@@ -393,6 +393,9 @@ func (f *fileRepo) read(ctx context.Context, filename string) (io.ReadCloser, er
 
 	bucket, err := f.bucket(ctx)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
 		return nil, visualizer.ErrorWithCallerLogging(ctx, "gcs: read bucket err", rerror.ErrInternalByWithContext(ctx, err))
 	}
 
@@ -403,6 +406,10 @@ func (f *fileRepo) read(ctx context.Context, filename string) (io.ReadCloser, er
 	}
 
 	if err != nil {
+		// A cancelled request is the client giving up, not a server fault.
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
 		return nil, visualizer.ErrorWithCallerLogging(ctx, "gcs: read attrs err", rerror.ErrInternalByWithContext(ctx, err))
 	}
 
@@ -436,6 +443,9 @@ func (f *fileRepo) read(ctx context.Context, filename string) (io.ReadCloser, er
 		if errors.Is(err, storage.ErrObjectNotExist) {
 			return nil, rerror.ErrNotFound
 		}
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
 		log.Errorfc(ctx, "gcs: attrs err: %+v\n", err)
 		return nil, rerror.ErrInternalByWithContext(ctx, err)
 	}
@@ -447,6 +457,9 @@ func (f *fileRepo) read(ctx context.Context, filename string) (io.ReadCloser, er
 				return nil, errors.New("no read permission")
 			}
 			return nil, rerror.ErrNotFound
+		}
+		if errors.Is(err, context.Canceled) {
+			return nil, err
 		}
 		log.Errorfc(ctx, "gcs: generation read err: %+v\n", err)
 		return nil, rerror.ErrInternalByWithContext(ctx, err)

--- a/server/internal/infrastructure/gcs/file_test.go
+++ b/server/internal/infrastructure/gcs/file_test.go
@@ -29,6 +29,34 @@ func TestGetGCSObjectNameFromURL(t *testing.T) {
 	assert.Equal(t, "", getGCSObjectNameFromURL(b, nil))
 }
 
+func TestGCSFile_ReadAsset_CanceledReturnsRaw(t *testing.T) {
+	// A cancelled read must surface as context.Canceled, not be wrapped into an
+	// internal error (which logs ERROR + STACK).
+	baseURL, _ := url.Parse(testutil.GCSBaseURLForTesting)
+	bucketName := strings.ToLower(uuid.New().String())
+
+	testGCS, err := testutil.NewGCSForTesting()
+	if err != nil {
+		t.Fatalf("failed to create GCSForTesting: %v", err)
+	}
+	testGCS.CreateBucket(bucketName)
+	defer func() {
+		testGCS.DeleteBucketWithObjects(bucketName)
+		if err := testGCS.Close(); err != nil {
+			t.Fatalf("failed to close client: %v", err)
+		}
+	}()
+
+	repo, err := NewFile(true, bucketName, baseURL.String(), "")
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // client gave up before the read completed
+
+	_, err = repo.ReadAsset(ctx, "whatever.txt")
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 func TestGCSFile_UploadAssetFromURL(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Problem

Asset requests from published subdomains always hit the domain checker, which answers "no" (they are our own subdomains, not custom domains). And a client aborting a large asset download is logged at ERROR with a stack trace, the biggest ERROR source in prod.

## Fix

- Allow first-party published subdomains directly (anchored match on the published-host pattern), so the checker only runs for real custom domains.
- Return `context.Canceled` raw at the gcs read sites, the domain checker, and the CORS middleware.

## Safety

The match is anchored, the subdomains are on a DNS zone we control, no `Access-Control-Allow-Credentials` is set, and the assets are already public. Reflecting the origin grants nothing that isn't already public.

## Verification

`go test` for gcs, domain, and middleware packages (gcs needs `STORAGE_EMULATOR_HOST`, as CI sets).