### PR TITLE
chore(web): update plugin playground preset doc URLs to docs.reearth.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
   <a href="https://renewal2025.reearth.io/">Website</a>
   ·
-  <a href="https://visualizer.developer.reearth.io/">Documentation</a>
+  <a href="https://docs.reearth.io/developer/?utm_source=visualizer">Documentation</a>
   ·
   <a href="https://github.com/reearth/reearth-visualizer/issues">Issues</a>
 </p>

--- a/web/src/app/features/PluginPlayground/Plugins/presets/camera/cameraPosition.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/camera/cameraPosition.ts
@@ -174,7 +174,7 @@ const widgetFile: FileType = {
 </script>
 \`);
 
-// Documentation on Camera "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#move-1
+// Documentation on Camera "on" event: https://docs.reearth.io/developer/plugin/api-reference/camera/#move-1
 reearth.camera.on("move", (camera) => {
   reearth.ui.postMessage({
     type: 'currentPosition',
@@ -189,7 +189,7 @@ reearth.camera.on("move", (camera) => {
   });
 });
 
-// Documentation on Extension "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
+// Documentation on Extension "on" event: https://docs.reearth.io/developer/plugin/api-reference/extension/#message
 reearth.extension.on('message', (msg) => {
   // Apply camera position
   if (msg.type === 'applyCameraPosition') {
@@ -214,7 +214,7 @@ reearth.extension.on('message', (msg) => {
       );
 
       // Send confirmation message
-      // Documentation on UI "postMessage" event: https://docs.reearth.io/en/developer/plugin/api-reference/ui/#postmessage
+      // Documentation on UI "postMessage" event: https://docs.reearth.io/developer/plugin/api-reference/ui/#postmessage
       reearth.ui.postMessage({
         type: 'positionApplied'
       });

--- a/web/src/app/features/PluginPlayground/Plugins/presets/camera/cameraPosition.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/camera/cameraPosition.ts
@@ -174,7 +174,7 @@ const widgetFile: FileType = {
 </script>
 \`);
 
-// Documentation on Camera "on" event: https://visualizer.developer.reearth.io/plugin-api/camera/#move-1
+// Documentation on Camera "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#move-1
 reearth.camera.on("move", (camera) => {
   reearth.ui.postMessage({
     type: 'currentPosition',
@@ -189,7 +189,7 @@ reearth.camera.on("move", (camera) => {
   });
 });
 
-// Documentation on Extension "on" event: https://visualizer.developer.reearth.io/plugin-api/extension/#message-1
+// Documentation on Extension "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
 reearth.extension.on('message', (msg) => {
   // Apply camera position
   if (msg.type === 'applyCameraPosition') {
@@ -214,7 +214,7 @@ reearth.extension.on('message', (msg) => {
       );
 
       // Send confirmation message
-      // Documentation on UI "postMessage" event: https://visualizer.developer.reearth.io/plugin-api/ui/#postmessage
+      // Documentation on UI "postMessage" event: https://docs.reearth.io/en/developer/plugin/api-reference/ui/#postmessage
       reearth.ui.postMessage({
         type: 'positionApplied'
       });

--- a/web/src/app/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
@@ -84,10 +84,10 @@ const sample3dTiles = {
 };
 
 // Add the 3D Tiles layer to Re:Earth
-// Documentation on Layers "add" event: https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(sample3dTiles);
 
-// Documentation on Viewer "overrideProperty" event: https://visualizer.developer.reearth.io/plugin-api/viewer/#overrideproperty
+// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
 reearth.viewer.overrideProperty({
   // Enable Cesium World Terrain
   terrain: {
@@ -100,7 +100,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to the specified position
-// Documentation on Camera "flyTo" event: https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     // Define the camera's target position
@@ -118,7 +118,7 @@ reearth.camera.flyTo(
 );
 
 // Listen for messages from the UI to trigger camera rotation
-// Documentation on Extension "on" event: https://visualizer.developer.reearth.io/plugin-api/extension/#message-1
+// Documentation on Extension "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
   if (action === "rotateCamera"){

--- a/web/src/app/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/camera/cameraRotation.ts
@@ -84,10 +84,10 @@ const sample3dTiles = {
 };
 
 // Add the 3D Tiles layer to Re:Earth
-// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(sample3dTiles);
 
-// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
+// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/developer/plugin/api-reference/viewer/#overrideproperty
 reearth.viewer.overrideProperty({
   // Enable Cesium World Terrain
   terrain: {
@@ -100,7 +100,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to the specified position
-// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     // Define the camera's target position
@@ -118,7 +118,7 @@ reearth.camera.flyTo(
 );
 
 // Listen for messages from the UI to trigger camera rotation
-// Documentation on Extension "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
+// Documentation on Extension "on" event: https://docs.reearth.io/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
   if (action === "rotateCamera"){

--- a/web/src/app/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
@@ -68,15 +68,15 @@ reearth.ui.show(\`
 // ================================
 
 // Listen for messages from the UI and update zoom level
-// Documentation on Extension "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
+// Documentation on Extension "on" event: https://docs.reearth.io/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
   if (action === "zoomIn") {
     // Increasing the value increases the change to zoom
-    // Documentation on Camera "zoomIn" method: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#zoomin
+    // Documentation on Camera "zoomIn" method: https://docs.reearth.io/developer/plugin/api-reference/camera/#zoomin
     reearth.camera.zoomIn(2);
   } else if (action === "zoomOut") {
-  // Documentation on Camera "zoomOut" method: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#zoomout
+  // Documentation on Camera "zoomOut" method: https://docs.reearth.io/developer/plugin/api-reference/camera/#zoomout
     reearth.camera.zoomOut(2);
   }
 });`

--- a/web/src/app/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/camera/zoomInOut.ts
@@ -68,15 +68,15 @@ reearth.ui.show(\`
 // ================================
 
 // Listen for messages from the UI and update zoom level
-// Documentation on Extension "on" event: https://visualizer.developer.reearth.io/plugin-api/extension/#message-1
+// Documentation on Extension "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
   if (action === "zoomIn") {
     // Increasing the value increases the change to zoom
-    // Documentation on Camera "zoomIn" method: https://visualizer.developer.reearth.io/plugin-api/camera/#zoomin
+    // Documentation on Camera "zoomIn" method: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#zoomin
     reearth.camera.zoomIn(2);
   } else if (action === "zoomOut") {
-  // Documentation on Camera "zoomOut" method: https://visualizer.developer.reearth.io/plugin-api/camera/#zoomout
+  // Documentation on Camera "zoomOut" method: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#zoomout
     reearth.camera.zoomOut(2);
   }
 });`

--- a/web/src/app/features/PluginPlayground/Plugins/presets/data/clientStorageThemeSelector.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/data/clientStorageThemeSelector.ts
@@ -138,9 +138,9 @@ logOperation(\\\`Storage updated: Theme preference is \\\${storedTheme ? \\\`set
 const THEME_KEY = "user_theme_preference";
 
 async function updateStorageDisplay() {
-// Documentation on Client Storage "getAsync" method: https://docs.reearth.io/en/developer/plugin/api-reference/data/#getasync
+// Documentation on Client Storage "getAsync" method: https://docs.reearth.io/developer/plugin/api-reference/data/#getasync
   const theme = await reearth.data.clientStorage.getAsync(THEME_KEY);
-  // Documentation on UI "postMessage" method: https://docs.reearth.io/en/developer/plugin/api-reference/ui/#postmessage
+  // Documentation on UI "postMessage" method: https://docs.reearth.io/developer/plugin/api-reference/ui/#postmessage
   reearth.ui.postMessage({
     type: "storageUpdate",
     data: { [THEME_KEY]: theme }
@@ -160,7 +160,7 @@ reearth.extension.on("message", async msg => {
         break;
 
       case "setTheme":
-        // Documentation on Client Storage "setAsync" method: https://docs.reearth.io/en/developer/plugin/api-reference/data/#setasync
+        // Documentation on Client Storage "setAsync" method: https://docs.reearth.io/developer/plugin/api-reference/data/#setasync
         await reearth.data.clientStorage.setAsync(THEME_KEY, msg.theme);
         reearth.ui.postMessage({
           type: "themeUpdate",
@@ -170,7 +170,7 @@ reearth.extension.on("message", async msg => {
         break;
 
       case "viewKeys":
-        // Documentation on Client Storage "keysAsync" method: https://docs.reearth.io/en/developer/plugin/api-reference/data/#keysasync
+        // Documentation on Client Storage "keysAsync" method: https://docs.reearth.io/developer/plugin/api-reference/data/#keysasync
         const keys = await reearth.data.clientStorage.keysAsync();
         reearth.ui.postMessage({
           type: "keysUpdate",
@@ -179,7 +179,7 @@ reearth.extension.on("message", async msg => {
         break;
 
       case "clearStorage":
-        // Documentation on Client Storage "dropStoreAsync" method: https://docs.reearth.io/en/developer/plugin/api-reference/data/#dropstoreasync
+        // Documentation on Client Storage "dropStoreAsync" method: https://docs.reearth.io/developer/plugin/api-reference/data/#dropstoreasync
         await reearth.data.clientStorage.dropStoreAsync();
         reearth.ui.postMessage({
           type: "storageCleared"

--- a/web/src/app/features/PluginPlayground/Plugins/presets/data/clientStorageThemeSelector.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/data/clientStorageThemeSelector.ts
@@ -138,9 +138,9 @@ logOperation(\\\`Storage updated: Theme preference is \\\${storedTheme ? \\\`set
 const THEME_KEY = "user_theme_preference";
 
 async function updateStorageDisplay() {
-// Documentation on Client Storage "getAsync" method: https://visualizer.developer.reearth.io/plugin-api/data/#getasync
+// Documentation on Client Storage "getAsync" method: https://docs.reearth.io/en/developer/plugin/api-reference/data/#getasync
   const theme = await reearth.data.clientStorage.getAsync(THEME_KEY);
-  // Documentation on UI "postMessage" method: https://visualizer.developer.reearth.io/plugin-api/ui/#postmessage
+  // Documentation on UI "postMessage" method: https://docs.reearth.io/en/developer/plugin/api-reference/ui/#postmessage
   reearth.ui.postMessage({
     type: "storageUpdate",
     data: { [THEME_KEY]: theme }
@@ -160,7 +160,7 @@ reearth.extension.on("message", async msg => {
         break;
 
       case "setTheme":
-        // Documentation on Client Storage "setAsync" method: https://visualizer.developer.reearth.io/plugin-api/data/#setasync
+        // Documentation on Client Storage "setAsync" method: https://docs.reearth.io/en/developer/plugin/api-reference/data/#setasync
         await reearth.data.clientStorage.setAsync(THEME_KEY, msg.theme);
         reearth.ui.postMessage({
           type: "themeUpdate",
@@ -170,7 +170,7 @@ reearth.extension.on("message", async msg => {
         break;
 
       case "viewKeys":
-        // Documentation on Client Storage "keysAsync" method: https://visualizer.developer.reearth.io/plugin-api/data/#keysasync
+        // Documentation on Client Storage "keysAsync" method: https://docs.reearth.io/en/developer/plugin/api-reference/data/#keysasync
         const keys = await reearth.data.clientStorage.keysAsync();
         reearth.ui.postMessage({
           type: "keysUpdate",
@@ -179,7 +179,7 @@ reearth.extension.on("message", async msg => {
         break;
 
       case "clearStorage":
-        // Documentation on Client Storage "dropStoreAsync" method: https://visualizer.developer.reearth.io/plugin-api/data/#dropstoreasync
+        // Documentation on Client Storage "dropStoreAsync" method: https://docs.reearth.io/en/developer/plugin/api-reference/data/#dropstoreasync
         await reearth.data.clientStorage.dropStoreAsync();
         reearth.ui.postMessage({
           type: "storageCleared"

--- a/web/src/app/features/PluginPlayground/Plugins/presets/data/extensionProperty.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/data/extensionProperty.ts
@@ -233,10 +233,10 @@ const storyBlockFile: FileType = {
 
 // Get block property values and send to UI.
 // Property schema is defined in reearth.yml.
-// Documentation on UI "postMessage" method: https://docs.reearth.io/en/developer/plugin/api-reference/ui/#postmessage
+// Documentation on UI "postMessage" method: https://docs.reearth.io/developer/plugin/api-reference/ui/#postmessage
 reearth.ui.postMessage({
   type: "getBlockProperty",
-  // Documentation on Extension Block https://docs.reearth.io/en/developer/plugin/api-reference/extension/#block
+  // Documentation on Extension Block https://docs.reearth.io/developer/plugin/api-reference/extension/#block
   property: reearth.extension.block?.property
 });`
 };

--- a/web/src/app/features/PluginPlayground/Plugins/presets/data/extensionProperty.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/data/extensionProperty.ts
@@ -233,10 +233,10 @@ const storyBlockFile: FileType = {
 
 // Get block property values and send to UI.
 // Property schema is defined in reearth.yml.
-// Documentation on UI "postMessage" method: https://visualizer.developer.reearth.io/plugin-api/ui/#postmessage
+// Documentation on UI "postMessage" method: https://docs.reearth.io/en/developer/plugin/api-reference/ui/#postmessage
 reearth.ui.postMessage({
   type: "getBlockProperty",
-  // Documentation on Extension Block https://visualizer.developer.reearth.io/plugin-api/extension/#block
+  // Documentation on Extension Block https://docs.reearth.io/en/developer/plugin/api-reference/extension/#block
   property: reearth.extension.block?.property
 });`
 };

--- a/web/src/app/features/PluginPlayground/Plugins/presets/data/messengerBetweenExtensions.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/data/messengerBetweenExtensions.ts
@@ -68,14 +68,14 @@ reearth.ui.show(\`
 \`);
 
 // Handle messages from UI to send to other extension
-// Documentation on Extension "on" event https://visualizer.developer.reearth.io/plugin-api/extension/#message-1
+// Documentation on Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", msg => {
   if (msg.type === "send") {
-  // Documentation on Extension List https://visualizer.developer.reearth.io/plugin-api/extension/#list
+  // Documentation on Extension List https://docs.reearth.io/en/developer/plugin/api-reference/extension/#list
     const extensions = reearth.extension.list;
     const target = extensions.find(ext => ext.extensionId === "extension-2");
     if (target) {
-    // Documentation on Extension "postMessage" method https://visualizer.developer.reearth.io/plugin-api/extension/#postmessage
+    // Documentation on Extension "postMessage" method https://docs.reearth.io/en/developer/plugin/api-reference/extension/#postmessage
       reearth.extension.postMessage(target.id, msg.message);
     }
   }

--- a/web/src/app/features/PluginPlayground/Plugins/presets/data/messengerBetweenExtensions.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/data/messengerBetweenExtensions.ts
@@ -68,14 +68,14 @@ reearth.ui.show(\`
 \`);
 
 // Handle messages from UI to send to other extension
-// Documentation on Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
+// Documentation on Extension "on" event https://docs.reearth.io/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", msg => {
   if (msg.type === "send") {
-  // Documentation on Extension List https://docs.reearth.io/en/developer/plugin/api-reference/extension/#list
+  // Documentation on Extension List https://docs.reearth.io/developer/plugin/api-reference/extension/#list
     const extensions = reearth.extension.list;
     const target = extensions.find(ext => ext.extensionId === "extension-2");
     if (target) {
-    // Documentation on Extension "postMessage" method https://docs.reearth.io/en/developer/plugin/api-reference/extension/#postmessage
+    // Documentation on Extension "postMessage" method https://docs.reearth.io/developer/plugin/api-reference/extension/#postmessage
       reearth.extension.postMessage(target.id, msg.message);
     }
   }

--- a/web/src/app/features/PluginPlayground/Plugins/presets/data/uiExtensionMessenger.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/data/uiExtensionMessenger.ts
@@ -86,9 +86,9 @@ const widgetFile: FileType = {
 \`);
 
 // Send message to UI when globe is clicked
-// Documentation on Viewer "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#mouse-events
+// Documentation on Viewer "on" event: https://docs.reearth.io/developer/plugin/api-reference/viewer/#mouse-events
 reearth.viewer.on("click", (event) => {
-// Documentation on UI "postMessage" method: https://docs.reearth.io/en/developer/plugin/api-reference/ui/#postmessage
+// Documentation on UI "postMessage" method: https://docs.reearth.io/developer/plugin/api-reference/ui/#postmessage
   reearth.ui.postMessage({
     type: "position",
     lat: event.lat,
@@ -97,10 +97,10 @@ reearth.viewer.on("click", (event) => {
 });
 
 // Handle messages from UI to move camera
-// Documentation on Extension "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
+// Documentation on Extension "on" event: https://docs.reearth.io/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", msg => {
   if (msg.type === "fly") {
-  // Documentation on Camera "flyTo" method: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+  // Documentation on Camera "flyTo" method: https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
     reearth.camera.flyTo(
       {
         lat: msg.lat,

--- a/web/src/app/features/PluginPlayground/Plugins/presets/data/uiExtensionMessenger.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/data/uiExtensionMessenger.ts
@@ -86,9 +86,9 @@ const widgetFile: FileType = {
 \`);
 
 // Send message to UI when globe is clicked
-// Documentation on Viewer "on" event: https://visualizer.developer.reearth.io/plugin-api/viewer/#mouse-events
+// Documentation on Viewer "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#mouse-events
 reearth.viewer.on("click", (event) => {
-// Documentation on UI "postMessage" method: https://visualizer.developer.reearth.io/plugin-api/ui/#postmessage
+// Documentation on UI "postMessage" method: https://docs.reearth.io/en/developer/plugin/api-reference/ui/#postmessage
   reearth.ui.postMessage({
     type: "position",
     lat: event.lat,
@@ -97,10 +97,10 @@ reearth.viewer.on("click", (event) => {
 });
 
 // Handle messages from UI to move camera
-// Documentation on Extension "on" event: https://visualizer.developer.reearth.io/plugin-api/extension/#message-1
+// Documentation on Extension "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", msg => {
   if (msg.type === "fly") {
-  // Documentation on Camera "flyTo" method: https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+  // Documentation on Camera "flyTo" method: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
     reearth.camera.flyTo(
       {
         lat: msg.lat,

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/featureStyle3dTiles.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/featureStyle3dTiles.ts
@@ -51,11 +51,11 @@ const sample3dTiles02 = {
 };
 
 // Add the 3D Tiles layers to Re:Earth
-// Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation for Layers "add" method https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(sample3dTiles01);
 reearth.layers.add(sample3dTiles02);
 
-// Documentation for Viewer "overrideProperty" method https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
+// Documentation for Viewer "overrideProperty" method https://docs.reearth.io/developer/plugin/api-reference/viewer/#overrideproperty
 reearth.viewer.overrideProperty({
   // Enable Cesium World Terrain
   terrain: {
@@ -74,7 +74,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to the specified position
-// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     // Define the camera target position

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/featureStyle3dTiles.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/featureStyle3dTiles.ts
@@ -51,11 +51,11 @@ const sample3dTiles02 = {
 };
 
 // Add the 3D Tiles layers to Re:Earth
-// Documentation for Layers "add" method https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(sample3dTiles01);
 reearth.layers.add(sample3dTiles02);
 
-// Documentation for Viewer "overrideProperty" method https://visualizer.developer.reearth.io/plugin-api/viewer/#overrideproperty
+// Documentation for Viewer "overrideProperty" method https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
 reearth.viewer.overrideProperty({
   // Enable Cesium World Terrain
   terrain: {
@@ -74,7 +74,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to the specified position
-// Documentation for Camera "flyTo" method https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     // Define the camera target position

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/featureStyle3dmodel.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/featureStyle3dmodel.ts
@@ -71,13 +71,13 @@ const model3D02 = {
 };
 
 // Add 3D models to the layer
-// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(model3D01);
 reearth.layers.add(model3D02);
 
 // In this example, the time width is set to set the time for the shadow to appear
 // Set the time range on the timeline
-// Documentation on Timeline "setTime" event: https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#settime
+// Documentation on Timeline "setTime" event: https://docs.reearth.io/developer/plugin/api-reference/timeline/#settime
 reearth.timeline.setTime({
   // Start time
   start: new Date("2023-12-01T09:00:00-06:00"),
@@ -88,15 +88,15 @@ reearth.timeline.setTime({
 });
 
 // To animate the 3D model, you need to play the timeline
-// Documentation on Timeline "play" event: https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#play  
+// Documentation on Timeline "play" event: https://docs.reearth.io/developer/plugin/api-reference/timeline/#play  
 reearth.timeline.play();
 
 // Set the playback speed of the timeline (1 = normal speed)
-// Documentation on Timeline "setSpeed" event: https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#setspeed
+// Documentation on Timeline "setSpeed" event: https://docs.reearth.io/developer/plugin/api-reference/timeline/#setspeed
 reearth.timeline.setSpeed(1);
 
 // Enable shadow settings in the Re:Earth viewer
-// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
+// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/developer/plugin/api-reference/viewer/#overrideproperty
 reearth.viewer.overrideProperty({
   scene: {
     shadow: {
@@ -106,7 +106,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to a specified position
-// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     // Defines the target camera position

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/featureStyle3dmodel.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/featureStyle3dmodel.ts
@@ -71,13 +71,13 @@ const model3D02 = {
 };
 
 // Add 3D models to the layer
-// Documentation on Layers "add" event: https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(model3D01);
 reearth.layers.add(model3D02);
 
 // In this example, the time width is set to set the time for the shadow to appear
 // Set the time range on the timeline
-// Documentation on Timeline "setTime" event: https://visualizer.developer.reearth.io/plugin-api/timeline/#settime
+// Documentation on Timeline "setTime" event: https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#settime
 reearth.timeline.setTime({
   // Start time
   start: new Date("2023-12-01T09:00:00-06:00"),
@@ -88,15 +88,15 @@ reearth.timeline.setTime({
 });
 
 // To animate the 3D model, you need to play the timeline
-// Documentation on Timeline "play" event: https://visualizer.developer.reearth.io/plugin-api/timeline/#play  
+// Documentation on Timeline "play" event: https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#play  
 reearth.timeline.play();
 
 // Set the playback speed of the timeline (1 = normal speed)
-// Documentation on Timeline "setSpeed" event: https://visualizer.developer.reearth.io/plugin-api/timeline/#setspeed
+// Documentation on Timeline "setSpeed" event: https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#setspeed
 reearth.timeline.setSpeed(1);
 
 // Enable shadow settings in the Re:Earth viewer
-// Documentation on Viewer "overrideProperty" event: https://visualizer.developer.reearth.io/plugin-api/viewer/#overrideproperty
+// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
 reearth.viewer.overrideProperty({
   scene: {
     shadow: {
@@ -106,7 +106,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to a specified position
-// Documentation on Camera "flyTo" event: https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     // Defines the target camera position

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/filterFeaturebyStyle.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/filterFeaturebyStyle.ts
@@ -89,11 +89,11 @@ const samplePointData = {
 };
 
 // Add the layer to Re:Earth
-// Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation for Layers "add" method https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 const layerId = reearth.layers.add(samplePointData);
 
 // Move the camera to the specified position
-// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     // Define the camera's target position
@@ -111,7 +111,7 @@ reearth.camera.flyTo(
 );
 
 // Listen for messages from the UI and override the style
-// Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
+// Documentation for Extension "on" event https://docs.reearth.io/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
   if (action === "showAllFeatures") {
@@ -121,7 +121,7 @@ reearth.extension.on("message", (msg) => {
       },
     });
   } else if (action === "showFeaturesBelow20000") {
-  // Documentation for Layers "override" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#override
+  // Documentation for Layers "override" method https://docs.reearth.io/developer/plugin/api-reference/layers/#override
     reearth.layers.override(layerId, {
       marker: {
         show: {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/filterFeaturebyStyle.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/filterFeaturebyStyle.ts
@@ -89,11 +89,11 @@ const samplePointData = {
 };
 
 // Add the layer to Re:Earth
-// Documentation for Layers "add" method https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 const layerId = reearth.layers.add(samplePointData);
 
 // Move the camera to the specified position
-// Documentation for Camera "flyTo" method https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     // Define the camera's target position
@@ -111,7 +111,7 @@ reearth.camera.flyTo(
 );
 
 // Listen for messages from the UI and override the style
-// Documentation for Extension "on" event https://visualizer.developer.reearth.io/plugin-api/extension/#message-1
+// Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
   if (action === "showAllFeatures") {
@@ -121,7 +121,7 @@ reearth.extension.on("message", (msg) => {
       },
     });
   } else if (action === "showFeaturesBelow20000") {
-  // Documentation for Layers "override" method https://visualizer.developer.reearth.io/plugin-api/layers/#override
+  // Documentation for Layers "override" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#override
     reearth.layers.override(layerId, {
       marker: {
         show: {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/layerStylingExamples.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/layerStylingExamples.ts
@@ -140,14 +140,14 @@ const widgetFile: FileType = {
   };
 
   // Add all layers
-  // Documentation for Layers "add" method https://visualizer.developer.reearth.io/plugin-api/layers/#add
+  // Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
   reearth.layers.add(geojsonLayer);
   reearth.layers.add(czmlLayer);
   reearth.layers.add(kmlLayer);
   reearth.layers.add(csvLayer);
 
   // Position camera to view all features
-  // Documentation for Camera "flyTo" method https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+  // Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
   reearth.camera.flyTo({
     lng: 139.750,  // Center position to align all features
     lat: 35.7609591,   // Adjusted for better view of all features

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/layerStylingExamples.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/layerStylingExamples.ts
@@ -140,14 +140,14 @@ const widgetFile: FileType = {
   };
 
   // Add all layers
-  // Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+  // Documentation for Layers "add" method https://docs.reearth.io/developer/plugin/api-reference/layers/#add
   reearth.layers.add(geojsonLayer);
   reearth.layers.add(czmlLayer);
   reearth.layers.add(kmlLayer);
   reearth.layers.add(csvLayer);
 
   // Position camera to view all features
-  // Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+  // Documentation for Camera "flyTo" method https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
   reearth.camera.flyTo({
     lng: 139.750,  // Center position to align all features
     lat: 35.7609591,   // Adjusted for better view of all features

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/overrideStyle.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/overrideStyle.ts
@@ -75,10 +75,10 @@ const sample3dTiles = {
 };
 
 // Add the 3D Tiles layer to Re:Earth
-// Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation for Layers "add" method https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 const layerId = reearth.layers.add(sample3dTiles);
 
-// Documentation for Layers "override" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#override
+// Documentation for Layers "override" method https://docs.reearth.io/developer/plugin/api-reference/layers/#override
 reearth.viewer.overrideProperty({
   // Enable Cesium World Terrain
   terrain: {
@@ -91,7 +91,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to the specified position
-// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     // Define the camera's target position
@@ -109,7 +109,7 @@ reearth.camera.flyTo(
 );
 
 // Listen for messages from the UI and override the style for "Cool Style or "Warm Style"
-// Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
+// Documentation for Extension "on" event https://docs.reearth.io/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
   if (action === "updateStyleCool") {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/overrideStyle.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/overrideStyle.ts
@@ -75,10 +75,10 @@ const sample3dTiles = {
 };
 
 // Add the 3D Tiles layer to Re:Earth
-// Documentation for Layers "add" method https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 const layerId = reearth.layers.add(sample3dTiles);
 
-// Documentation for Layers "override" method https://visualizer.developer.reearth.io/plugin-api/layers/#override
+// Documentation for Layers "override" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#override
 reearth.viewer.overrideProperty({
   // Enable Cesium World Terrain
   terrain: {
@@ -91,7 +91,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to the specified position
-// Documentation for Camera "flyTo" method https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     // Define the camera's target position
@@ -109,7 +109,7 @@ reearth.camera.flyTo(
 );
 
 // Listen for messages from the UI and override the style for "Cool Style or "Warm Style"
-// Documentation for Extension "on" event https://visualizer.developer.reearth.io/plugin-api/extension/#message-1
+// Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
   if (action === "updateStyleCool") {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/styleWithCondition.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/styleWithCondition.ts
@@ -54,7 +54,7 @@ const sample3dTiles = {
 };
 
 // Add the 3D Tiles layer to Re:Earth
-// Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation for Layers "add" method https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(sample3dTiles);
 
 reearth.viewer.overrideProperty({
@@ -69,7 +69,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to the specified position
-// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     // Define the camera's target position
@@ -87,7 +87,7 @@ reearth.camera.flyTo(
 );
 
 // Set the timeline to a morning hour so that building colors are easy to see
-// Documentation for Timeline "setTime" method https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#settime
+// Documentation for Timeline "setTime" method https://docs.reearth.io/developer/plugin/api-reference/timeline/#settime
 reearth.timeline.setTime({
     start: new Date("2023-01-01T00:00:00Z"),
     stop: new Date("2023-01-01T10:00:00Z"),

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/styleWithCondition.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layerStyles/styleWithCondition.ts
@@ -54,7 +54,7 @@ const sample3dTiles = {
 };
 
 // Add the 3D Tiles layer to Re:Earth
-// Documentation for Layers "add" method https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(sample3dTiles);
 
 reearth.viewer.overrideProperty({
@@ -69,7 +69,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to the specified position
-// Documentation for Camera "flyTo" method https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     // Define the camera's target position
@@ -87,7 +87,7 @@ reearth.camera.flyTo(
 );
 
 // Set the timeline to a morning hour so that building colors are easy to see
-// Documentation for Timeline "setTime" method https://visualizer.developer.reearth.io/plugin-api/timeline/#settime
+// Documentation for Timeline "setTime" method https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#settime
 reearth.timeline.setTime({
     start: new Date("2023-01-01T00:00:00Z"),
     stop: new Date("2023-01-01T10:00:00Z"),

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-3Dtiles.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-3Dtiles.ts
@@ -35,11 +35,11 @@ const layer3dTiles = {
 };
 
 // Add the 3D Tiles layer from the URL to Re:Earth
-// Documentation on Layers "add" event: https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layer3dTiles);
 
 // Enable Terrain
-// Documentation on Viewer "overrideProperty" event: https://visualizer.developer.reearth.io/plugin-api/viewer/#overrideproperty
+// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
 reearth.viewer.overrideProperty({
   terrain: {
     enabled: true,
@@ -47,7 +47,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to the position where the CZML data is displayed.
-// Documentation on Camera "flyTo" event: https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-3Dtiles.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-3Dtiles.ts
@@ -35,11 +35,11 @@ const layer3dTiles = {
 };
 
 // Add the 3D Tiles layer from the URL to Re:Earth
-// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layer3dTiles);
 
 // Enable Terrain
-// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
+// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/developer/plugin/api-reference/viewer/#overrideproperty
 reearth.viewer.overrideProperty({
   terrain: {
     enabled: true,
@@ -47,7 +47,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to the position where the CZML data is displayed.
-// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-OSM-3DTiles.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-OSM-3DTiles.ts
@@ -30,11 +30,11 @@ const layerOsm3dTiles = {
 };
 
 // Add the OSM 3D Tiles layer from the URL to Re:Earth
-// Documentation on Layers "add" event: https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerOsm3dTiles);
 
 // Enable Terrain
-// Documentation on Viewer "overrideProperty" event: https://visualizer.developer.reearth.io/plugin-api/viewer/#overrideproperty
+// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
 reearth.viewer.overrideProperty({
   terrain: {
     enabled: true,
@@ -42,7 +42,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to the position where the OSM 3D Tiles data is displayed.
-// Documentation on Camera "flyTo" event: https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-OSM-3DTiles.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-OSM-3DTiles.ts
@@ -30,11 +30,11 @@ const layerOsm3dTiles = {
 };
 
 // Add the OSM 3D Tiles layer from the URL to Re:Earth
-// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerOsm3dTiles);
 
 // Enable Terrain
-// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
+// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/developer/plugin/api-reference/viewer/#overrideproperty
 reearth.viewer.overrideProperty({
   terrain: {
     enabled: true,
@@ -42,7 +42,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to the position where the OSM 3D Tiles data is displayed.
-// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-csv.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-csv.ts
@@ -54,11 +54,11 @@ const layerCsv = {
 };
 
 // Add the CSV layer from the URL to Visualizer
-// Documentation on Layers "add" event: https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerCsv);
 
 // Move the camera to the position where the CSV data is displayed.
-// Documentation on Camera "flyTo" event: https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-csv.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-csv.ts
@@ -54,11 +54,11 @@ const layerCsv = {
 };
 
 // Add the CSV layer from the URL to Visualizer
-// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerCsv);
 
 // Move the camera to the position where the CSV data is displayed.
-// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-czml.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-czml.ts
@@ -72,14 +72,14 @@ const layerCzmlUrl = {
 };
 
 // Add the encoded CZML layer to Re:Earth
-// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerCzmlEncoded);
 
 // Add the CZML layer from the URL to Re:Earth
 reearth.layers.add(layerCzmlUrl);
 
 // Move the camera to the position where the CZML data is displayed
-// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     lng: -88.93602871895675,

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-czml.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-czml.ts
@@ -72,14 +72,14 @@ const layerCzmlUrl = {
 };
 
 // Add the encoded CZML layer to Re:Earth
-// Documentation on Layers "add" event: https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerCzmlEncoded);
 
 // Add the CZML layer from the URL to Re:Earth
 reearth.layers.add(layerCzmlUrl);
 
 // Move the camera to the position where the CZML data is displayed
-// Documentation on Camera "flyTo" event: https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     lng: -88.93602871895675,

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-geojson.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-geojson.ts
@@ -74,7 +74,7 @@ const parking = {
     },
   },
   // Settings for the feature style. This statement is required even if no style is set.
-  // Documentation on feature style: https://visualizer.developer.reearth.io/plugin-api/layers/#layer-appearance-types
+  // Documentation on feature style: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#layer-appearance-types
   marker: {
     image:
       "https://reearth.github.io/visualizer-plugin-sample-data/public/image/parking.svg",
@@ -109,7 +109,7 @@ const road = {
 };
 
 // Add the inline GeoJSON layer to Re:Earth
-// Documentation on Layers "add" event: https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(parking);
 reearth.layers.add(buildings);
 reearth.layers.add(road);

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-geojson.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-geojson.ts
@@ -74,7 +74,7 @@ const parking = {
     },
   },
   // Settings for the feature style. This statement is required even if no style is set.
-  // Documentation on feature style: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#layer-appearance-types
+  // Documentation on feature style: https://docs.reearth.io/developer/plugin/api-reference/layers/#layer-appearance-types
   marker: {
     image:
       "https://reearth.github.io/visualizer-plugin-sample-data/public/image/parking.svg",
@@ -109,7 +109,7 @@ const road = {
 };
 
 // Add the inline GeoJSON layer to Re:Earth
-// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(parking);
 reearth.layers.add(buildings);
 reearth.layers.add(road);

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-google-photorealistic-3d-tiles.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-google-photorealistic-3d-tiles.ts
@@ -36,11 +36,11 @@ const layerPhotorealistic3dTiles = {
 };
 
 // Add the Google Photorealistic 3D Tiles layer to Re:Earth
-// Documentation on Layers "add" event: https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerPhotorealistic3dTiles);
 
 // Move the camera to the position where the Google Photorealistic 3D Tiles data is displayed.
-// Documentation on Camera "flyTo" event: https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-google-photorealistic-3d-tiles.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-google-photorealistic-3d-tiles.ts
@@ -36,11 +36,11 @@ const layerPhotorealistic3dTiles = {
 };
 
 // Add the Google Photorealistic 3D Tiles layer to Re:Earth
-// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerPhotorealistic3dTiles);
 
 // Move the camera to the position where the Google Photorealistic 3D Tiles data is displayed.
-// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-kml.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-kml.ts
@@ -68,7 +68,7 @@ const layerKmlUrl = {
 };
 
 // Add the encoded KML layer to Re:Earth
-// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerKmlEncoded);
 
 // Add the KML layer from the URL to Re:Earth

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-kml.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-kml.ts
@@ -68,7 +68,7 @@ const layerKmlUrl = {
 };
 
 // Add the encoded KML layer to Re:Earth
-// Documentation on Layers "add" event: https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerKmlEncoded);
 
 // Add the KML layer from the URL to Re:Earth

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-large-geojson.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-large-geojson.ts
@@ -66,7 +66,7 @@ const kanagawaStyledGeoJson = {
 };
 
 // Add the GeoJSON layer from the URL to Visualizer
-// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(tokyoBoundary);
 reearth.layers.add(kanagawaStyledGeoJson);
 

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-large-geojson.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-large-geojson.ts
@@ -66,7 +66,7 @@ const kanagawaStyledGeoJson = {
 };
 
 // Add the GeoJSON layer from the URL to Visualizer
-// Documentation on Layers "add" event: https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(tokyoBoundary);
 reearth.layers.add(kanagawaStyledGeoJson);
 

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-photogrammetric-3D-model.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-photogrammetric-3D-model.ts
@@ -32,11 +32,11 @@ const photogrammetry = {
 };
 
 // Add the 3D Tiles layer from the URL to Re:Earth
-// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(photogrammetry);
 
 // Enable Terrain
-// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
+// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/developer/plugin/api-reference/viewer/#overrideproperty
 reearth.viewer.overrideProperty({
   terrain: {
     enabled: true,
@@ -44,7 +44,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to the position where the 3D model is displayed.
-// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-photogrammetric-3D-model.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-photogrammetric-3D-model.ts
@@ -32,11 +32,11 @@ const photogrammetry = {
 };
 
 // Add the 3D Tiles layer from the URL to Re:Earth
-// Documentation on Layers "add" event: https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(photogrammetry);
 
 // Enable Terrain
-// Documentation on Viewer "overrideProperty" event: https://visualizer.developer.reearth.io/plugin-api/viewer/#overrideproperty
+// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
 reearth.viewer.overrideProperty({
   terrain: {
     enabled: true,
@@ -44,7 +44,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Move the camera to the position where the 3D model is displayed.
-// Documentation on Camera "flyTo" event: https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-point-cloud.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-point-cloud.ts
@@ -32,11 +32,11 @@ const pointcloud = {
 };
 
 // Add the 3D Tiles layer from the URL to Re:Earth
-// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(pointcloud);
 
 // Move the camera to the position where point cloud data is displayed.
-// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-point-cloud.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-point-cloud.ts
@@ -32,11 +32,11 @@ const pointcloud = {
 };
 
 // Add the 3D Tiles layer from the URL to Re:Earth
-// Documentation on Layers "add" event: https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(pointcloud);
 
 // Move the camera to the position where point cloud data is displayed.
-// Documentation on Camera "flyTo" event: https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-wms.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-wms.ts
@@ -32,7 +32,7 @@ const layerWmsUrl = {
 };
 
 // Add the WMS layer from the URL to Re:Earth
-// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerWmsUrl);
 
 //WMS data is provided by NASA GIBS（https://www.earthdata.nasa.gov/engage/open-data-services-software/earthdata-developer-portal/gibs-api)`

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-wms.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/add-wms.ts
@@ -32,7 +32,7 @@ const layerWmsUrl = {
 };
 
 // Add the WMS layer from the URL to Re:Earth
-// Documentation on Layers "add" event: https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerWmsUrl);
 
 //WMS data is provided by NASA GIBS（https://www.earthdata.nasa.gov/engage/open-data-services-software/earthdata-developer-portal/gibs-api)`

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/hideFlyToDeleteLayer.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/hideFlyToDeleteLayer.ts
@@ -182,7 +182,7 @@ reearth.ui.show(\`
 </script>
 \`);
 
-// Documentation on Extension "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
+// Documentation on Extension "on" event: https://docs.reearth.io/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   switch (msg.type) {
     case "delete":

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/hideFlyToDeleteLayer.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/hideFlyToDeleteLayer.ts
@@ -182,7 +182,7 @@ reearth.ui.show(\`
 </script>
 \`);
 
-// Documentation on Extension "on" event: https://visualizer.developer.reearth.io/plugin-api/extension/#message-1
+// Documentation on Extension "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   switch (msg.type) {
     case "delete":

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/overrideLayerData.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/overrideLayerData.ts
@@ -138,7 +138,7 @@ const LayerManager = {
     };
 
     // Geometry update with override
-    // Documentation on Layers "override" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#override
+    // Documentation on Layers "override" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#override
     reearth.layers.override(this._layerId, {
       data: {
         type: "geojson",
@@ -152,7 +152,7 @@ const LayerManager = {
 };
 
 // Call "LayerManager" in the event handler
-// Documentation on Extension "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
+// Documentation on Extension "on" event: https://docs.reearth.io/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", msg => {
   if (msg.action === "updatePolygon") {
     const corners = msg.payload?.corners;

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/overrideLayerData.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/overrideLayerData.ts
@@ -138,7 +138,7 @@ const LayerManager = {
     };
 
     // Geometry update with override
-    // Documentation on Layers "override" event: https://visualizer.developer.reearth.io/plugin-api/layers/#override
+    // Documentation on Layers "override" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#override
     reearth.layers.override(this._layerId, {
       data: {
         type: "geojson",
@@ -152,7 +152,7 @@ const LayerManager = {
 };
 
 // Call "LayerManager" in the event handler
-// Documentation on Extension "on" event: https://visualizer.developer.reearth.io/plugin-api/extension/#message-1
+// Documentation on Extension "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", msg => {
   if (msg.action === "updatePolygon") {
     const corners = msg.payload?.corners;

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
@@ -74,11 +74,11 @@ const layer3dTiles = {
 };
 
 // Add the 3D Tiles layer from the URL to Re:Earth
-// Documentation on Layers "add" event: https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layer3dTiles);
 
 // Enable Terrain
-// Documentation on Viewer "overrideProperty" event: https://visualizer.developer.reearth.io/plugin-api/viewer/#overrideproperty
+// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
 reearth.viewer.overrideProperty({
   terrain: {
     enabled: true,
@@ -86,7 +86,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Define the camera position to be moved to
-// Documentation on Camera "flyTo" event: https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     heading: 4.022965234428543,
@@ -119,14 +119,14 @@ function handleLayerSelect(layerId, featureId) {
   const building_height = feature?.properties?.["bldg:measuredHeight"] || "";
 
   // Send selected feature id and height to plugin UI
-  // Documentation on UI "postMessage" event: https://visualizer.developer.reearth.io/plugin-api/ui/#postmessage
+  // Documentation on UI "postMessage" event: https://docs.reearth.io/en/developer/plugin/api-reference/ui/#postmessage
   reearth.ui.postMessage({
     action: "buildingClick",
     payload: { gmlId: gml_id ,buildingHeight : building_height},
   });
 }
 // Set "handleLayerSelect" to work when a feature is selected
-// Documentation on Layers "on" event: https://visualizer.developer.reearth.io/plugin-api/layers/#select-1
+// Documentation on Layers "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#select-1
 reearth.layers.on("select", handleLayerSelect);`
 };
 

--- a/web/src/app/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/layers/showSelectedFeaturesInformation.ts
@@ -74,11 +74,11 @@ const layer3dTiles = {
 };
 
 // Add the 3D Tiles layer from the URL to Re:Earth
-// Documentation on Layers "add" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation on Layers "add" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layer3dTiles);
 
 // Enable Terrain
-// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
+// Documentation on Viewer "overrideProperty" event: https://docs.reearth.io/developer/plugin/api-reference/viewer/#overrideproperty
 reearth.viewer.overrideProperty({
   terrain: {
     enabled: true,
@@ -86,7 +86,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Define the camera position to be moved to
-// Documentation on Camera "flyTo" event: https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation on Camera "flyTo" event: https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     heading: 4.022965234428543,
@@ -119,14 +119,14 @@ function handleLayerSelect(layerId, featureId) {
   const building_height = feature?.properties?.["bldg:measuredHeight"] || "";
 
   // Send selected feature id and height to plugin UI
-  // Documentation on UI "postMessage" event: https://docs.reearth.io/en/developer/plugin/api-reference/ui/#postmessage
+  // Documentation on UI "postMessage" event: https://docs.reearth.io/developer/plugin/api-reference/ui/#postmessage
   reearth.ui.postMessage({
     action: "buildingClick",
     payload: { gmlId: gml_id ,buildingHeight : building_height},
   });
 }
 // Set "handleLayerSelect" to work when a feature is selected
-// Documentation on Layers "on" event: https://docs.reearth.io/en/developer/plugin/api-reference/layers/#select-1
+// Documentation on Layers "on" event: https://docs.reearth.io/developer/plugin/api-reference/layers/#select-1
 reearth.layers.on("select", handleLayerSelect);`
 };
 

--- a/web/src/app/features/PluginPlayground/Plugins/presets/timeline/playbackControl.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/timeline/playbackControl.ts
@@ -172,11 +172,11 @@ const widgetFile: FileType = {
   };
 
   // Add the 3D Tiles layer
-  // Documentation for Layers "add" method https://visualizer.developer.reearth.io/plugin-api/layers/#add
+  // Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
   reearth.layers.add(buildings3dTiles);
 
   // Configure viewer for realistic day/night cycle
-  // Documentation for Viewer "overrideProperty" method https://visualizer.developer.reearth.io/plugin-api/viewer/#overrideproperty
+  // Documentation for Viewer "overrideProperty" method https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
   reearth.viewer.overrideProperty({
     globe: {
       enableLighting: true,
@@ -221,7 +221,7 @@ const widgetFile: FileType = {
 });
 
   // Set camera position for optimal ground+sky view
-  // Documentation for Camera "flyTo" method https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+  // Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
   reearth.camera.flyTo({
     lat: 35.4562,
     lng: 139.6431,
@@ -260,7 +260,7 @@ const widgetFile: FileType = {
   }
 
   // Handle messages from UI
-  // Documentation for Extension "on" event https://visualizer.developer.reearth.io/plugin-api/extension/#message-1
+  // Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
   reearth.extension.on("message", msg => {
     switch (msg.type) {
       case "playback":
@@ -291,7 +291,7 @@ const widgetFile: FileType = {
   });
 
   // Listen for timeline ticks
-  // Documentation for Timeline "tick" event https://visualizer.developer.reearth.io/plugin-api/timeline/#tick-1
+  // Documentation for Timeline "tick" event https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#tick-1
   timeline.on("tick", (time) => {
     reearth.ui.postMessage({
       type: "timeUpdate",

--- a/web/src/app/features/PluginPlayground/Plugins/presets/timeline/playbackControl.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/timeline/playbackControl.ts
@@ -172,11 +172,11 @@ const widgetFile: FileType = {
   };
 
   // Add the 3D Tiles layer
-  // Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+  // Documentation for Layers "add" method https://docs.reearth.io/developer/plugin/api-reference/layers/#add
   reearth.layers.add(buildings3dTiles);
 
   // Configure viewer for realistic day/night cycle
-  // Documentation for Viewer "overrideProperty" method https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
+  // Documentation for Viewer "overrideProperty" method https://docs.reearth.io/developer/plugin/api-reference/viewer/#overrideproperty
   reearth.viewer.overrideProperty({
     globe: {
       enableLighting: true,
@@ -221,7 +221,7 @@ const widgetFile: FileType = {
 });
 
   // Set camera position for optimal ground+sky view
-  // Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+  // Documentation for Camera "flyTo" method https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
   reearth.camera.flyTo({
     lat: 35.4562,
     lng: 139.6431,
@@ -260,7 +260,7 @@ const widgetFile: FileType = {
   }
 
   // Handle messages from UI
-  // Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
+  // Documentation for Extension "on" event https://docs.reearth.io/developer/plugin/api-reference/extension/#message
   reearth.extension.on("message", msg => {
     switch (msg.type) {
       case "playback":
@@ -291,7 +291,7 @@ const widgetFile: FileType = {
   });
 
   // Listen for timeline ticks
-  // Documentation for Timeline "tick" event https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#tick-1
+  // Documentation for Timeline "tick" event https://docs.reearth.io/developer/plugin/api-reference/timeline/#tick-1
   timeline.on("tick", (time) => {
     reearth.ui.postMessage({
       type: "timeUpdate",

--- a/web/src/app/features/PluginPlayground/Plugins/presets/timeline/timeDrivenFeatures.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/timeline/timeDrivenFeatures.ts
@@ -120,15 +120,15 @@ const layerCzmlEncoded = {
 };
 
 // Add the encoded CZML layer to Re:Earth
-// Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation for Layers "add" method https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerCzmlEncoded);
 
 // Play timeline
-// Documentation for Timeline "play" method https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#play
+// Documentation for Timeline "play" method https://docs.reearth.io/developer/plugin/api-reference/timeline/#play
 reearth.timeline.play();
 
 // Move the camera to the position where the CZML data is displayed
-// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     heading: 5.672603993826703,

--- a/web/src/app/features/PluginPlayground/Plugins/presets/timeline/timeDrivenFeatures.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/timeline/timeDrivenFeatures.ts
@@ -120,15 +120,15 @@ const layerCzmlEncoded = {
 };
 
 // Add the encoded CZML layer to Re:Earth
-// Documentation for Layers "add" method https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerCzmlEncoded);
 
 // Play timeline
-// Documentation for Timeline "play" method https://visualizer.developer.reearth.io/plugin-api/timeline/#play
+// Documentation for Timeline "play" method https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#play
 reearth.timeline.play();
 
 // Move the camera to the position where the CZML data is displayed
-// Documentation for Camera "flyTo" method https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     heading: 5.672603993826703,

--- a/web/src/app/features/PluginPlayground/Plugins/presets/timeline/timeDrivenPath.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/timeline/timeDrivenPath.ts
@@ -97,15 +97,15 @@ const layerCzmlEncoded = {
 };
 
 // Add the encoded CZML layer to Re:Earth
-// Documentation for Layers "add" method https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerCzmlEncoded);
 
 // Play timeline
-// Documentation for Timeline "play" method https://visualizer.developer.reearth.io/plugin-api/timeline/#play
+// Documentation for Timeline "play" method https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#play
 reearth.timeline.play();
 
 // Move the camera to the position where the CZML data is displayed
-// Documentation for Camera "flyTo" method https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     heading: 6.246954319760702,

--- a/web/src/app/features/PluginPlayground/Plugins/presets/timeline/timeDrivenPath.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/timeline/timeDrivenPath.ts
@@ -97,15 +97,15 @@ const layerCzmlEncoded = {
 };
 
 // Add the encoded CZML layer to Re:Earth
-// Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation for Layers "add" method https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(layerCzmlEncoded);
 
 // Play timeline
-// Documentation for Timeline "play" method https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#play
+// Documentation for Timeline "play" method https://docs.reearth.io/developer/plugin/api-reference/timeline/#play
 reearth.timeline.play();
 
 // Move the camera to the position where the CZML data is displayed
-// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     heading: 6.246954319760702,

--- a/web/src/app/features/PluginPlayground/Plugins/presets/ui/modalWindow.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/ui/modalWindow.ts
@@ -39,7 +39,7 @@ const widgetFile: FileType = {
   </div>\`
 
 // Set a modal window
-// Documentation for Modal "show" method https://visualizer.developer.reearth.io/plugin-api/modal/#show
+// Documentation for Modal "show" method https://docs.reearth.io/en/developer/plugin/api-reference/modal/#show
 reearth.modal.show(modalContent, {
   width: 400, // Define window width
   height: 300, // Define window height
@@ -48,11 +48,11 @@ reearth.modal.show(modalContent, {
 });
 
 // Listen for a message from the modal window and close it
-// Documentation for Extension "on" event https://visualizer.developer.reearth.io/plugin-api/extension/#message-1
+// Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", msg => {
   if (msg.action === "closeModal") {
     // Close a modal window
-    // Documentation for Modal "close" method https://visualizer.developer.reearth.io/plugin-api/modal/#close
+    // Documentation for Modal "close" method https://docs.reearth.io/en/developer/plugin/api-reference/modal/#close
     reearth.modal.close();
   }
 });`

--- a/web/src/app/features/PluginPlayground/Plugins/presets/ui/modalWindow.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/ui/modalWindow.ts
@@ -39,7 +39,7 @@ const widgetFile: FileType = {
   </div>\`
 
 // Set a modal window
-// Documentation for Modal "show" method https://docs.reearth.io/en/developer/plugin/api-reference/modal/#show
+// Documentation for Modal "show" method https://docs.reearth.io/developer/plugin/api-reference/modal/#show
 reearth.modal.show(modalContent, {
   width: 400, // Define window width
   height: 300, // Define window height
@@ -48,11 +48,11 @@ reearth.modal.show(modalContent, {
 });
 
 // Listen for a message from the modal window and close it
-// Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
+// Documentation for Extension "on" event https://docs.reearth.io/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", msg => {
   if (msg.action === "closeModal") {
     // Close a modal window
-    // Documentation for Modal "close" method https://docs.reearth.io/en/developer/plugin/api-reference/modal/#close
+    // Documentation for Modal "close" method https://docs.reearth.io/developer/plugin/api-reference/modal/#close
     reearth.modal.close();
   }
 });`

--- a/web/src/app/features/PluginPlayground/Plugins/presets/ui/popup.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/ui/popup.ts
@@ -293,28 +293,28 @@ const widgetFile: FileType = {
 \`;
 
 // Handle messages from the UI
-// Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
+// Documentation for Extension "on" event https://docs.reearth.io/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   if (msg.type === "showPopup") {
-  // Documentation for Popup "show" method https://docs.reearth.io/en/developer/plugin/api-reference/popup/#show
+  // Documentation for Popup "show" method https://docs.reearth.io/developer/plugin/api-reference/popup/#show
     reearth.popup.show(popupHTML, { position: "bottom-start" });
   }
   else if (msg.type === "closePopup") {
-  // Documentation for Popup "close" method https://docs.reearth.io/en/developer/plugin/api-reference/popup/#close
+  // Documentation for Popup "close" method https://docs.reearth.io/developer/plugin/api-reference/popup/#close
     reearth.popup.close();
     // Notify UI that popup is closed
-    // Documentation for Extension "postMessage" method https://docs.reearth.io/en/developer/plugin/api-reference/ui/#postmessage
+    // Documentation for Extension "postMessage" method https://docs.reearth.io/developer/plugin/api-reference/ui/#postmessage
     reearth.ui.postMessage({ type: "popupClosed" });
   }
   else if (msg.type === "updatePopup") {
-  // Documentation for Popup "update" method https://docs.reearth.io/en/developer/plugin/api-reference/popup/#update
+  // Documentation for Popup "update" method https://docs.reearth.io/developer/plugin/api-reference/popup/#update
     reearth.popup.update({
       position: msg.position,
       offset: msg.offset
     });
   }
   else if (msg.type === "postMessageToPopup") {
-  // Documentation for Popup "postMessage" method https://docs.reearth.io/en/developer/plugin/api-reference/popup/#postmessage
+  // Documentation for Popup "postMessage" method https://docs.reearth.io/developer/plugin/api-reference/popup/#postmessage
     reearth.popup.postMessage({ message: msg.message });
   }
   else if (msg.type === "messageToUI") {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/ui/popup.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/ui/popup.ts
@@ -293,28 +293,28 @@ const widgetFile: FileType = {
 \`;
 
 // Handle messages from the UI
-// Documentation for Extension "on" event https://visualizer.developer.reearth.io/plugin-api/extension/#message-1
+// Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   if (msg.type === "showPopup") {
-  // Documentation for Popup "show" method https://visualizer.developer.reearth.io/plugin-api/popup/#show
+  // Documentation for Popup "show" method https://docs.reearth.io/en/developer/plugin/api-reference/popup/#show
     reearth.popup.show(popupHTML, { position: "bottom-start" });
   }
   else if (msg.type === "closePopup") {
-  // Documentation for Popup "close" method https://visualizer.developer.reearth.io/plugin-api/popup/#close
+  // Documentation for Popup "close" method https://docs.reearth.io/en/developer/plugin/api-reference/popup/#close
     reearth.popup.close();
     // Notify UI that popup is closed
-    // Documentation for Extension "postMessage" method https://visualizer.developer.reearth.io/plugin-api/ui/#postmessage
+    // Documentation for Extension "postMessage" method https://docs.reearth.io/en/developer/plugin/api-reference/ui/#postmessage
     reearth.ui.postMessage({ type: "popupClosed" });
   }
   else if (msg.type === "updatePopup") {
-  // Documentation for Popup "update" method https://visualizer.developer.reearth.io/plugin-api/popup/#update
+  // Documentation for Popup "update" method https://docs.reearth.io/en/developer/plugin/api-reference/popup/#update
     reearth.popup.update({
       position: msg.position,
       offset: msg.offset
     });
   }
   else if (msg.type === "postMessageToPopup") {
-  // Documentation for Popup "postMessage" method https://visualizer.developer.reearth.io/plugin-api/popup/#postmessage
+  // Documentation for Popup "postMessage" method https://docs.reearth.io/en/developer/plugin/api-reference/popup/#postmessage
     reearth.popup.postMessage({ message: msg.message });
   }
   else if (msg.type === "messageToUI") {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/viewer/enableShadowStyle.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/viewer/enableShadowStyle.ts
@@ -92,11 +92,11 @@ const model3D = {
 };
 
 // Add 3D models to the layer
-// Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
+// Documentation for Layers "add" method https://docs.reearth.io/developer/plugin/api-reference/layers/#add
 reearth.layers.add(model3D);
 
 // Move the camera to a specified position
-// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     // Defines the target camera position
@@ -115,7 +115,7 @@ reearth.camera.flyTo(
 
 // In this example, the time width is set to set the time for the shadow to appear
 // Set the time range on the timeline
-// Documentation for Timeline "setTime" method https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#settime
+// Documentation for Timeline "setTime" method https://docs.reearth.io/developer/plugin/api-reference/timeline/#settime
 reearth.timeline.setTime({
 start: new Date("2023-12-01T09:00:00+01:00"),
 stop: new Date("2023-12-01T10:00:00+01:00"),
@@ -123,7 +123,7 @@ current: new Date("2023-12-01T09:00:00+01:00"),
 });
 
 // Listen for messages from the UI to trigger shadow
-// Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
+// Documentation for Extension "on" event https://docs.reearth.io/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
   if (action === "activateShadow") {
@@ -135,7 +135,7 @@ reearth.extension.on("message", (msg) => {
       },
     });
   } else if (action === "deactivateShadow") {
-  // Documentation for Viewer "overrideProperty" method https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
+  // Documentation for Viewer "overrideProperty" method https://docs.reearth.io/developer/plugin/api-reference/viewer/#overrideproperty
     reearth.viewer.overrideProperty({
       scene: {
         shadow: {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/viewer/enableShadowStyle.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/viewer/enableShadowStyle.ts
@@ -92,11 +92,11 @@ const model3D = {
 };
 
 // Add 3D models to the layer
-// Documentation for Layers "add" method https://visualizer.developer.reearth.io/plugin-api/layers/#add
+// Documentation for Layers "add" method https://docs.reearth.io/en/developer/plugin/api-reference/layers/#add
 reearth.layers.add(model3D);
 
 // Move the camera to a specified position
-// Documentation for Camera "flyTo" method https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   {
     // Defines the target camera position
@@ -115,7 +115,7 @@ reearth.camera.flyTo(
 
 // In this example, the time width is set to set the time for the shadow to appear
 // Set the time range on the timeline
-// Documentation for Timeline "setTime" method https://visualizer.developer.reearth.io/plugin-api/timeline/#settime
+// Documentation for Timeline "setTime" method https://docs.reearth.io/en/developer/plugin/api-reference/timeline/#settime
 reearth.timeline.setTime({
 start: new Date("2023-12-01T09:00:00+01:00"),
 stop: new Date("2023-12-01T10:00:00+01:00"),
@@ -123,7 +123,7 @@ current: new Date("2023-12-01T09:00:00+01:00"),
 });
 
 // Listen for messages from the UI to trigger shadow
-// Documentation for Extension "on" event https://visualizer.developer.reearth.io/plugin-api/extension/#message-1
+// Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
   if (action === "activateShadow") {
@@ -135,7 +135,7 @@ reearth.extension.on("message", (msg) => {
       },
     });
   } else if (action === "deactivateShadow") {
-  // Documentation for Viewer "overrideProperty" method https://visualizer.developer.reearth.io/plugin-api/viewer/#overrideproperty
+  // Documentation for Viewer "overrideProperty" method https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
     reearth.viewer.overrideProperty({
       scene: {
         shadow: {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/viewer/enableTerrain.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/viewer/enableTerrain.ts
@@ -70,7 +70,7 @@ reearth.ui.show(\`
 // ================================
 
 // Move the camera to a specified position
-// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {
@@ -88,11 +88,11 @@ reearth.camera.flyTo(
 );
 
 // Listen for messages from the UI to trigger terrain
-// Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
+// Documentation for Extension "on" event https://docs.reearth.io/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
   if (action === "activateTerrain") {
-  // Documentation for Viewer "overrideProperty" method https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
+  // Documentation for Viewer "overrideProperty" method https://docs.reearth.io/developer/plugin/api-reference/viewer/#overrideproperty
     reearth.viewer.overrideProperty({
       // Enable Cesium World Terrain
       terrain: {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/viewer/enableTerrain.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/viewer/enableTerrain.ts
@@ -70,7 +70,7 @@ reearth.ui.show(\`
 // ================================
 
 // Move the camera to a specified position
-// Documentation for Camera "flyTo" method https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {
@@ -88,11 +88,11 @@ reearth.camera.flyTo(
 );
 
 // Listen for messages from the UI to trigger terrain
-// Documentation for Extension "on" event https://visualizer.developer.reearth.io/plugin-api/extension/#message-1
+// Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
 reearth.extension.on("message", (msg) => {
   const { action } = msg;
   if (action === "activateTerrain") {
-  // Documentation for Viewer "overrideProperty" method https://visualizer.developer.reearth.io/plugin-api/viewer/#overrideproperty
+  // Documentation for Viewer "overrideProperty" method https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#overrideproperty
     reearth.viewer.overrideProperty({
       // Enable Cesium World Terrain
       terrain: {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/viewer/getCurrentLocation.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/viewer/getCurrentLocation.ts
@@ -101,7 +101,7 @@ reearth.ui.show(\`
 \`);
 
 // Handle button click to get current location
-// Documentation for Viewer "getCurrentLocationAsync" function https://visualizer.developer.reearth.io/plugin-api/viewer/#-getcurrentlocationasync
+// Documentation for Viewer "getCurrentLocationAsync" function https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#-getcurrentlocationasync
 reearth.extension.on("message", async (msg) => {
   if (msg.type === "getCurrentLocation") {
     const myLocation = await reearth.viewer.tools.getCurrentLocationAsync();

--- a/web/src/app/features/PluginPlayground/Plugins/presets/viewer/getCurrentLocation.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/viewer/getCurrentLocation.ts
@@ -101,7 +101,7 @@ reearth.ui.show(\`
 \`);
 
 // Handle button click to get current location
-// Documentation for Viewer "getCurrentLocationAsync" function https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#-getcurrentlocationasync
+// Documentation for Viewer "getCurrentLocationAsync" function https://docs.reearth.io/developer/plugin/api-reference/viewer/#-getcurrentlocationasync
 reearth.extension.on("message", async (msg) => {
   if (msg.type === "getCurrentLocation") {
     const myLocation = await reearth.viewer.tools.getCurrentLocationAsync();

--- a/web/src/app/features/PluginPlayground/Plugins/presets/viewer/mouseEvent.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/viewer/mouseEvent.ts
@@ -81,7 +81,7 @@ const widgetFile: FileType = {
 \`);
 
 // Handle click events and send to UI for any map click
-// Documentation for Viewer "on" event https://visualizer.developer.reearth.io/plugin-api/viewer/#mouse-events
+// Documentation for Viewer "on" event https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#mouse-events
 reearth.viewer.on("click", (event) => {
   const { lat, lng, height } = event;
 

--- a/web/src/app/features/PluginPlayground/Plugins/presets/viewer/mouseEvent.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/viewer/mouseEvent.ts
@@ -81,7 +81,7 @@ const widgetFile: FileType = {
 \`);
 
 // Handle click events and send to UI for any map click
-// Documentation for Viewer "on" event https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#mouse-events
+// Documentation for Viewer "on" event https://docs.reearth.io/developer/plugin/api-reference/viewer/#mouse-events
 reearth.viewer.on("click", (event) => {
   const { lat, lng, height } = event;
 

--- a/web/src/app/features/PluginPlayground/Plugins/presets/viewer/showLabel.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/viewer/showLabel.ts
@@ -32,7 +32,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Define the camera position to be moved to
-// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/viewer/showLabel.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/viewer/showLabel.ts
@@ -32,7 +32,7 @@ reearth.viewer.overrideProperty({
 });
 
 // Define the camera position to be moved to
-// Documentation for Camera "flyTo" method https://visualizer.developer.reearth.io/plugin-api/camera/#flyto
+// Documentation for Camera "flyTo" method https://docs.reearth.io/en/developer/plugin/api-reference/camera/#flyto
 reearth.camera.flyTo(
   // Define the camera position to be moved to
   {

--- a/web/src/app/features/PluginPlayground/Plugins/presets/viewer/takeScreenshot.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/viewer/takeScreenshot.ts
@@ -97,16 +97,16 @@ const widgetFile: FileType = {
 \`);
 
 // Set up the extension to handle messages from the UI
-// Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
+// Documentation for Extension "on" event https://docs.reearth.io/developer/plugin/api-reference/extension/#message
 reearth.extension.on('message', msg => {
   if (msg.type === 'capture-request') {
     try {
       // Capture the current view as a PNG image
-      // Documentation for Viewer "capture" method: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#capture
+      // Documentation for Viewer "capture" method: https://docs.reearth.io/developer/plugin/api-reference/viewer/#capture
       const imageData = reearth.viewer.capture('image/png');
 
       // Check if capture was successful and send response
-      // Documentation for UI "postMessage" method: https://docs.reearth.io/en/developer/plugin/api-reference/ui/#postmessage
+      // Documentation for UI "postMessage" method: https://docs.reearth.io/developer/plugin/api-reference/ui/#postmessage
       reearth.ui.postMessage({
         type: 'capture-response',
         imageData: imageData || null,

--- a/web/src/app/features/PluginPlayground/Plugins/presets/viewer/takeScreenshot.ts
+++ b/web/src/app/features/PluginPlayground/Plugins/presets/viewer/takeScreenshot.ts
@@ -97,16 +97,16 @@ const widgetFile: FileType = {
 \`);
 
 // Set up the extension to handle messages from the UI
-// Documentation for Extension "on" event https://visualizer.developer.reearth.io/plugin-api/extension/#message-1
+// Documentation for Extension "on" event https://docs.reearth.io/en/developer/plugin/api-reference/extension/#message
 reearth.extension.on('message', msg => {
   if (msg.type === 'capture-request') {
     try {
       // Capture the current view as a PNG image
-      // Documentation for Viewer "capture" method: https://visualizer.developer.reearth.io/plugin-api/viewer/#capture
+      // Documentation for Viewer "capture" method: https://docs.reearth.io/en/developer/plugin/api-reference/viewer/#capture
       const imageData = reearth.viewer.capture('image/png');
 
       // Check if capture was successful and send response
-      // Documentation for UI "postMessage" method: https://visualizer.developer.reearth.io/plugin-api/ui/#postmessage
+      // Documentation for UI "postMessage" method: https://docs.reearth.io/en/developer/plugin/api-reference/ui/#postmessage
       reearth.ui.postMessage({
         type: 'capture-response',
         imageData: imageData || null,


### PR DESCRIPTION
# Overview

Replaced all plugin playground preset documentation links pointing to the
old developer site with the new docs site URL.

## What I've done

- Replaced 110 references to `https://visualizer.developer.reearth.io/plugin-api/`
  with `https://docs.reearth.io/en/developer/plugin/api-reference/` across 38 preset files
- Fixed the `extension/#message-1` anchor which was renamed to `#message` on the new docs site

## What I haven't done

- UTM tracking parameters have not been added yet - the parameter name/value
  is yet to be confirmed with the team
- Language switching (locale-based URL prefix) is not implemented yet

## How I tested

- Verified 0 remaining references to the old URL via grep
- Verified all 110 occurrences were replaced with the new URL
- Spot-checked individual preset files to confirm URLs resolve to the correct sections

## Which point I want you to review particularly

- Confirm the new base URL path (`/en/developer/plugin/api-reference/`) is correct
  and stable

## Memo

UTM parameters will be added in a follow-up PR once the parameter naming
convention is agreed upon by the team.

## Checklist

- [x] Verified backward compatibility related to feature modifications (if not compatible, reported deployment notes to the next release owner).
- [x] Confirmed backward compatibility for migrations.
- [x] Verified that no personally identifiable information (PII) is included in any values that may be displayed.
- [x] Verified that all relevant documentation has been created or updated.
