### PR TITLE
fix(server): log the stack when an import panics

### DIFF
--- a/server/internal/app/file_split_uploader.go
+++ b/server/internal/app/file_split_uploader.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime/debug"
 	"strconv"
 	"sync"
 	"time"
@@ -459,7 +460,10 @@ func (m *SplitUploadManager) runImportJob(job importJob) {
 	defer func() {
 		if r := recover(); r != nil {
 			errMsg := fmt.Sprintf("panic during import: %v", r)
-			log.Errorf("[Import] %s (file %s)", errMsg, job.fileID)
+			// Log the goroutine stack so the panicking line is diagnosable. It is
+			// kept out of errMsg, which is surfaced to the client via the import
+			// result log; only the server log gets the stack.
+			log.Errorf("[Import] %s (file %s)\n%s", errMsg, job.fileID, debug.Stack())
 			UpdateImportStatus(bgctx, job.usecases, job.op, job.projectID, project.ProjectImportStatusFailed, errMsg, result)
 		}
 	}()


### PR DESCRIPTION
The import worker recovers panics and logs `panic during import: <message>`, but not the goroutine stack. A nil-pointer dereference in the import path is therefore recorded with only "invalid memory address or nil pointer dereference" and no `file:line`, so it cannot be located from the logs. There are ~6 such panics a day on dev with no way to find the culprit.

## Change

Add `debug.Stack()` to that recover log line so the panicking site is diagnosable. The stack is kept out of the user-facing `errMsg` (which is surfaced via the import result log); only the server log gets it.

## Verification

- `go build ./...`, `go vet`, `go test ./internal/app/`